### PR TITLE
Rewrite debug info: variable locations, integer types, formatting

### DIFF
--- a/debug/Core/xlCoreGCN.c
+++ b/debug/Core/xlCoreGCN.c
@@ -1,323 +1,320 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlCoreGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x800055A0 -> 0x80005E04
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// size = 0x8081, address = 0x800D3720
+u8 gTgPcTPL[32897];
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x4, address = 0x80135580
+static s32 gnCountArgument;
 
-// Location: 0x20370D80
-unsigned char gTgPcTPL[32897];
+// size = 0x4, address = 0x80135584
+static char** gaszArgument;
 
-// Local to compilation unit
-// Location: 0x80135580
-static int gnCountArgument;
+// size = 0x4, address = 0x80135588
+static void* DefaultFifo;
 
-// Local to compilation unit
-// Location: 0x80135584
-static char **gaszArgument;
+struct __anon_0x238 {
+    /* 0x0 */ u8 pad[128];
+}; // size = 0x80
 
-// Local to compilation unit
-// Location: 0x80135588
-static void *DefaultFifo;
+// size = 0x4, address = 0x8013558C
+static struct __anon_0x238* DefaultFifoObj;
 
-// size: 0x80
-struct __anon_0x238
-{
-	unsigned char pad[128]; // 0x0
+enum __anon_0x29F {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
 };
 
-// Local to compilation unit
-// Location: 0x8013558C
-static __anon_0x238 *DefaultFifoObj;
-
-// size: 0x4
-enum __anon_0x29F
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
+enum __anon_0x3EC {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
 };
 
-// size: 0x4
-enum __anon_0x3EC
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
-};
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0x29F viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0x3EC xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
 
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0x29F viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0x3EC xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
+// size = 0x3C, address = 0x800F3EE0
+static struct _GXRenderModeObj rmodeobj;
 
-// Local to compilation unit
-// Location: 0x800F3EE0
-static _GXRenderModeObj rmodeobj;
+// size = 0x4, address = 0x80135590
+static void* gpHeap;
 
-// Local to compilation unit
-// Location: 0x80135590
-static void *gpHeap;
+// size = 0x4, address = 0x80135594
+static void* gArenaHi;
 
-// Local to compilation unit
-// Location: 0x80135594
-static void *gArenaHi;
+// size = 0x4, address = 0x80135598
+static void* gArenaLo;
 
-// Local to compilation unit
-// Location: 0x80135598
-static void *gArenaLo;
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
 
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
+// size = 0x80, address = 0x800F3F1C
+struct _GXTexObj g_texMap[4];
 
-// Location: 0x1C3F0F80
-_GXTexObj g_texMap[4];
+// size = 0x4, address = 0x8013559C
+struct _GXRenderModeObj* rmode;
 
-// Location: 0x8013559C
-_GXRenderModeObj *rmode;
-
-void xlCoreBeforeRender()
-{
-	// References: rmode (0x8013559C)
+// Range: 0x800055A0 -> 0x80005674
+void xlCoreBeforeRender() {
+    // References
+    // -> struct _GXRenderModeObj* rmode;
 }
 
-// Location: 0x20541380
-int __OSCurrHeap;
+// size = 0x4, address = 0x80135420
+s32 __OSCurrHeap;
 
-// Location: 0x80135A94
-void *DemoFrameBuffer1;
+// size = 0x4, address = 0x80135A94
+void* DemoFrameBuffer1;
 
-// Location: 0x80135A8C
-void *DemoCurrentBuffer;
+// size = 0x4, address = 0x80135A8C
+void* DemoCurrentBuffer;
 
-// Location: 0x80135A90
-void *DemoFrameBuffer2;
+// size = 0x4, address = 0x80135A90
+void* DemoFrameBuffer2;
 
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// size: 0x4
-enum _GXTexFilter
-{
-	GX_NEAR = 0,
-	GX_LINEAR = 1,
-	GX_NEAR_MIP_NEAR = 2,
-	GX_LIN_MIP_NEAR = 3,
-	GX_NEAR_MIP_LIN = 4,
-	GX_LIN_MIP_LIN = 5
+enum _GXTexFilter {
+    GX_NEAR = 0,
+    GX_LINEAR = 1,
+    GX_NEAR_MIP_NEAR = 2,
+    GX_LIN_MIP_NEAR = 3,
+    GX_NEAR_MIP_LIN = 4,
+    GX_LIN_MIP_LIN = 5,
 };
 
-// size: 0x24
-struct __anon_0x9F7
-{
-	unsigned short height; // 0x0
-	unsigned short width; // 0x2
-	unsigned long format; // 0x4
-	char *data; // 0x8
-	_GXTexWrapMode wrapS; // 0xC
-	_GXTexWrapMode wrapT; // 0x10
-	_GXTexFilter minFilter; // 0x14
-	_GXTexFilter magFilter; // 0x18
-	float LODBias; // 0x1C
-	unsigned char edgeLODEnable; // 0x20
-	unsigned char minLOD; // 0x21
-	unsigned char maxLOD; // 0x22
-	unsigned char unpacked; // 0x23
+struct __anon_0x9F7 {
+    /* 0x00 */ u16 height;
+    /* 0x02 */ u16 width;
+    /* 0x04 */ u32 format;
+    /* 0x08 */ char* data;
+    /* 0x0C */ enum _GXTexWrapMode wrapS;
+    /* 0x10 */ enum _GXTexWrapMode wrapT;
+    /* 0x14 */ enum _GXTexFilter minFilter;
+    /* 0x18 */ enum _GXTexFilter magFilter;
+    /* 0x1C */ float LODBias;
+    /* 0x20 */ u8 edgeLODEnable;
+    /* 0x21 */ u8 minLOD;
+    /* 0x22 */ u8 maxLOD;
+    /* 0x23 */ u8 unpacked;
+}; // size = 0x24
+
+enum _GXTlutFmt {
+    GX_TL_IA8 = 0,
+    GX_TL_RGB565 = 1,
+    GX_TL_RGB5A3 = 2,
+    GX_MAX_TLUTFMT = 3,
 };
 
-// size: 0x4
-enum _GXTlutFmt
-{
-	GX_TL_IA8 = 0,
-	GX_TL_RGB565 = 1,
-	GX_TL_RGB5A3 = 2,
-	GX_MAX_TLUTFMT = 3
+struct __anon_0xC52 {
+    /* 0x0 */ u16 numEntries;
+    /* 0x2 */ u8 unpacked;
+    /* 0x3 */ u8 pad8;
+    /* 0x4 */ enum _GXTlutFmt format;
+    /* 0x8 */ char* data;
+}; // size = 0xC
+
+struct __anon_0xD1E {
+    /* 0x0 */ struct __anon_0x9F7* textureHeader;
+    /* 0x4 */ struct __anon_0xC52* CLUTHeader;
+}; // size = 0x8
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+// Range: 0x80005674 -> 0x800058DC
+s32 main(s32 nCount, char** aszArgument) {
+    // Parameters
+    // s32 nCount; // r1+0x8
+    // char** aszArgument; // r1+0xC
+
+    // Local variables
+    s32 nSize; // r31
+    void* pHeap; // r27
+    s32 nSizeHeap; // r3
+    struct __anon_0xD1E* tdp; // r1+0x8
+    struct _GXColor black; // r1+0x10
+    u32 i; // r26
+
+    // References
+    // -> s32 __OSCurrHeap;
+    // -> static void* gpHeap;
+    // -> struct _GXTexObj g_texMap[4];
+    // -> u8 gTgPcTPL[32897];
+    // -> struct _GXRenderModeObj* rmode;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+    // -> static void* DefaultFifo;
+    // -> static struct __anon_0x238* DefaultFifoObj;
+    // -> static char** gaszArgument;
+    // -> static s32 gnCountArgument;
+}
+
+// Erased
+static s32 xlCoreGetUpper24MB(void* ppBuffer) {
+    // Parameters
+    // void* ppBuffer; // r1+0x0
+}
+
+union DoubleLongLong {
+    /* 0x0 */ double f;
+    /* 0x0 */ s64 i;
 };
 
-// size: 0xC
-struct __anon_0xC52
-{
-	unsigned short numEntries; // 0x0
-	unsigned char unpacked; // 0x2
-	unsigned char pad8; // 0x3
-	_GXTlutFmt format; // 0x4
-	char *data; // 0x8
-};
-
-// size: 0x8
-struct __anon_0xD1E
-{
-	__anon_0x9F7 *textureHeader; // 0x0
-	__anon_0xC52 *CLUTHeader; // 0x4
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-int main(int nCount, char **aszArgument)
-{
-	int nSize;
-	void *pHeap;
-	long nSizeHeap;
-	__anon_0xD1E *tdp;
-	_GXColor black;
-	unsigned long i;
-	// References: __OSCurrHeap (0x20541380)
-	// References: gpHeap (0x80135590)
-	// References: g_texMap (0x1C3F0F80)
-	// References: gTgPcTPL (0x20370D80)
-	// References: rmode (0x8013559C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DefaultFifo (0x80135588)
-	// References: DefaultFifoObj (0x8013558C)
-	// References: gaszArgument (0x80135584)
-	// References: gnCountArgument (0x80135580)
+// Erased
+static s32 xlCoreEnableFPExceptions() {
+    // Local variables
+    double control; // r1+0x8
+    union DoubleLongLong d; // r1+0x8
 }
 
-int xlCoreGetUpper24MB(void *ppBuffer);
+// Range: 0x800058DC -> 0x800058E4
+s32 xlCoreHiResolution() {}
 
-// size: 0x8
-union DoubleLongLong
-{
-	long float f; // 0x0
-	signed long long i; // 0x0
-};
+// Range: 0x800058E4 -> 0x80005918
+s32 xlCoreGetArgument(s32 iArgument, char** pszArgument) {
+    // Parameters
+    // s32 iArgument; // r1+0x0
+    // char** pszArgument; // r1+0x4
 
-int xlCoreEnableFPExceptions()
-{
-	long float control;
-	DoubleLongLong d;
+    // References
+    // -> static char** gaszArgument;
+    // -> static s32 gnCountArgument;
 }
 
-int xlCoreHiResolution();
-
-int xlCoreGetArgument(int iArgument, char **pszArgument)
-{
-	// References: gaszArgument (0x80135584)
-	// References: gnCountArgument (0x80135580)
+// Range: 0x80005918 -> 0x80005920
+s32 xlCoreGetArgumentCount() {
+    // References
+    // -> static s32 gnCountArgument;
 }
 
-int xlCoreGetArgumentCount()
-{
-	// References: gnCountArgument (0x80135580)
+// Erased
+static void xlCoreInitVI() {
+    // References
+    // -> struct _GXRenderModeObj* rmode;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
 }
 
-void xlCoreInitVI()
-{
-	// References: rmode (0x8013559C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer1 (0x80135A94)
+// Range: 0x80005920 -> 0x80005B7C
+static void xlCoreInitGX() {
+    // Local variables
+    u8 newFilter[7]; // r1+0x18
+
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> struct _GXRenderModeObj* rmode;
 }
 
-// Local to compilation unit
-static void xlCoreInitGX()
-{
-	unsigned char newFilter[7];
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: rmode (0x8013559C)
+// Range: 0x80005B7C -> 0x80005C54
+static void xlCoreInitMem() {
+    // Local variables
+    void* arenaLo; // r1+0x8
+    void* arenaHi; // r1+0x8
+    u32 fbSize; // r3
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> static void* gArenaHi;
+    // -> static void* gArenaLo;
 }
 
-// Local to compilation unit
-static void xlCoreInitMem()
-{
-	void *arenaLo;
-	void *arenaHi;
-	unsigned long fbSize;
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: rmode (0x8013559C)
-	// References: gArenaHi (0x80135594)
-	// References: gArenaLo (0x80135598)
+// size = 0x3C, address = 0x800F1E60
+struct _GXRenderModeObj GXNtsc480IntDf;
+
+// size = 0x3C, address = 0x800F1E9C
+struct _GXRenderModeObj GXNtsc480Prog;
+
+// size = 0x3C, address = 0x800F1F14
+struct _GXRenderModeObj GXPal528IntDf;
+
+// size = 0x3C, address = 0x800F1ED8
+struct _GXRenderModeObj GXMpal480IntDf;
+
+// Range: 0x80005C54 -> 0x80005DC8
+static void xlCoreInitRenderMode(struct _GXRenderModeObj* mode) {
+    // Parameters
+    // struct _GXRenderModeObj* mode; // r1+0x8
+
+    // Local variables
+    char* szText; // r31
+    s32 iArgument; // r5
+
+    // References
+    // -> static struct _GXRenderModeObj rmodeobj;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> struct _GXRenderModeObj GXMpal480IntDf;
+    // -> struct _GXRenderModeObj GXPal528IntDf;
+    // -> struct _GXRenderModeObj GXNtsc480Prog;
+    // -> static s32 gnCountArgument;
+    // -> static char** gaszArgument;
+    // -> struct _GXRenderModeObj GXNtsc480IntDf;
 }
 
-// Location: 0x601E0F80
-_GXRenderModeObj GXNtsc480IntDf;
-
-// Location: 0x800F1E9C
-_GXRenderModeObj GXNtsc480Prog;
-
-// Location: 0x141F0F80
-_GXRenderModeObj GXPal528IntDf;
-
-// Location: 0x800F1ED8
-_GXRenderModeObj GXMpal480IntDf;
-
-// Local to compilation unit
-static void xlCoreInitRenderMode(_GXRenderModeObj *mode)
-{
-	char *szText;
-	int iArgument;
-	// References: rmodeobj (0x800F3EE0)
-	// References: rmode (0x8013559C)
-	// References: GXMpal480IntDf (0x800F1ED8)
-	// References: GXPal528IntDf (0x141F0F80)
-	// References: GXNtsc480Prog (0x800F1E9C)
-	// References: gnCountArgument (0x80135580)
-	// References: gaszArgument (0x80135584)
-	// References: GXNtsc480IntDf (0x601E0F80)
+// Range: 0x80005DC8 -> 0x80005E04
+s32 xlCoreReset() {
+    // References
+    // -> static void* gArenaHi;
+    // -> static void* gArenaLo;
+    // -> static void* gpHeap;
+    // -> s32 __OSCurrHeap;
 }
 
-int xlCoreReset()
-{
-	// References: gArenaHi (0x80135594)
-	// References: gArenaLo (0x80135598)
-	// References: gpHeap (0x80135590)
-	// References: __OSCurrHeap (0x20541380)
-}
+// Erased
+static void xlCoreInit(struct _GXRenderModeObj* mode) {
+    // Parameters
+    // struct _GXRenderModeObj* mode; // r31
 
-void xlCoreInit(_GXRenderModeObj *mode)
-{
-	// References: rmode (0x8013559C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DefaultFifo (0x80135588)
-	// References: DefaultFifoObj (0x8013558C)
-	// References: __OSCurrHeap (0x20541380)
+    // References
+    // -> struct _GXRenderModeObj* rmode;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+    // -> static void* DefaultFifo;
+    // -> static struct __anon_0x238* DefaultFifoObj;
+    // -> s32 __OSCurrHeap;
 }
-

--- a/debug/Core/xlCoreGCN.c
+++ b/debug/Core/xlCoreGCN.c
@@ -19,14 +19,14 @@ static char** gaszArgument;
 // size = 0x4, address = 0x80135588
 static void* DefaultFifo;
 
-struct __anon_0x238 {
+typedef struct __anon_0x238 {
     /* 0x0 */ u8 pad[128];
-}; // size = 0x80
+} __anon_0x238; // size = 0x80
 
 // size = 0x4, address = 0x8013558C
 static struct __anon_0x238* DefaultFifoObj;
 
-enum __anon_0x29F {
+typedef enum __anon_0x29F {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -39,14 +39,14 @@ enum __anon_0x29F {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0x29F;
 
-enum __anon_0x3EC {
+typedef enum __anon_0x3EC {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0x3EC;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0x29F viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -60,7 +60,7 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0x4A0; // size = 0x3C
 
 // size = 0x3C, address = 0x800F3EE0
 static struct _GXRenderModeObj rmodeobj;
@@ -74,9 +74,9 @@ static void* gArenaHi;
 // size = 0x4, address = 0x80135598
 static void* gArenaLo;
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x769; // size = 0x20
 
 // size = 0x80, address = 0x800F3F1C
 struct _GXTexObj g_texMap[4];
@@ -102,23 +102,23 @@ void* DemoCurrentBuffer;
 // size = 0x4, address = 0x80135A90
 void* DemoFrameBuffer2;
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x8FD;
 
-enum _GXTexFilter {
+typedef enum _GXTexFilter {
     GX_NEAR = 0,
     GX_LINEAR = 1,
     GX_NEAR_MIP_NEAR = 2,
     GX_LIN_MIP_NEAR = 3,
     GX_NEAR_MIP_LIN = 4,
     GX_LIN_MIP_LIN = 5,
-};
+} __anon_0x966;
 
-struct __anon_0x9F7 {
+typedef struct __anon_0x9F7 {
     /* 0x00 */ u16 height;
     /* 0x02 */ u16 width;
     /* 0x04 */ u32 format;
@@ -132,34 +132,34 @@ struct __anon_0x9F7 {
     /* 0x21 */ u8 minLOD;
     /* 0x22 */ u8 maxLOD;
     /* 0x23 */ u8 unpacked;
-}; // size = 0x24
+} __anon_0x9F7; // size = 0x24
 
-enum _GXTlutFmt {
+typedef enum _GXTlutFmt {
     GX_TL_IA8 = 0,
     GX_TL_RGB565 = 1,
     GX_TL_RGB5A3 = 2,
     GX_MAX_TLUTFMT = 3,
-};
+} __anon_0xBEA;
 
-struct __anon_0xC52 {
+typedef struct __anon_0xC52 {
     /* 0x0 */ u16 numEntries;
     /* 0x2 */ u8 unpacked;
     /* 0x3 */ u8 pad8;
     /* 0x4 */ enum _GXTlutFmt format;
     /* 0x8 */ char* data;
-}; // size = 0xC
+} __anon_0xC52; // size = 0xC
 
-struct __anon_0xD1E {
+typedef struct __anon_0xD1E {
     /* 0x0 */ struct __anon_0x9F7* textureHeader;
     /* 0x4 */ struct __anon_0xC52* CLUTHeader;
-}; // size = 0x8
+} __anon_0xD1E; // size = 0x8
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0xD8F; // size = 0x4
 
 // Range: 0x80005674 -> 0x800058DC
 s32 main(s32 nCount, char** aszArgument) {
@@ -196,10 +196,10 @@ static s32 xlCoreGetUpper24MB(void* ppBuffer) {
     // void* ppBuffer; // r1+0x0
 }
 
-union DoubleLongLong {
+typedef union DoubleLongLong {
     /* 0x0 */ double f;
     /* 0x0 */ s64 i;
-};
+} __anon_0x1026;
 
 // Erased
 static s32 xlCoreEnableFPExceptions() {

--- a/debug/Core/xlFileGCN.c
+++ b/debug/Core/xlFileGCN.c
@@ -1,156 +1,214 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlFileGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80005E68 -> 0x80006280
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800DB7E0
+struct _XL_OBJECTTYPE gTypeFile;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+// size = 0x4, address = 0x801355A0
+static s32 (*gpfOpen)(char*, struct DVDFileInfo*);
+
+// size = 0x4, address = 0x801355A4
+static s32 (*gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+
+struct tXL_FILE {
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ enum __anon_0x2757 eType;
+    /* 0x1C */ struct DVDFileInfo info;
+}; // size = 0x58
+
+// Range: 0x80005E68 -> 0x80005F18
+s32 xlFileEvent(struct tXL_FILE* pFile, s32 nEvent) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r31
+    // s32 nEvent; // r1+0xC
+}
+
+// Erased
+static s32 xlFileGetPosition(struct tXL_FILE* pFile, s32* pnOffset) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r1+0x0
+    // s32* pnOffset; // r1+0x4
+}
+
+// Range: 0x80005F18 -> 0x80005F40
+s32 xlFileSetPosition(struct tXL_FILE* pFile, s32 nOffset) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r1+0x0
+    // s32 nOffset; // r1+0x4
+}
+
+// Erased
+static s32 xlFilePutLine() {}
+
+// Erased
+static s32 xlFilePutFlip(s32 nSizeBytes) {
+    // Parameters
+    // s32 nSizeBytes; // r1+0x8
+}
+
+// Erased
+static s32 xlFilePut() {}
+
+// Erased
+static s32 xlFileGetLine(struct tXL_FILE* pFile, char* acLine, s32 nSizeLine) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r28
+    // char* acLine; // r29
+    // s32 nSizeLine; // r30
+
+    // Local variables
+    s32 iCharacter; // r31
+    char nCharacter; // r1+0x14
+}
+
+// Erased
+static s32 xlFileGetFlip(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r30
+    // void* pTarget; // r31
+    // s32 nSizeBytes; // r1+0x10
+}
+
+// Range: 0x80005F40 -> 0x80006044
+s32 xlFileGet(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r27
+    // void* pTarget; // r28
+    // s32 nSizeBytes; // r29
+
+    // Local variables
+    s32 nOffset; // r6
+    s32 nOffsetExtra; // r1+0x8
+    s32 nSize; // r5
+    s32 nSizeUsed; // r30
+
+    // References
+    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+}
+
+// Range: 0x80006044 -> 0x80006078
+s32 xlFileClose(struct tXL_FILE** ppFile) {
+    // Parameters
+    // struct tXL_FILE** ppFile; // r3
+}
+
+// Erased
+static s32 xlFileCreate() {}
+
+enum __anon_0x2757 {
+    XLFT_NONE = -1,
+    XLFT_TEXT = 0,
+    XLFT_BINARY = 1,
 };
 
-// Location: 0x800DB7E0
-_XL_OBJECTTYPE gTypeFile;
+// Range: 0x80006078 -> 0x8000614C
+s32 xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {
+    // Parameters
+    // struct tXL_FILE** ppFile; // r29
+    // enum __anon_0x2757 eType; // r30
+    // char* szFileName; // r31
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+    // Local variables
+    s32 nStatus; // r3
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// Local to compilation unit
-// Location: 0x801355A0
-static int (*gpfOpen)(char */* unknown0 */, DVDFileInfo */* unknown1 */);
-
-// Local to compilation unit
-// Location: 0x801355A4
-static int (*gpfRead)(DVDFileInfo */* unknown0 */, void */* unknown1 */, int /* unknown2 */, int /* unknown3 */, void (*/* unknown4 */)(long /* unknown0 */, DVDFileInfo */* unknown1 */));
-
-// size: 0x58
-struct tXL_FILE
-{
-	int iBuffer; // 0x0
-	void *pData; // 0x4
-	void *pBuffer; // 0x8
-	int nAttributes; // 0xC
-	int nSize; // 0x10
-	int nOffset; // 0x14
-	__anon_0x2757 eType; // 0x18
-	DVDFileInfo info; // 0x1C
-};
-
-int xlFileEvent(tXL_FILE *pFile, int nEvent);
-
-int xlFileGetPosition(tXL_FILE *pFile, int *pnOffset);
-
-int xlFileSetPosition(tXL_FILE *pFile, int nOffset);
-
-int xlFilePutLine();
-
-int xlFilePutFlip(int nSizeBytes);
-
-int xlFilePut();
-
-int xlFileGetLine(tXL_FILE *pFile, char *acLine, int nSizeLine)
-{
-	int iCharacter;
-	char nCharacter;
+    // References
+    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
-int xlFileGetFlip(tXL_FILE *pFile, void *pTarget, int nSizeBytes);
+// Erased
+static s32 xlFileLoad(char* szFileName, void* ppBuffer) {
+    // Parameters
+    // char* szFileName; // r30
+    // void* ppBuffer; // r31
 
-int xlFileGet(tXL_FILE *pFile, void *pTarget, int nSizeBytes)
-{
-	int nOffset;
-	int nOffsetExtra;
-	int nSize;
-	int nSizeUsed;
-	// References: gpfRead (0x801355A4)
+    // Local variables
+    s32 nSize; // r1+0x18
+    struct tXL_FILE* pFile; // r1+0x14
+
+    // References
+    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
-int xlFileClose(tXL_FILE **ppFile);
+// Range: 0x8000614C -> 0x80006268
+s32 xlFileGetSize(s32* pnSize, char* szFileName) {
+    // Parameters
+    // s32* pnSize; // r31
+    // char* szFileName; // r30
 
-int xlFileCreate();
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x10
 
-// size: 0x4
-enum __anon_0x2757
-{
-	XLFT_NONE = 4294967295,
-	XLFT_TEXT = 0,
-	XLFT_BINARY = 1
-};
-
-int xlFileOpen(tXL_FILE **ppFile, __anon_0x2757 eType, char *szFileName)
-{
-	int nStatus;
-	// References: gpfOpen (0x801355A0)
-	// References: gTypeFile (0x800DB7E0)
+    // References
+    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
-int xlFileLoad(char *szFileName, void *ppBuffer)
-{
-	int nSize;
-	tXL_FILE *pFile;
-	// References: gpfOpen (0x801355A0)
-	// References: gTypeFile (0x800DB7E0)
+// Range: 0x80006268 -> 0x80006274
+s32 xlFileSetRead(s32 (*pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*))) {
+    // Parameters
+    // s32 (* pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*)); // r1+0x0
+
+    // References
+    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
 }
 
-int xlFileGetSize(int *pnSize, char *szFileName)
-{
-	tXL_FILE *pFile;
-	// References: gpfOpen (0x801355A0)
-	// References: gTypeFile (0x800DB7E0)
-}
+// Range: 0x80006274 -> 0x80006280
+s32 xlFileSetOpen(s32 (*pfOpen)(char*, struct DVDFileInfo*)) {
+    // Parameters
+    // s32 (* pfOpen)(char*, struct DVDFileInfo*); // r1+0x0
 
-int xlFileSetRead(int (*pfRead)(DVDFileInfo */* unknown0 */, void */* unknown1 */, int /* unknown2 */, int /* unknown3 */, void (*/* unknown4 */)(long /* unknown0 */, DVDFileInfo */* unknown1 */)))
-{
-	// References: gpfRead (0x801355A4)
+    // References
+    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
 }
-
-int xlFileSetOpen(int (*pfOpen)(char */* unknown0 */, DVDFileInfo */* unknown1 */))
-{
-	// References: gpfOpen (0x801355A0)
-}
-

--- a/debug/Core/xlFileGCN.c
+++ b/debug/Core/xlFileGCN.c
@@ -7,17 +7,17 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x19EC; // size = 0x10
 
 // size = 0x10, address = 0x800DB7E0
 struct _XL_OBJECTTYPE gTypeFile;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -25,9 +25,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x1B3D; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -40,14 +40,14 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x1CAD; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x1ED3; // size = 0x3C
 
 // size = 0x4, address = 0x801355A0
 static s32 (*gpfOpen)(char*, struct DVDFileInfo*);
@@ -55,7 +55,7 @@ static s32 (*gpfOpen)(char*, struct DVDFileInfo*);
 // size = 0x4, address = 0x801355A4
 static s32 (*gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
 
-struct tXL_FILE {
+typedef struct tXL_FILE {
     /* 0x00 */ s32 iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
@@ -64,7 +64,7 @@ struct tXL_FILE {
     /* 0x14 */ s32 nOffset;
     /* 0x18 */ enum __anon_0x2757 eType;
     /* 0x1C */ struct DVDFileInfo info;
-}; // size = 0x58
+} __anon_0x2085; // size = 0x58
 
 // Range: 0x80005E68 -> 0x80005F18
 s32 xlFileEvent(struct tXL_FILE* pFile, s32 nEvent) {
@@ -145,11 +145,11 @@ s32 xlFileClose(struct tXL_FILE** ppFile) {
 // Erased
 static s32 xlFileCreate() {}
 
-enum __anon_0x2757 {
+typedef enum __anon_0x2757 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
-};
+} __anon_0x2757;
 
 // Range: 0x80006078 -> 0x8000614C
 s32 xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {

--- a/debug/Core/xlHeap.c
+++ b/debug/Core/xlHeap.c
@@ -1,213 +1,294 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlHeap.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80006648 -> 0x80007BC0
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// size = 0x4, address = 0x801355A8
+static u32* gpHeap;
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x4, address = 0x801355AC
+static u32* gpHeapBlockFirst;
 
-// Local to compilation unit
-// Location: 0x801355A8
-static unsigned int *gpHeap;
+// size = 0x4, address = 0x801355B0
+static u32* gpHeapBlockLast;
 
-// Local to compilation unit
-// Location: 0x801355AC
-static unsigned int *gpHeapBlockFirst;
+// size = 0x4, address = 0x801355B4
+static s32 gnHeapTakeCount;
 
-// Local to compilation unit
-// Location: 0x801355B0
-static unsigned int *gpHeapBlockLast;
+// size = 0x4, address = 0x801355B8
+static s32 gnHeapFreeCount;
 
-// Local to compilation unit
-// Location: 0x801355B4
-static int gnHeapTakeCount;
+// size = 0x4, address = 0x801355BC
+static s32 gnHeapTakeCacheCount;
 
-// Local to compilation unit
-// Location: 0x801355B8
-static int gnHeapFreeCount;
+// size = 0x580, address = 0x800F3FB0
+static u32* gapHeapBlockCache[11][32];
 
-// Local to compilation unit
-// Location: 0x801355BC
-static int gnHeapTakeCacheCount;
+// size = 0x4, address = 0x801355C0
+s32 gnSizeHeap;
 
-// Local to compilation unit
-// Location: 0x800F3FB0
-static unsigned int  *gapHeapBlockCache[11][32];
+// Range: 0x80006648 -> 0x800066B0
+s32 xlHeapReset() {
+    // Local variables
+    s32 nBlockSize; // r6
 
-// Location: 0x801355C0
-int gnSizeHeap;
-
-int xlHeapReset()
-{
-	int nBlockSize;
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
-	// References: gpHeap (0x801355A8)
-	// References: gnSizeHeap (0x801355C0)
+    // References
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
+    // -> static u32* gpHeap;
+    // -> s32 gnSizeHeap;
 }
 
-int xlHeapSetup(void *pHeap, int nSizeBytes)
-{
-	int nSizeWords;
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
-	// References: gpHeap (0x801355A8)
-	// References: gnSizeHeap (0x801355C0)
+// Range: 0x800066B0 -> 0x80006870
+s32 xlHeapSetup(void* pHeap, s32 nSizeBytes) {
+    // Parameters
+    // void* pHeap; // r6
+    // s32 nSizeBytes; // r1+0xC
+
+    // Local variables
+    s32 nSizeWords; // r5
+
+    // References
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
+    // -> static u32* gpHeap;
+    // -> s32 gnSizeHeap;
 }
 
-int xlHeapGetFree(int *pnFreeBytes)
-{
-	int nBlockSize;
-	int nFree;
-	int nCount;
-	unsigned int *pBlock;
-	unsigned int nBlock;
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
+// Range: 0x80006870 -> 0x80006908
+s32 xlHeapGetFree(s32* pnFreeBytes) {
+    // Parameters
+    // s32* pnFreeBytes; // r31
+
+    // Local variables
+    s32 nBlockSize; // r3
+    s32 nFree; // r5
+    s32 nCount; // r1+0x8
+    u32* pBlock; // r6
+    u32 nBlock; // r7
+
+    // References
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
 }
 
-int xlHeapFill32(void *pHeap, int nByteCount, unsigned int nData)
-{
-	unsigned int *pnTarget;
+// Range: 0x80006908 -> 0x80006AF0
+s32 xlHeapFill32(void* pHeap, s32 nByteCount, u32 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r6
+    // u32 nData; // r1+0x8
+
+    // Local variables
+    u32* pnTarget; // r3
 }
 
-int xlHeapFill16(void *pHeap, int nByteCount, unsigned short nData)
-{
-	unsigned short *pnTarget;
+// Erased
+static s32 xlHeapFill16(void* pHeap, s32 nByteCount, u16 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r6
+    // u16 nData; // r1+0x8
+
+    // Local variables
+    u16* pnTarget; // r3
 }
 
-int xlHeapFill8(void *pHeap, int nByteCount, unsigned char nData)
-{
-	unsigned char *pnTarget;
+// Erased
+static s32 xlHeapFill8(void* pHeap, s32 nByteCount, u8 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r4
+    // u8 nData; // r1+0x8
+
+    // Local variables
+    u8* pnTarget; // r3
 }
 
-int xlHeapCopy(void *pHeapTarget, void *pHeapSource, int nByteCount)
-{
-	unsigned char *pSource8;
-	unsigned char *pTarget8;
-	unsigned int *pSource32;
-	unsigned int *pTarget32;
+// Range: 0x80006AF0 -> 0x80006F68
+s32 xlHeapCopy(void* pHeapTarget, void* pHeapSource, s32 nByteCount) {
+    // Parameters
+    // void* pHeapTarget; // r3
+    // void* pHeapSource; // r4
+    // s32 nByteCount; // r5
+
+    // Local variables
+    u8* pSource8; // r4
+    u8* pTarget8; // r3
+    u32* pSource32; // r4
+    u32* pTarget32; // r3
 }
 
-int xlHeapCompact()
-{
-	int nCount;
-	int nBlockLarge;
-	int nBlockSize;
-	int nBlockNextSize;
-	int anBlockLarge[6];
-	unsigned int nBlock;
-	unsigned int *pBlock;
-	unsigned int *pBlockPrevious;
-	unsigned int nBlockNext;
-	unsigned int *pBlockNext;
-	// References: gpHeapBlockFirst (0x801355AC)
+// Range: 0x80006F68 -> 0x80007098
+s32 xlHeapCompact() {
+    // Local variables
+    s32 nCount; // r1+0x8
+    s32 nBlockLarge; // r1+0x8
+    s32 nBlockSize; // r4
+    s32 nBlockNextSize; // r3
+    s32 anBlockLarge[6]; // r1+0x8
+    u32 nBlock; // r1+0x8
+    u32* pBlock; // r5
+    u32* pBlockPrevious; // r6
+    u32 nBlockNext; // r7
+    u32* pBlockNext; // r8
+
+    // References
+    // -> static u32* gpHeapBlockFirst;
 }
 
-int xlHeapTest(void *pHeap)
-{
-	unsigned int *pBlock;
+// Erased
+static s32 xlHeapTest(void* pHeap) {
+    // Parameters
+    // void* pHeap; // r1+0x0
+
+    // Local variables
+    u32* pBlock; // r3
 }
 
-int xlHeapFree(void *ppHeap)
-{
-	int nBlockSize;
-	int nBlockNextSize;
-	unsigned int *pBlock;
-	unsigned int *pBlockNext;
-	// References: gnHeapFreeCount (0x801355B8)
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
+// Range: 0x80007098 -> 0x800071B4
+s32 xlHeapFree(void* ppHeap) {
+    // Parameters
+    // void* ppHeap; // r31
+
+    // Local variables
+    s32 nBlockSize; // r30
+    s32 nBlockNextSize; // r29
+    u32* pBlock; // r28
+    u32* pBlockNext; // r3
+
+    // References
+    // -> static s32 gnHeapFreeCount;
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
 }
 
-int xlHeapTake(void *ppHeap, int nByteCount)
-{
-	int bValid;
-	unsigned int nSizeExtra;
-	unsigned int iTry;
-	int nSize;
-	int nBlockSize;
-	int nBlockNextSize;
-	int nBlockNextNextSize;
-	unsigned int nBlock;
-	unsigned int *pBlock;
-	unsigned int *pBlockNext;
-	unsigned int *pBlockNextNext;
-	// References: gnHeapTakeCount (0x801355B4)
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
+// Range: 0x800071B4 -> 0x8000743C
+s32 xlHeapTake(void* ppHeap, s32 nByteCount) {
+    // Parameters
+    // void* ppHeap; // r26
+    // s32 nByteCount; // r1+0xC
+
+    // Local variables
+    s32 bValid; // r30
+    u32 nSizeExtra; // r29
+    u32 iTry; // r28
+    s32 nSize; // r27
+    s32 nBlockSize; // r1+0x14
+    s32 nBlockNextSize; // r28
+    s32 nBlockNextNextSize; // r30
+    u32 nBlock; // r6
+    u32* pBlock; // r1+0x10
+    u32* pBlockNext; // r31
+    u32* pBlockNextNext; // r3
+
+    // References
+    // -> static s32 gnHeapTakeCount;
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
 }
 
-// Local to compilation unit
-static int xlHeapFindUpperBlock(int nSize, unsigned int **ppBlock, int *pnBlockSize)
-{
-	int nBlockSize;
-	unsigned int nBlock;
-	unsigned int *pBlock;
-	unsigned int *pBlockBest;
-	unsigned int *pBlockNext;
-	// References: gpHeapBlockLast (0x801355B0)
-	// References: gpHeapBlockFirst (0x801355AC)
+// Range: 0x8000743C -> 0x80007540
+static s32 xlHeapFindUpperBlock(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+    // Parameters
+    // s32 nSize; // r28
+    // u32** ppBlock; // r29
+    // s32* pnBlockSize; // r30
+
+    // Local variables
+    s32 nBlockSize; // r3
+    u32 nBlock; // r4
+    u32* pBlock; // r7
+    u32* pBlockBest; // r31
+    u32* pBlockNext; // r27
+
+    // References
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
 }
 
-// Local to compilation unit
-static int xlHeapBlockCacheReset()
-{
-	int nBlockSize;
-	unsigned int *pBlock;
-	unsigned int nBlock;
-	// References: gpHeapBlockFirst (0x801355AC)
-	// References: gapHeapBlockCache (0x800F3FB0)
-	// References: gnHeapFreeCount (0x801355B8)
-	// References: gnHeapTakeCount (0x801355B4)
-	// References: gnHeapTakeCacheCount (0x801355BC)
+// Range: 0x80007540 -> 0x8000764C
+static s32 xlHeapBlockCacheReset() {
+    // Local variables
+    s32 nBlockSize; // r1+0x8
+    u32* pBlock; // r30
+    u32 nBlock; // r1+0x8
+
+    // References
+    // -> static u32* gpHeapBlockFirst;
+    // -> static u32* gapHeapBlockCache[11][32];
+    // -> static s32 gnHeapFreeCount;
+    // -> static s32 gnHeapTakeCount;
+    // -> static s32 gnHeapTakeCacheCount;
 }
 
-// Local to compilation unit
-static int xlHeapBlockCacheClear(unsigned int *pBlock)
-{
-	int nSize;
-	int nBlock;
-	int nBlockSize;
-	// References: gapHeapBlockCache (0x800F3FB0)
+// Range: 0x8000764C -> 0x80007758
+static s32 xlHeapBlockCacheClear(u32* pBlock) {
+    // Parameters
+    // u32* pBlock; // r1+0x0
+
+    // Local variables
+    s32 nSize; // r1+0x0
+    s32 nBlock; // r6
+    s32 nBlockSize; // r1+0x0
+
+    // References
+    // -> static u32* gapHeapBlockCache[11][32];
 }
 
-// Local to compilation unit
-static int xlHeapBlockCacheAdd(unsigned int *pBlock)
-{
-	int nSize;
-	int nBlock;
-	int nBlockSize;
-	int nBlockCachedSize;
-	unsigned int *pBlockCached;
-	// References: gapHeapBlockCache (0x800F3FB0)
+// Range: 0x80007758 -> 0x800079C0
+static s32 xlHeapBlockCacheAdd(u32* pBlock) {
+    // Parameters
+    // u32* pBlock; // r1+0x0
+
+    // Local variables
+    s32 nSize; // r6
+    s32 nBlock; // r7
+    s32 nBlockSize; // r1+0x0
+    s32 nBlockCachedSize; // r1+0x0
+    u32* pBlockCached; // r8
+
+    // References
+    // -> static u32* gapHeapBlockCache[11][32];
 }
 
-// Local to compilation unit
-static int xlHeapBlockCacheGet(int nSize, unsigned int **ppBlock, int *pnBlockSize)
-{
-	int nBlockCachedSize;
-	int nBlock;
-	int nBlockSize;
-	int nBlockBest;
-	int nBlockBestSize;
-	unsigned int *pBlock;
-	// References: gnHeapTakeCacheCount (0x801355BC)
-	// References: gapHeapBlockCache (0x800F3FB0)
+// Range: 0x800079C0 -> 0x80007BC0
+static s32 xlHeapBlockCacheGet(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+    // Parameters
+    // s32 nSize; // r1+0x0
+    // u32** ppBlock; // r1+0x4
+    // s32* pnBlockSize; // r1+0x8
+
+    // Local variables
+    s32 nBlockCachedSize; // r1+0x0
+    s32 nBlock; // r8
+    s32 nBlockSize; // r9
+    s32 nBlockBest; // r10
+    s32 nBlockBestSize; // r11
+    u32* pBlock; // r12
+
+    // References
+    // -> static s32 gnHeapTakeCacheCount;
+    // -> static u32* gapHeapBlockCache[11][32];
 }
 
-void xlHeapStatisticsReset()
-{
-	// References: gnHeapFreeCount (0x801355B8)
-	// References: gnHeapTakeCount (0x801355B4)
-	// References: gnHeapTakeCacheCount (0x801355BC)
+// Erased
+static void xlHeapStatisticsReset() {
+    // References
+    // -> static s32 gnHeapFreeCount;
+    // -> static s32 gnHeapTakeCount;
+    // -> static s32 gnHeapTakeCacheCount;
 }
 
-void xlHeapShowStatistics();
+// Erased
+static void xlHeapShowStatistics() {}
 
-int xlHeapTestBlock(unsigned int nBlock);
-
+// Erased
+static s32 xlHeapTestBlock(u32 nBlock) {
+    // Parameters
+    // u32 nBlock; // r1+0x0
+}

--- a/debug/Core/xlList.c
+++ b/debug/Core/xlList.c
@@ -1,115 +1,183 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlList.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80006280 -> 0x80006648
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct tXL_LIST {
+    /* 0x0 */ s32 nItemSize;
+    /* 0x4 */ s32 nItemCount;
+    /* 0x8 */ void* pNodeHead;
+    /* 0xC */ void* pNodeNext;
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800F3FA0
+static struct tXL_LIST gListList;
 
-// size: 0x10
-struct tXL_LIST
-{
-	int nItemSize; // 0x0
-	int nItemCount; // 0x4
-	void *pNodeHead; // 0x8
-	void *pNodeNext; // 0xC
-};
+// Range: 0x80006280 -> 0x80006288
+s32 xlListReset() {}
 
-// Local to compilation unit
-// Location: 0x800F3FA0
-static tXL_LIST gListList;
-
-int xlListReset();
-
-int xlListSetup()
-{
-	// References: gListList (0x800F3FA0)
+// Range: 0x80006288 -> 0x800062B0
+s32 xlListSetup() {
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListMoveItemToTail(tXL_LIST *pList, void *pItem)
-{
-	void *pNode;
-	void *pNodeLast;
-	void *pNodeItem;
-	void *pNodeItemLast;
+// Erased
+static s32 xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
+
+    // Local variables
+    void* pNode; // r5
+    void* pNodeLast; // r6
+    void* pNodeItem; // r7
+    void* pNodeItemLast; // r8
 }
 
-int xlListMoveItemToHead(tXL_LIST *pList, void *pItem)
-{
-	void *pNode;
-	void *pNodeLast;
+// Erased
+static s32 xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
+
+    // Local variables
+    void* pNode; // r5
+    void* pNodeLast; // r6
 }
 
-int xlListNodeGetNext(tXL_LIST *pList, void *ppListNode)
-{
-	// References: gListList (0x800F3FA0)
+// Erased
+static s32 xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* ppListNode; // r1+0x4
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListNodeGetHead(tXL_LIST *pList, void *ppListNode)
-{
-	// References: gListList (0x800F3FA0)
+// Erased
+static s32 xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* ppListNode; // r1+0x4
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListEnumerate(tXL_LIST *pList, int (*pfCallback)(void */* unknown0 */))
-{
-	void *pNode;
+// Erased
+static s32 xlListEnumerate(struct tXL_LIST* pList, s32 (*pfCallback)(void*)) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x8
+    // s32 (* pfCallback)(void*); // r30
+
+    // Local variables
+    void* pNode; // r31
 }
 
-int xlListFindItemIndex(tXL_LIST *pList, int *piItem, void *pItem)
-{
-	int iItem;
-	void *pListNode;
+// Erased
+static s32 xlListFindItemIndex(struct tXL_LIST* pList, s32* piItem, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // s32* piItem; // r1+0x4
+    // void* pItem; // r1+0x8
+
+    // Local variables
+    s32 iItem; // r3
+    void* pListNode; // r6
 }
 
-int xlListFindItem(tXL_LIST *pList, int iItem, void *ppItem)
-{
-	int nItemCount;
-	void *pListNode;
+// Erased
+static s32 xlListFindItem(struct tXL_LIST* pList, s32 iItem, void* ppItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // s32 iItem; // r1+0x4
+    // void* ppItem; // r1+0x8
+
+    // Local variables
+    s32 nItemCount; // r3
+    void* pListNode; // r6
 }
 
-int xlListTestItem(tXL_LIST *pList, void *pItem)
-{
-	void *pListNode;
-	// References: gListList (0x800F3FA0)
+// Range: 0x800062B0 -> 0x8000633C
+s32 xlListTestItem(struct tXL_LIST* pList, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
+
+    // Local variables
+    void* pListNode; // r3
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListFreeItem(tXL_LIST *pList, void *ppItem)
-{
-	void *pNode;
-	void *pNodeNext;
+// Range: 0x8000633C -> 0x800063E8
+s32 xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r31
+    // void* ppItem; // r1+0xC
+
+    // Local variables
+    void* pNode; // r6
+    void* pNodeNext; // r1+0x10
 }
 
-int xlListMakeItem(tXL_LIST *pList, void *ppItem)
-{
-	int nSize;
-	void *pListNode;
-	void *pNode;
-	void *pNodeNext;
+// Range: 0x800063E8 -> 0x80006494
+s32 xlListMakeItem(struct tXL_LIST* pList, void* ppItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r30
+    // void* ppItem; // r31
+
+    // Local variables
+    s32 nSize; // r4
+    void* pListNode; // r1+0x10
+    void* pNode; // r4
+    void* pNodeNext; // r1+0x8
 }
 
-int xlListTest(tXL_LIST *pList)
-{
-	void *pNode;
-	// References: gListList (0x800F3FA0)
+// Erased
+static s32 xlListTest(struct tXL_LIST* pList) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+
+    // Local variables
+    void* pNode; // r4
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListFree(tXL_LIST **ppList)
-{
-	// References: gListList (0x800F3FA0)
+// Range: 0x80006494 -> 0x80006550
+s32 xlListFree(struct tXL_LIST** ppList) {
+    // Parameters
+    // struct tXL_LIST** ppList; // r29
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListMake(tXL_LIST **ppList, int nItemSize)
-{
-	// References: gListList (0x800F3FA0)
+// Range: 0x80006550 -> 0x80006648
+s32 xlListMake(struct tXL_LIST** ppList, s32 nItemSize) {
+    // Parameters
+    // struct tXL_LIST** ppList; // r31
+    // s32 nItemSize; // r29
+
+    // References
+    // -> static struct tXL_LIST gListList;
 }
 
-int xlListWipe(tXL_LIST *pList)
-{
-	void *pNode;
-	void *pNodeNext;
-}
+// Erased
+static s32 xlListWipe(struct tXL_LIST* pList) {
+    // Parameters
+    // struct tXL_LIST* pList; // r30
 
+    // Local variables
+    void* pNode; // r1+0xC
+    void* pNodeNext; // r31
+}

--- a/debug/Core/xlList.c
+++ b/debug/Core/xlList.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct tXL_LIST {
+typedef struct tXL_LIST {
     /* 0x0 */ s32 nItemSize;
     /* 0x4 */ s32 nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
-}; // size = 0x10
+} __anon_0x2C35; // size = 0x10
 
 // size = 0x10, address = 0x800F3FA0
 static struct tXL_LIST gListList;

--- a/debug/Core/xlObject.c
+++ b/debug/Core/xlObject.c
@@ -7,27 +7,27 @@
 
 #include "types.h"
 
-struct tXL_LIST {
+typedef struct tXL_LIST {
     /* 0x0 */ s32 nItemSize;
     /* 0x4 */ s32 nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
-}; // size = 0x10
+} __anon_0x4E6F; // size = 0x10
 
 // size = 0x4, address = 0x801355C8
 static struct tXL_LIST* gpListData;
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x4F98; // size = 0x10
 
-struct __anon_0x5062 {
+typedef struct __anon_0x5062 {
     /* 0x0 */ struct tXL_LIST* pList;
     /* 0x4 */ struct _XL_OBJECTTYPE* pType;
-}; // size = 0x8
+} __anon_0x5062; // size = 0x8
 
 // Range: 0x80007BC0 -> 0x80007C30
 s32 xlObjectReset() {

--- a/debug/Core/xlObject.c
+++ b/debug/Core/xlObject.c
@@ -1,94 +1,133 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlObject.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80007BC0 -> 0x80007F80
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct tXL_LIST {
+    /* 0x0 */ s32 nItemSize;
+    /* 0x4 */ s32 nItemCount;
+    /* 0x8 */ void* pNodeHead;
+    /* 0xC */ void* pNodeNext;
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x4, address = 0x801355C8
+static struct tXL_LIST* gpListData;
 
-// size: 0x10
-struct tXL_LIST
-{
-	int nItemSize; // 0x0
-	int nItemCount; // 0x4
-	void *pNodeHead; // 0x8
-	void *pNodeNext; // 0xC
-};
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Local to compilation unit
-// Location: 0x801355C8
-static tXL_LIST *gpListData;
+struct __anon_0x5062 {
+    /* 0x0 */ struct tXL_LIST* pList;
+    /* 0x4 */ struct _XL_OBJECTTYPE* pType;
+}; // size = 0x8
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+// Range: 0x80007BC0 -> 0x80007C30
+s32 xlObjectReset() {
+    // Local variables
+    struct __anon_0x5062* pData; // r3
+    void* pListNode; // r31
 
-// size: 0x8
-struct __anon_0x5062
-{
-	tXL_LIST *pList; // 0x0
-	_XL_OBJECTTYPE *pType; // 0x4
-};
-
-int xlObjectReset()
-{
-	__anon_0x5062 *pData;
-	void *pListNode;
-	// References: gpListData (0x801355C8)
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectSetup()
-{
-	// References: gpListData (0x801355C8)
+// Range: 0x80007C30 -> 0x80007C6C
+s32 xlObjectSetup() {
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectEvent(void *pObject, int nEvent, void *pArgument)
-{
-	__anon_0x5062 *pData;
-	// References: gpListData (0x801355C8)
+// Range: 0x80007C6C -> 0x80007D24
+s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument) {
+    // Parameters
+    // void* pObject; // r26
+    // s32 nEvent; // r27
+    // void* pArgument; // r28
+
+    // Local variables
+    struct __anon_0x5062* pData; // r29
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectFindType(void *pObject, _XL_OBJECTTYPE **ppType)
-{
-	__anon_0x5062 *pData;
-	// References: gpListData (0x801355C8)
+// Erased
+static s32 xlObjectFindType(void* pObject, struct _XL_OBJECTTYPE** ppType) {
+    // Parameters
+    // void* pObject; // r1+0x8
+    // struct _XL_OBJECTTYPE** ppType; // r30
+
+    // Local variables
+    struct __anon_0x5062* pData; // r31
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectTest(void *pObject, _XL_OBJECTTYPE *pType)
-{
-	__anon_0x5062 *pData;
-	// References: gpListData (0x801355C8)
+// Range: 0x80007D24 -> 0x80007D8C
+s32 xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // void* pObject; // r1+0x8
+    // struct _XL_OBJECTTYPE* pType; // r30
+
+    // Local variables
+    struct __anon_0x5062* pData; // r31
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectFree(void *ppObject)
-{
-	__anon_0x5062 *pData;
+// Range: 0x80007D8C -> 0x80007E24
+s32 xlObjectFree(void* ppObject) {
+    // Parameters
+    // void* ppObject; // r30
+
+    // Local variables
+    struct __anon_0x5062* pData; // r31
 }
 
-int xlObjectMake(void *ppObject, void *pArgument, _XL_OBJECTTYPE *pType)
-{
-	int bFlag;
-	__anon_0x5062 *pData;
-	// References: gpListData (0x801355C8)
+// Range: 0x80007E24 -> 0x80007F80
+s32 xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // void* ppObject; // r28
+    // void* pArgument; // r29
+    // struct _XL_OBJECTTYPE* pType; // r30
+
+    // Local variables
+    s32 bFlag; // r31
+    struct __anon_0x5062* pData; // r1+0x14
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectMakeData(__anon_0x5062 **ppData, _XL_OBJECTTYPE *pType)
-{
-	// References: gpListData (0x801355C8)
+// Erased
+static s32 xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // struct __anon_0x5062** ppData; // r30
+    // struct _XL_OBJECTTYPE* pType; // r31
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
 }
 
-int xlObjectFindData(__anon_0x5062 **ppData, _XL_OBJECTTYPE *pType)
-{
-	void *pListNode;
-	// References: gpListData (0x801355C8)
-}
+// Erased
+static s32 xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // struct __anon_0x5062** ppData; // r1+0x0
+    // struct _XL_OBJECTTYPE* pType; // r1+0x4
 
+    // Local variables
+    void* pListNode; // r6
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
+}

--- a/debug/Core/xlPostGCN.c
+++ b/debug/Core/xlPostGCN.c
@@ -1,27 +1,17 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Core\xlPostGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80005E04 -> 0x80005E68
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// Range: 0x80005E04 -> 0x80005E0C
+s32 xlPostReset() {}
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// Range: 0x80005E0C -> 0x80005E14
+s32 xlPostSetup() {}
 
-// Location: 0x0
-char *gszPostFail;
-
-// Location: 0x0
-char *gszPostFailSafe;
-
-// Location: 0x0
-char *gszPostFailTest;
-
-int xlPostReset();
-
-int xlPostSetup();
-
-int xlPostText();
-
+// Range: 0x80005E14 -> 0x80005E68
+s32 xlPostText() {}

--- a/debug/Fire/THPAudioDecode.c
+++ b/debug/Fire/THPAudioDecode.c
@@ -10,7 +10,7 @@
 // size = 0x4, address = 0x80135638
 static s32 AudioDecodeThreadCreated;
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -26,36 +26,36 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x125F9; // size = 0x2C8
 
-struct OSThreadQueue {
+typedef struct OSThreadQueue {
     /* 0x0 */ struct OSThread* head;
     /* 0x4 */ struct OSThread* tail;
-}; // size = 0x8
+} __anon_0x12812; // size = 0x8
 
-struct OSThreadLink {
+typedef struct OSThreadLink {
     /* 0x0 */ struct OSThread* next;
     /* 0x4 */ struct OSThread* prev;
-}; // size = 0x8
+} __anon_0x12884; // size = 0x8
 
-struct OSMutexLink {
+typedef struct OSMutexLink {
     /* 0x0 */ struct OSMutex* next;
     /* 0x4 */ struct OSMutex* prev;
-}; // size = 0x8
+} __anon_0x128F5; // size = 0x8
 
-struct OSMutex {
+typedef struct OSMutex {
     /* 0x00 */ struct OSThreadQueue queue;
     /* 0x08 */ struct OSThread* thread;
     /* 0x0C */ s32 count;
     /* 0x10 */ struct OSMutexLink link;
-}; // size = 0x18
+} __anon_0x12965; // size = 0x18
 
-struct OSMutexQueue {
+typedef struct OSMutexQueue {
     /* 0x0 */ struct OSMutex* head;
     /* 0x4 */ struct OSMutex* tail;
-}; // size = 0x8
+} __anon_0x12A16; // size = 0x8
 
-struct OSThread {
+typedef struct OSThread {
     /* 0x000 */ struct OSContext context;
     /* 0x2C8 */ u16 state;
     /* 0x2CA */ u16 attr;
@@ -73,7 +73,7 @@ struct OSThread {
     /* 0x308 */ u32* stackEnd;
     /* 0x30C */ s32 error;
     /* 0x310 */ void* specific[2];
-}; // size = 0x318
+} __anon_0x12AA7; // size = 0x318
 
 // size = 0x318, address = 0x800F9E50
 static struct OSThread AudioDecodeThread;
@@ -81,14 +81,14 @@ static struct OSThread AudioDecodeThread;
 // size = 0x1000, address = 0x800FA168
 static u8 AudioDecodeThreadStack[4096];
 
-struct OSMessageQueue {
+typedef struct OSMessageQueue {
     /* 0x00 */ struct OSThreadQueue queueSend;
     /* 0x08 */ struct OSThreadQueue queueReceive;
     /* 0x10 */ void* msgArray;
     /* 0x14 */ s32 msgCount;
     /* 0x18 */ s32 firstIndex;
     /* 0x1C */ s32 usedCount;
-}; // size = 0x20
+} __anon_0x12DC3; // size = 0x20
 
 // size = 0x20, address = 0x800FB168
 static struct OSMessageQueue FreeAudioBufferQueue;
@@ -138,7 +138,7 @@ static void* AudioDecoder() {
     struct __anon_0x14130* readBuffer; // r31
 }
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -146,9 +146,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x131C5; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -161,16 +161,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x13335; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x1355B; // size = 0x3C
 
-struct __anon_0x13633 {
+typedef struct __anon_0x13633 {
     /* 0x00 */ char magic[4];
     /* 0x04 */ u32 version;
     /* 0x08 */ u32 bufSize;
@@ -183,40 +183,40 @@ struct __anon_0x13633 {
     /* 0x24 */ u32 offsetDataOffsets;
     /* 0x28 */ u32 movieDataOffsets;
     /* 0x2C */ u32 finalFrameDataOffsets;
-}; // size = 0x30
+} __anon_0x13633; // size = 0x30
 
-struct __anon_0x1385F {
+typedef struct __anon_0x1385F {
     /* 0x0 */ u32 numComponents;
     /* 0x4 */ u8 frameComp[16];
-}; // size = 0x14
+} __anon_0x1385F; // size = 0x14
 
-struct __anon_0x138C7 {
+typedef struct __anon_0x138C7 {
     /* 0x0 */ u32 xSize;
     /* 0x4 */ u32 ySize;
     /* 0x8 */ u32 videoType;
-}; // size = 0xC
+} __anon_0x138C7; // size = 0xC
 
-struct __anon_0x13947 {
+typedef struct __anon_0x13947 {
     /* 0x0 */ u32 sndChannels;
     /* 0x4 */ u32 sndFrequency;
     /* 0x8 */ u32 sndNumSamples;
     /* 0xC */ u32 sndNumTracks;
-}; // size = 0x10
+} __anon_0x13947; // size = 0x10
 
-struct __anon_0x13A01 {
+typedef struct __anon_0x13A01 {
     /* 0x0 */ u8* ytexture;
     /* 0x4 */ u8* utexture;
     /* 0x8 */ u8* vtexture;
     /* 0xC */ s32 frameNumber;
-}; // size = 0x10
+} __anon_0x13A01; // size = 0x10
 
-struct __anon_0x13AB7 {
+typedef struct __anon_0x13AB7 {
     /* 0x0 */ s16* buffer;
     /* 0x4 */ s16* curPtr;
     /* 0x8 */ u32 validSample;
-}; // size = 0xC
+} __anon_0x13AB7; // size = 0xC
 
-struct __anon_0x13BA7 {
+typedef struct __anon_0x13BA7 {
     /* 0x000 */ struct DVDFileInfo fileInfo;
     /* 0x03C */ struct __anon_0x13633 header;
     /* 0x06C */ struct __anon_0x1385F compInfo;
@@ -251,16 +251,16 @@ struct __anon_0x13BA7 {
     /* 0x100 */ struct __anon_0x14130 readBuffer[10];
     /* 0x178 */ struct __anon_0x13A01 textureSet[3];
     /* 0x1A8 */ struct __anon_0x13AB7 audioBuffer[3];
-}; // size = 0x1D0
+} __anon_0x13BA7; // size = 0x1D0
 
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x13BA7 ActivePlayer;
 
-struct __anon_0x14130 {
+typedef struct __anon_0x14130 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
     /* 0x8 */ s32 isValid;
-}; // size = 0xC
+} __anon_0x14130; // size = 0xC
 
 // Range: 0x80010ED8 -> 0x80010F88
 static void* AudioDecoderForOnMemory(void* ptr) {

--- a/debug/Fire/THPAudioDecode.c
+++ b/debug/Fire/THPAudioDecode.c
@@ -1,337 +1,334 @@
-﻿// Local to compilation unit
-// Location: 0x38561380
-static long AudioDecodeThreadCreated;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\THPAudioDecode.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80010D9C -> 0x80011138
+*/
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
+#include "types.h"
 
-// size: 0x8
-struct OSThreadQueue
-{
-	OSThread *head; // 0x0
-	OSThread *tail; // 0x4
-};
+// size = 0x4, address = 0x80135638
+static s32 AudioDecodeThreadCreated;
 
-// size: 0x8
-struct OSThreadLink
-{
-	OSThread *next; // 0x0
-	OSThread *prev; // 0x4
-};
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
 
-// size: 0x8
-struct OSMutexLink
-{
-	OSMutex *next; // 0x0
-	OSMutex *prev; // 0x4
-};
+struct OSThreadQueue {
+    /* 0x0 */ struct OSThread* head;
+    /* 0x4 */ struct OSThread* tail;
+}; // size = 0x8
 
-// size: 0x18
-struct OSMutex
-{
-	OSThreadQueue queue; // 0x0
-	OSThread *thread; // 0x8
-	long count; // 0xC
-	OSMutexLink link; // 0x10
-};
+struct OSThreadLink {
+    /* 0x0 */ struct OSThread* next;
+    /* 0x4 */ struct OSThread* prev;
+}; // size = 0x8
 
-// size: 0x8
-struct OSMutexQueue
-{
-	OSMutex *head; // 0x0
-	OSMutex *tail; // 0x4
-};
+struct OSMutexLink {
+    /* 0x0 */ struct OSMutex* next;
+    /* 0x4 */ struct OSMutex* prev;
+}; // size = 0x8
 
-// size: 0x318
-struct OSThread
-{
-	OSContext context; // 0x0
-	unsigned short state; // 0x2C8
-	unsigned short attr; // 0x2CA
-	long suspend; // 0x2CC
-	long priority; // 0x2D0
-	long base; // 0x2D4
-	void *val; // 0x2D8
-	OSThreadQueue *queue; // 0x2DC
-	OSThreadLink link; // 0x2E0
-	OSThreadQueue queueJoin; // 0x2E8
-	OSMutex *mutex; // 0x2F0
-	OSMutexQueue queueMutex; // 0x2F4
-	OSThreadLink linkActive; // 0x2FC
-	unsigned char *stackBase; // 0x304
-	unsigned long *stackEnd; // 0x308
-	long error; // 0x30C
-	void *specific[2]; // 0x310
-};
+struct OSMutex {
+    /* 0x00 */ struct OSThreadQueue queue;
+    /* 0x08 */ struct OSThread* thread;
+    /* 0x0C */ s32 count;
+    /* 0x10 */ struct OSMutexLink link;
+}; // size = 0x18
 
-// Local to compilation unit
-// Location: 0x509E0F80
-static OSThread AudioDecodeThread;
+struct OSMutexQueue {
+    /* 0x0 */ struct OSMutex* head;
+    /* 0x4 */ struct OSMutex* tail;
+}; // size = 0x8
 
-// Local to compilation unit
-// Location: 0x68A10F80
-static unsigned char AudioDecodeThreadStack[4096];
+struct OSThread {
+    /* 0x000 */ struct OSContext context;
+    /* 0x2C8 */ u16 state;
+    /* 0x2CA */ u16 attr;
+    /* 0x2CC */ s32 suspend;
+    /* 0x2D0 */ s32 priority;
+    /* 0x2D4 */ s32 base;
+    /* 0x2D8 */ void* val;
+    /* 0x2DC */ struct OSThreadQueue* queue;
+    /* 0x2E0 */ struct OSThreadLink link;
+    /* 0x2E8 */ struct OSThreadQueue queueJoin;
+    /* 0x2F0 */ struct OSMutex* mutex;
+    /* 0x2F4 */ struct OSMutexQueue queueMutex;
+    /* 0x2FC */ struct OSThreadLink linkActive;
+    /* 0x304 */ u8* stackBase;
+    /* 0x308 */ u32* stackEnd;
+    /* 0x30C */ s32 error;
+    /* 0x310 */ void* specific[2];
+}; // size = 0x318
 
-// size: 0x20
-struct OSMessageQueue
-{
-	OSThreadQueue queueSend; // 0x0
-	OSThreadQueue queueReceive; // 0x8
-	void *msgArray; // 0x10
-	long msgCount; // 0x14
-	long firstIndex; // 0x18
-	long usedCount; // 0x1C
-};
+// size = 0x318, address = 0x800F9E50
+static struct OSThread AudioDecodeThread;
 
-// Local to compilation unit
-// Location: 0x68B10F80
-static OSMessageQueue FreeAudioBufferQueue;
+// size = 0x1000, address = 0x800FA168
+static u8 AudioDecodeThreadStack[4096];
 
-// Local to compilation unit
-// Location: 0x800FB188
-static OSMessageQueue DecodedAudioBufferQueue;
+struct OSMessageQueue {
+    /* 0x00 */ struct OSThreadQueue queueSend;
+    /* 0x08 */ struct OSThreadQueue queueReceive;
+    /* 0x10 */ void* msgArray;
+    /* 0x14 */ s32 msgCount;
+    /* 0x18 */ s32 firstIndex;
+    /* 0x1C */ s32 usedCount;
+}; // size = 0x20
 
-// Local to compilation unit
-// Location: 0x800FB1A8
-static void *FreeAudioBufferMessage[3];
+// size = 0x20, address = 0x800FB168
+static struct OSMessageQueue FreeAudioBufferQueue;
 
-// Local to compilation unit
-// Location: 0x800FB1B4
-static void *DecodedAudioBufferMessage[3];
+// size = 0x20, address = 0x800FB188
+static struct OSMessageQueue DecodedAudioBufferQueue;
 
-int CreateAudioDecodeThread(long priority, unsigned char *ptr)
-{
-	// References: AudioDecodeThreadCreated (0x38561380)
-	// References: DecodedAudioBufferMessage (0x800FB1B4)
-	// References: DecodedAudioBufferQueue (0x800FB188)
-	// References: FreeAudioBufferMessage (0x800FB1A8)
-	// References: FreeAudioBufferQueue (0x68B10F80)
-	// References: AudioDecodeThreadStack (0x68A10F80)
-	// References: AudioDecodeThread (0x509E0F80)
+// size = 0xC, address = 0x800FB1A8
+static void* FreeAudioBufferMessage[3];
+
+// size = 0xC, address = 0x800FB1B4
+static void* DecodedAudioBufferMessage[3];
+
+// Range: 0x80010D9C -> 0x80010E7C
+s32 CreateAudioDecodeThread(s32 priority, u8* ptr) {
+    // Parameters
+    // s32 priority; // r8
+    // u8* ptr; // r5
+
+    // References
+    // -> static s32 AudioDecodeThreadCreated;
+    // -> static void* DecodedAudioBufferMessage[3];
+    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+    // -> static void* FreeAudioBufferMessage[3];
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
+    // -> static u8 AudioDecodeThreadStack[4096];
+    // -> static struct OSThread AudioDecodeThread;
 }
 
-void AudioDecodeThreadStart()
-{
-	// References: AudioDecodeThread (0x509E0F80)
-	// References: AudioDecodeThreadCreated (0x38561380)
+// Range: 0x80010E7C -> 0x80010EB0
+void AudioDecodeThreadStart() {
+    // References
+    // -> static struct OSThread AudioDecodeThread;
+    // -> static s32 AudioDecodeThreadCreated;
 }
 
-void AudioDecodeThreadCancel()
-{
-	// References: AudioDecodeThreadCreated (0x38561380)
-	// References: AudioDecodeThread (0x509E0F80)
+// Erased
+static void AudioDecodeThreadCancel() {
+    // References
+    // -> static s32 AudioDecodeThreadCreated;
+    // -> static struct OSThread AudioDecodeThread;
 }
 
-// Local to compilation unit
-static void *AudioDecoder()
-{
-	__anon_0x14130 *readBuffer;
+// Range: 0x80010EB0 -> 0x80010ED8
+static void* AudioDecoder() {
+    // Local variables
+    struct __anon_0x14130* readBuffer; // r31
 }
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
 
-// size: 0x30
-struct __anon_0x13633
-{
-	char magic[4]; // 0x0
-	unsigned long version; // 0x4
-	unsigned long bufSize; // 0x8
-	unsigned long audioMaxSamples; // 0xC
-	float frameRate; // 0x10
-	unsigned long numFrames; // 0x14
-	unsigned long firstFrameSize; // 0x18
-	unsigned long movieDataSize; // 0x1C
-	unsigned long compInfoDataOffsets; // 0x20
-	unsigned long offsetDataOffsets; // 0x24
-	unsigned long movieDataOffsets; // 0x28
-	unsigned long finalFrameDataOffsets; // 0x2C
-};
+struct __anon_0x13633 {
+    /* 0x00 */ char magic[4];
+    /* 0x04 */ u32 version;
+    /* 0x08 */ u32 bufSize;
+    /* 0x0C */ u32 audioMaxSamples;
+    /* 0x10 */ float frameRate;
+    /* 0x14 */ u32 numFrames;
+    /* 0x18 */ u32 firstFrameSize;
+    /* 0x1C */ u32 movieDataSize;
+    /* 0x20 */ u32 compInfoDataOffsets;
+    /* 0x24 */ u32 offsetDataOffsets;
+    /* 0x28 */ u32 movieDataOffsets;
+    /* 0x2C */ u32 finalFrameDataOffsets;
+}; // size = 0x30
 
-// size: 0x14
-struct __anon_0x1385F
-{
-	unsigned long numComponents; // 0x0
-	unsigned char frameComp[16]; // 0x4
-};
+struct __anon_0x1385F {
+    /* 0x0 */ u32 numComponents;
+    /* 0x4 */ u8 frameComp[16];
+}; // size = 0x14
 
-// size: 0xC
-struct __anon_0x138C7
-{
-	unsigned long xSize; // 0x0
-	unsigned long ySize; // 0x4
-	unsigned long videoType; // 0x8
-};
+struct __anon_0x138C7 {
+    /* 0x0 */ u32 xSize;
+    /* 0x4 */ u32 ySize;
+    /* 0x8 */ u32 videoType;
+}; // size = 0xC
 
-// size: 0x10
-struct __anon_0x13947
-{
-	unsigned long sndChannels; // 0x0
-	unsigned long sndFrequency; // 0x4
-	unsigned long sndNumSamples; // 0x8
-	unsigned long sndNumTracks; // 0xC
-};
+struct __anon_0x13947 {
+    /* 0x0 */ u32 sndChannels;
+    /* 0x4 */ u32 sndFrequency;
+    /* 0x8 */ u32 sndNumSamples;
+    /* 0xC */ u32 sndNumTracks;
+}; // size = 0x10
 
-// size: 0x10
-struct __anon_0x13A01
-{
-	unsigned char *ytexture; // 0x0
-	unsigned char *utexture; // 0x4
-	unsigned char *vtexture; // 0x8
-	long frameNumber; // 0xC
-};
+struct __anon_0x13A01 {
+    /* 0x0 */ u8* ytexture;
+    /* 0x4 */ u8* utexture;
+    /* 0x8 */ u8* vtexture;
+    /* 0xC */ s32 frameNumber;
+}; // size = 0x10
 
-// size: 0xC
-struct __anon_0x13AB7
-{
-	signed short *buffer; // 0x0
-	signed short *curPtr; // 0x4
-	unsigned long validSample; // 0x8
-};
+struct __anon_0x13AB7 {
+    /* 0x0 */ s16* buffer;
+    /* 0x4 */ s16* curPtr;
+    /* 0x8 */ u32 validSample;
+}; // size = 0xC
 
-// size: 0x1D0
-struct __anon_0x13BA7
-{
-	DVDFileInfo fileInfo; // 0x0
-	__anon_0x13633 header; // 0x3C
-	__anon_0x1385F compInfo; // 0x6C
-	__anon_0x138C7 videoInfo; // 0x80
-	__anon_0x13947 audioInfo; // 0x8C
-	void *thpWork; // 0x9C
-	int open; // 0xA0
-	unsigned char state; // 0xA4
-	unsigned char internalState; // 0xA5
-	unsigned char playFlag; // 0xA6
-	unsigned char audioExist; // 0xA7
-	long dvdError; // 0xA8
-	long videoError; // 0xAC
-	int onMemory; // 0xB0
-	unsigned char *movieData; // 0xB4
-	long initOffset; // 0xB8
-	long initReadSize; // 0xBC
-	long initReadFrame; // 0xC0
-	signed long long retraceCount; // 0xC8
-	long prevCount; // 0xD0
-	long curCount; // 0xD4
-	long videoAhead; // 0xD8
-	float curVolume; // 0xDC
-	float targetVolume; // 0xE0
-	float deltaVolume; // 0xE4
-	long rampCount; // 0xE8
-	long curAudioTrack; // 0xEC
-	long curVideoNumber; // 0xF0
-	long curAudioNumber; // 0xF4
-	__anon_0x13A01 *dispTextureSet; // 0xF8
-	__anon_0x13AB7 *playAudioBuffer; // 0xFC
-	__anon_0x14130 readBuffer[10]; // 0x100
-	__anon_0x13A01 textureSet[3]; // 0x178
-	__anon_0x13AB7 audioBuffer[3]; // 0x1A8
-};
+struct __anon_0x13BA7 {
+    /* 0x000 */ struct DVDFileInfo fileInfo;
+    /* 0x03C */ struct __anon_0x13633 header;
+    /* 0x06C */ struct __anon_0x1385F compInfo;
+    /* 0x080 */ struct __anon_0x138C7 videoInfo;
+    /* 0x08C */ struct __anon_0x13947 audioInfo;
+    /* 0x09C */ void* thpWork;
+    /* 0x0A0 */ s32 open;
+    /* 0x0A4 */ u8 state;
+    /* 0x0A5 */ u8 internalState;
+    /* 0x0A6 */ u8 playFlag;
+    /* 0x0A7 */ u8 audioExist;
+    /* 0x0A8 */ s32 dvdError;
+    /* 0x0AC */ s32 videoError;
+    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B4 */ u8* movieData;
+    /* 0x0B8 */ s32 initOffset;
+    /* 0x0BC */ s32 initReadSize;
+    /* 0x0C0 */ s32 initReadFrame;
+    /* 0x0C8 */ s64 retraceCount;
+    /* 0x0D0 */ s32 prevCount;
+    /* 0x0D4 */ s32 curCount;
+    /* 0x0D8 */ s32 videoAhead;
+    /* 0x0DC */ float curVolume;
+    /* 0x0E0 */ float targetVolume;
+    /* 0x0E4 */ float deltaVolume;
+    /* 0x0E8 */ s32 rampCount;
+    /* 0x0EC */ s32 curAudioTrack;
+    /* 0x0F0 */ s32 curVideoNumber;
+    /* 0x0F4 */ s32 curAudioNumber;
+    /* 0x0F8 */ struct __anon_0x13A01* dispTextureSet;
+    /* 0x0FC */ struct __anon_0x13AB7* playAudioBuffer;
+    /* 0x100 */ struct __anon_0x14130 readBuffer[10];
+    /* 0x178 */ struct __anon_0x13A01 textureSet[3];
+    /* 0x1A8 */ struct __anon_0x13AB7 audioBuffer[3];
+}; // size = 0x1D0
 
-// Location: 0x800F9C80
-__anon_0x13BA7 ActivePlayer;
+// size = 0x1D0, address = 0x800F9C80
+struct __anon_0x13BA7 ActivePlayer;
 
-// size: 0xC
-struct __anon_0x14130
-{
-	unsigned char *ptr; // 0x0
-	long frameNumber; // 0x4
-	int isValid; // 0x8
-};
+struct __anon_0x14130 {
+    /* 0x0 */ u8* ptr;
+    /* 0x4 */ s32 frameNumber;
+    /* 0x8 */ s32 isValid;
+}; // size = 0xC
 
-// Local to compilation unit
-static void *AudioDecoderForOnMemory(void *ptr)
-{
-	__anon_0x14130 readBuffer;
-	long tmp;
-	long size;
-	long readFrame;
-	// References: AudioDecodeThread (0x509E0F80)
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x80010ED8 -> 0x80010F88
+static void* AudioDecoderForOnMemory(void* ptr) {
+    // Parameters
+    // void* ptr; // r1+0x8
+
+    // Local variables
+    struct __anon_0x14130 readBuffer; // r1+0x10
+    s32 tmp; // r4
+    s32 size; // r28
+    s32 readFrame; // r31
+
+    // References
+    // -> static struct OSThread AudioDecodeThread;
+    // -> struct __anon_0x13BA7 ActivePlayer;
 }
 
-// Local to compilation unit
-static void AudioDecode(__anon_0x14130 *readBuffer)
-{
-	__anon_0x13AB7 *audioBuffer;
-	unsigned long i;
-	unsigned long sample;
-	unsigned long *compSizePtr;
-	unsigned char *ptr;
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x80010F88 -> 0x80011060
+static void AudioDecode(struct __anon_0x14130* readBuffer) {
+    // Parameters
+    // struct __anon_0x14130* readBuffer; // r1+0x8
+
+    // Local variables
+    struct __anon_0x13AB7* audioBuffer; // r30
+    u32 i; // r1+0x8
+    u32 sample; // r1+0x8
+    u32* compSizePtr; // r29
+    u8* ptr; // r28
+
+    // References
+    // -> struct __anon_0x13BA7 ActivePlayer;
 }
 
-void *PopFreeAudioBuffer()
-{
-	void *msg;
-	// References: FreeAudioBufferQueue (0x68B10F80)
+// Range: 0x80011060 -> 0x80011094
+void* PopFreeAudioBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
 }
 
-void PushFreeAudioBuffer(void *buffer)
-{
-	// References: FreeAudioBufferQueue (0x68B10F80)
+// Range: 0x80011094 -> 0x800110C4
+void PushFreeAudioBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
 }
 
-void *PopDecodedAudioBuffer(long flag)
-{
-	void *msg;
-	// References: DecodedAudioBufferQueue (0x800FB188)
+// Range: 0x800110C4 -> 0x80011108
+void* PopDecodedAudioBuffer(s32 flag) {
+    // Parameters
+    // s32 flag; // r5
+
+    // Local variables
+    void* msg; // r1+0xC
+
+    // References
+    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
 }
 
-void PushDecodedAudioBuffer(void *buffer)
-{
-	// References: DecodedAudioBufferQueue (0x800FB188)
-}
+// Range: 0x80011108 -> 0x80011138
+void PushDecodedAudioBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
 
+    // References
+    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+}

--- a/debug/Fire/THPDraw.c
+++ b/debug/Fire/THPDraw.c
@@ -1,65 +1,83 @@
-﻿void THPGXRestore();
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\THPDraw.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80011138 -> 0x80011938
+*/
 
-// size: 0x4
-enum __anon_0x14611
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
+#include "types.h"
+
+// Range: 0x80011138 -> 0x80011250
+void THPGXRestore() {}
+
+enum __anon_0x14611 {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
 };
 
-// size: 0x4
-enum __anon_0x1475B
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
+enum __anon_0x1475B {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
 };
 
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0x14611 viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0x1475B xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0x14611 viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0x1475B xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
 
-void THPGXYuv2RgbSetup(_GXRenderModeObj *rmode)
-{
-	long scrWidth;
-	long scrHeight;
-	float pMtx[4][4];
-	float mMtx[3][4];
+// Range: 0x80011250 -> 0x80011754
+void THPGXYuv2RgbSetup(struct _GXRenderModeObj* rmode) {
+    // Parameters
+    // struct _GXRenderModeObj* rmode; // r1+0x8
+
+    // Local variables
+    s32 scrWidth; // r28
+    s32 scrHeight; // r27
+    float pMtx[4][4]; // r1+0x74
+    float mMtx[3][4]; // r1+0x44
 }
 
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
 
-void THPGXYuv2RgbDraw(unsigned char *y_data, unsigned char *u_data, unsigned char *v_data, signed short x, signed short y, signed short textureWidth, signed short textureHeight, signed short polygonWidth, signed short polygonHeight)
-{
-	_GXTexObj tobj0;
-	_GXTexObj tobj1;
-	_GXTexObj tobj2;
+// Range: 0x80011754 -> 0x80011938
+void THPGXYuv2RgbDraw(u8* y_data, u8* u_data, u8* v_data, s16 x, s16 y, s16 textureWidth, s16 textureHeight,
+                      s16 polygonWidth, s16 polygonHeight) {
+    // Parameters
+    // u8* y_data; // r3
+    // u8* u_data; // r24
+    // u8* v_data; // r25
+    // s16 x; // r30
+    // s16 y; // r31
+    // s16 textureWidth; // r28
+    // s16 textureHeight; // r29
+    // s16 polygonWidth; // r26
+    // s16 polygonHeight; // r27
+
+    // Local variables
+    struct _GXTexObj tobj0; // r1+0x60
+    struct _GXTexObj tobj1; // r1+0x40
+    struct _GXTexObj tobj2; // r1+0x20
 }
-

--- a/debug/Fire/THPDraw.c
+++ b/debug/Fire/THPDraw.c
@@ -10,7 +10,7 @@
 // Range: 0x80011138 -> 0x80011250
 void THPGXRestore() {}
 
-enum __anon_0x14611 {
+typedef enum __anon_0x14611 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -23,14 +23,14 @@ enum __anon_0x14611 {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0x14611;
 
-enum __anon_0x1475B {
+typedef enum __anon_0x1475B {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0x1475B;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0x14611 viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -44,7 +44,7 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0x1480C; // size = 0x3C
 
 // Range: 0x80011250 -> 0x80011754
 void THPGXYuv2RgbSetup(struct _GXRenderModeObj* rmode) {
@@ -58,9 +58,9 @@ void THPGXYuv2RgbSetup(struct _GXRenderModeObj* rmode) {
     float mMtx[3][4]; // r1+0x44
 }
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x14BBE; // size = 0x20
 
 // Range: 0x80011754 -> 0x80011938
 void THPGXYuv2RgbDraw(u8* y_data, u8* u_data, u8* v_data, s16 x, s16 y, s16 textureWidth, s16 textureHeight,

--- a/debug/Fire/THPPlayer.c
+++ b/debug/Fire/THPPlayer.c
@@ -16,7 +16,7 @@ static s32 Initialized;
 // size = 0x40, address = 0x800F96E0
 static s32 WorkBuffer[16];
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -32,31 +32,31 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0xF5C0; // size = 0x2C8
 
-struct OSThreadLink {
+typedef struct OSThreadLink {
     /* 0x0 */ struct OSThread* next;
     /* 0x4 */ struct OSThread* prev;
-}; // size = 0x8
+} __anon_0xF7D9; // size = 0x8
 
-struct OSMutexLink {
+typedef struct OSMutexLink {
     /* 0x0 */ struct OSMutex* next;
     /* 0x4 */ struct OSMutex* prev;
-}; // size = 0x8
+} __anon_0xF84A; // size = 0x8
 
-struct OSMutex {
+typedef struct OSMutex {
     /* 0x00 */ struct OSThreadQueue queue;
     /* 0x08 */ struct OSThread* thread;
     /* 0x0C */ s32 count;
     /* 0x10 */ struct OSMutexLink link;
-}; // size = 0x18
+} __anon_0xF8BA; // size = 0x18
 
-struct OSMutexQueue {
+typedef struct OSMutexQueue {
     /* 0x0 */ struct OSMutex* head;
     /* 0x4 */ struct OSMutex* tail;
-}; // size = 0x8
+} __anon_0xF96B; // size = 0x8
 
-struct OSThread {
+typedef struct OSThread {
     /* 0x000 */ struct OSContext context;
     /* 0x2C8 */ u16 state;
     /* 0x2CA */ u16 attr;
@@ -74,21 +74,21 @@ struct OSThread {
     /* 0x308 */ u32* stackEnd;
     /* 0x30C */ s32 error;
     /* 0x310 */ void* specific[2];
-}; // size = 0x318
+} __anon_0xF9FC; // size = 0x318
 
-struct OSThreadQueue {
+typedef struct OSThreadQueue {
     /* 0x0 */ struct OSThread* head;
     /* 0x4 */ struct OSThread* tail;
-}; // size = 0x8
+} __anon_0xFC95; // size = 0x8
 
-struct OSMessageQueue {
+typedef struct OSMessageQueue {
     /* 0x00 */ struct OSThreadQueue queueSend;
     /* 0x08 */ struct OSThreadQueue queueReceive;
     /* 0x10 */ void* msgArray;
     /* 0x14 */ s32 msgCount;
     /* 0x18 */ s32 firstIndex;
     /* 0x1C */ s32 usedCount;
-}; // size = 0x20
+} __anon_0xFD07; // size = 0x20
 
 // size = 0x20, address = 0x800F9720
 static struct OSMessageQueue PrepareReadyQueue;
@@ -123,7 +123,7 @@ static s16* CurAudioBuffer;
 // size = 0x4, address = 0x80135634
 static s32 AudioSystem;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -131,9 +131,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x10108; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -146,16 +146,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x10278; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x1049E; // size = 0x3C
 
-struct __anon_0x10576 {
+typedef struct __anon_0x10576 {
     /* 0x00 */ char magic[4];
     /* 0x04 */ u32 version;
     /* 0x08 */ u32 bufSize;
@@ -168,46 +168,46 @@ struct __anon_0x10576 {
     /* 0x24 */ u32 offsetDataOffsets;
     /* 0x28 */ u32 movieDataOffsets;
     /* 0x2C */ u32 finalFrameDataOffsets;
-}; // size = 0x30
+} __anon_0x10576; // size = 0x30
 
-struct __anon_0x107A2 {
+typedef struct __anon_0x107A2 {
     /* 0x0 */ u32 numComponents;
     /* 0x4 */ u8 frameComp[16];
-}; // size = 0x14
+} __anon_0x107A2; // size = 0x14
 
-struct __anon_0x1080A {
+typedef struct __anon_0x1080A {
     /* 0x0 */ u32 xSize;
     /* 0x4 */ u32 ySize;
     /* 0x8 */ u32 videoType;
-}; // size = 0xC
+} __anon_0x1080A; // size = 0xC
 
-struct __anon_0x1088A {
+typedef struct __anon_0x1088A {
     /* 0x0 */ u32 sndChannels;
     /* 0x4 */ u32 sndFrequency;
     /* 0x8 */ u32 sndNumSamples;
     /* 0xC */ u32 sndNumTracks;
-}; // size = 0x10
+} __anon_0x1088A; // size = 0x10
 
-struct __anon_0x10944 {
+typedef struct __anon_0x10944 {
     /* 0x0 */ u8* ytexture;
     /* 0x4 */ u8* utexture;
     /* 0x8 */ u8* vtexture;
     /* 0xC */ s32 frameNumber;
-}; // size = 0x10
+} __anon_0x10944; // size = 0x10
 
-struct __anon_0x109FA {
+typedef struct __anon_0x109FA {
     /* 0x0 */ s16* buffer;
     /* 0x4 */ s16* curPtr;
     /* 0x8 */ u32 validSample;
-}; // size = 0xC
+} __anon_0x109FA; // size = 0xC
 
-struct __anon_0x10A84 {
+typedef struct __anon_0x10A84 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
     /* 0x8 */ s32 isValid;
-}; // size = 0xC
+} __anon_0x10A84; // size = 0xC
 
-struct __anon_0x10B6F {
+typedef struct __anon_0x10B6F {
     /* 0x000 */ struct DVDFileInfo fileInfo;
     /* 0x03C */ struct __anon_0x10576 header;
     /* 0x06C */ struct __anon_0x107A2 compInfo;
@@ -242,7 +242,7 @@ struct __anon_0x10B6F {
     /* 0x100 */ struct __anon_0x10A84 readBuffer[10];
     /* 0x178 */ struct __anon_0x10944 textureSet[3];
     /* 0x1A8 */ struct __anon_0x109FA audioBuffer[3];
-}; // size = 0x1D0
+} __anon_0x10B6F; // size = 0x1D0
 
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x10B6F ActivePlayer;
@@ -438,7 +438,7 @@ static s32 ProperTimingForGettingNextFrame() {
     // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-enum __anon_0x119E9 {
+typedef enum __anon_0x119E9 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -451,14 +451,14 @@ enum __anon_0x119E9 {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0x119E9;
 
-enum __anon_0x11B35 {
+typedef enum __anon_0x11B35 {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0x11B35;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0x119E9 viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -472,7 +472,7 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0x11BE8; // size = 0x3C
 
 // Range: 0x8001071C -> 0x800107E8
 s32 THPPlayerDrawCurrentFrame(struct _GXRenderModeObj* rmode, u32 x, u32 y, u32 polygonW, u32 polygonH) {

--- a/debug/Fire/THPPlayer.c
+++ b/debug/Fire/THPPlayer.c
@@ -1,555 +1,608 @@
-﻿// Local to compilation unit
-// Location: 0x800EA1E8
-static unsigned short VolumeTable[128];
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\THPPlayer.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x8000F890 -> 0x80010D9C
+*/
 
-// Local to compilation unit
-// Location: 0x18561380
-static int Initialized;
+#include "types.h"
 
-// Local to compilation unit
-// Location: 0x800F96E0
-static long WorkBuffer[16];
+// size = 0x100, address = 0x800EA1E8
+static u16 VolumeTable[128];
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
+// size = 0x4, address = 0x80135618
+static s32 Initialized;
 
-// size: 0x8
-struct OSThreadLink
-{
-	OSThread *next; // 0x0
-	OSThread *prev; // 0x4
-};
+// size = 0x40, address = 0x800F96E0
+static s32 WorkBuffer[16];
 
-// size: 0x8
-struct OSMutexLink
-{
-	OSMutex *next; // 0x0
-	OSMutex *prev; // 0x4
-};
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
 
-// size: 0x18
-struct OSMutex
-{
-	OSThreadQueue queue; // 0x0
-	OSThread *thread; // 0x8
-	long count; // 0xC
-	OSMutexLink link; // 0x10
-};
+struct OSThreadLink {
+    /* 0x0 */ struct OSThread* next;
+    /* 0x4 */ struct OSThread* prev;
+}; // size = 0x8
 
-// size: 0x8
-struct OSMutexQueue
-{
-	OSMutex *head; // 0x0
-	OSMutex *tail; // 0x4
-};
+struct OSMutexLink {
+    /* 0x0 */ struct OSMutex* next;
+    /* 0x4 */ struct OSMutex* prev;
+}; // size = 0x8
 
-// size: 0x318
-struct OSThread
-{
-	OSContext context; // 0x0
-	unsigned short state; // 0x2C8
-	unsigned short attr; // 0x2CA
-	long suspend; // 0x2CC
-	long priority; // 0x2D0
-	long base; // 0x2D4
-	void *val; // 0x2D8
-	OSThreadQueue *queue; // 0x2DC
-	OSThreadLink link; // 0x2E0
-	OSThreadQueue queueJoin; // 0x2E8
-	OSMutex *mutex; // 0x2F0
-	OSMutexQueue queueMutex; // 0x2F4
-	OSThreadLink linkActive; // 0x2FC
-	unsigned char *stackBase; // 0x304
-	unsigned long *stackEnd; // 0x308
-	long error; // 0x30C
-	void *specific[2]; // 0x310
-};
+struct OSMutex {
+    /* 0x00 */ struct OSThreadQueue queue;
+    /* 0x08 */ struct OSThread* thread;
+    /* 0x0C */ s32 count;
+    /* 0x10 */ struct OSMutexLink link;
+}; // size = 0x18
 
-// size: 0x8
-struct OSThreadQueue
-{
-	OSThread *head; // 0x0
-	OSThread *tail; // 0x4
-};
+struct OSMutexQueue {
+    /* 0x0 */ struct OSMutex* head;
+    /* 0x4 */ struct OSMutex* tail;
+}; // size = 0x8
 
-// size: 0x20
-struct OSMessageQueue
-{
-	OSThreadQueue queueSend; // 0x0
-	OSThreadQueue queueReceive; // 0x8
-	void *msgArray; // 0x10
-	long msgCount; // 0x14
-	long firstIndex; // 0x18
-	long usedCount; // 0x1C
-};
+struct OSThread {
+    /* 0x000 */ struct OSContext context;
+    /* 0x2C8 */ u16 state;
+    /* 0x2CA */ u16 attr;
+    /* 0x2CC */ s32 suspend;
+    /* 0x2D0 */ s32 priority;
+    /* 0x2D4 */ s32 base;
+    /* 0x2D8 */ void* val;
+    /* 0x2DC */ struct OSThreadQueue* queue;
+    /* 0x2E0 */ struct OSThreadLink link;
+    /* 0x2E8 */ struct OSThreadQueue queueJoin;
+    /* 0x2F0 */ struct OSMutex* mutex;
+    /* 0x2F4 */ struct OSMutexQueue queueMutex;
+    /* 0x2FC */ struct OSThreadLink linkActive;
+    /* 0x304 */ u8* stackBase;
+    /* 0x308 */ u32* stackEnd;
+    /* 0x30C */ s32 error;
+    /* 0x310 */ void* specific[2];
+}; // size = 0x318
 
-// Local to compilation unit
-// Location: 0x20970F80
-static OSMessageQueue PrepareReadyQueue;
+struct OSThreadQueue {
+    /* 0x0 */ struct OSThread* head;
+    /* 0x4 */ struct OSThread* tail;
+}; // size = 0x8
 
-// Local to compilation unit
-// Location: 0x40970F80
-static OSMessageQueue UsedTextureSetQueue;
+struct OSMessageQueue {
+    /* 0x00 */ struct OSThreadQueue queueSend;
+    /* 0x08 */ struct OSThreadQueue queueReceive;
+    /* 0x10 */ void* msgArray;
+    /* 0x14 */ s32 msgCount;
+    /* 0x18 */ s32 firstIndex;
+    /* 0x1C */ s32 usedCount;
+}; // size = 0x20
 
-// Local to compilation unit
-// Location: 0x1C561380
-static void *PrepareReadyMessage;
+// size = 0x20, address = 0x800F9720
+static struct OSMessageQueue PrepareReadyQueue;
 
-// Local to compilation unit
-// Location: 0x60970F80
-static void *UsedTextureSetMessage[3];
+// size = 0x20, address = 0x800F9740
+static struct OSMessageQueue UsedTextureSetQueue;
 
-// Local to compilation unit
-// Location: 0x20561380
-static void (*OldVIPostCallback)(unsigned long /* unknown0 */);
+// size = 0x4, address = 0x8013561C
+static void* PrepareReadyMessage;
 
-// Local to compilation unit
-// Location: 0x800F9780
-static signed short SoundBuffer[2][320];
+// size = 0xC, address = 0x800F9760
+static void* UsedTextureSetMessage[3];
 
-// Local to compilation unit
-// Location: 0x24561380
-static long SoundBufferIndex;
+// size = 0x4, address = 0x80135620
+static void (*OldVIPostCallback)(u32);
 
-// Local to compilation unit
-// Location: 0x28561380
+// size = 0x500, address = 0x800F9780
+static s16 SoundBuffer[2][320];
+
+// size = 0x4, address = 0x80135624
+static s32 SoundBufferIndex;
+
+// size = 0x4, address = 0x80135628
 static void (*OldAIDCallback)();
 
-// Local to compilation unit
-// Location: 0x2C561380
-static signed short *LastAudioBuffer;
+// size = 0x4, address = 0x8013562C
+static s16* LastAudioBuffer;
 
-// Local to compilation unit
-// Location: 0x30561380
-static signed short *CurAudioBuffer;
+// size = 0x4, address = 0x80135630
+static s16* CurAudioBuffer;
 
-// Local to compilation unit
-// Location: 0x34561380
-static long AudioSystem;
+// size = 0x4, address = 0x80135634
+static s32 AudioSystem;
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+struct __anon_0x10576 {
+    /* 0x00 */ char magic[4];
+    /* 0x04 */ u32 version;
+    /* 0x08 */ u32 bufSize;
+    /* 0x0C */ u32 audioMaxSamples;
+    /* 0x10 */ float frameRate;
+    /* 0x14 */ u32 numFrames;
+    /* 0x18 */ u32 firstFrameSize;
+    /* 0x1C */ u32 movieDataSize;
+    /* 0x20 */ u32 compInfoDataOffsets;
+    /* 0x24 */ u32 offsetDataOffsets;
+    /* 0x28 */ u32 movieDataOffsets;
+    /* 0x2C */ u32 finalFrameDataOffsets;
+}; // size = 0x30
+
+struct __anon_0x107A2 {
+    /* 0x0 */ u32 numComponents;
+    /* 0x4 */ u8 frameComp[16];
+}; // size = 0x14
+
+struct __anon_0x1080A {
+    /* 0x0 */ u32 xSize;
+    /* 0x4 */ u32 ySize;
+    /* 0x8 */ u32 videoType;
+}; // size = 0xC
+
+struct __anon_0x1088A {
+    /* 0x0 */ u32 sndChannels;
+    /* 0x4 */ u32 sndFrequency;
+    /* 0x8 */ u32 sndNumSamples;
+    /* 0xC */ u32 sndNumTracks;
+}; // size = 0x10
+
+struct __anon_0x10944 {
+    /* 0x0 */ u8* ytexture;
+    /* 0x4 */ u8* utexture;
+    /* 0x8 */ u8* vtexture;
+    /* 0xC */ s32 frameNumber;
+}; // size = 0x10
+
+struct __anon_0x109FA {
+    /* 0x0 */ s16* buffer;
+    /* 0x4 */ s16* curPtr;
+    /* 0x8 */ u32 validSample;
+}; // size = 0xC
+
+struct __anon_0x10A84 {
+    /* 0x0 */ u8* ptr;
+    /* 0x4 */ s32 frameNumber;
+    /* 0x8 */ s32 isValid;
+}; // size = 0xC
+
+struct __anon_0x10B6F {
+    /* 0x000 */ struct DVDFileInfo fileInfo;
+    /* 0x03C */ struct __anon_0x10576 header;
+    /* 0x06C */ struct __anon_0x107A2 compInfo;
+    /* 0x080 */ struct __anon_0x1080A videoInfo;
+    /* 0x08C */ struct __anon_0x1088A audioInfo;
+    /* 0x09C */ void* thpWork;
+    /* 0x0A0 */ s32 open;
+    /* 0x0A4 */ u8 state;
+    /* 0x0A5 */ u8 internalState;
+    /* 0x0A6 */ u8 playFlag;
+    /* 0x0A7 */ u8 audioExist;
+    /* 0x0A8 */ s32 dvdError;
+    /* 0x0AC */ s32 videoError;
+    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B4 */ u8* movieData;
+    /* 0x0B8 */ s32 initOffset;
+    /* 0x0BC */ s32 initReadSize;
+    /* 0x0C0 */ s32 initReadFrame;
+    /* 0x0C8 */ s64 retraceCount;
+    /* 0x0D0 */ s32 prevCount;
+    /* 0x0D4 */ s32 curCount;
+    /* 0x0D8 */ s32 videoAhead;
+    /* 0x0DC */ float curVolume;
+    /* 0x0E0 */ float targetVolume;
+    /* 0x0E4 */ float deltaVolume;
+    /* 0x0E8 */ s32 rampCount;
+    /* 0x0EC */ s32 curAudioTrack;
+    /* 0x0F0 */ s32 curVideoNumber;
+    /* 0x0F4 */ s32 curAudioNumber;
+    /* 0x0F8 */ struct __anon_0x10944* dispTextureSet;
+    /* 0x0FC */ struct __anon_0x109FA* playAudioBuffer;
+    /* 0x100 */ struct __anon_0x10A84 readBuffer[10];
+    /* 0x178 */ struct __anon_0x10944 textureSet[3];
+    /* 0x1A8 */ struct __anon_0x109FA audioBuffer[3];
+}; // size = 0x1D0
+
+// size = 0x1D0, address = 0x800F9C80
+struct __anon_0x10B6F ActivePlayer;
+
+// Range: 0x8000F890 -> 0x8000F9C8
+s32 THPPlayerInit(s32 audioSystem) {
+    // Parameters
+    // s32 audioSystem; // r30
+
+    // Local variables
+    s32 old; // r30
+
+    // References
+    // -> static s32 Initialized;
+    // -> static s32 SoundBufferIndex;
+    // -> static s16 SoundBuffer[2][320];
+    // -> static s32 AudioSystem;
+    // -> static void (* OldAIDCallback)();
+    // -> static s16* CurAudioBuffer;
+    // -> static s16* LastAudioBuffer;
+    // -> static void* UsedTextureSetMessage[3];
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static void THPPlayerQuit() {
+    // Local variables
+    s32 old; // r31
+
+    // References
+    // -> static s32 Initialized;
+    // -> static void (* OldAIDCallback)();
+}
+
+// Range: 0x8000F9C8 -> 0x8000FC40
+s32 THPPlayerOpen(char* fileName, s32 onMemory) {
+    // Parameters
+    // char* fileName; // r21
+    // s32 onMemory; // r30
+
+    // Local variables
+    s32 offset; // r22
+    s32 i; // r21
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static s32 WorkBuffer[16];
+    // -> static s32 Initialized;
+}
+
+// Erased
+static s32 THPPlayerClose() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000FC40 -> 0x8000FCE8
+u32 THPPlayerCalcNeedMemory() {
+    // Local variables
+    u32 size; // r6
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000FCE8 -> 0x8000FF24
+s32 THPPlayerSetBuffer(u8* buffer) {
+    // Parameters
+    // u8* buffer; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x8
+    u8* ptr; // r30
+    u32 ysize; // r27
+    u32 uvsize; // r26
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000FF24 -> 0x8000FFF0
+static void InitAllMessageQueue() {
+    // Local variables
+    s32 i; // r28
+    struct __anon_0x10A84* readBuffer; // r3
+    struct __anon_0x10944* textureSet; // r3
+    struct __anon_0x109FA* audioBuffer; // r3
+
+    // References
+    // -> static void* PrepareReadyMessage;
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 WaitUntilPrepare() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+}
+
+// Range: 0x8000FFF0 -> 0x80010020
+void PrepareReady(s32 flag) {
+    // Parameters
+    // s32 flag; // r4
+
+    // References
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+}
+
+// Range: 0x80010020 -> 0x80010294
+s32 THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
+    // Parameters
+    // s32 frameNum; // r29
+    // s32 playFlag; // r26
+    // s32 audioTrack; // r27
+
+    // Local variables
+    s32 offset; // r6
+    u8* ptr; // r26
+
+    // References
+    // -> static void (* OldVIPostCallback)(u32);
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+    // -> static s32 WorkBuffer[16];
+}
+
+// Range: 0x80010294 -> 0x800102F0
+s32 THPPlayerPlay() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static void THPPlayerStop() {
+    // Local variables
+    void* texture; // r1+0x8
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static void (* OldVIPostCallback)(u32);
+}
+
+// Erased
+static s32 THPPlayerPause() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 THPPlayerSkip() {
+    // Local variables
+    s32 old; // r3
+    s32 frameNumber; // r3
+    s32 audioGet; // r29
+    s32 videoGet; // r1+0x8
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x800102F0 -> 0x8001058C
+static void PlayControl(u32 retraceCount) {
+    // Parameters
+    // u32 retraceCount; // r3
+
+    // Local variables
+    s32 diff; // r1+0x8
+    s32 frameNumber; // r4
+    struct __anon_0x10944* textureSet; // r29
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static void (* OldVIPostCallback)(u32);
+}
+
+// Range: 0x8001058C -> 0x800105F8
+static s32 ProperTimingForStart() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x800105F8 -> 0x8001071C
+static s32 ProperTimingForGettingNextFrame() {
+    // Local variables
+    s32 frameRate; // r30
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+enum __anon_0x119E9 {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
 };
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
+enum __anon_0x11B35 {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
 };
 
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0x119E9 viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0x11B35 xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
 
-// size: 0x30
-struct __anon_0x10576
-{
-	char magic[4]; // 0x0
-	unsigned long version; // 0x4
-	unsigned long bufSize; // 0x8
-	unsigned long audioMaxSamples; // 0xC
-	float frameRate; // 0x10
-	unsigned long numFrames; // 0x14
-	unsigned long firstFrameSize; // 0x18
-	unsigned long movieDataSize; // 0x1C
-	unsigned long compInfoDataOffsets; // 0x20
-	unsigned long offsetDataOffsets; // 0x24
-	unsigned long movieDataOffsets; // 0x28
-	unsigned long finalFrameDataOffsets; // 0x2C
-};
+// Range: 0x8001071C -> 0x800107E8
+s32 THPPlayerDrawCurrentFrame(struct _GXRenderModeObj* rmode, u32 x, u32 y, u32 polygonW, u32 polygonH) {
+    // Parameters
+    // struct _GXRenderModeObj* rmode; // r3
+    // u32 x; // r26
+    // u32 y; // r27
+    // u32 polygonW; // r28
+    // u32 polygonH; // r29
 
-// size: 0x14
-struct __anon_0x107A2
-{
-	unsigned long numComponents; // 0x0
-	unsigned char frameComp[16]; // 0x4
-};
-
-// size: 0xC
-struct __anon_0x1080A
-{
-	unsigned long xSize; // 0x0
-	unsigned long ySize; // 0x4
-	unsigned long videoType; // 0x8
-};
-
-// size: 0x10
-struct __anon_0x1088A
-{
-	unsigned long sndChannels; // 0x0
-	unsigned long sndFrequency; // 0x4
-	unsigned long sndNumSamples; // 0x8
-	unsigned long sndNumTracks; // 0xC
-};
-
-// size: 0x10
-struct __anon_0x10944
-{
-	unsigned char *ytexture; // 0x0
-	unsigned char *utexture; // 0x4
-	unsigned char *vtexture; // 0x8
-	long frameNumber; // 0xC
-};
-
-// size: 0xC
-struct __anon_0x109FA
-{
-	signed short *buffer; // 0x0
-	signed short *curPtr; // 0x4
-	unsigned long validSample; // 0x8
-};
-
-// size: 0xC
-struct __anon_0x10A84
-{
-	unsigned char *ptr; // 0x0
-	long frameNumber; // 0x4
-	int isValid; // 0x8
-};
-
-// size: 0x1D0
-struct __anon_0x10B6F
-{
-	DVDFileInfo fileInfo; // 0x0
-	__anon_0x10576 header; // 0x3C
-	__anon_0x107A2 compInfo; // 0x6C
-	__anon_0x1080A videoInfo; // 0x80
-	__anon_0x1088A audioInfo; // 0x8C
-	void *thpWork; // 0x9C
-	int open; // 0xA0
-	unsigned char state; // 0xA4
-	unsigned char internalState; // 0xA5
-	unsigned char playFlag; // 0xA6
-	unsigned char audioExist; // 0xA7
-	long dvdError; // 0xA8
-	long videoError; // 0xAC
-	int onMemory; // 0xB0
-	unsigned char *movieData; // 0xB4
-	long initOffset; // 0xB8
-	long initReadSize; // 0xBC
-	long initReadFrame; // 0xC0
-	signed long long retraceCount; // 0xC8
-	long prevCount; // 0xD0
-	long curCount; // 0xD4
-	long videoAhead; // 0xD8
-	float curVolume; // 0xDC
-	float targetVolume; // 0xE0
-	float deltaVolume; // 0xE4
-	long rampCount; // 0xE8
-	long curAudioTrack; // 0xEC
-	long curVideoNumber; // 0xF0
-	long curAudioNumber; // 0xF4
-	__anon_0x10944 *dispTextureSet; // 0xF8
-	__anon_0x109FA *playAudioBuffer; // 0xFC
-	__anon_0x10A84 readBuffer[10]; // 0x100
-	__anon_0x10944 textureSet[3]; // 0x178
-	__anon_0x109FA audioBuffer[3]; // 0x1A8
-};
-
-// Location: 0x800F9C80
-__anon_0x10B6F ActivePlayer;
-
-int THPPlayerInit(long audioSystem)
-{
-	int old;
-	// References: Initialized (0x18561380)
-	// References: SoundBufferIndex (0x24561380)
-	// References: SoundBuffer (0x800F9780)
-	// References: AudioSystem (0x34561380)
-	// References: OldAIDCallback (0x28561380)
-	// References: CurAudioBuffer (0x30561380)
-	// References: LastAudioBuffer (0x2C561380)
-	// References: UsedTextureSetMessage (0x60970F80)
-	// References: UsedTextureSetQueue (0x40970F80)
-	// References: ActivePlayer (0x800F9C80)
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-void THPPlayerQuit()
-{
-	int old;
-	// References: Initialized (0x18561380)
-	// References: OldAIDCallback (0x28561380)
+// Erased
+static s32 THPPlayerGetVideoInfo(struct __anon_0x1080A* videoInfo) {
+    // Parameters
+    // struct __anon_0x1080A* videoInfo; // r3
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-int THPPlayerOpen(char *fileName, int onMemory)
-{
-	long offset;
-	long i;
-	// References: ActivePlayer (0x800F9C80)
-	// References: WorkBuffer (0x800F96E0)
-	// References: Initialized (0x18561380)
+// Erased
+static s32 THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
+    // Parameters
+    // struct __anon_0x1088A* audioInfo; // r3
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-int THPPlayerClose()
-{
-	// References: ActivePlayer (0x800F9C80)
+// Erased
+static float THPPlayerGetFrameRate() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-unsigned long THPPlayerCalcNeedMemory()
-{
-	unsigned long size;
-	// References: ActivePlayer (0x800F9C80)
+// Erased
+static u32 THPPlayerGetTotalFrame() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-int THPPlayerSetBuffer(unsigned char *buffer)
-{
-	unsigned long i;
-	unsigned char *ptr;
-	unsigned long ysize;
-	unsigned long uvsize;
-	// References: ActivePlayer (0x800F9C80)
+// Erased
+static s32 THPPlayerGetState() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-// Local to compilation unit
-static void InitAllMessageQueue()
-{
-	long i;
-	__anon_0x10A84 *readBuffer;
-	__anon_0x10944 *textureSet;
-	__anon_0x109FA *audioBuffer;
-	// References: PrepareReadyMessage (0x1C561380)
-	// References: PrepareReadyQueue (0x20970F80)
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x800107E8 -> 0x80010818
+static void PushUsedTextureSet(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
 }
 
-int WaitUntilPrepare()
-{
-	void *msg;
-	// References: PrepareReadyQueue (0x20970F80)
+// Erased
+static void* PopUsedTextureSet() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
 }
 
-void PrepareReady(int flag)
-{
-	// References: PrepareReadyQueue (0x20970F80)
+// Range: 0x80010818 -> 0x80010888
+void THPPlayerDrawDone() {
+    // Local variables
+    void* textureSet; // r3
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
+    // -> static s32 Initialized;
 }
 
-int THPPlayerPrepare(long frameNum, long playFlag, long audioTrack)
-{
-	long offset;
-	unsigned char *ptr;
-	// References: OldVIPostCallback (0x20561380)
-	// References: ActivePlayer (0x800F9C80)
-	// References: PrepareReadyQueue (0x20970F80)
-	// References: WorkBuffer (0x800F96E0)
+// Range: 0x80010888 -> 0x80010A00
+static void THPAudioMixCallback() {
+    // Local variables
+    s32 old; // r30
+
+    // References
+    // -> static s32 SoundBufferIndex;
+    // -> static s16 SoundBuffer[2][320];
+    // -> static s16* CurAudioBuffer;
+    // -> static void (* OldAIDCallback)();
+    // -> static s16* LastAudioBuffer;
+    // -> static s32 AudioSystem;
 }
 
-int THPPlayerPlay()
-{
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x80010A00 -> 0x80010D9C
+static void MixAudio(s16* destination, s16* source, u32 sample) {
+    // Parameters
+    // s16* destination; // r3
+    // s16* source; // r4
+    // u32 sample; // r5
+
+    // Local variables
+    u32 sampleNum; // r1+0x8
+    u32 requestSample; // r26
+    u32 i; // r1+0x8
+    s32 mix; // r4
+    s16* dst; // r27
+    s16* libsrc; // r25
+    s16* thpsrc; // r3
+    u16 attenuation; // r1+0x8
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static u16 VolumeTable[128];
 }
 
-void THPPlayerStop()
-{
-	void *texture;
-	// References: ActivePlayer (0x800F9C80)
-	// References: OldVIPostCallback (0x20561380)
+// Erased
+static s32 THPPlayerSetVolume(s32 vol, s32 time) {
+    // Parameters
+    // s32 vol; // r28
+    // s32 time; // r29
+
+    // Local variables
+    s32 old; // r3
+    s32 samplePerMs; // r30
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
-int THPPlayerPause()
-{
-	// References: ActivePlayer (0x800F9C80)
+// Erased
+static s32 THPPlayerGetVolume() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
-
-int THPPlayerSkip()
-{
-	int old;
-	long frameNumber;
-	long audioGet;
-	long videoGet;
-	// References: ActivePlayer (0x800F9C80)
-}
-
-// Local to compilation unit
-static void PlayControl(unsigned long retraceCount)
-{
-	long diff;
-	long frameNumber;
-	__anon_0x10944 *textureSet;
-	// References: ActivePlayer (0x800F9C80)
-	// References: OldVIPostCallback (0x20561380)
-}
-
-// Local to compilation unit
-static int ProperTimingForStart()
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-// Local to compilation unit
-static int ProperTimingForGettingNextFrame()
-{
-	long frameRate;
-	// References: ActivePlayer (0x800F9C80)
-}
-
-// size: 0x4
-enum __anon_0x119E9
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
-};
-
-// size: 0x4
-enum __anon_0x11B35
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
-};
-
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0x119E9 viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0x11B35 xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
-
-long THPPlayerDrawCurrentFrame(_GXRenderModeObj *rmode, unsigned long x, unsigned long y, unsigned long polygonW, unsigned long polygonH)
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-int THPPlayerGetVideoInfo(__anon_0x1080A *videoInfo)
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-int THPPlayerGetAudioInfo(__anon_0x1088A *audioInfo)
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-float THPPlayerGetFrameRate()
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-unsigned long THPPlayerGetTotalFrame()
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-long THPPlayerGetState()
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-
-// Local to compilation unit
-static void PushUsedTextureSet(void *buffer)
-{
-	// References: UsedTextureSetQueue (0x40970F80)
-}
-
-void *PopUsedTextureSet()
-{
-	void *msg;
-	// References: UsedTextureSetQueue (0x40970F80)
-}
-
-void THPPlayerDrawDone()
-{
-	void *textureSet;
-	// References: UsedTextureSetQueue (0x40970F80)
-	// References: Initialized (0x18561380)
-}
-
-// Local to compilation unit
-static void THPAudioMixCallback()
-{
-	int old;
-	// References: SoundBufferIndex (0x24561380)
-	// References: SoundBuffer (0x800F9780)
-	// References: CurAudioBuffer (0x30561380)
-	// References: OldAIDCallback (0x28561380)
-	// References: LastAudioBuffer (0x2C561380)
-	// References: AudioSystem (0x34561380)
-}
-
-// Local to compilation unit
-static void MixAudio(signed short *destination, signed short *source, unsigned long sample)
-{
-	unsigned long sampleNum;
-	unsigned long requestSample;
-	unsigned long i;
-	long mix;
-	signed short *dst;
-	signed short *libsrc;
-	signed short *thpsrc;
-	unsigned short attenuation;
-	// References: ActivePlayer (0x800F9C80)
-	// References: VolumeTable (0x800EA1E8)
-}
-
-int THPPlayerSetVolume(long vol, long time)
-{
-	int old;
-	long samplePerMs;
-	// References: ActivePlayer (0x800F9C80)
-}
-
-long THPPlayerGetVolume()
-{
-	// References: ActivePlayer (0x800F9C80)
-}
-

--- a/debug/Fire/THPRead.c
+++ b/debug/Fire/THPRead.c
@@ -1,595 +1,585 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\THPRead.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80011938 -> 0x80012F20
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// size = 0x4, address = 0x80135640
+static s32 ReadThreadCreated;
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+struct OSThreadQueue {
+    /* 0x0 */ struct OSThread* head;
+    /* 0x4 */ struct OSThread* tail;
+}; // size = 0x8
 
-// Local to compilation unit
-// Location: 0x40561380
-static long ReadThreadCreated;
+struct OSMessageQueue {
+    /* 0x00 */ struct OSThreadQueue queueSend;
+    /* 0x08 */ struct OSThreadQueue queueReceive;
+    /* 0x10 */ void* msgArray;
+    /* 0x14 */ s32 msgCount;
+    /* 0x18 */ s32 firstIndex;
+    /* 0x1C */ s32 usedCount;
+}; // size = 0x20
 
-// size: 0x8
-struct OSThreadQueue
-{
-	OSThread *head; // 0x0
-	OSThread *tail; // 0x4
-};
+// size = 0x20, address = 0x800FB1C0
+static struct OSMessageQueue FreeReadBufferQueue;
 
-// size: 0x20
-struct OSMessageQueue
-{
-	OSThreadQueue queueSend; // 0x0
-	OSThreadQueue queueReceive; // 0x8
-	void *msgArray; // 0x10
-	long msgCount; // 0x14
-	long firstIndex; // 0x18
-	long usedCount; // 0x1C
-};
+// size = 0x20, address = 0x800FB1E0
+static struct OSMessageQueue ReadedBufferQueue;
 
-// Local to compilation unit
-// Location: 0x800FB1C0
-static OSMessageQueue FreeReadBufferQueue;
+// size = 0x20, address = 0x800FB200
+static struct OSMessageQueue ReadedBufferQueue2;
 
-// Local to compilation unit
-// Location: 0x800FB1E0
-static OSMessageQueue ReadedBufferQueue;
+// size = 0x28, address = 0x800FB220
+static void* FreeReadBufferMessage[10];
 
-// Local to compilation unit
-// Location: 0xB20F80
-static OSMessageQueue ReadedBufferQueue2;
+// size = 0x28, address = 0x800FB248
+static void* ReadedBufferMessage[10];
 
-// Local to compilation unit
-// Location: 0x20B20F80
-static void *FreeReadBufferMessage[10];
+// size = 0x28, address = 0x800FB270
+static void* ReadedBufferMessage2[10];
 
-// Local to compilation unit
-// Location: 0x48B20F80
-static void *ReadedBufferMessage[10];
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
 
-// Local to compilation unit
-// Location: 0x70B20F80
-static void *ReadedBufferMessage2[10];
+struct OSThreadLink {
+    /* 0x0 */ struct OSThread* next;
+    /* 0x4 */ struct OSThread* prev;
+}; // size = 0x8
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
+struct OSMutexLink {
+    /* 0x0 */ struct OSMutex* next;
+    /* 0x4 */ struct OSMutex* prev;
+}; // size = 0x8
 
-// size: 0x8
-struct OSThreadLink
-{
-	OSThread *next; // 0x0
-	OSThread *prev; // 0x4
-};
+struct OSMutex {
+    /* 0x00 */ struct OSThreadQueue queue;
+    /* 0x08 */ struct OSThread* thread;
+    /* 0x0C */ s32 count;
+    /* 0x10 */ struct OSMutexLink link;
+}; // size = 0x18
 
-// size: 0x8
-struct OSMutexLink
-{
-	OSMutex *next; // 0x0
-	OSMutex *prev; // 0x4
-};
+struct OSMutexQueue {
+    /* 0x0 */ struct OSMutex* head;
+    /* 0x4 */ struct OSMutex* tail;
+}; // size = 0x8
 
-// size: 0x18
-struct OSMutex
-{
-	OSThreadQueue queue; // 0x0
-	OSThread *thread; // 0x8
-	long count; // 0xC
-	OSMutexLink link; // 0x10
-};
+struct OSThread {
+    /* 0x000 */ struct OSContext context;
+    /* 0x2C8 */ u16 state;
+    /* 0x2CA */ u16 attr;
+    /* 0x2CC */ s32 suspend;
+    /* 0x2D0 */ s32 priority;
+    /* 0x2D4 */ s32 base;
+    /* 0x2D8 */ void* val;
+    /* 0x2DC */ struct OSThreadQueue* queue;
+    /* 0x2E0 */ struct OSThreadLink link;
+    /* 0x2E8 */ struct OSThreadQueue queueJoin;
+    /* 0x2F0 */ struct OSMutex* mutex;
+    /* 0x2F4 */ struct OSMutexQueue queueMutex;
+    /* 0x2FC */ struct OSThreadLink linkActive;
+    /* 0x304 */ u8* stackBase;
+    /* 0x308 */ u32* stackEnd;
+    /* 0x30C */ s32 error;
+    /* 0x310 */ void* specific[2];
+}; // size = 0x318
 
-// size: 0x8
-struct OSMutexQueue
-{
-	OSMutex *head; // 0x0
-	OSMutex *tail; // 0x4
-};
+// size = 0x318, address = 0x800FB298
+static struct OSThread ReadThread;
 
-// size: 0x318
-struct OSThread
-{
-	OSContext context; // 0x0
-	unsigned short state; // 0x2C8
-	unsigned short attr; // 0x2CA
-	long suspend; // 0x2CC
-	long priority; // 0x2D0
-	long base; // 0x2D4
-	void *val; // 0x2D8
-	OSThreadQueue *queue; // 0x2DC
-	OSThreadLink link; // 0x2E0
-	OSThreadQueue queueJoin; // 0x2E8
-	OSMutex *mutex; // 0x2F0
-	OSMutexQueue queueMutex; // 0x2F4
-	OSThreadLink linkActive; // 0x2FC
-	unsigned char *stackBase; // 0x304
-	unsigned long *stackEnd; // 0x308
-	long error; // 0x30C
-	void *specific[2]; // 0x310
-};
+// size = 0x1000, address = 0x800FB5B0
+static u8 ReadThreadStack[4096];
 
-// Local to compilation unit
-// Location: 0x800FB298
-static OSThread ReadThread;
-
-// Local to compilation unit
-// Location: 0x800FB5B0
-static unsigned char ReadThreadStack[4096];
-
-// Local to compilation unit
-// Location: 0x800FC5B0
+// size = 0x40, address = 0x800FC5B0
 static float gOrthoMtx[4][4];
 
-// Location: 0x44561380
-int gMovieErrorToggle;
+// size = 0x4, address = 0x80135644
+s32 gMovieErrorToggle;
 
-// Local to compilation unit
-// Location: 0x48561380
-static int toggle$184;
+// size = 0x4, address = 0x80135648
+static s32 toggle$184;
 
-// Local to compilation unit
-// Location: 0x4C561380
-static int gbReset;
+// size = 0x4, address = 0x8013564C
+static s32 gbReset;
 
-// Local to compilation unit
-// Location: 0x50561380
-static unsigned int gnTickReset;
+// size = 0x4, address = 0x80135650
+static u32 gnTickReset;
 
-void PushReadedBuffer2(void *buffer)
-{
-	// References: ReadedBufferQueue2 (0xB20F80)
+// Range: 0x80011938 -> 0x80011968
+void PushReadedBuffer2(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
 }
 
-void *PopReadedBuffer2()
-{
-	void *msg;
-	// References: ReadedBufferQueue2 (0xB20F80)
+// Range: 0x80011968 -> 0x8001199C
+void* PopReadedBuffer2() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
 }
 
-void PushFreeReadBuffer(void *buffer)
-{
-	// References: FreeReadBufferQueue (0x800FB1C0)
+// Range: 0x8001199C -> 0x800119CC
+void PushFreeReadBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
 }
 
-void *PopFreeReadBuffer()
-{
-	void *msg;
-	// References: FreeReadBufferQueue (0x800FB1C0)
+// Erased
+static void* PopFreeReadBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
 }
 
-void PushReadedBuffer(void *buffer)
-{
-	// References: ReadedBufferQueue (0x800FB1E0)
+// Erased
+static void PushReadedBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue;
 }
 
-void *PopReadedBuffer()
-{
-	void *msg;
-	// References: ReadedBufferQueue (0x800FB1E0)
+// Range: 0x800119CC -> 0x80011A00
+void* PopReadedBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue;
 }
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
 
-// size: 0x30
-struct __anon_0x16250
-{
-	char magic[4]; // 0x0
-	unsigned long version; // 0x4
-	unsigned long bufSize; // 0x8
-	unsigned long audioMaxSamples; // 0xC
-	float frameRate; // 0x10
-	unsigned long numFrames; // 0x14
-	unsigned long firstFrameSize; // 0x18
-	unsigned long movieDataSize; // 0x1C
-	unsigned long compInfoDataOffsets; // 0x20
-	unsigned long offsetDataOffsets; // 0x24
-	unsigned long movieDataOffsets; // 0x28
-	unsigned long finalFrameDataOffsets; // 0x2C
-};
+struct __anon_0x16250 {
+    /* 0x00 */ char magic[4];
+    /* 0x04 */ u32 version;
+    /* 0x08 */ u32 bufSize;
+    /* 0x0C */ u32 audioMaxSamples;
+    /* 0x10 */ float frameRate;
+    /* 0x14 */ u32 numFrames;
+    /* 0x18 */ u32 firstFrameSize;
+    /* 0x1C */ u32 movieDataSize;
+    /* 0x20 */ u32 compInfoDataOffsets;
+    /* 0x24 */ u32 offsetDataOffsets;
+    /* 0x28 */ u32 movieDataOffsets;
+    /* 0x2C */ u32 finalFrameDataOffsets;
+}; // size = 0x30
 
-// size: 0x14
-struct __anon_0x1647C
-{
-	unsigned long numComponents; // 0x0
-	unsigned char frameComp[16]; // 0x4
-};
+struct __anon_0x1647C {
+    /* 0x0 */ u32 numComponents;
+    /* 0x4 */ u8 frameComp[16];
+}; // size = 0x14
 
-// size: 0xC
-struct __anon_0x164E4
-{
-	unsigned long xSize; // 0x0
-	unsigned long ySize; // 0x4
-	unsigned long videoType; // 0x8
-};
+struct __anon_0x164E4 {
+    /* 0x0 */ u32 xSize;
+    /* 0x4 */ u32 ySize;
+    /* 0x8 */ u32 videoType;
+}; // size = 0xC
 
-// size: 0x10
-struct __anon_0x16564
-{
-	unsigned long sndChannels; // 0x0
-	unsigned long sndFrequency; // 0x4
-	unsigned long sndNumSamples; // 0x8
-	unsigned long sndNumTracks; // 0xC
-};
+struct __anon_0x16564 {
+    /* 0x0 */ u32 sndChannels;
+    /* 0x4 */ u32 sndFrequency;
+    /* 0x8 */ u32 sndNumSamples;
+    /* 0xC */ u32 sndNumTracks;
+}; // size = 0x10
 
-// size: 0x10
-struct __anon_0x1661E
-{
-	unsigned char *ytexture; // 0x0
-	unsigned char *utexture; // 0x4
-	unsigned char *vtexture; // 0x8
-	long frameNumber; // 0xC
-};
+struct __anon_0x1661E {
+    /* 0x0 */ u8* ytexture;
+    /* 0x4 */ u8* utexture;
+    /* 0x8 */ u8* vtexture;
+    /* 0xC */ s32 frameNumber;
+}; // size = 0x10
 
-// size: 0xC
-struct __anon_0x166D4
-{
-	signed short *buffer; // 0x0
-	signed short *curPtr; // 0x4
-	unsigned long validSample; // 0x8
-};
+struct __anon_0x166D4 {
+    /* 0x0 */ s16* buffer;
+    /* 0x4 */ s16* curPtr;
+    /* 0x8 */ u32 validSample;
+}; // size = 0xC
 
-// size: 0xC
-struct __anon_0x1675E
-{
-	unsigned char *ptr; // 0x0
-	long frameNumber; // 0x4
-	int isValid; // 0x8
-};
+struct __anon_0x1675E {
+    /* 0x0 */ u8* ptr;
+    /* 0x4 */ s32 frameNumber;
+    /* 0x8 */ s32 isValid;
+}; // size = 0xC
 
-// size: 0x1D0
-struct __anon_0x16849
-{
-	DVDFileInfo fileInfo; // 0x0
-	__anon_0x16250 header; // 0x3C
-	__anon_0x1647C compInfo; // 0x6C
-	__anon_0x164E4 videoInfo; // 0x80
-	__anon_0x16564 audioInfo; // 0x8C
-	void *thpWork; // 0x9C
-	int open; // 0xA0
-	unsigned char state; // 0xA4
-	unsigned char internalState; // 0xA5
-	unsigned char playFlag; // 0xA6
-	unsigned char audioExist; // 0xA7
-	long dvdError; // 0xA8
-	long videoError; // 0xAC
-	int onMemory; // 0xB0
-	unsigned char *movieData; // 0xB4
-	long initOffset; // 0xB8
-	long initReadSize; // 0xBC
-	long initReadFrame; // 0xC0
-	signed long long retraceCount; // 0xC8
-	long prevCount; // 0xD0
-	long curCount; // 0xD4
-	long videoAhead; // 0xD8
-	float curVolume; // 0xDC
-	float targetVolume; // 0xE0
-	float deltaVolume; // 0xE4
-	long rampCount; // 0xE8
-	long curAudioTrack; // 0xEC
-	long curVideoNumber; // 0xF0
-	long curAudioNumber; // 0xF4
-	__anon_0x1661E *dispTextureSet; // 0xF8
-	__anon_0x166D4 *playAudioBuffer; // 0xFC
-	__anon_0x1675E readBuffer[10]; // 0x100
-	__anon_0x1661E textureSet[3]; // 0x178
-	__anon_0x166D4 audioBuffer[3]; // 0x1A8
-};
+struct __anon_0x16849 {
+    /* 0x000 */ struct DVDFileInfo fileInfo;
+    /* 0x03C */ struct __anon_0x16250 header;
+    /* 0x06C */ struct __anon_0x1647C compInfo;
+    /* 0x080 */ struct __anon_0x164E4 videoInfo;
+    /* 0x08C */ struct __anon_0x16564 audioInfo;
+    /* 0x09C */ void* thpWork;
+    /* 0x0A0 */ s32 open;
+    /* 0x0A4 */ u8 state;
+    /* 0x0A5 */ u8 internalState;
+    /* 0x0A6 */ u8 playFlag;
+    /* 0x0A7 */ u8 audioExist;
+    /* 0x0A8 */ s32 dvdError;
+    /* 0x0AC */ s32 videoError;
+    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B4 */ u8* movieData;
+    /* 0x0B8 */ s32 initOffset;
+    /* 0x0BC */ s32 initReadSize;
+    /* 0x0C0 */ s32 initReadFrame;
+    /* 0x0C8 */ s64 retraceCount;
+    /* 0x0D0 */ s32 prevCount;
+    /* 0x0D4 */ s32 curCount;
+    /* 0x0D8 */ s32 videoAhead;
+    /* 0x0DC */ float curVolume;
+    /* 0x0E0 */ float targetVolume;
+    /* 0x0E4 */ float deltaVolume;
+    /* 0x0E8 */ s32 rampCount;
+    /* 0x0EC */ s32 curAudioTrack;
+    /* 0x0F0 */ s32 curVideoNumber;
+    /* 0x0F4 */ s32 curAudioNumber;
+    /* 0x0F8 */ struct __anon_0x1661E* dispTextureSet;
+    /* 0x0FC */ struct __anon_0x166D4* playAudioBuffer;
+    /* 0x100 */ struct __anon_0x1675E readBuffer[10];
+    /* 0x178 */ struct __anon_0x1661E textureSet[3];
+    /* 0x1A8 */ struct __anon_0x166D4 audioBuffer[3];
+}; // size = 0x1D0
 
-// Location: 0x800F9C80
-__anon_0x16849 ActivePlayer;
+// size = 0x1D0, address = 0x800F9C80
+struct __anon_0x16849 ActivePlayer;
 
-// Local to compilation unit
-static void *Reader()
-{
-	__anon_0x1675E *readBuffer;
-	long offset;
-	long size;
-	long readFrame;
-	// References: ReadThread (0x800FB298)
-	// References: ActivePlayer (0x800F9C80)
-	// References: ReadedBufferQueue (0x800FB1E0)
-	// References: gMovieErrorToggle (0x44561380)
-	// References: FreeReadBufferQueue (0x800FB1C0)
+// Range: 0x80011A00 -> 0x80011B2C
+static void* Reader() {
+    // Local variables
+    struct __anon_0x1675E* readBuffer; // r27
+    s32 offset; // r26
+    s32 size; // r25
+    s32 readFrame; // r24
+
+    // References
+    // -> static struct OSThread ReadThread;
+    // -> struct __anon_0x16849 ActivePlayer;
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+    // -> s32 gMovieErrorToggle;
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
 }
 
-void ReadThreadCancel()
-{
-	// References: ReadThreadCreated (0x40561380)
-	// References: ReadThread (0x800FB298)
+// Erased
+static void ReadThreadCancel() {
+    // References
+    // -> static s32 ReadThreadCreated;
+    // -> static struct OSThread ReadThread;
 }
 
-void ReadThreadStart()
-{
-	// References: ReadThread (0x800FB298)
-	// References: ReadThreadCreated (0x40561380)
+// Range: 0x80011B2C -> 0x80011B60
+void ReadThreadStart() {
+    // References
+    // -> static struct OSThread ReadThread;
+    // -> static s32 ReadThreadCreated;
 }
 
-int CreateReadThread(long priority)
-{
-	// References: ReadThreadCreated (0x40561380)
-	// References: ReadedBufferMessage2 (0x70B20F80)
-	// References: ReadedBufferQueue2 (0xB20F80)
-	// References: ReadedBufferMessage (0x48B20F80)
-	// References: ReadedBufferQueue (0x800FB1E0)
-	// References: FreeReadBufferMessage (0x20B20F80)
-	// References: FreeReadBufferQueue (0x800FB1C0)
-	// References: ReadThreadStack (0x800FB5B0)
-	// References: ReadThread (0x800FB298)
+// Range: 0x80011B60 -> 0x80011C0C
+s32 CreateReadThread(s32 priority) {
+    // Parameters
+    // s32 priority; // r3
+
+    // References
+    // -> static s32 ReadThreadCreated;
+    // -> static void* ReadedBufferMessage2[10];
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
+    // -> static void* ReadedBufferMessage[10];
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+    // -> static void* FreeReadBufferMessage[10];
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
+    // -> static u8 ReadThreadStack[4096];
+    // -> static struct OSThread ReadThread;
 }
 
-void movieReset(int IPL, int forceMenu);
-
-// size: 0xC
-struct PADStatus
-{
-	unsigned short button; // 0x0
-	signed char stickX; // 0x2
-	signed char stickY; // 0x3
-	signed char substickX; // 0x4
-	signed char substickY; // 0x5
-	unsigned char triggerLeft; // 0x6
-	unsigned char triggerRight; // 0x7
-	unsigned char analogA; // 0x8
-	unsigned char analogB; // 0x9
-	signed char err; // 0xA
-};
-
-// size: 0x1E
-struct __anon_0x171A2
-{
-	PADStatus pst; // 0x0
-	unsigned short buttonDown; // 0xC
-	unsigned short buttonUp; // 0xE
-	unsigned short dirs; // 0x10
-	unsigned short dirsNew; // 0x12
-	unsigned short dirsReleased; // 0x14
-	signed short stickDeltaX; // 0x16
-	signed short stickDeltaY; // 0x18
-	signed short substickDeltaX; // 0x1A
-	signed short substickDeltaY; // 0x1C
-};
-
-// Location: 0x58271380
-__anon_0x171A2 DemoPad[4];
-
-int movieTestReset(int IPL, int forceMenu)
-{
-	unsigned int bFlag;
-	unsigned int nTick;
-	// References: gnTickReset (0x50561380)
-	// References: gbReset (0x4C561380)
-	// References: DemoPad (0x58271380)
+// Range: 0x80011C0C -> 0x80011CAC
+void movieReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r30
+    // s32 forceMenu; // r31
 }
 
-int movieDVDRead(DVDFileInfo *pFileInfo, void *anData, long nSizeRead, long nOffset)
-{
-	int nStatus;
-	int bRetry;
-	// References: gMovieErrorToggle (0x44561380)
+struct PADStatus {
+    /* 0x0 */ u16 button;
+    /* 0x2 */ s8 stickX;
+    /* 0x3 */ s8 stickY;
+    /* 0x4 */ s8 substickX;
+    /* 0x5 */ s8 substickY;
+    /* 0x6 */ u8 triggerLeft;
+    /* 0x7 */ u8 triggerRight;
+    /* 0x8 */ u8 analogA;
+    /* 0x9 */ u8 analogB;
+    /* 0xA */ s8 err;
+}; // size = 0xC
+
+struct __anon_0x171A2 {
+    /* 0x00 */ struct PADStatus pst;
+    /* 0x0C */ u16 buttonDown;
+    /* 0x0E */ u16 buttonUp;
+    /* 0x10 */ u16 dirs;
+    /* 0x12 */ u16 dirsNew;
+    /* 0x14 */ u16 dirsReleased;
+    /* 0x16 */ s16 stickDeltaX;
+    /* 0x18 */ s16 stickDeltaY;
+    /* 0x1A */ s16 substickDeltaX;
+    /* 0x1C */ s16 substickDeltaY;
+}; // size = 0x1E
+
+// size = 0x78, address = 0x80132758
+struct __anon_0x171A2 DemoPad[4];
+
+// Range: 0x80011CAC -> 0x80011E60
+s32 movieTestReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r29
+    // s32 forceMenu; // r30
+
+    // Local variables
+    u32 bFlag; // r1+0x8
+    u32 nTick; // r1+0x8
+
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0x171A2 DemoPad[4];
 }
 
-// size: 0x4
-enum __anon_0x17564
-{
-	M_M_NONE = 4294967295,
-	M_M_DISK_COVER_OPEN = 0,
-	M_M_DISK_WRONG_DISK = 1,
-	M_M_DISK_READING_DISK = 2,
-	M_M_DISK_FATAL_ERROR = 3,
-	M_M_DISK_RETRY_ERROR = 4,
-	M_M_DISK_NO_DISK = 5,
-	M_M_DISK_DEFAULT_ERROR = 6
-};
+// Range: 0x80011E60 -> 0x80011F10
+s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset) {
+    // Parameters
+    // struct DVDFileInfo* pFileInfo; // r26
+    // void* anData; // r27
+    // s32 nSizeRead; // r28
+    // s32 nOffset; // r29
 
-int movieDVDShowError(int nStatus)
-{
-	__anon_0x17564 nMessage;
-	// References: gnTickReset (0x50561380)
-	// References: gbReset (0x4C561380)
-	// References: DemoPad (0x58271380)
-	// References: toggle$184 (0x48561380)
-	// References: gMovieErrorToggle (0x44561380)
+    // Local variables
+    s32 nStatus; // r31
+    s32 bRetry; // r30
+
+    // References
+    // -> s32 gMovieErrorToggle;
 }
 
-// Location: 0xB80D80
-unsigned char gcoverOpen[];
+enum __anon_0x17564 {
+    M_M_NONE = -1,
+    M_M_DISK_COVER_OPEN = 0,
+    M_M_DISK_WRONG_DISK = 1,
+    M_M_DISK_READING_DISK = 2,
+    M_M_DISK_FATAL_ERROR = 3,
+    M_M_DISK_RETRY_ERROR = 4,
+    M_M_DISK_NO_DISK = 5,
+    M_M_DISK_DEFAULT_ERROR = 6,
+};
 
-// Location: 0x60570E80
-unsigned char gwrongDisk[];
+// Range: 0x80011F10 -> 0x80012170
+s32 movieDVDShowError(s32 nStatus) {
+    // Parameters
+    // s32 nStatus; // r1+0x8
 
-// Location: 0x800E7680
-unsigned char greadingDisk[];
+    // Local variables
+    enum __anon_0x17564 nMessage; // r31
 
-// Location: 0xE80
-unsigned char gretryErr[];
-
-// Location: 0x60240E80
-unsigned char gfatalErr[];
-
-// Location: 0x800DE0E0
-unsigned char gnoDisk[];
-
-int movieDrawErrorMessage(__anon_0x17564 movieMessage)
-{
-	// References: gfatalErr (0x60240E80)
-	// References: gnoDisk (0x800DE0E0)
-	// References: gretryErr (0xE80)
-	// References: greadingDisk (0x800E7680)
-	// References: gwrongDisk (0x60570E80)
-	// References: gcoverOpen (0xB80D80)
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0x171A2 DemoPad[4];
+    // -> static s32 toggle$184;
+    // -> s32 gMovieErrorToggle;
 }
 
-// Location: 0x60990E80
-signed short Vert_s16[];
+// size = 0x0, address = 0x800DB800
+u8 gcoverOpen[];
 
-// Location: 0x9A0E80
-unsigned long Colors_u32[];
+// size = 0x0, address = 0x800E5760
+u8 gwrongDisk[];
 
-// Location: 0x209A0E80
-unsigned char TexCoords_u8[];
+// size = 0x0, address = 0x800E7680
+u8 greadingDisk[];
 
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
+// size = 0x0, address = 0x800E0000
+u8 gretryErr[];
 
-// size: 0x4
-enum _GXTexFilter
-{
-	GX_NEAR = 0,
-	GX_LINEAR = 1,
-	GX_NEAR_MIP_NEAR = 2,
-	GX_LIN_MIP_NEAR = 3,
-	GX_NEAR_MIP_LIN = 4,
-	GX_LIN_MIP_LIN = 5
-};
+// size = 0x0, address = 0x800E2460
+u8 gfatalErr[];
 
-// size: 0x24
-struct __anon_0x17AF5
-{
-	unsigned short height; // 0x0
-	unsigned short width; // 0x2
-	unsigned long format; // 0x4
-	char *data; // 0x8
-	_GXTexWrapMode wrapS; // 0xC
-	_GXTexWrapMode wrapT; // 0x10
-	_GXTexFilter minFilter; // 0x14
-	_GXTexFilter magFilter; // 0x18
-	float LODBias; // 0x1C
-	unsigned char edgeLODEnable; // 0x20
-	unsigned char minLOD; // 0x21
-	unsigned char maxLOD; // 0x22
-	unsigned char unpacked; // 0x23
-};
+// size = 0x0, address = 0x800DE0E0
+u8 gnoDisk[];
 
-// size: 0x4
-enum _GXTlutFmt
-{
-	GX_TL_IA8 = 0,
-	GX_TL_RGB565 = 1,
-	GX_TL_RGB5A3 = 2,
-	GX_MAX_TLUTFMT = 3
-};
+// Range: 0x80012170 -> 0x80012334
+s32 movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
+    // Parameters
+    // enum __anon_0x17564 movieMessage; // r1+0x8
 
-// size: 0xC
-struct __anon_0x17D50
-{
-	unsigned short numEntries; // 0x0
-	unsigned char unpacked; // 0x2
-	unsigned char pad8; // 0x3
-	_GXTlutFmt format; // 0x4
-	char *data; // 0x8
-};
-
-// size: 0x8
-struct __anon_0x17E1C
-{
-	__anon_0x17AF5 *textureHeader; // 0x0
-	__anon_0x17D50 *CLUTHeader; // 0x4
-};
-
-// size: 0xC
-struct __anon_0x17E8D
-{
-	unsigned long versionNumber; // 0x0
-	unsigned long numDescriptors; // 0x4
-	__anon_0x17E1C *descriptorArray; // 0x8
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-int movieDrawImage(__anon_0x17E8D *tpl, signed short nX0, signed short nY0)
-{
-	_GXTexObj texObj;
-	_GXColor color;
-	float identity_mtx[3][4];
-	float g2DviewMtx[3][4];
-	float g2[3][4];
-	// References: TexCoords_u8 (0x209A0E80)
-	// References: Colors_u32 (0x9A0E80)
-	// References: Vert_s16 (0x60990E80)
-	// References: gOrthoMtx (0x800FC5B0)
+    // References
+    // -> u8 gfatalErr[];
+    // -> u8 gnoDisk[];
+    // -> u8 gretryErr[];
+    // -> u8 greadingDisk[];
+    // -> u8 gwrongDisk[];
+    // -> u8 gcoverOpen[];
 }
 
-int movieGXInit()
-{
-	int i;
-	_GXColor GX_DEFAULT_BG;
-	_GXColor BLACK;
-	_GXColor WHITE;
-	float identity_mtx[3][4];
+// size = 0x0, address = 0x800E9960
+s16 Vert_s16[];
+
+// size = 0x0, address = 0x800E9A00
+u32 Colors_u32[];
+
+// size = 0x0, address = 0x800E9A20
+u8 TexCoords_u8[];
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
+};
+
+enum _GXTexFilter {
+    GX_NEAR = 0,
+    GX_LINEAR = 1,
+    GX_NEAR_MIP_NEAR = 2,
+    GX_LIN_MIP_NEAR = 3,
+    GX_NEAR_MIP_LIN = 4,
+    GX_LIN_MIP_LIN = 5,
+};
+
+struct __anon_0x17AF5 {
+    /* 0x00 */ u16 height;
+    /* 0x02 */ u16 width;
+    /* 0x04 */ u32 format;
+    /* 0x08 */ char* data;
+    /* 0x0C */ enum _GXTexWrapMode wrapS;
+    /* 0x10 */ enum _GXTexWrapMode wrapT;
+    /* 0x14 */ enum _GXTexFilter minFilter;
+    /* 0x18 */ enum _GXTexFilter magFilter;
+    /* 0x1C */ float LODBias;
+    /* 0x20 */ u8 edgeLODEnable;
+    /* 0x21 */ u8 minLOD;
+    /* 0x22 */ u8 maxLOD;
+    /* 0x23 */ u8 unpacked;
+}; // size = 0x24
+
+enum _GXTlutFmt {
+    GX_TL_IA8 = 0,
+    GX_TL_RGB565 = 1,
+    GX_TL_RGB5A3 = 2,
+    GX_MAX_TLUTFMT = 3,
+};
+
+struct __anon_0x17D50 {
+    /* 0x0 */ u16 numEntries;
+    /* 0x2 */ u8 unpacked;
+    /* 0x3 */ u8 pad8;
+    /* 0x4 */ enum _GXTlutFmt format;
+    /* 0x8 */ char* data;
+}; // size = 0xC
+
+struct __anon_0x17E1C {
+    /* 0x0 */ struct __anon_0x17AF5* textureHeader;
+    /* 0x4 */ struct __anon_0x17D50* CLUTHeader;
+}; // size = 0x8
+
+struct __anon_0x17E8D {
+    /* 0x0 */ u32 versionNumber;
+    /* 0x4 */ u32 numDescriptors;
+    /* 0x8 */ struct __anon_0x17E1C* descriptorArray;
+}; // size = 0xC
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+// Range: 0x80012334 -> 0x80012850
+s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
+    // Parameters
+    // struct __anon_0x17E8D* tpl; // r25
+    // s16 nX0; // r26
+    // s16 nY0; // r27
+
+    // Local variables
+    struct _GXTexObj texObj; // r1+0xB0
+    struct _GXColor color; // r1+0xA8
+    float identity_mtx[3][4]; // r1+0x78
+    float g2DviewMtx[3][4]; // r1+0x48
+    float g2[3][4]; // r1+0x18
+
+    // References
+    // -> u8 TexCoords_u8[];
+    // -> u32 Colors_u32[];
+    // -> s16 Vert_s16[];
+    // -> static float gOrthoMtx[4][4];
 }
 
+// Range: 0x80012850 -> 0x80012F20
+s32 movieGXInit() {
+    // Local variables
+    s32 i; // r31
+    struct _GXColor GX_DEFAULT_BG; // r1+0x58
+    struct _GXColor BLACK; // r1+0x54
+    struct _GXColor WHITE; // r1+0x50
+    float identity_mtx[3][4]; // r1+0x20
+}

--- a/debug/Fire/THPRead.c
+++ b/debug/Fire/THPRead.c
@@ -10,19 +10,19 @@
 // size = 0x4, address = 0x80135640
 static s32 ReadThreadCreated;
 
-struct OSThreadQueue {
+typedef struct OSThreadQueue {
     /* 0x0 */ struct OSThread* head;
     /* 0x4 */ struct OSThread* tail;
-}; // size = 0x8
+} __anon_0x14F87; // size = 0x8
 
-struct OSMessageQueue {
+typedef struct OSMessageQueue {
     /* 0x00 */ struct OSThreadQueue queueSend;
     /* 0x08 */ struct OSThreadQueue queueReceive;
     /* 0x10 */ void* msgArray;
     /* 0x14 */ s32 msgCount;
     /* 0x18 */ s32 firstIndex;
     /* 0x1C */ s32 usedCount;
-}; // size = 0x20
+} __anon_0x14FF9; // size = 0x20
 
 // size = 0x20, address = 0x800FB1C0
 static struct OSMessageQueue FreeReadBufferQueue;
@@ -42,7 +42,7 @@ static void* ReadedBufferMessage[10];
 // size = 0x28, address = 0x800FB270
 static void* ReadedBufferMessage2[10];
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -58,31 +58,31 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x15310; // size = 0x2C8
 
-struct OSThreadLink {
+typedef struct OSThreadLink {
     /* 0x0 */ struct OSThread* next;
     /* 0x4 */ struct OSThread* prev;
-}; // size = 0x8
+} __anon_0x15529; // size = 0x8
 
-struct OSMutexLink {
+typedef struct OSMutexLink {
     /* 0x0 */ struct OSMutex* next;
     /* 0x4 */ struct OSMutex* prev;
-}; // size = 0x8
+} __anon_0x1559A; // size = 0x8
 
-struct OSMutex {
+typedef struct OSMutex {
     /* 0x00 */ struct OSThreadQueue queue;
     /* 0x08 */ struct OSThread* thread;
     /* 0x0C */ s32 count;
     /* 0x10 */ struct OSMutexLink link;
-}; // size = 0x18
+} __anon_0x1560A; // size = 0x18
 
-struct OSMutexQueue {
+typedef struct OSMutexQueue {
     /* 0x0 */ struct OSMutex* head;
     /* 0x4 */ struct OSMutex* tail;
-}; // size = 0x8
+} __anon_0x156BB; // size = 0x8
 
-struct OSThread {
+typedef struct OSThread {
     /* 0x000 */ struct OSContext context;
     /* 0x2C8 */ u16 state;
     /* 0x2CA */ u16 attr;
@@ -100,7 +100,7 @@ struct OSThread {
     /* 0x308 */ u32* stackEnd;
     /* 0x30C */ s32 error;
     /* 0x310 */ void* specific[2];
-}; // size = 0x318
+} __anon_0x1574C; // size = 0x318
 
 // size = 0x318, address = 0x800FB298
 static struct OSThread ReadThread;
@@ -177,7 +177,7 @@ void* PopReadedBuffer() {
     // -> static struct OSMessageQueue ReadedBufferQueue;
 }
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -185,9 +185,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x15DE2; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -200,16 +200,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x15F52; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x16178; // size = 0x3C
 
-struct __anon_0x16250 {
+typedef struct __anon_0x16250 {
     /* 0x00 */ char magic[4];
     /* 0x04 */ u32 version;
     /* 0x08 */ u32 bufSize;
@@ -222,46 +222,46 @@ struct __anon_0x16250 {
     /* 0x24 */ u32 offsetDataOffsets;
     /* 0x28 */ u32 movieDataOffsets;
     /* 0x2C */ u32 finalFrameDataOffsets;
-}; // size = 0x30
+} __anon_0x16250; // size = 0x30
 
-struct __anon_0x1647C {
+typedef struct __anon_0x1647C {
     /* 0x0 */ u32 numComponents;
     /* 0x4 */ u8 frameComp[16];
-}; // size = 0x14
+} __anon_0x1647C; // size = 0x14
 
-struct __anon_0x164E4 {
+typedef struct __anon_0x164E4 {
     /* 0x0 */ u32 xSize;
     /* 0x4 */ u32 ySize;
     /* 0x8 */ u32 videoType;
-}; // size = 0xC
+} __anon_0x164E4; // size = 0xC
 
-struct __anon_0x16564 {
+typedef struct __anon_0x16564 {
     /* 0x0 */ u32 sndChannels;
     /* 0x4 */ u32 sndFrequency;
     /* 0x8 */ u32 sndNumSamples;
     /* 0xC */ u32 sndNumTracks;
-}; // size = 0x10
+} __anon_0x16564; // size = 0x10
 
-struct __anon_0x1661E {
+typedef struct __anon_0x1661E {
     /* 0x0 */ u8* ytexture;
     /* 0x4 */ u8* utexture;
     /* 0x8 */ u8* vtexture;
     /* 0xC */ s32 frameNumber;
-}; // size = 0x10
+} __anon_0x1661E; // size = 0x10
 
-struct __anon_0x166D4 {
+typedef struct __anon_0x166D4 {
     /* 0x0 */ s16* buffer;
     /* 0x4 */ s16* curPtr;
     /* 0x8 */ u32 validSample;
-}; // size = 0xC
+} __anon_0x166D4; // size = 0xC
 
-struct __anon_0x1675E {
+typedef struct __anon_0x1675E {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
     /* 0x8 */ s32 isValid;
-}; // size = 0xC
+} __anon_0x1675E; // size = 0xC
 
-struct __anon_0x16849 {
+typedef struct __anon_0x16849 {
     /* 0x000 */ struct DVDFileInfo fileInfo;
     /* 0x03C */ struct __anon_0x16250 header;
     /* 0x06C */ struct __anon_0x1647C compInfo;
@@ -296,7 +296,7 @@ struct __anon_0x16849 {
     /* 0x100 */ struct __anon_0x1675E readBuffer[10];
     /* 0x178 */ struct __anon_0x1661E textureSet[3];
     /* 0x1A8 */ struct __anon_0x166D4 audioBuffer[3];
-}; // size = 0x1D0
+} __anon_0x16849; // size = 0x1D0
 
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x16849 ActivePlayer;
@@ -355,7 +355,7 @@ void movieReset(s32 IPL, s32 forceMenu) {
     // s32 forceMenu; // r31
 }
 
-struct PADStatus {
+typedef struct PADStatus {
     /* 0x0 */ u16 button;
     /* 0x2 */ s8 stickX;
     /* 0x3 */ s8 stickY;
@@ -366,9 +366,9 @@ struct PADStatus {
     /* 0x8 */ u8 analogA;
     /* 0x9 */ u8 analogB;
     /* 0xA */ s8 err;
-}; // size = 0xC
+} __anon_0x17012; // size = 0xC
 
-struct __anon_0x171A2 {
+typedef struct __anon_0x171A2 {
     /* 0x00 */ struct PADStatus pst;
     /* 0x0C */ u16 buttonDown;
     /* 0x0E */ u16 buttonUp;
@@ -379,7 +379,7 @@ struct __anon_0x171A2 {
     /* 0x18 */ s16 stickDeltaY;
     /* 0x1A */ s16 substickDeltaX;
     /* 0x1C */ s16 substickDeltaY;
-}; // size = 0x1E
+} __anon_0x171A2; // size = 0x1E
 
 // size = 0x78, address = 0x80132758
 struct __anon_0x171A2 DemoPad[4];
@@ -416,7 +416,7 @@ s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32
     // -> s32 gMovieErrorToggle;
 }
 
-enum __anon_0x17564 {
+typedef enum __anon_0x17564 {
     M_M_NONE = -1,
     M_M_DISK_COVER_OPEN = 0,
     M_M_DISK_WRONG_DISK = 1,
@@ -425,7 +425,7 @@ enum __anon_0x17564 {
     M_M_DISK_RETRY_ERROR = 4,
     M_M_DISK_NO_DISK = 5,
     M_M_DISK_DEFAULT_ERROR = 6,
-};
+} __anon_0x17564;
 
 // Range: 0x80011F10 -> 0x80012170
 s32 movieDVDShowError(s32 nStatus) {
@@ -484,23 +484,23 @@ u32 Colors_u32[];
 // size = 0x0, address = 0x800E9A20
 u8 TexCoords_u8[];
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x179FB;
 
-enum _GXTexFilter {
+typedef enum _GXTexFilter {
     GX_NEAR = 0,
     GX_LINEAR = 1,
     GX_NEAR_MIP_NEAR = 2,
     GX_LIN_MIP_NEAR = 3,
     GX_NEAR_MIP_LIN = 4,
     GX_LIN_MIP_LIN = 5,
-};
+} __anon_0x17A64;
 
-struct __anon_0x17AF5 {
+typedef struct __anon_0x17AF5 {
     /* 0x00 */ u16 height;
     /* 0x02 */ u16 width;
     /* 0x04 */ u32 format;
@@ -514,44 +514,44 @@ struct __anon_0x17AF5 {
     /* 0x21 */ u8 minLOD;
     /* 0x22 */ u8 maxLOD;
     /* 0x23 */ u8 unpacked;
-}; // size = 0x24
+} __anon_0x17AF5; // size = 0x24
 
-enum _GXTlutFmt {
+typedef enum _GXTlutFmt {
     GX_TL_IA8 = 0,
     GX_TL_RGB565 = 1,
     GX_TL_RGB5A3 = 2,
     GX_MAX_TLUTFMT = 3,
-};
+} __anon_0x17CE8;
 
-struct __anon_0x17D50 {
+typedef struct __anon_0x17D50 {
     /* 0x0 */ u16 numEntries;
     /* 0x2 */ u8 unpacked;
     /* 0x3 */ u8 pad8;
     /* 0x4 */ enum _GXTlutFmt format;
     /* 0x8 */ char* data;
-}; // size = 0xC
+} __anon_0x17D50; // size = 0xC
 
-struct __anon_0x17E1C {
+typedef struct __anon_0x17E1C {
     /* 0x0 */ struct __anon_0x17AF5* textureHeader;
     /* 0x4 */ struct __anon_0x17D50* CLUTHeader;
-}; // size = 0x8
+} __anon_0x17E1C; // size = 0x8
 
-struct __anon_0x17E8D {
+typedef struct __anon_0x17E8D {
     /* 0x0 */ u32 versionNumber;
     /* 0x4 */ u32 numDescriptors;
     /* 0x8 */ struct __anon_0x17E1C* descriptorArray;
-}; // size = 0xC
+} __anon_0x17E8D; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x17F49; // size = 0x20
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x17F8F; // size = 0x4
 
 // Range: 0x80012334 -> 0x80012850
 s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {

--- a/debug/Fire/THPVideoDecode.c
+++ b/debug/Fire/THPVideoDecode.c
@@ -1,347 +1,345 @@
-﻿// Local to compilation unit
-// Location: 0x58561380
-static long VideoDecodeThreadCreated;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\THPVideoDecode.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80012F20 -> 0x80013440
+*/
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
+#include "types.h"
 
-// size: 0x8
-struct OSThreadQueue
-{
-	OSThread *head; // 0x0
-	OSThread *tail; // 0x4
-};
+// size = 0x4, address = 0x80135658
+static s32 VideoDecodeThreadCreated;
 
-// size: 0x8
-struct OSThreadLink
-{
-	OSThread *next; // 0x0
-	OSThread *prev; // 0x4
-};
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
 
-// size: 0x8
-struct OSMutexLink
-{
-	OSMutex *next; // 0x0
-	OSMutex *prev; // 0x4
-};
+struct OSThreadQueue {
+    /* 0x0 */ struct OSThread* head;
+    /* 0x4 */ struct OSThread* tail;
+}; // size = 0x8
 
-// size: 0x18
-struct OSMutex
-{
-	OSThreadQueue queue; // 0x0
-	OSThread *thread; // 0x8
-	long count; // 0xC
-	OSMutexLink link; // 0x10
-};
+struct OSThreadLink {
+    /* 0x0 */ struct OSThread* next;
+    /* 0x4 */ struct OSThread* prev;
+}; // size = 0x8
 
-// size: 0x8
-struct OSMutexQueue
-{
-	OSMutex *head; // 0x0
-	OSMutex *tail; // 0x4
-};
+struct OSMutexLink {
+    /* 0x0 */ struct OSMutex* next;
+    /* 0x4 */ struct OSMutex* prev;
+}; // size = 0x8
 
-// size: 0x318
-struct OSThread
-{
-	OSContext context; // 0x0
-	unsigned short state; // 0x2C8
-	unsigned short attr; // 0x2CA
-	long suspend; // 0x2CC
-	long priority; // 0x2D0
-	long base; // 0x2D4
-	void *val; // 0x2D8
-	OSThreadQueue *queue; // 0x2DC
-	OSThreadLink link; // 0x2E0
-	OSThreadQueue queueJoin; // 0x2E8
-	OSMutex *mutex; // 0x2F0
-	OSMutexQueue queueMutex; // 0x2F4
-	OSThreadLink linkActive; // 0x2FC
-	unsigned char *stackBase; // 0x304
-	unsigned long *stackEnd; // 0x308
-	long error; // 0x30C
-	void *specific[2]; // 0x310
-};
+struct OSMutex {
+    /* 0x00 */ struct OSThreadQueue queue;
+    /* 0x08 */ struct OSThread* thread;
+    /* 0x0C */ s32 count;
+    /* 0x10 */ struct OSMutexLink link;
+}; // size = 0x18
 
-// Local to compilation unit
-// Location: 0x800FC5F0
-static OSThread VideoDecodeThread;
+struct OSMutexQueue {
+    /* 0x0 */ struct OSMutex* head;
+    /* 0x4 */ struct OSMutex* tail;
+}; // size = 0x8
 
-// Local to compilation unit
-// Location: 0x8C90F80
-static unsigned char VideoDecodeThreadStack[4096];
+struct OSThread {
+    /* 0x000 */ struct OSContext context;
+    /* 0x2C8 */ u16 state;
+    /* 0x2CA */ u16 attr;
+    /* 0x2CC */ s32 suspend;
+    /* 0x2D0 */ s32 priority;
+    /* 0x2D4 */ s32 base;
+    /* 0x2D8 */ void* val;
+    /* 0x2DC */ struct OSThreadQueue* queue;
+    /* 0x2E0 */ struct OSThreadLink link;
+    /* 0x2E8 */ struct OSThreadQueue queueJoin;
+    /* 0x2F0 */ struct OSMutex* mutex;
+    /* 0x2F4 */ struct OSMutexQueue queueMutex;
+    /* 0x2FC */ struct OSThreadLink linkActive;
+    /* 0x304 */ u8* stackBase;
+    /* 0x308 */ u32* stackEnd;
+    /* 0x30C */ s32 error;
+    /* 0x310 */ void* specific[2];
+}; // size = 0x318
 
-// size: 0x20
-struct OSMessageQueue
-{
-	OSThreadQueue queueSend; // 0x0
-	OSThreadQueue queueReceive; // 0x8
-	void *msgArray; // 0x10
-	long msgCount; // 0x14
-	long firstIndex; // 0x18
-	long usedCount; // 0x1C
-};
+// size = 0x318, address = 0x800FC5F0
+static struct OSThread VideoDecodeThread;
 
-// Local to compilation unit
-// Location: 0x8D90F80
-static OSMessageQueue FreeTextureSetQueue;
+// size = 0x1000, address = 0x800FC908
+static u8 VideoDecodeThreadStack[4096];
 
-// Local to compilation unit
-// Location: 0x28D90F80
-static OSMessageQueue DecodedTextureSetQueue;
+struct OSMessageQueue {
+    /* 0x00 */ struct OSThreadQueue queueSend;
+    /* 0x08 */ struct OSThreadQueue queueReceive;
+    /* 0x10 */ void* msgArray;
+    /* 0x14 */ s32 msgCount;
+    /* 0x18 */ s32 firstIndex;
+    /* 0x1C */ s32 usedCount;
+}; // size = 0x20
 
-// Local to compilation unit
-// Location: 0x48D90F80
-static void *FreeTextureSetMessage[3];
+// size = 0x20, address = 0x800FD908
+static struct OSMessageQueue FreeTextureSetQueue;
 
-// Local to compilation unit
-// Location: 0x54D90F80
-static void *DecodedTextureSetMessage[3];
+// size = 0x20, address = 0x800FD928
+static struct OSMessageQueue DecodedTextureSetQueue;
 
-// Local to compilation unit
-// Location: 0x5C561380
-static long First;
+// size = 0xC, address = 0x800FD948
+static void* FreeTextureSetMessage[3];
 
-int CreateVideoDecodeThread(long priority, unsigned char *ptr)
-{
-	// References: First (0x5C561380)
-	// References: VideoDecodeThreadCreated (0x58561380)
-	// References: DecodedTextureSetMessage (0x54D90F80)
-	// References: DecodedTextureSetQueue (0x28D90F80)
-	// References: FreeTextureSetMessage (0x48D90F80)
-	// References: FreeTextureSetQueue (0x8D90F80)
-	// References: VideoDecodeThreadStack (0x8C90F80)
-	// References: VideoDecodeThread (0x800FC5F0)
+// size = 0xC, address = 0x800FD954
+static void* DecodedTextureSetMessage[3];
+
+// size = 0x4, address = 0x8013565C
+static s32 First;
+
+// Range: 0x80012F20 -> 0x80013004
+s32 CreateVideoDecodeThread(s32 priority, u8* ptr) {
+    // Parameters
+    // s32 priority; // r8
+    // u8* ptr; // r5
+
+    // References
+    // -> static s32 First;
+    // -> static s32 VideoDecodeThreadCreated;
+    // -> static void* DecodedTextureSetMessage[3];
+    // -> static struct OSMessageQueue DecodedTextureSetQueue;
+    // -> static void* FreeTextureSetMessage[3];
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
+    // -> static u8 VideoDecodeThreadStack[4096];
+    // -> static struct OSThread VideoDecodeThread;
 }
 
-void VideoDecodeThreadStart()
-{
-	// References: VideoDecodeThread (0x800FC5F0)
-	// References: VideoDecodeThreadCreated (0x58561380)
+// Range: 0x80013004 -> 0x80013038
+void VideoDecodeThreadStart() {
+    // References
+    // -> static struct OSThread VideoDecodeThread;
+    // -> static s32 VideoDecodeThreadCreated;
 }
 
-void VideoDecodeThreadCancel()
-{
-	// References: VideoDecodeThreadCreated (0x58561380)
-	// References: VideoDecodeThread (0x800FC5F0)
+// Erased
+static void VideoDecodeThreadCancel() {
+    // References
+    // -> static s32 VideoDecodeThreadCreated;
+    // -> static struct OSThread VideoDecodeThread;
 }
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
 
-// size: 0x30
-struct __anon_0x19428
-{
-	char magic[4]; // 0x0
-	unsigned long version; // 0x4
-	unsigned long bufSize; // 0x8
-	unsigned long audioMaxSamples; // 0xC
-	float frameRate; // 0x10
-	unsigned long numFrames; // 0x14
-	unsigned long firstFrameSize; // 0x18
-	unsigned long movieDataSize; // 0x1C
-	unsigned long compInfoDataOffsets; // 0x20
-	unsigned long offsetDataOffsets; // 0x24
-	unsigned long movieDataOffsets; // 0x28
-	unsigned long finalFrameDataOffsets; // 0x2C
-};
+struct __anon_0x19428 {
+    /* 0x00 */ char magic[4];
+    /* 0x04 */ u32 version;
+    /* 0x08 */ u32 bufSize;
+    /* 0x0C */ u32 audioMaxSamples;
+    /* 0x10 */ float frameRate;
+    /* 0x14 */ u32 numFrames;
+    /* 0x18 */ u32 firstFrameSize;
+    /* 0x1C */ u32 movieDataSize;
+    /* 0x20 */ u32 compInfoDataOffsets;
+    /* 0x24 */ u32 offsetDataOffsets;
+    /* 0x28 */ u32 movieDataOffsets;
+    /* 0x2C */ u32 finalFrameDataOffsets;
+}; // size = 0x30
 
-// size: 0x14
-struct __anon_0x19654
-{
-	unsigned long numComponents; // 0x0
-	unsigned char frameComp[16]; // 0x4
-};
+struct __anon_0x19654 {
+    /* 0x0 */ u32 numComponents;
+    /* 0x4 */ u8 frameComp[16];
+}; // size = 0x14
 
-// size: 0xC
-struct __anon_0x196BC
-{
-	unsigned long xSize; // 0x0
-	unsigned long ySize; // 0x4
-	unsigned long videoType; // 0x8
-};
+struct __anon_0x196BC {
+    /* 0x0 */ u32 xSize;
+    /* 0x4 */ u32 ySize;
+    /* 0x8 */ u32 videoType;
+}; // size = 0xC
 
-// size: 0x10
-struct __anon_0x1973C
-{
-	unsigned long sndChannels; // 0x0
-	unsigned long sndFrequency; // 0x4
-	unsigned long sndNumSamples; // 0x8
-	unsigned long sndNumTracks; // 0xC
-};
+struct __anon_0x1973C {
+    /* 0x0 */ u32 sndChannels;
+    /* 0x4 */ u32 sndFrequency;
+    /* 0x8 */ u32 sndNumSamples;
+    /* 0xC */ u32 sndNumTracks;
+}; // size = 0x10
 
-// size: 0x10
-struct __anon_0x197F6
-{
-	unsigned char *ytexture; // 0x0
-	unsigned char *utexture; // 0x4
-	unsigned char *vtexture; // 0x8
-	long frameNumber; // 0xC
-};
+struct __anon_0x197F6 {
+    /* 0x0 */ u8* ytexture;
+    /* 0x4 */ u8* utexture;
+    /* 0x8 */ u8* vtexture;
+    /* 0xC */ s32 frameNumber;
+}; // size = 0x10
 
-// size: 0xC
-struct __anon_0x198AC
-{
-	signed short *buffer; // 0x0
-	signed short *curPtr; // 0x4
-	unsigned long validSample; // 0x8
-};
+struct __anon_0x198AC {
+    /* 0x0 */ s16* buffer;
+    /* 0x4 */ s16* curPtr;
+    /* 0x8 */ u32 validSample;
+}; // size = 0xC
 
-// size: 0x1D0
-struct __anon_0x1999C
-{
-	DVDFileInfo fileInfo; // 0x0
-	__anon_0x19428 header; // 0x3C
-	__anon_0x19654 compInfo; // 0x6C
-	__anon_0x196BC videoInfo; // 0x80
-	__anon_0x1973C audioInfo; // 0x8C
-	void *thpWork; // 0x9C
-	int open; // 0xA0
-	unsigned char state; // 0xA4
-	unsigned char internalState; // 0xA5
-	unsigned char playFlag; // 0xA6
-	unsigned char audioExist; // 0xA7
-	long dvdError; // 0xA8
-	long videoError; // 0xAC
-	int onMemory; // 0xB0
-	unsigned char *movieData; // 0xB4
-	long initOffset; // 0xB8
-	long initReadSize; // 0xBC
-	long initReadFrame; // 0xC0
-	signed long long retraceCount; // 0xC8
-	long prevCount; // 0xD0
-	long curCount; // 0xD4
-	long videoAhead; // 0xD8
-	float curVolume; // 0xDC
-	float targetVolume; // 0xE0
-	float deltaVolume; // 0xE4
-	long rampCount; // 0xE8
-	long curAudioTrack; // 0xEC
-	long curVideoNumber; // 0xF0
-	long curAudioNumber; // 0xF4
-	__anon_0x197F6 *dispTextureSet; // 0xF8
-	__anon_0x198AC *playAudioBuffer; // 0xFC
-	__anon_0x19FA4 readBuffer[10]; // 0x100
-	__anon_0x197F6 textureSet[3]; // 0x178
-	__anon_0x198AC audioBuffer[3]; // 0x1A8
-};
+struct __anon_0x1999C {
+    /* 0x000 */ struct DVDFileInfo fileInfo;
+    /* 0x03C */ struct __anon_0x19428 header;
+    /* 0x06C */ struct __anon_0x19654 compInfo;
+    /* 0x080 */ struct __anon_0x196BC videoInfo;
+    /* 0x08C */ struct __anon_0x1973C audioInfo;
+    /* 0x09C */ void* thpWork;
+    /* 0x0A0 */ s32 open;
+    /* 0x0A4 */ u8 state;
+    /* 0x0A5 */ u8 internalState;
+    /* 0x0A6 */ u8 playFlag;
+    /* 0x0A7 */ u8 audioExist;
+    /* 0x0A8 */ s32 dvdError;
+    /* 0x0AC */ s32 videoError;
+    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B4 */ u8* movieData;
+    /* 0x0B8 */ s32 initOffset;
+    /* 0x0BC */ s32 initReadSize;
+    /* 0x0C0 */ s32 initReadFrame;
+    /* 0x0C8 */ s64 retraceCount;
+    /* 0x0D0 */ s32 prevCount;
+    /* 0x0D4 */ s32 curCount;
+    /* 0x0D8 */ s32 videoAhead;
+    /* 0x0DC */ float curVolume;
+    /* 0x0E0 */ float targetVolume;
+    /* 0x0E4 */ float deltaVolume;
+    /* 0x0E8 */ s32 rampCount;
+    /* 0x0EC */ s32 curAudioTrack;
+    /* 0x0F0 */ s32 curVideoNumber;
+    /* 0x0F4 */ s32 curAudioNumber;
+    /* 0x0F8 */ struct __anon_0x197F6* dispTextureSet;
+    /* 0x0FC */ struct __anon_0x198AC* playAudioBuffer;
+    /* 0x100 */ struct __anon_0x19FA4 readBuffer[10];
+    /* 0x178 */ struct __anon_0x197F6 textureSet[3];
+    /* 0x1A8 */ struct __anon_0x198AC audioBuffer[3];
+}; // size = 0x1D0
 
-// Location: 0x800F9C80
-__anon_0x1999C ActivePlayer;
+// size = 0x1D0, address = 0x800F9C80
+struct __anon_0x1999C ActivePlayer;
 
-// Local to compilation unit
-static void *VideoDecoder()
-{
-	__anon_0x19FA4 *readBuffer;
-	int old;
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x80013038 -> 0x80013114
+static void* VideoDecoder() {
+    // Local variables
+    struct __anon_0x19FA4* readBuffer; // r28
+    s32 old; // r3
+
+    // References
+    // -> struct __anon_0x1999C ActivePlayer;
 }
 
-// size: 0xC
-struct __anon_0x19FA4
-{
-	unsigned char *ptr; // 0x0
-	long frameNumber; // 0x4
-	int isValid; // 0x8
-};
+struct __anon_0x19FA4 {
+    /* 0x0 */ u8* ptr;
+    /* 0x4 */ s32 frameNumber;
+    /* 0x8 */ s32 isValid;
+}; // size = 0xC
 
-// Local to compilation unit
-static void *VideoDecoderForOnMemory(void *ptr)
-{
-	__anon_0x19FA4 readBuffer;
-	int old;
-	long tmp;
-	long size;
-	long readFrame;
-	// References: VideoDecodeThread (0x800FC5F0)
-	// References: ActivePlayer (0x800F9C80)
+// Range: 0x80013114 -> 0x80013248
+static void* VideoDecoderForOnMemory(void* ptr) {
+    // Parameters
+    // void* ptr; // r1+0x8
+
+    // Local variables
+    struct __anon_0x19FA4 readBuffer; // r1+0x10
+    s32 old; // r3
+    s32 tmp; // r4
+    s32 size; // r29
+    s32 readFrame; // r28
+
+    // References
+    // -> static struct OSThread VideoDecodeThread;
+    // -> struct __anon_0x1999C ActivePlayer;
 }
 
-// Local to compilation unit
-static void VideoDecode(__anon_0x19FA4 *readBuffer)
-{
-	__anon_0x197F6 *textureSet;
-	unsigned long i;
-	unsigned long *compSizePtr;
-	unsigned char *ptr;
-	int old;
-	// References: First (0x5C561380)
-	// References: ActivePlayer (0x800F9C80)
-	// References: VideoDecodeThread (0x800FC5F0)
+// Range: 0x80013248 -> 0x80013368
+static void VideoDecode(struct __anon_0x19FA4* readBuffer) {
+    // Parameters
+    // struct __anon_0x19FA4* readBuffer; // r24
+
+    // Local variables
+    struct __anon_0x197F6* textureSet; // r28
+    u32 i; // r27
+    u32* compSizePtr; // r26
+    u8* ptr; // r25
+    s32 old; // r3
+
+    // References
+    // -> static s32 First;
+    // -> struct __anon_0x1999C ActivePlayer;
+    // -> static struct OSThread VideoDecodeThread;
 }
 
-void *PopFreeTextureSet()
-{
-	void *msg;
-	// References: FreeTextureSetQueue (0x8D90F80)
+// Range: 0x80013368 -> 0x8001339C
+void* PopFreeTextureSet() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
 }
 
-void PushFreeTextureSet(void *buffer)
-{
-	// References: FreeTextureSetQueue (0x8D90F80)
+// Range: 0x8001339C -> 0x800133CC
+void PushFreeTextureSet(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
 }
 
-void *PopDecodedTextureSet(long flag)
-{
-	void *msg;
-	// References: DecodedTextureSetQueue (0x28D90F80)
+// Range: 0x800133CC -> 0x80013410
+void* PopDecodedTextureSet(s32 flag) {
+    // Parameters
+    // s32 flag; // r5
+
+    // Local variables
+    void* msg; // r1+0xC
+
+    // References
+    // -> static struct OSMessageQueue DecodedTextureSetQueue;
 }
 
-void PushDecodedTextureSet(void *buffer)
-{
-	// References: DecodedTextureSetQueue (0x28D90F80)
-}
+// Range: 0x80013410 -> 0x80013440
+void PushDecodedTextureSet(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
 
+    // References
+    // -> static struct OSMessageQueue DecodedTextureSetQueue;
+}

--- a/debug/Fire/THPVideoDecode.c
+++ b/debug/Fire/THPVideoDecode.c
@@ -10,7 +10,7 @@
 // size = 0x4, address = 0x80135658
 static s32 VideoDecodeThreadCreated;
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -26,36 +26,36 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x18425; // size = 0x2C8
 
-struct OSThreadQueue {
+typedef struct OSThreadQueue {
     /* 0x0 */ struct OSThread* head;
     /* 0x4 */ struct OSThread* tail;
-}; // size = 0x8
+} __anon_0x1863E; // size = 0x8
 
-struct OSThreadLink {
+typedef struct OSThreadLink {
     /* 0x0 */ struct OSThread* next;
     /* 0x4 */ struct OSThread* prev;
-}; // size = 0x8
+} __anon_0x186B0; // size = 0x8
 
-struct OSMutexLink {
+typedef struct OSMutexLink {
     /* 0x0 */ struct OSMutex* next;
     /* 0x4 */ struct OSMutex* prev;
-}; // size = 0x8
+} __anon_0x18721; // size = 0x8
 
-struct OSMutex {
+typedef struct OSMutex {
     /* 0x00 */ struct OSThreadQueue queue;
     /* 0x08 */ struct OSThread* thread;
     /* 0x0C */ s32 count;
     /* 0x10 */ struct OSMutexLink link;
-}; // size = 0x18
+} __anon_0x18791; // size = 0x18
 
-struct OSMutexQueue {
+typedef struct OSMutexQueue {
     /* 0x0 */ struct OSMutex* head;
     /* 0x4 */ struct OSMutex* tail;
-}; // size = 0x8
+} __anon_0x18842; // size = 0x8
 
-struct OSThread {
+typedef struct OSThread {
     /* 0x000 */ struct OSContext context;
     /* 0x2C8 */ u16 state;
     /* 0x2CA */ u16 attr;
@@ -73,7 +73,7 @@ struct OSThread {
     /* 0x308 */ u32* stackEnd;
     /* 0x30C */ s32 error;
     /* 0x310 */ void* specific[2];
-}; // size = 0x318
+} __anon_0x188D3; // size = 0x318
 
 // size = 0x318, address = 0x800FC5F0
 static struct OSThread VideoDecodeThread;
@@ -81,14 +81,14 @@ static struct OSThread VideoDecodeThread;
 // size = 0x1000, address = 0x800FC908
 static u8 VideoDecodeThreadStack[4096];
 
-struct OSMessageQueue {
+typedef struct OSMessageQueue {
     /* 0x00 */ struct OSThreadQueue queueSend;
     /* 0x08 */ struct OSThreadQueue queueReceive;
     /* 0x10 */ void* msgArray;
     /* 0x14 */ s32 msgCount;
     /* 0x18 */ s32 firstIndex;
     /* 0x1C */ s32 usedCount;
-}; // size = 0x20
+} __anon_0x18BEF; // size = 0x20
 
 // size = 0x20, address = 0x800FD908
 static struct OSMessageQueue FreeTextureSetQueue;
@@ -136,7 +136,7 @@ static void VideoDecodeThreadCancel() {
     // -> static struct OSThread VideoDecodeThread;
 }
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -144,9 +144,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x18FBA; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -159,16 +159,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x1912A; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x19350; // size = 0x3C
 
-struct __anon_0x19428 {
+typedef struct __anon_0x19428 {
     /* 0x00 */ char magic[4];
     /* 0x04 */ u32 version;
     /* 0x08 */ u32 bufSize;
@@ -181,40 +181,40 @@ struct __anon_0x19428 {
     /* 0x24 */ u32 offsetDataOffsets;
     /* 0x28 */ u32 movieDataOffsets;
     /* 0x2C */ u32 finalFrameDataOffsets;
-}; // size = 0x30
+} __anon_0x19428; // size = 0x30
 
-struct __anon_0x19654 {
+typedef struct __anon_0x19654 {
     /* 0x0 */ u32 numComponents;
     /* 0x4 */ u8 frameComp[16];
-}; // size = 0x14
+} __anon_0x19654; // size = 0x14
 
-struct __anon_0x196BC {
+typedef struct __anon_0x196BC {
     /* 0x0 */ u32 xSize;
     /* 0x4 */ u32 ySize;
     /* 0x8 */ u32 videoType;
-}; // size = 0xC
+} __anon_0x196BC; // size = 0xC
 
-struct __anon_0x1973C {
+typedef struct __anon_0x1973C {
     /* 0x0 */ u32 sndChannels;
     /* 0x4 */ u32 sndFrequency;
     /* 0x8 */ u32 sndNumSamples;
     /* 0xC */ u32 sndNumTracks;
-}; // size = 0x10
+} __anon_0x1973C; // size = 0x10
 
-struct __anon_0x197F6 {
+typedef struct __anon_0x197F6 {
     /* 0x0 */ u8* ytexture;
     /* 0x4 */ u8* utexture;
     /* 0x8 */ u8* vtexture;
     /* 0xC */ s32 frameNumber;
-}; // size = 0x10
+} __anon_0x197F6; // size = 0x10
 
-struct __anon_0x198AC {
+typedef struct __anon_0x198AC {
     /* 0x0 */ s16* buffer;
     /* 0x4 */ s16* curPtr;
     /* 0x8 */ u32 validSample;
-}; // size = 0xC
+} __anon_0x198AC; // size = 0xC
 
-struct __anon_0x1999C {
+typedef struct __anon_0x1999C {
     /* 0x000 */ struct DVDFileInfo fileInfo;
     /* 0x03C */ struct __anon_0x19428 header;
     /* 0x06C */ struct __anon_0x19654 compInfo;
@@ -249,7 +249,7 @@ struct __anon_0x1999C {
     /* 0x100 */ struct __anon_0x19FA4 readBuffer[10];
     /* 0x178 */ struct __anon_0x197F6 textureSet[3];
     /* 0x1A8 */ struct __anon_0x198AC audioBuffer[3];
-}; // size = 0x1D0
+} __anon_0x1999C; // size = 0x1D0
 
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x1999C ActivePlayer;
@@ -264,11 +264,11 @@ static void* VideoDecoder() {
     // -> struct __anon_0x1999C ActivePlayer;
 }
 
-struct __anon_0x19FA4 {
+typedef struct __anon_0x19FA4 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
     /* 0x8 */ s32 isValid;
-}; // size = 0xC
+} __anon_0x19FA4; // size = 0xC
 
 // Range: 0x80013114 -> 0x80013248
 static void* VideoDecoderForOnMemory(void* ptr) {

--- a/debug/Fire/_aspMain.c
+++ b/debug/Fire/_aspMain.c
@@ -1,652 +1,1019 @@
-﻿// Local to compilation unit
-static int rspParseABI4(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	unsigned int *pABI32;
-	unsigned int *pABILast32;
-	unsigned int nSize;
-	// References: nFirstTime$2796 (0x801352D0)
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_aspMain.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80080AA4 -> 0x8008CF0C
+*/
+
+#include "types.h"
+
+// Range: 0x80080AA4 -> 0x800811C0
+static s32 rspParseABI4(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
+
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x40
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2796;
 }
 
-int rspADMEMMove4(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short nDMEMOut;
-	unsigned short nCount;
-	unsigned int nDMEMIn;
+// Erased
+static s32 rspADMEMMove4(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 nDMEMOut; // r1+0x8
+    u16 nCount; // r4
+    u32 nDMEMIn; // r1+0x8
 }
 
-int rspAInterleave4(__anon_0x5845E *pRSP, unsigned int nCommandLo)
-{
-	unsigned int iIndex;
-	unsigned int iIndex2;
+// Erased
+static s32 rspAInterleave4(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    u32 iIndex; // r1+0x0
+    u32 iIndex2; // r9
 }
 
-int rspARingFilter4();
+// Erased
+static s32 rspARingFilter4() {}
 
-// Local to compilation unit
-static int rspInitAudioDMEM4(__anon_0x5845E *pRSP);
-
-// Local to compilation unit
-static int rspParseABI3(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	unsigned int *pABI32;
-	unsigned int *pABILast32;
-	unsigned int nSize;
-	// References: nFirstTime$2757 (0x801352CC)
+// Range: 0x800811C0 -> 0x80082624
+static s32 rspInitAudioDMEM4(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
-int rspADMEMCopy(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
+// Range: 0x80082624 -> 0x80082B94
+static s32 rspParseABI3(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
 
-// Local to compilation unit
-static int rspAMix3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned int i;
-	unsigned int nCount;
-	signed short *srcP;
-	int outData32;
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x38
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2757;
 }
 
-int rspAHalfCut3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int count;
-	int outp;
-	int inpp;
-	int i;
+// Erased
+static s32 rspADMEMCopy(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 }
 
-// Local to compilation unit
-static int rspAEnvMixer3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short vParams[8];
-	int i;
-	int j;
-	int inpp;
-	int outL;
-	int outR;
-	int outFL;
-	int outFR;
-	int count;
-	long id;
-	int waveL;
-	int waveR;
-	int waveI;
-	int srcL;
-	int srcR;
-	int srcFXL;
-	int srcFXR;
+// Range: 0x80082B94 -> 0x80082C2C
+static s32 rspAMix3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r8
+    s16* srcP; // r4
+    s32 outData32; // r6
 }
 
-int rspASaveBuffer3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
+// Erased
+static s32 rspAHalfCut3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s32 count; // r1+0x8
+    s32 outp; // r1+0x8
+    s32 inpp; // r7
+    s32 i; // r8
 }
 
-int rspALoadBuffer3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
+// Range: 0x80082C2C -> 0x80082E60
+static s32 rspAEnvMixer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 vParams[8]; // r1+0x20
+    s32 i; // r27
+    s32 j; // r1+0x8
+    s32 inpp; // r26
+    s32 outL; // r25
+    s32 outR; // r24
+    s32 outFL; // r23
+    s32 outFR; // r22
+    s32 count; // r21
+    s32 id; // r1+0x8
+    s32 waveL; // r20
+    s32 waveR; // r19
+    s32 waveI; // r19
+    s32 srcL; // r18
+    s32 srcR; // r17
+    s32 srcFXL; // r16
+    s32 srcFXR; // r12
 }
 
-int rspASetEnvParam32(__anon_0x5845E *pRSP, unsigned int nCommandLo);
+// Erased
+static s32 rspASaveBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
 
-int rspASetEnvParam3(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
-
-// Local to compilation unit
-static int rspInitAudioDMEM3(__anon_0x5845E *pRSP);
-
-// Local to compilation unit
-static int rspParseABI2(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	unsigned int *pABI32;
-	unsigned int *pABILast32;
-	unsigned int nSize;
-	// References: nFirstTime$2648 (0x801352C8)
+    // Local variables
+    void* pData; // r1+0x14
 }
 
-// Local to compilation unit
-static int rspAPCM8Dec2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int inpp;
-	int outp;
-	int count;
-	signed short flags;
-	signed short vtmp0[8];
-	signed short vtmp1[8];
-	int i;
-	int j;
-	int stateAddr;
-	int s;
-	void *pData;
-	signed short *pStateAddress;
-	signed short *pTempStateAddr;
+// Erased
+static s32 rspALoadBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
+
+    // Local variables
+    void* pData; // r1+0x14
 }
 
-int rspASaveBuffer2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
+// Erased
+static s32 rspASetEnvParam32(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
 }
 
-int rspALoadBuffer2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
+// Erased
+static s32 rspASetEnvParam3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspAEnvMixer2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	signed short vStep[8];
-	unsigned short vParams[8];
-	int i;
-	int j;
-	int inpp;
-	int outL;
-	int outR;
-	int outFL;
-	int outFR;
-	int count;
-	int temp;
-	long id;
-	int waveL;
-	int waveR;
-	int waveI;
-	int srcL;
-	int srcR;
-	int srcFXL;
-	int srcFXR;
+// Range: 0x80082E60 -> 0x8008429C
+static s32 rspInitAudioDMEM3(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
-int rspASetEnvParam22(__anon_0x5845E *pRSP, unsigned int nCommandLo)
-{
-	signed short tmp;
+// Range: 0x8008429C -> 0x80084984
+static s32 rspParseABI2(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
+
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x40
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2648;
 }
 
-int rspASetEnvParam2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	signed short temp;
+// Range: 0x80084984 -> 0x80085218
+static s32 rspAPCM8Dec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r25
+
+    // Local variables
+    s32 inpp; // r31
+    s32 outp; // r30
+    s32 count; // r26
+    s16 flags; // r1+0x8
+    s16 vtmp0[8]; // r1+0x60
+    s16 vtmp1[8]; // r1+0x50
+    s32 i; // r1+0x8
+    s32 j; // r1+0x8
+    s32 stateAddr; // r5
+    s32 s; // r1+0x8
+    void* pData; // r1+0x4C
+    s16* pStateAddress; // r29
+    s16* pTempStateAddr; // r7
 }
 
-int rspAHalfCut2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int count;
-	int outp;
-	int inpp;
-	int i;
+// Erased
+static s32 rspASaveBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
+
+    // Local variables
+    void* pData; // r1+0x14
 }
 
-int rspADMEMCopy2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
+// Erased
+static s32 rspALoadBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
 
-int rspASetLoop2(__anon_0x5845E *pRSP, unsigned int nCommandLo);
-
-// Local to compilation unit
-static int rspADistFilter2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	signed short dpow;
-	int i;
-	signed long long mult;
+    // Local variables
+    void* pData; // r1+0x14
 }
 
-// Local to compilation unit
-static int rspAInterleave2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int outp;
-	int inpr;
-	int inpl;
-	int count;
-	int i;
+// Range: 0x80085218 -> 0x800854F0
+static s32 rspAEnvMixer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16 vStep[8]; // r1+0x3C
+    u16 vParams[8]; // r1+0x2C
+    s32 i; // r28
+    s32 j; // r27
+    s32 inpp; // r26
+    s32 outL; // r25
+    s32 outR; // r24
+    s32 outFL; // r23
+    s32 outFR; // r22
+    s32 count; // r21
+    s32 temp; // r1+0x8
+    s32 id; // r1+0x8
+    s32 waveL; // r20
+    s32 waveR; // r19
+    s32 waveI; // r15
+    s32 srcL; // r18
+    s32 srcR; // r17
+    s32 srcFXL; // r16
+    s32 srcFXR; // r10
 }
 
-// Local to compilation unit
-static int rspAMix2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned int i;
-	unsigned int nCount;
-	signed short *srcP;
-	int outData32;
+// Erased
+static s32 rspASetEnvParam22(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    s16 tmp; // r6
 }
 
-int rspALoadADPCM2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
+// Erased
+static s32 rspASetEnvParam2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    s16 temp; // r7
 }
 
-int rspADMEMMove2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
+// Erased
+static s32 rspAHalfCut2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 
-int rspAWMEMCopy2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
-
-int rspASetBuffer2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short nDMEMIn;
-	unsigned short nDMEMOut;
-	unsigned short nCount;
+    // Local variables
+    s32 count; // r1+0x8
+    s32 outp; // r1+0x8
+    s32 inpp; // r7
+    s32 i; // r8
 }
 
-// Local to compilation unit
-static int rspAFirFilter2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int filterState;
-	int filterTable;
-	int i;
-	int pointer;
-	void *pData;
-	signed short *pStateAddress;
-	signed short flag;
-	signed short vANS[8];
-	signed short vOLD[8];
-	signed short vTP1[8];
-	signed short vT0[8];
-	int accumulator[8];
-	int temp32[8];
-	int stateAddr;
-	signed short anMatrix[8];
-	signed short anInputVec[15];
-	// References: counter$2409 (0x80135788)
+// Erased
+static s32 rspADMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 }
 
-int rspASResample2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	int outp;
-	int outCount;
-	int pitchSpeed;
-	int i;
-	int mainCounter;
+// Erased
+static s32 rspASetLoop2(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
 }
 
-// Local to compilation unit
-static int rspAResample2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	signed short *srcP;
-	signed short *dstP;
-	signed short lastValue;
-	unsigned short nCount;
-	unsigned short i;
-	int nSrcStep;
-	int nCursorPos;
-	unsigned int scratch;
-	unsigned char flags;
-	signed short *pData;
+// Range: 0x800854F0 -> 0x800855FC
+static s32 rspADistFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r26
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16 dpow; // r7
+    s32 i; // r27
+    s64 mult; // r3
 }
 
-// Local to compilation unit
-static int rspANMix2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned int nCount;
-	unsigned int i;
-	signed short *inP;
-	int out;
+// Range: 0x800855FC -> 0x80085848
+static s32 rspAInterleave2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s32 outp; // r6
+    s32 inpr; // r1+0x8
+    s32 inpl; // r1+0x8
+    s32 count; // r7
+    s32 i; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspANoise2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned int nDest;
-	unsigned int nSource;
-	unsigned int nCount;
-	unsigned int i;
-	unsigned int j;
-	signed short vIn[16];
-	signed short vOut[16];
-	signed long long accumulator[8];
+// Range: 0x80085848 -> 0x800858D0
+static s32 rspAMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r7
+    s16* srcP; // r8
+    s32 outData32; // r6
 }
 
-int rspAClearBuffer2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
+// Erased
+static s32 rspALoadADPCM2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r25
 
-int rspAADPCMDec2(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	char *pDMEM8;
-	int anCoef[8];
-	signed short anIData1[8];
-	signed short anOData0[8];
-	signed short *pStateAddress;
-	signed short *pDMEM16;
-	signed short anOData1[8];
-	signed short anIData0[8];
-	signed short anInputVec[10];
-	int nDMEMIn8;
-	int nDMEMOut;
-	int nCount;
-	int nSrcAddress;
-	int nOptPred;
-	int nHeaderBase8;
-	int nVScale;
-	int nScaleI;
-	int i;
-	int nHeader;
-	int nTIndex;
-	signed short *pTempStateAddr;
+    // Local variables
+    void* pData; // r1+0x20
 }
 
-// Local to compilation unit
-static int rspAADPCMDec2Fast(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	unsigned char ucControl;
-	char *pHeader;
-	signed short *pStateAddress;
-	signed short anIData0;
-	int nDMEMOut;
-	int nCount;
-	int nSrcAddress;
-	int nOptPred;
-	int nVScale;
-	int i;
-	unsigned int dwDecodeSelect;
-	unsigned int n;
-	int nA;
-	int nB;
-	signed short nSamp1;
-	signed short nSamp2;
-	signed short *pTempStateAddr;
-	signed short nibble[4];
-	int nOutput;
+// Erased
+static s32 rspADMEMMove2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r1+0x10
 }
 
-// Local to compilation unit
-static int rspInitAudioDMEM2(__anon_0x5845E *pRSP);
-
-// Local to compilation unit
-static int rspParseABI1(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	unsigned int *pABI32;
-	unsigned int *pABILast32;
-	unsigned int nSize;
-	// References: nFirstTime$2148 (0x801352C4)
+// Erased
+static s32 rspAWMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 }
 
-// Local to compilation unit
-static int rspParseABI(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned char *pFUCode;
-	unsigned int nCheckSum;
+// Erased
+static s32 rspASetBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u16 nDMEMIn; // r1+0x0
+    u16 nDMEMOut; // r5
+    u16 nCount; // r1+0x0
 }
 
-int rspALoadADPCM1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	void *pData;
-	unsigned int nCount;
-	int nAddress;
+// Range: 0x800858D0 -> 0x80086680
+static s32 rspAFirFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r16
+
+    // Local variables
+    s32 filterState; // r1+0x8
+    s32 filterTable; // r27
+    s32 i; // r1+0x8
+    s32 pointer; // r19
+    void* pData; // r1+0x114
+    s16* pStateAddress; // r29
+    s16 flag; // r1+0x8
+    s16 vANS[8]; // r1+0x104
+    s16 vOLD[8]; // r1+0xF4
+    s16 vTP1[8]; // r1+0xE4
+    s16 vT0[8]; // r1+0xD4
+    s32 accumulator[8]; // r1+0xB4
+    s32 temp32[8]; // r1+0x94
+    s32 stateAddr; // r1+0x8
+    s16 anMatrix[8]; // r1+0x84
+    s16 anInputVec[15]; // r1+0x64
+
+    // References
+    // -> static s32 counter$2409;
 }
 
-int rspADMEMMove1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short nDMEMOut;
-	unsigned short nCount;
-	unsigned int nDMEMIn;
+// Erased
+static s32 rspASResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    s32 outp; // r7
+    s32 outCount; // r6
+    s32 pitchSpeed; // r8
+    s32 i; // r9
+    s32 mainCounter; // r10
 }
 
-int rspASetLoop1(__anon_0x5845E *pRSP, unsigned int nCommandLo);
+// Range: 0x80086680 -> 0x800868B0
+static s32 rspAResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 
-// Local to compilation unit
-static int rspASetVolume1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short nFlags;
-	unsigned short v;
-	unsigned short t;
-	unsigned short r;
+    // Local variables
+    s16* srcP; // r30
+    s16* dstP; // r29
+    s16 lastValue; // r6
+    u16 nCount; // r28
+    u16 i; // r7
+    s32 nSrcStep; // r1+0x8
+    s32 nCursorPos; // r8
+    u32 scratch; // r1+0x8
+    u8 flags; // r27
+    s16* pData; // r1+0x30
 }
 
-// Local to compilation unit
-static int rspASetBuffer1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned short nDMEMIn;
-	unsigned short nDMEMOut;
-	unsigned short nCount;
+// Range: 0x800868B0 -> 0x8008691C
+static s32 rspANMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 nCount; // r5
+    u32 i; // r1+0x0
+    s16* inP; // r6
+    s32 out; // r5
 }
 
-int rspASegment1(__anon_0x5845E *pRSP, unsigned int nCommandLo);
+// Range: 0x8008691C -> 0x80086BE8
+static s32 rspANoise2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r23
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 
-int rspASaveBuffer1(__anon_0x5845E *pRSP, unsigned int nCommandLo)
-{
-	unsigned int nSize;
-	unsigned int *pData;
-	int nAddress;
+    // Local variables
+    u32 nDest; // r26
+    u32 nSource; // r25
+    u32 nCount; // r24
+    u32 i; // r12
+    u32 j; // r5
+    s16 vIn[16]; // r1+0x78
+    s16 vOut[16]; // r1+0x58
+    s64 accumulator[8]; // r1+0x18
 }
 
-// Local to compilation unit
-static int rspAResample1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	signed short *srcP;
-	signed short *dstP;
-	signed short lastValue;
-	unsigned short nCount;
-	unsigned short i;
-	int nSrcStep;
-	int nCursorPos;
-	int nExtra;
-	unsigned int scratch;
-	unsigned char flags;
-	signed short *pData;
+// Erased
+static s32 rspAClearBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r1+0x10
 }
 
-// Local to compilation unit
-static int rspAMix1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned int i;
-	unsigned int nCount;
-	signed short *srcP;
-	int outData32;
+// Erased
+static s32 rspAADPCMDec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r23
+    char* pDMEM8; // r1+0x110
+    s32 anCoef[8]; // r1+0xF0
+    s16 anIData1[8]; // r1+0xC0
+    s16 anOData0[8]; // r1+0xB0
+    s16* pStateAddress; // r1+0xAC
+    s16* pDMEM16; // r3
+    s16 anOData1[8]; // r1+0x9C
+    s16 anIData0[8]; // r1+0x8C
+    s16 anInputVec[10]; // r1+0x78
+    s32 nDMEMIn8; // r18
+    s32 nDMEMOut; // r30
+    s32 nCount; // r19
+    s32 nSrcAddress; // r1+0x8
+    s32 nOptPred; // r23
+    s32 nHeaderBase8; // r1+0x8
+    s32 nVScale; // r29
+    s32 nScaleI; // r22
+    s32 i; // r1+0x8
+    s32 nHeader; // r25
+    s32 nTIndex; // r1+0x8
+    s16* pTempStateAddr; // r1+0x74
 }
 
-int rspAInterleave1(__anon_0x5845E *pRSP, unsigned int nCommandLo)
-{
-	unsigned short nLeft;
-	unsigned int iIndex;
-	unsigned int iIndex2;
+// Range: 0x80086BE8 -> 0x80087520
+static s32 rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r19
+    u8 ucControl; // r6
+    char* pHeader; // r31
+    s16* pStateAddress; // r1+0x60
+    s16 anIData0; // r19
+    s32 nDMEMOut; // r30
+    s32 nCount; // r29
+    s32 nSrcAddress; // r5
+    s32 nOptPred; // r7
+    s32 nVScale; // r19
+    s32 i; // r1+0x8
+    u32 dwDecodeSelect; // r1+0x8
+    u32 n; // r10
+    s32 nA; // r11
+    s32 nB; // r12
+    s16 nSamp1; // r27
+    s16 nSamp2; // r26
+    s16* pTempStateAddr; // r1+0x50
+    s16 nibble[4]; // r1+0x48
+    s32 nOutput; // r19
 }
 
-// Local to compilation unit
-static int rspAEnvMixer1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	unsigned int s;
-	signed short *pStateAddress;
-	unsigned short anRamp[8];
-	int envVolRateL;
-	int envVolRateR;
-	int envVolFinalL;
-	int envVolFinalR;
-	int volVecL[8];
-	int volVecR[8];
-	signed short anOutL;
-	signed short anOutR;
-	signed short anAuxL;
-	signed short anAuxR;
-	signed short anIn;
-	unsigned int nInptr;
-	unsigned int nOutptrL;
-	unsigned int nOutptrR;
-	unsigned int nAuxptrL;
-	unsigned int nAuxptrR;
-	unsigned int i;
-	unsigned int nSrcAddress;
-	unsigned int nLoopCtl;
-	int nUpDownVolL;
-	int nUpDownVolR;
-	void *pData;
-	int *dataP;
-	signed long long tempL;
-	signed long long tempR;
-	signed long long totalL;
-	signed long long totalR;
-	signed long long resultL;
-	signed long long resultR;
-	int volL;
-	int volR;
-	signed long long temp;
-	int *dataP;
+// Range: 0x80087520 -> 0x800887E8
+static s32 rspInitAudioDMEM2(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
-int rspAClearBuffer1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi);
+// Range: 0x800887E8 -> 0x80088B48
+static s32 rspParseABI1(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x575BD* pTask; // r5
 
-// Local to compilation unit
-static int rspAPoleFilter1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	unsigned short nScale;
-	signed short anCoef[10][8];
-	signed short anEntries[8];
-	signed short nVTemp[8];
-	signed short nTempScale;
-	signed short anIData0[8];
-	signed short anOData0[8];
-	signed short anInputVec[10];
-	signed short *pStateAddress;
-	signed short *pDMEM16;
-	int nDMEMIn;
-	int nDMEMOut;
-	int nCount;
-	int nSrcAddress;
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r5
+    u32* pABI32; // r1+0x28
+    u32* pABILast32; // r30
+    u32 nSize; // r28
+
+    // References
+    // -> static s32 nFirstTime$2148;
 }
 
-int rspAADPCMDec1(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	char *pDMEM8;
-	char *pHeader;
-	int anCoef[8];
-	signed short anIData0[8];
-	signed short anOData0[8];
-	signed short *pStateAddress;
-	signed short *pDMEM16;
-	signed short anInputVec[10];
-	int nDMEMOut;
-	int nCount;
-	int nSrcAddress;
-	int nOptPred;
-	int nVScale;
-	int nScaleI;
-	int i;
-	int nHeader;
-	int nToggle;
-	int nTIndex;
-	signed short *pTempStateAddr;
+// Range: 0x80088B48 -> 0x80088D74
+static s32 rspParseABI(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r31
+
+    // Local variables
+    u8* pFUCode; // r1+0x1C
+    u32 nCheckSum; // r4
 }
 
-// Local to compilation unit
-static int rspAADPCMDec1Fast(__anon_0x5845E *pRSP, unsigned int nCommandLo, unsigned int nCommandHi)
-{
-	unsigned char nFlags;
-	unsigned char ucControl;
-	char *pHeader;
-	signed short *pStateAddress;
-	signed short anIData0;
-	int nDMEMOut;
-	int nCount;
-	int nSrcAddress;
-	int nOptPred;
-	int nVScale;
-	int i;
-	unsigned int dwDecodeSelect;
-	unsigned int n;
-	int nA;
-	int nB;
-	signed short nSamp1;
-	signed short nSamp2;
-	signed short *pTempStateAddr;
-	int nOutput;
+// Erased
+static s32 rspALoadADPCM1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    void* pData; // r1+0x20
+    u32 nCount; // r25
+    s32 nAddress; // r5
 }
 
-int rspALoadBuffer1(__anon_0x5845E *pRSP, unsigned int nCommandLo)
-{
-	void *pData;
-	int nAddress;
+// Erased
+static s32 rspADMEMMove1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 nDMEMOut; // r1+0x8
+    u16 nCount; // r5
+    u32 nDMEMIn; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspLoadADPCMCoefTable2(__anon_0x5845E *pRSP)
-{
-	unsigned int j;
-	unsigned int nCoefIndex;
+// Erased
+static s32 rspASetLoop1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
 }
 
-// Local to compilation unit
-static int rspLoadADPCMCoefTable1(__anon_0x5845E *pRSP)
-{
-	unsigned int j;
-	unsigned int nCoefIndex;
+// Range: 0x80088D74 -> 0x80088E0C
+static s32 rspASetVolume1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u16 nFlags; // r1+0x0
+    u16 v; // r5
+    u16 t; // r7
+    u16 r; // r8
 }
 
-int rspLoadADPCMCoefRow(__anon_0x5845E *pRSP, unsigned int nCoefIndex, unsigned int nOptPred);
+// Range: 0x80088E0C -> 0x80088F14
+static s32 rspASetBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
 
-int rspDumpBinaryDMEMToFile(__anon_0x5845E *pRSP)
-{
-	tXL_FILE *fp;
-	int i;
-	unsigned int nSize;
+    // Local variables
+    u16 nDMEMIn; // r5
+    u16 nDMEMOut; // r6
+    u16 nCount; // r4
 }
 
-int rspDumpMotorolaSDMEMTOFile(__anon_0x5845E *pRSP)
-{
-	tXL_FILE *fp;
-	int i;
-	unsigned int nStartAddress;
-	unsigned int nSize;
-	char acDMEMLine[512];
+// Erased
+static s32 rspASegment1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
 }
 
-int rspDumpDMEMToFile(__anon_0x5845E *pRSP)
-{
-	tXL_FILE *fp;
-	int i;
-	unsigned int nStartAddress;
-	unsigned int nSize;
-	char acDMEMLine[64];
+// Erased
+static s32 rspASaveBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+
+    // Local variables
+    u32 nSize; // r1+0x18
+    u32* pData; // r1+0x14
+    s32 nAddress; // r5
 }
 
-int rspMultPolef(signed short *matrix[8], signed short *vectorIn, signed short *vectorOut)
-{
-	int sum;
-	int vec0;
-	int vec1;
-	int vec2;
-	int vec3;
-	int vec4;
-	int vec5;
-	int vec6;
-	int vec7;
-	int vec8;
-	int vec9;
+// Range: 0x80088F14 -> 0x8008920C
+static s32 rspAResample1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r26
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16* srcP; // r30
+    s16* dstP; // r29
+    s16 lastValue; // r7
+    u16 nCount; // r28
+    u16 i; // r10
+    s32 nSrcStep; // r1+0x8
+    s32 nCursorPos; // r8
+    s32 nExtra; // r3
+    u32 scratch; // r1+0x8
+    u8 flags; // r27
+    s16* pData; // r1+0x34
 }
 
-int rspMultADPCMCoef1(__anon_0x5845E *pRSP, int *matrix, signed short *vectorIn, signed short *vectorOut, int nOptPred)
-{
-	int sum;
-	int vec0;
-	int vec1;
-	int vec2;
-	int vec3;
-	int vec4;
-	int vec5;
-	int vec6;
-	int vec7;
-	int vec8;
+// Range: 0x8008920C -> 0x800892A4
+static s32 rspAMix1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r8
+    s16* srcP; // r4
+    s32 outData32; // r6
 }
 
-int rspDotProduct8x15MatrixBy15x1Vector(signed short *matrix, signed short *vectorIn, signed short *vectorOut)
-{
-	int sum;
-	int vec1;
-	int vec2;
-	int vec3;
-	int vec4;
-	int vec5;
-	int vec6;
-	int vec7;
-	int vec8;
-	int vec9;
-	int vec10;
-	int vec11;
-	int vec12;
-	int vec13;
-	int vec14;
+// Erased
+static s32 rspAInterleave1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    u16 nLeft; // r1+0x0
+    u32 iIndex; // r1+0x0
+    u32 iIndex2; // r9
 }
 
-// Local to compilation unit
-static int rspInitAudioDMEM1(__anon_0x5845E *pRSP);
+// Range: 0x800892A4 -> 0x80089E7C
+static s32 rspAEnvMixer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r23
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
 
+    // Local variables
+    u8 nFlags; // r1+0x104
+    u32 s; // r1+0x8
+    s16* pStateAddress; // r1+0x100
+    u16 anRamp[8]; // r1+0xA8
+    s32 envVolRateL; // r1+0xFC
+    s32 envVolRateR; // r1+0xF8
+    s32 envVolFinalL; // r16
+    s32 envVolFinalR; // r18
+    s32 volVecL[8]; // r1+0x88
+    s32 volVecR[8]; // r1+0x68
+    s16 anOutL; // r24
+    s16 anOutR; // r20
+    s16 anAuxL; // r24
+    s16 anAuxR; // r1+0x8
+    s16 anIn; // r1+0x8
+    u32 nInptr; // r1+0xF4
+    u32 nOutptrL; // r1+0xF0
+    u32 nOutptrR; // r1+0xEC
+    u32 nAuxptrL; // r1+0xE8
+    u32 nAuxptrR; // r1+0xE4
+    u32 i; // r4
+    u32 nSrcAddress; // r1+0x8
+    u32 nLoopCtl; // r1+0xE0
+    s32 nUpDownVolL; // r1+0x8
+    s32 nUpDownVolR; // r1+0x8
+    void* pData; // r1+0x58
+    s32* dataP; // r5
+    s64 tempL; // r1+0xD8
+    s64 tempR; // r1+0xD0
+    s64 totalL; // r1+0xC8
+    s64 totalR; // r30
+    s64 resultL; // r1+0x8
+    s64 resultR; // r6
+    s32 volL; // r1+0x8
+    s32 volR; // r27
+    s64 temp; // r0
+    s32* dataP; // r3
+}
+
+// Erased
+static s32 rspAClearBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r1+0x10
+}
+
+// Range: 0x80089E7C -> 0x8008A7E0
+static s32 rspAPoleFilter1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r25
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r24
+    u16 nScale; // r30
+    s16 anCoef[10][8]; // r1+0xC0
+    s16 anEntries[8]; // r1+0xB0
+    s16 nVTemp[8]; // r1+0xA0
+    s16 nTempScale; // r4
+    s16 anIData0[8]; // r1+0x90
+    s16 anOData0[8]; // r1+0x80
+    s16 anInputVec[10]; // r1+0x6C
+    s16* pStateAddress; // r1+0x68
+    s16* pDMEM16; // r29
+    s32 nDMEMIn; // r28
+    s32 nDMEMOut; // r27
+    s32 nCount; // r26
+    s32 nSrcAddress; // r5
+}
+
+// Erased
+static s32 rspAADPCMDec1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r20
+    char* pDMEM8; // r27
+    char* pHeader; // r1+0xD8
+    s32 anCoef[8]; // r1+0xAC
+    s16 anIData0[8]; // r1+0x8C
+    s16 anOData0[8]; // r1+0x7C
+    s16* pStateAddress; // r1+0x78
+    s16* pDMEM16; // r4
+    s16 anInputVec[10]; // r1+0x64
+    s32 nDMEMOut; // r30
+    s32 nCount; // r14
+    s32 nSrcAddress; // r1+0x8
+    s32 nOptPred; // r1+0x8
+    s32 nVScale; // r1+0x8
+    s32 nScaleI; // r4
+    s32 i; // r1+0x8
+    s32 nHeader; // r23
+    s32 nToggle; // r1+0xD4
+    s32 nTIndex; // r1+0x8
+    s16* pTempStateAddr; // r1+0x60
+}
+
+// Range: 0x8008A7E0 -> 0x8008B080
+static s32 rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r21
+    u8 ucControl; // r6
+    char* pHeader; // r31
+    s16* pStateAddress; // r1+0x60
+    s16 anIData0; // r23
+    s32 nDMEMOut; // r30
+    s32 nCount; // r29
+    s32 nSrcAddress; // r5
+    s32 nOptPred; // r7
+    s32 nVScale; // r1+0x8
+    s32 i; // r1+0x8
+    u32 dwDecodeSelect; // r1+0x8
+    u32 n; // r1+0x8
+    s32 nA; // r8
+    s32 nB; // r9
+    s16 nSamp1; // r10
+    s16 nSamp2; // r1+0x8
+    s16* pTempStateAddr; // r1+0x4C
+    s32 nOutput; // r10
+}
+
+// Erased
+static s32 rspALoadBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+
+    // Local variables
+    void* pData; // r1+0x14
+    s32 nAddress; // r5
+}
+
+// Range: 0x8008B080 -> 0x8008B1FC
+static s32 rspLoadADPCMCoefTable2(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+
+    // Local variables
+    u32 j; // r1+0x8
+    u32 nCoefIndex; // r5
+}
+
+// Range: 0x8008B1FC -> 0x8008B378
+static s32 rspLoadADPCMCoefTable1(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+
+    // Local variables
+    u32 j; // r1+0x8
+    u32 nCoefIndex; // r5
+}
+
+// Erased
+static s32 rspLoadADPCMCoefRow(struct __anon_0x5845E* pRSP, u32 nCoefIndex, u32 nOptPred) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCoefIndex; // r6
+    // u32 nOptPred; // r1+0x10
+}
+
+// Erased
+static s32 rspDumpBinaryDMEMToFile(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+
+    // Local variables
+    struct tXL_FILE* fp; // r1+0x10
+    s32 i; // r30
+    u32 nSize; // r1+0xC
+}
+
+// Erased
+static s32 rspDumpMotorolaSDMEMTOFile(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+
+    // Local variables
+    struct tXL_FILE* fp; // r1+0x220
+    s32 i; // r29
+    u32 nStartAddress; // r28
+    u32 nSize; // r1+0x21C
+    char acDMEMLine[512]; // r1+0x1C
+}
+
+// Erased
+static s32 rspDumpDMEMToFile(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+
+    // Local variables
+    struct tXL_FILE* fp; // r1+0x50
+    s32 i; // r30
+    u32 nStartAddress; // r29
+    u32 nSize; // r1+0x4C
+    char acDMEMLine[64]; // r1+0xC
+}
+
+// Range: 0x8008B378 -> 0x8008B768
+s32 rspMultPolef(s16 (*matrix)[8], s16* vectorIn, s16* vectorOut) {
+    // Parameters
+    // s16 (* matrix)[8]; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+
+    // Local variables
+    s32 sum; // r22
+    s32 vec0; // r1+0x8
+    s32 vec1; // r1+0x8
+    s32 vec2; // r8
+    s32 vec3; // r9
+    s32 vec4; // r10
+    s32 vec5; // r11
+    s32 vec6; // r12
+    s32 vec7; // r31
+    s32 vec8; // r5
+    s32 vec9; // r1+0x8
+}
+
+// Erased
+static s32 rspMultADPCMCoef1(struct __anon_0x5845E* pRSP, s32* matrix, s16* vectorIn, s16* vectorOut, s32 nOptPred) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32* matrix; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+    // s32 nOptPred; // r1+0x18
+
+    // Local variables
+    s32 sum; // r12
+    s32 vec0; // r1+0x8
+    s32 vec1; // r1+0x8
+    s32 vec2; // r26
+    s32 vec3; // r25
+    s32 vec4; // r24
+    s32 vec5; // r23
+    s32 vec6; // r22
+    s32 vec7; // r21
+    s32 vec8; // r20
+}
+
+// Range: 0x8008B768 -> 0x8008BBDC
+s32 rspDotProduct8x15MatrixBy15x1Vector(s16* matrix, s16* vectorIn, s16* vectorOut) {
+    // Parameters
+    // s16* matrix; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+
+    // Local variables
+    s32 sum; // r12
+    s32 vec1; // r1+0x8
+    s32 vec2; // r1+0x8
+    s32 vec3; // r1+0x8
+    s32 vec4; // r1+0x8
+    s32 vec5; // r1+0x8
+    s32 vec6; // r1+0x8
+    s32 vec7; // r1+0x8
+    s32 vec8; // r31
+    s32 vec9; // r30
+    s32 vec10; // r29
+    s32 vec11; // r28
+    s32 vec12; // r27
+    s32 vec13; // r26
+    s32 vec14; // r5
+}
+
+// Range: 0x8008BBDC -> 0x8008CF0C
+static s32 rspInitAudioDMEM1(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+}

--- a/debug/Fire/_buildtev.c
+++ b/debug/Fire/_buildtev.c
@@ -1,0 +1,360 @@
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_buildtev.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x800986A4 -> 0x8009BABC
+*/
+
+#include "types.h"
+
+enum _GXTevColorArg {
+    GX_CC_CPREV = 0,
+    GX_CC_APREV = 1,
+    GX_CC_C0 = 2,
+    GX_CC_A0 = 3,
+    GX_CC_C1 = 4,
+    GX_CC_A1 = 5,
+    GX_CC_C2 = 6,
+    GX_CC_A2 = 7,
+    GX_CC_TEXC = 8,
+    GX_CC_TEXA = 9,
+    GX_CC_RASC = 10,
+    GX_CC_RASA = 11,
+    GX_CC_ONE = 12,
+    GX_CC_HALF = 13,
+    GX_CC_KONST = 14,
+    GX_CC_ZERO = 15,
+    GX_CC_TEXRRR = 16,
+    GX_CC_TEXGGG = 17,
+    GX_CC_TEXBBB = 18,
+    GX_CC_QUARTER = 14,
+};
+
+// size = 0x40, address = 0x800F0460
+enum _GXTevColorArg gColorArgs[16];
+
+enum _GXTevAlphaArg {
+    GX_CA_APREV = 0,
+    GX_CA_A0 = 1,
+    GX_CA_A1 = 2,
+    GX_CA_A2 = 3,
+    GX_CA_TEXA = 4,
+    GX_CA_RASA = 5,
+    GX_CA_KONST = 6,
+    GX_CA_ZERO = 7,
+    GX_CA_ONE = 6,
+};
+
+// size = 0x28, address = 0x800F04A0
+enum _GXTevAlphaArg gAlphaArgs[10];
+
+enum _GXTevOp {
+    GX_TEV_ADD = 0,
+    GX_TEV_SUB = 1,
+    GX_TEV_COMP_R8_GT = 8,
+    GX_TEV_COMP_R8_EQ = 9,
+    GX_TEV_COMP_GR16_GT = 10,
+    GX_TEV_COMP_GR16_EQ = 11,
+    GX_TEV_COMP_BGR24_GT = 12,
+    GX_TEV_COMP_BGR24_EQ = 13,
+    GX_TEV_COMP_RGB8_GT = 14,
+    GX_TEV_COMP_RGB8_EQ = 15,
+    GX_TEV_COMP_A8_GT = 14,
+    GX_TEV_COMP_A8_EQ = 15,
+};
+
+enum _GXTevBias {
+    GX_TB_ZERO = 0,
+    GX_TB_ADDHALF = 1,
+    GX_TB_SUBHALF = 2,
+    GX_MAX_TEVBIAS = 3,
+};
+
+enum _GXTevScale {
+    GX_CS_SCALE_1 = 0,
+    GX_CS_SCALE_2 = 1,
+    GX_CS_SCALE_4 = 2,
+    GX_CS_DIVIDE_2 = 3,
+    GX_MAX_TEVSCALE = 4,
+};
+
+enum _GXTevRegID {
+    GX_TEVPREV = 0,
+    GX_TEVREG0 = 1,
+    GX_TEVREG1 = 2,
+    GX_TEVREG2 = 3,
+    GX_MAX_TEVREG = 4,
+};
+
+struct TevColorOp {
+    /* 0x00 */ enum _GXTevOp op;
+    /* 0x04 */ enum _GXTevBias bias;
+    /* 0x08 */ enum _GXTevScale scale;
+    /* 0x0C */ u8 clamp;
+    /* 0x10 */ enum _GXTevRegID out_reg;
+}; // size = 0x14
+
+// size = 0x50, address = 0x800F04C8
+static struct TevColorOp sUsualOps[4];
+
+// size = 0x10, address = 0x800F0518
+static enum _GXTevColorArg sUsualCArgs[4];
+
+// size = 0x10, address = 0x800F0528
+static enum _GXTevAlphaArg sUsualAArgs[4];
+
+// size = 0x8, address = 0x80135400
+static s32 zeroType$182[2];
+
+// size = 0x20, address = 0x800F0538
+static s32 texelType$183[2][4];
+
+// size = 0x10, address = 0x800F0558
+static s32 lightType$184[2][2];
+
+enum _GXTexCoordID {
+    GX_TEXCOORD0 = 0,
+    GX_TEXCOORD1 = 1,
+    GX_TEXCOORD2 = 2,
+    GX_TEXCOORD3 = 3,
+    GX_TEXCOORD4 = 4,
+    GX_TEXCOORD5 = 5,
+    GX_TEXCOORD6 = 6,
+    GX_TEXCOORD7 = 7,
+    GX_MAX_TEXCOORD = 8,
+    GX_TEXCOORD_NULL = 255,
+};
+
+enum _GXTexMapID {
+    GX_TEXMAP0 = 0,
+    GX_TEXMAP1 = 1,
+    GX_TEXMAP2 = 2,
+    GX_TEXMAP3 = 3,
+    GX_TEXMAP4 = 4,
+    GX_TEXMAP5 = 5,
+    GX_TEXMAP6 = 6,
+    GX_TEXMAP7 = 7,
+    GX_MAX_TEXMAP = 8,
+    GX_TEXMAP_NULL = 255,
+    GX_TEX_DISABLE = 256,
+};
+
+enum _GXChannelID {
+    GX_COLOR0 = 0,
+    GX_COLOR1 = 1,
+    GX_ALPHA0 = 2,
+    GX_ALPHA1 = 3,
+    GX_COLOR0A0 = 4,
+    GX_COLOR1A1 = 5,
+    GX_COLOR_ZERO = 6,
+    GX_ALPHA_BUMP = 7,
+    GX_ALPHA_BUMPN = 8,
+    GX_COLOR_NULL = 255,
+};
+
+struct TevOrder {
+    /* 0x0 */ enum _GXTexCoordID coordID;
+    /* 0x4 */ enum _GXTexMapID mapID;
+    /* 0x8 */ enum _GXChannelID chanID;
+}; // size = 0xC
+
+struct CombineModeTev {
+    /* 0x000 */ u32 ccCodes[2][2];
+    /* 0x010 */ u8 numCycles;
+    /* 0x011 */ u8 numStages;
+    /* 0x012 */ u8 numTexGen;
+    /* 0x013 */ u8 numChan;
+    /* 0x014 */ u32 flags;
+    /* 0x018 */ struct TevOrder tevOrder[8];
+    /* 0x078 */ struct TevColorOp tevColorOpP[8][2];
+    /* 0x1B8 */ enum _GXTevColorArg tevColorArg[8][4];
+    /* 0x238 */ enum _GXTevAlphaArg tevAlphaArg[8][4];
+}; // size = 0x2B8
+
+// size = 0x2B8, address = 0x80130C50
+static struct CombineModeTev tevStages$519;
+
+// Range: 0x800986A4 -> 0x80098AE0
+struct CombineModeTev* BuildCombineModeTev(u32 color1, u32 alpha1, u32 color2, u32 alpha2, u32 numCycles) {
+    // Parameters
+    // u32 color1; // r26
+    // u32 alpha1; // r27
+    // u32 color2; // r28
+    // u32 alpha2; // r29
+    // u32 numCycles; // r30
+
+    // Local variables
+    u8 stageValues[2][2][4]; // r1+0x28
+    s32 i; // r1+0x8
+    s32 j; // r6
+    u8* tempPtr; // r1+0x8
+
+    // References
+    // -> static struct CombineModeTev tevStages$519;
+    // -> static enum _GXTevAlphaArg sUsualAArgs[4];
+    // -> static enum _GXTevColorArg sUsualCArgs[4];
+}
+
+// Range: 0x80098AE0 -> 0x80098BCC
+void BuildCycle(struct CombineModeTev* tvP, u8 (*stageValues)[4]) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r31
+    // u8 (* stageValues)[4]; // r29
+
+    // Local variables
+    s32 numCParts; // r1+0x8
+    s32 numAParts; // r1+0x8
+    s32 i; // r5
+}
+
+// Range: 0x80098BCC -> 0x8009B6BC
+s32 SetupStage(struct CombineModeTev* tvP, u8* stageValues, s32 type) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r26
+    // u8* stageValues; // r27
+    // s32 type; // r22
+
+    // Local variables
+    s32 zero; // r1+0x8
+    s32 curStage; // r31
+    s32 textureFoundPos; // r30
+    s32 numFound[2]; // r1+0x18
+    s32 retStages; // r29
+    s32 ret; // r1+0x8
+    s32 i; // r21
+    s32 num; // r6
+    s32 j; // r7
+    s32 foundTypes; // r28
+    s32 texelNum; // r10
+    s32 mask; // r5
+    s32 mask; // r21
+    s32 index1; // r1+0x8
+    s32 index2; // r23
+    s32 index1; // r1+0x8
+    s32 index2; // r23
+    s32 flag; // r7
+    s32 mask; // r4
+
+    // References
+    // -> enum _GXTevAlphaArg gAlphaArgs[10];
+    // -> static struct TevColorOp sUsualOps[4];
+    // -> enum _GXTevColorArg gColorArgs[16];
+    // -> static s32 lightType$184[2][2];
+    // -> static s32 texelType$183[2][4];
+    // -> static s32 zeroType$182[2];
+}
+
+// Erased
+static void AddColorTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r1+0x0
+    // s32 foundTypes; // r1+0x4
+    // s32 curStage; // r1+0x8
+}
+
+// Range: 0x8009B6BC -> 0x8009B7DC
+static s32 AddAlphaTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r1+0x0
+    // s32 foundTypes; // r1+0x4
+    // s32 curStage; // r5
+
+    // Local variables
+    s32 ret; // r6
+
+    // References
+    // -> static struct TevColorOp sUsualOps[4];
+}
+
+// Range: 0x8009B7DC -> 0x8009B914
+void SetAlpha(u8* stageValues, u32 alphaVal, u8 cycle) {
+    // Parameters
+    // u8* stageValues; // r1+0x0
+    // u32 alphaVal; // r1+0x4
+    // u8 cycle; // r1+0x8
+
+    // Local variables
+    s32 i; // r8
+}
+
+enum __anon_0x8A896 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
+
+struct __anon_0x8A8FE {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x8A9AF {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
+};
+
+enum __anon_0x8AAE1 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
+};
+
+struct __anon_0x8AC22 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x8A896 eMode;
+    /* 0x10 */ struct __anon_0x8A8FE romCopy;
+    /* 0x20 */ enum __anon_0x8A9AF eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x8AAE1 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x8AC22* gpSystem;
+
+// Range: 0x8009B914 -> 0x8009BABC
+void SetColor(u8* stageValues, u32 colorVal, u8 cycle) {
+    // Parameters
+    // u8* stageValues; // r1+0x0
+    // u32 colorVal; // r1+0x4
+    // u8 cycle; // r1+0x8
+
+    // Local variables
+    s32 i; // r10
+
+    // References
+    // -> struct __anon_0x8AC22* gpSystem;
+}

--- a/debug/Fire/_buildtev.c
+++ b/debug/Fire/_buildtev.c
@@ -7,7 +7,7 @@
 
 #include "types.h"
 
-enum _GXTevColorArg {
+typedef enum _GXTevColorArg {
     GX_CC_CPREV = 0,
     GX_CC_APREV = 1,
     GX_CC_C0 = 2,
@@ -28,12 +28,12 @@ enum _GXTevColorArg {
     GX_CC_TEXGGG = 17,
     GX_CC_TEXBBB = 18,
     GX_CC_QUARTER = 14,
-};
+} __anon_0x891C8;
 
 // size = 0x40, address = 0x800F0460
 enum _GXTevColorArg gColorArgs[16];
 
-enum _GXTevAlphaArg {
+typedef enum _GXTevAlphaArg {
     GX_CA_APREV = 0,
     GX_CA_A0 = 1,
     GX_CA_A1 = 2,
@@ -43,12 +43,12 @@ enum _GXTevAlphaArg {
     GX_CA_KONST = 6,
     GX_CA_ZERO = 7,
     GX_CA_ONE = 6,
-};
+} __anon_0x89366;
 
 // size = 0x28, address = 0x800F04A0
 enum _GXTevAlphaArg gAlphaArgs[10];
 
-enum _GXTevOp {
+typedef enum _GXTevOp {
     GX_TEV_ADD = 0,
     GX_TEV_SUB = 1,
     GX_TEV_COMP_R8_GT = 8,
@@ -61,38 +61,38 @@ enum _GXTevOp {
     GX_TEV_COMP_RGB8_EQ = 15,
     GX_TEV_COMP_A8_GT = 14,
     GX_TEV_COMP_A8_EQ = 15,
-};
+} __anon_0x8945B;
 
-enum _GXTevBias {
+typedef enum _GXTevBias {
     GX_TB_ZERO = 0,
     GX_TB_ADDHALF = 1,
     GX_TB_SUBHALF = 2,
     GX_MAX_TEVBIAS = 3,
-};
+} __anon_0x89586;
 
-enum _GXTevScale {
+typedef enum _GXTevScale {
     GX_CS_SCALE_1 = 0,
     GX_CS_SCALE_2 = 1,
     GX_CS_SCALE_4 = 2,
     GX_CS_DIVIDE_2 = 3,
     GX_MAX_TEVSCALE = 4,
-};
+} __anon_0x895F1;
 
-enum _GXTevRegID {
+typedef enum _GXTevRegID {
     GX_TEVPREV = 0,
     GX_TEVREG0 = 1,
     GX_TEVREG1 = 2,
     GX_TEVREG2 = 3,
     GX_MAX_TEVREG = 4,
-};
+} __anon_0x89674;
 
-struct TevColorOp {
+typedef struct TevColorOp {
     /* 0x00 */ enum _GXTevOp op;
     /* 0x04 */ enum _GXTevBias bias;
     /* 0x08 */ enum _GXTevScale scale;
     /* 0x0C */ u8 clamp;
     /* 0x10 */ enum _GXTevRegID out_reg;
-}; // size = 0x14
+} __anon_0x896E8; // size = 0x14
 
 // size = 0x50, address = 0x800F04C8
 static struct TevColorOp sUsualOps[4];
@@ -112,7 +112,7 @@ static s32 texelType$183[2][4];
 // size = 0x10, address = 0x800F0558
 static s32 lightType$184[2][2];
 
-enum _GXTexCoordID {
+typedef enum _GXTexCoordID {
     GX_TEXCOORD0 = 0,
     GX_TEXCOORD1 = 1,
     GX_TEXCOORD2 = 2,
@@ -123,9 +123,9 @@ enum _GXTexCoordID {
     GX_TEXCOORD7 = 7,
     GX_MAX_TEXCOORD = 8,
     GX_TEXCOORD_NULL = 255,
-};
+} __anon_0x89A00;
 
-enum _GXTexMapID {
+typedef enum _GXTexMapID {
     GX_TEXMAP0 = 0,
     GX_TEXMAP1 = 1,
     GX_TEXMAP2 = 2,
@@ -137,9 +137,9 @@ enum _GXTexMapID {
     GX_MAX_TEXMAP = 8,
     GX_TEXMAP_NULL = 255,
     GX_TEX_DISABLE = 256,
-};
+} __anon_0x89AD9;
 
-enum _GXChannelID {
+typedef enum _GXChannelID {
     GX_COLOR0 = 0,
     GX_COLOR1 = 1,
     GX_ALPHA0 = 2,
@@ -150,15 +150,15 @@ enum _GXChannelID {
     GX_ALPHA_BUMP = 7,
     GX_ALPHA_BUMPN = 8,
     GX_COLOR_NULL = 255,
-};
+} __anon_0x89BAF;
 
-struct TevOrder {
+typedef struct TevOrder {
     /* 0x0 */ enum _GXTexCoordID coordID;
     /* 0x4 */ enum _GXTexMapID mapID;
     /* 0x8 */ enum _GXChannelID chanID;
-}; // size = 0xC
+} __anon_0x89C77; // size = 0xC
 
-struct CombineModeTev {
+typedef struct CombineModeTev {
     /* 0x000 */ u32 ccCodes[2][2];
     /* 0x010 */ u8 numCycles;
     /* 0x011 */ u8 numStages;
@@ -169,7 +169,7 @@ struct CombineModeTev {
     /* 0x078 */ struct TevColorOp tevColorOpP[8][2];
     /* 0x1B8 */ enum _GXTevColorArg tevColorArg[8][4];
     /* 0x238 */ enum _GXTevAlphaArg tevAlphaArg[8][4];
-}; // size = 0x2B8
+} __anon_0x89DF5; // size = 0x2B8
 
 // size = 0x2B8, address = 0x80130C50
 static struct CombineModeTev tevStages$519;
@@ -277,20 +277,20 @@ void SetAlpha(u8* stageValues, u32 alphaVal, u8 cycle) {
     s32 i; // r8
 }
 
-enum __anon_0x8A896 {
+typedef enum __anon_0x8A896 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x8A896;
 
-struct __anon_0x8A8FE {
+typedef struct __anon_0x8A8FE {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x8A8FE; // size = 0x10
 
-enum __anon_0x8A9AF {
+typedef enum __anon_0x8A9AF {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -305,9 +305,9 @@ enum __anon_0x8A9AF {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x8A9AF;
 
-enum __anon_0x8AAE1 {
+typedef enum __anon_0x8AAE1 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -326,9 +326,9 @@ enum __anon_0x8AAE1 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x8AAE1;
 
-struct __anon_0x8AC22 {
+typedef struct __anon_0x8AC22 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -340,7 +340,7 @@ struct __anon_0x8AC22 {
     /* 0x70 */ enum __anon_0x8AAE1 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x8AC22; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x8AC22* gpSystem;

--- a/debug/Fire/_cpuDecodePPC2.c
+++ b/debug/Fire/_cpuDecodePPC2.c
@@ -1,242 +1,368 @@
-﻿// Local to compilation unit
-static int cpuCompile_LWR(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_cpuDecodePPC2.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80068368 -> 0x8006BE68
+*/
+
+#include "types.h"
+
+// Range: 0x80068368 -> 0x800684F4
+static s32 cpuCompile_LWR(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LWL(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x800684F4 -> 0x80068684
+static s32 cpuCompile_LWL(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r9
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_SDC(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068684 -> 0x8006880C
+static s32 cpuCompile_SDC(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LDC(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006880C -> 0x80068994
+static s32 cpuCompile_LDC(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_SW(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068994 -> 0x80068AF0
+static s32 cpuCompile_SW(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_SH(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068AF0 -> 0x80068C4C
+static s32 cpuCompile_SH(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_SB(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068C4C -> 0x80068DA8
+static s32 cpuCompile_SB(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LHU(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068DA8 -> 0x80068F00
+static s32 cpuCompile_LHU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LBU(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80068F00 -> 0x80069058
+static s32 cpuCompile_LBU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LW(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069058 -> 0x800691B0
+static s32 cpuCompile_LW(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LH(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x800691B0 -> 0x8006931C
+static s32 cpuCompile_LH(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r9
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_LB(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006931C -> 0x80069488
+static s32 cpuCompile_LB(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r9
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_TRUNC_W(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_TRUNC_W(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_ROUND_W(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_ROUND_W(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_FLOOR_W(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069488 -> 0x80069644
+static s32 cpuCompile_FLOOR_W(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_CEIL_W(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069644 -> 0x80069800
+static s32 cpuCompile_CEIL_W(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_L_CVT_SD(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069800 -> 0x80069D80
+static s32 cpuCompile_L_CVT_SD(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_W_CVT_SD(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069D80 -> 0x80069F30
+static s32 cpuCompile_W_CVT_SD(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r30
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r30
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_D_SQRT(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x80069F30 -> 0x8006A364
+static s32 cpuCompile_D_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r22
+    // s32* addressGCN; // r21
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r21
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_S_SQRT(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006A364 -> 0x8006A6A4
+static s32 cpuCompile_S_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r19
+    // s32* addressGCN; // r18
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r29
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_DSUBU(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_DSUBU(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_DSUB(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_DSUB(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_DADDU(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_DADDU(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-int cpuCompile_DADD(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Erased
+static s32 cpuCompile_DADD(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DDIVU(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006A6A4 -> 0x8006AAC0
+static s32 cpuCompile_DDIVU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r24
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r9
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DDIV(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006AAC0 -> 0x8006B07C
+static s32 cpuCompile_DDIV(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r16
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r23
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DMULTU(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006B07C -> 0x8006B390
+static s32 cpuCompile_DMULTU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r30
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DMULT(_CPU *pCPU, int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006B390 -> 0x8006B894
+static s32 cpuCompile_DMULT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r27
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DSRAV(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006B894 -> 0x8006BA98
+static s32 cpuCompile_DSRAV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r1+0x8
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DSRLV(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
+// Range: 0x8006BA98 -> 0x8006BC80
+static s32 cpuCompile_DSRLV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r11
+    s32 nSize; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuCompile_DSLLV(int *addressGCN)
-{
-	int *compile;
-	int count;
-	int nSize;
-}
+// Range: 0x8006BC80 -> 0x8006BE68
+static s32 cpuCompile_DSLLV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
 
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r11
+    s32 nSize; // r1+0x8
+}

--- a/debug/Fire/_cpuGCN.c
+++ b/debug/Fire/_cpuGCN.c
@@ -1,286 +1,456 @@
-﻿int cpuExecute(_CPU *pCPU)
-{
-	int iGPR;
-	int *pnCode;
-	int nData;
-	cpu_function *pFunction;
-	void (*pfCode)();
-	// References: cpuCompile_LWR_function (0x5C571380)
-	// References: cpuCompile_LWL_function (0x58571380)
-	// References: cpuCompile_SDC_function (0x54571380)
-	// References: cpuCompile_LDC_function (0x50571380)
-	// References: cpuCompile_SW_function (0x4C571380)
-	// References: cpuCompile_SH_function (0x48571380)
-	// References: cpuCompile_SB_function (0x44571380)
-	// References: cpuCompile_LHU_function (0x40571380)
-	// References: cpuCompile_LBU_function (0x3C571380)
-	// References: cpuCompile_LW_function (0x38571380)
-	// References: cpuCompile_LH_function (0x34571380)
-	// References: cpuCompile_LB_function (0x30571380)
-	// References: cpuCompile_ROUND_W_function (0x28571380)
-	// References: cpuCompile_TRUNC_W_function (0x2C571380)
-	// References: cpuCompile_FLOOR_W_function (0x24571380)
-	// References: cpuCompile_CEIL_W_function (0x20571380)
-	// References: cpuCompile_L_CVT_SD_function (0x1C571380)
-	// References: cpuCompile_W_CVT_SD_function (0x18571380)
-	// References: cpuCompile_D_SQRT_function (0x14571380)
-	// References: cpuCompile_S_SQRT_function (0x10571380)
-	// References: cpuCompile_DSUBU_function (0xC571380)
-	// References: cpuCompile_DSUB_function (0x8571380)
-	// References: cpuCompile_DADDU_function (0x4571380)
-	// References: cpuCompile_DADD_function (0x571380)
-	// References: cpuCompile_DDIVU_function (0x801356FC)
-	// References: cpuCompile_DDIV_function (0x801356F8)
-	// References: cpuCompile_DMULTU_function (0x801356F4)
-	// References: cpuCompile_DMULT_function (0x801356F0)
-	// References: cpuCompile_DSRAV_function (0x801356EC)
-	// References: cpuCompile_DSRLV_function (0x801356E8)
-	// References: cpuCompile_DSLLV_function (0x801356E4)
-	// References: ganMapGPR (0x70BE0E80)
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_cpuGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80036870 -> 0x80068368
+*/
+
+#include "types.h"
+
+// Range: 0x80036870 -> 0x800374DC
+s32 cpuExecute(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 iGPR; // r8
+    s32* pnCode; // r1+0x54
+    s32 nData; // r1+0x8
+    struct cpu_function* pFunction; // r1+0x4C
+    void (*pfCode)(); // r1+0x48
+
+    // References
+    // -> static s32 cpuCompile_LWR_function;
+    // -> static s32 cpuCompile_LWL_function;
+    // -> static s32 cpuCompile_SDC_function;
+    // -> static s32 cpuCompile_LDC_function;
+    // -> static s32 cpuCompile_SW_function;
+    // -> static s32 cpuCompile_SH_function;
+    // -> static s32 cpuCompile_SB_function;
+    // -> static s32 cpuCompile_LHU_function;
+    // -> static s32 cpuCompile_LBU_function;
+    // -> static s32 cpuCompile_LW_function;
+    // -> static s32 cpuCompile_LH_function;
+    // -> static s32 cpuCompile_LB_function;
+    // -> static s32 cpuCompile_ROUND_W_function;
+    // -> static s32 cpuCompile_TRUNC_W_function;
+    // -> static s32 cpuCompile_FLOOR_W_function;
+    // -> static s32 cpuCompile_CEIL_W_function;
+    // -> static s32 cpuCompile_L_CVT_SD_function;
+    // -> static s32 cpuCompile_W_CVT_SD_function;
+    // -> static s32 cpuCompile_D_SQRT_function;
+    // -> static s32 cpuCompile_S_SQRT_function;
+    // -> static s32 cpuCompile_DSUBU_function;
+    // -> static s32 cpuCompile_DSUB_function;
+    // -> static s32 cpuCompile_DADDU_function;
+    // -> static s32 cpuCompile_DADD_function;
+    // -> static s32 cpuCompile_DDIVU_function;
+    // -> static s32 cpuCompile_DDIV_function;
+    // -> static s32 cpuCompile_DMULTU_function;
+    // -> static s32 cpuCompile_DMULT_function;
+    // -> static s32 cpuCompile_DSRAV_function;
+    // -> static s32 cpuCompile_DSRLV_function;
+    // -> static s32 cpuCompile_DSLLV_function;
+    // -> s32 ganMapGPR[32];
 }
 
-void __cpuTest();
+// Erased
+static void __cpuTest() {}
 
-int cpuFreeLink(void (**ppfLink)());
-
-// Local to compilation unit
-static int cpuMakeLink(_CPU *pCPU, void (**ppfLink)(), void (*pfFunction)())
-{
-	int iGPR;
-	int *pnCode;
-	int nData;
-	// References: ganMapGPR (0x70BE0E80)
+// Erased
+static s32 cpuFreeLink(void (**ppfLink)()) {
+    // Parameters
+    // void (** ppfLink)(); // r1+0xC
 }
 
-// Local to compilation unit
-static int cpuExecuteLoadStoreF(_CPU *pCPU, int nAddressN64, int nAddressGCN)
-{
-	unsigned int *opcode;
-	int address;
-	int iRegisterA;
-	int iRegisterB;
-	unsigned char device;
-	int total;
-	int count;
-	int save;
-	int interpret;
-	int *before;
-	int *after;
-	int check2;
-	int *anCode;
-	// References: ganMapGPR (0x70BE0E80)
+// Range: 0x800374DC -> 0x8003779C
+static s32 cpuMakeLink(struct _CPU* pCPU, void (**ppfLink)(), void (*pfFunction)()) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // void (** ppfLink)(); // r30
+    // void (* pfFunction)(); // r31
+
+    // Local variables
+    s32 iGPR; // r1+0x8
+    s32* pnCode; // r1+0x18
+    s32 nData; // r1+0x8
+
+    // References
+    // -> s32 ganMapGPR[32];
 }
 
-// Local to compilation unit
-static int cpuExecuteLoadStore(_CPU *pCPU, int nAddressN64, int nAddressGCN)
-{
-	unsigned int *opcode;
-	int address;
-	int iRegisterA;
-	int iRegisterB;
-	unsigned char device;
-	int total;
-	int count;
-	int save;
-	int interpret;
-	int *before;
-	int *after;
-	int check2;
-	int *anCode;
-	// References: ganMapGPR (0x70BE0E80)
+// Range: 0x8003779C -> 0x800382F8
+static s32 cpuExecuteLoadStoreF(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r25
+
+    // Local variables
+    u32* opcode; // r1+0x1C
+    s32 address; // r1+0x8
+    s32 iRegisterA; // r6
+    s32 iRegisterB; // r1+0x8
+    u8 device; // r5
+    s32 total; // r30
+    s32 count; // r29
+    s32 save; // r28
+    s32 interpret; // r27
+    s32* before; // r26
+    s32* after; // r25
+    s32 check2; // r24
+    s32* anCode; // r23
+
+    // References
+    // -> s32 ganMapGPR[32];
 }
 
-// Local to compilation unit
-static int cpuExecuteCall(_CPU *pCPU, int nCount, int nAddressN64, int nAddressGCN)
-{
-	int count;
-	int *anCode;
-	int saveGCN;
-	cpu_function *node;
-	cpu_callerID *block;
-	int nDeltaAddress;
-	// References: ganMapGPR (0x70BE0E80)
+// Range: 0x800382F8 -> 0x80039158
+static s32 cpuExecuteLoadStore(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r27
+
+    // Local variables
+    u32* opcode; // r1+0x1C
+    s32 address; // r1+0x8
+    s32 iRegisterA; // r5
+    s32 iRegisterB; // r1+0x8
+    u8 device; // r5
+    s32 total; // r23
+    s32 count; // r31
+    s32 save; // r30
+    s32 interpret; // r29
+    s32* before; // r28
+    s32* after; // r27
+    s32 check2; // r26
+    s32* anCode; // r25
+
+    // References
+    // -> s32 ganMapGPR[32];
 }
 
-// Local to compilation unit
-static int cpuExecuteJump(_CPU *pCPU, int nCount, int nAddressN64, int nAddressGCN)
-{
-	// References: gpSystem (0x561380)
+// Range: 0x80039158 -> 0x800393B8
+static s32 cpuExecuteCall(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 nCount; // r29
+    // s32 nAddressN64; // r30
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    s32 count; // r4
+    s32* anCode; // r30
+    s32 saveGCN; // r31
+    struct cpu_function* node; // r1+0x18
+    struct cpu_callerID* block; // r5
+    s32 nDeltaAddress; // r1+0x8
+
+    // References
+    // -> s32 ganMapGPR[32];
 }
 
-// Local to compilation unit
-static int cpuExecuteIdle(_CPU *pCPU, int nCount, int nAddressN64, int nAddressGCN)
-{
-	__anon_0x443F6 *pROM;
+// Range: 0x800393B8 -> 0x80039488
+static s32 cpuExecuteJump(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nCount; // r30
+    // s32 nAddressN64; // r31
+    // s32 nAddressGCN; // r1+0x14
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
 }
 
-// Local to compilation unit
-static int cpuExecuteOpcode(_CPU *pCPU, int nCount, int nAddressN64, int nAddressGCN)
-{
-	unsigned long long save;
-	int restore;
-	unsigned int nOpcode;
-	unsigned int *opcode;
-	__anon_0x3EB4F **apDevice;
-	unsigned char *aiDevice;
-	int iEntry;
-	int nCount;
-	char nData8;
-	signed short nData16;
-	int nData32;
-	signed long long nData64;
-	int nAddress;
-	cpu_function *pFunction;
-	// References: __float_huge (0x7C3E0F80)
-	// References: __float_nan (0x783E0F80)
+// Range: 0x80039488 -> 0x80039594
+static s32 cpuExecuteIdle(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32 nCount; // r28
+    // s32 nAddressN64; // r29
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    struct __anon_0x443F6* pROM; // r30
 }
 
-// Local to compilation unit
-static int cpuExecuteUpdate(_CPU *pCPU, int *pnAddressGCN, unsigned int nCount)
-{
-	__anon_0x44829 eModeUpdate;
-	__anon_0x3DB14 *pSystem;
-	int nDelta;
-	unsigned int nCounter;
-	unsigned int nCompare;
-	// References: gpSystem (0x561380)
-	// References: nTickMultiplier (0x604E1380)
-	// References: fTickScale (0x644E1380)
+// Range: 0x80039594 -> 0x8003DF08
+static s32 cpuExecuteOpcode(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32 nCount; // r1+0xC
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    u64 save; // r25
+    s32 restore; // r27
+    u32 nOpcode; // r30
+    u32* opcode; // r1+0x6C
+    struct __anon_0x3EB4F** apDevice; // r28
+    u8* aiDevice; // r29
+    s32 iEntry; // r4
+    s32 nCount; // r22
+    char nData8; // r1+0x66
+    s16 nData16; // r1+0x64
+    s32 nData32; // r1+0x60
+    s64 nData64; // r1+0x58
+    s32 nAddress; // r23
+    struct cpu_function* pFunction; // r1+0x50
+
+    // References
+    // -> s32 __float_huge[];
+    // -> s32 __float_nan[];
 }
 
-int cpuRetraceReset();
+// Range: 0x8003DF08 -> 0x8003E204
+static s32 cpuExecuteUpdate(struct _CPU* pCPU, s32* pnAddressGCN, u32 nCount) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32* pnAddressGCN; // r29
+    // u32 nCount; // r30
 
-int cpuRetraceSetup(_CPU *pCPU);
+    // Local variables
+    enum __anon_0x44829 eModeUpdate; // r4
+    struct __anon_0x3DB14* pSystem; // r31
+    s32 nDelta; // r1+0x8
+    u32 nCounter; // r1+0x8
+    u32 nCompare; // r1+0x8
 
-// Local to compilation unit
-static void cpuRetraceCallback(unsigned int nCount)
-{
-	// References: gpSystem (0x561380)
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+    // -> u32 nTickMultiplier;
+    // -> float fTickScale;
 }
 
-void cpuAlarmCallback(OSAlarm *pAlarm)
-{
-	_CPU *pCPU;
-	// References: gpSystem (0x561380)
+// Erased
+static s32 cpuRetraceReset() {}
+
+// Erased
+static s32 cpuRetraceSetup(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
 }
 
-// Local to compilation unit
-static int cpuNextInstruction(_CPU *pCPU, int addressN64, int opcode, int *anCode, int *iCode);
+// Range: 0x8003E204 -> 0x8003E214
+static void cpuRetraceCallback(u32 nCount) {
+    // Parameters
+    // u32 nCount; // r1+0x0
 
-int cpuStackOffset(_CPU *pCPU, int currentAddress, int *anCode, int source, int target);
-
-int cpuCutStoreLoadF(_CPU *pCPU, int currentAddress, int source);
-
-int cpuCutStoreLoad(_CPU *pCPU, int currentAddress, int source);
-
-int cpuNoBranchTo(cpu_function *pFunction, int currentAddress)
-{
-	int i;
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
 }
 
-// Local to compilation unit
-static int cpuFindAddress(_CPU *pCPU, int nAddressN64, int *pnAddressGCN)
-{
-	int iJump;
-	int iCode;
-	int nAddress;
-	cpu_function *pFunction;
+// Erased
+static void cpuAlarmCallback(struct OSAlarm* pAlarm) {
+    // Parameters
+    // struct OSAlarm* pAlarm; // r3
+
+    // Local variables
+    struct _CPU* pCPU; // r31
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
 }
 
-int cpuFreeFunction(_CPU *pCPU, cpu_function *pFunction);
-
-int cpuMakeFunction(_CPU *pCPU, cpu_function **ppFunction, int nAddressN64)
-{
-	int iCode;
-	int iCode0;
-	int iJump;
-	int iCheck;
-	int firstTime;
-	int kill_value;
-	int memory_used;
-	int codeMemory;
-	int blockMemory;
-	int *chunkMemory;
-	int *anCode;
-	int nAddress;
-	cpu_function *pFunction;
-	__anon_0x3DE78 aJump[1024];
+// Range: 0x8003E214 -> 0x8003E4D8
+static s32 cpuNextInstruction(struct _CPU* pCPU, s32 addressN64, s32 opcode, s32* anCode, s32* iCode) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 addressN64; // r10
+    // s32 opcode; // r5
+    // s32* anCode; // r1+0x14
+    // s32* iCode; // r1+0x18
 }
 
-// Local to compilation unit
-static int cpuGetPPC(_CPU *pCPU, int *pnAddress, cpu_function *pFunction, int *anCode, int *piCode, int bSlot)
-{
-	int nSize;
-	int iHack;
-	int bInterpret;
-	int iCode;
-	int iJump;
-	int nAddress;
-	int nDeltaAddress;
-	int bFlag;
-	int nAddressJump;
-	int nOffset;
-	unsigned int nOpcode;
-	unsigned int nOpcodePrev;
-	unsigned int nOpcodeNext;
-	unsigned int *pnOpcode;
-	int prev;
-	int iRegisterA;
-	int iRegisterB;
-	int iRegisterC;
-	int nTemp1;
-	int nTemp2;
-	int nTemp3;
-	int update;
-	int iUpdate;
-	int nTarget;
-	// References: ganMapGPR (0x70BE0E80)
-	// References: cpuCompile_SDC_function (0x54571380)
-	// References: cpuCompile_SW_function (0x4C571380)
-	// References: cpuCompile_LDC_function (0x50571380)
-	// References: cpuCompile_LW_function (0x38571380)
-	// References: gpSystem (0x561380)
-	// References: cpuCompile_SH_function (0x48571380)
-	// References: cpuCompile_SB_function (0x44571380)
-	// References: cpuCompile_LWR_function (0x5C571380)
-	// References: cpuCompile_LHU_function (0x40571380)
-	// References: cpuCompile_LBU_function (0x3C571380)
-	// References: cpuCompile_LWL_function (0x58571380)
-	// References: cpuCompile_LH_function (0x34571380)
-	// References: cpuCompile_LB_function (0x30571380)
-	// References: cpuCompile_L_CVT_SD_function (0x1C571380)
-	// References: cpuCompile_W_CVT_SD_function (0x18571380)
-	// References: cpuCompile_TRUNC_W_function (0x2C571380)
-	// References: cpuCompile_FLOOR_W_function (0x24571380)
-	// References: cpuCompile_CEIL_W_function (0x20571380)
-	// References: cpuCompile_ROUND_W_function (0x28571380)
-	// References: cpuCompile_D_SQRT_function (0x14571380)
-	// References: cpuCompile_S_SQRT_function (0x10571380)
-	// References: cpuCompile_DSUBU_function (0xC571380)
-	// References: cpuCompile_DSUB_function (0x8571380)
-	// References: cpuCompile_DADDU_function (0x4571380)
-	// References: cpuCompile_DADD_function (0x571380)
-	// References: cpuCompile_DDIVU_function (0x801356FC)
-	// References: cpuCompile_DDIV_function (0x801356F8)
-	// References: cpuCompile_DMULTU_function (0x801356F4)
-	// References: cpuCompile_DMULT_function (0x801356F0)
-	// References: cpuCompile_DSRAV_function (0x801356EC)
-	// References: cpuCompile_DSRLV_function (0x801356E8)
-	// References: cpuCompile_DSLLV_function (0x801356E4)
+// Erased
+static s32 cpuStackOffset(struct _CPU* pCPU, s32 currentAddress, s32* anCode, s32 source, s32 target) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32* anCode; // r1+0x8
+    // s32 source; // r1+0xC
+    // s32 target; // r1+0x10
 }
 
-int cpuRecompileFunction(_CPU *pCPU, cpu_function *pFunction, int nAddressN64);
-
-void cpuCompileNOP(int *anCode, int *iCode, int number);
-
-// Local to compilation unit
-static int cpuCheckDelaySlot(unsigned int opcode)
-{
-	int flag;
+// Erased
+static s32 cpuCutStoreLoadF(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32 source; // r1+0x8
 }
 
-int cpuFindBranchOffset(cpu_function *pFunction, int *pnOffset, int nAddress, int *anCode)
-{
-	int iJump;
+// Erased
+static s32 cpuCutStoreLoad(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32 source; // r1+0x8
 }
 
+// Erased
+static s32 cpuNoBranchTo(struct cpu_function* pFunction, s32 currentAddress) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Range: 0x8003E4D8 -> 0x8003E974
+static s32 cpuFindAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nAddressN64; // r30
+    // s32* pnAddressGCN; // r31
+
+    // Local variables
+    s32 iJump; // r6
+    s32 iCode; // r1+0x20
+    s32 nAddress; // r1+0x1C
+    struct cpu_function* pFunction; // r1+0x18
+}
+
+// Erased
+static s32 cpuFreeFunction(struct _CPU* pCPU, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // struct cpu_function* pFunction; // r4
+}
+
+// Range: 0x8003E974 -> 0x8003EE04
+s32 cpuMakeFunction(struct _CPU* pCPU, struct cpu_function** ppFunction, s32 nAddressN64) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // struct cpu_function** ppFunction; // r31
+    // s32 nAddressN64; // r5
+
+    // Local variables
+    s32 iCode; // r1+0x2028
+    s32 iCode0; // r1+0x8
+    s32 iJump; // r7
+    s32 iCheck; // r1+0x8
+    s32 firstTime; // r24
+    s32 kill_value; // r23
+    s32 memory_used; // r22
+    s32 codeMemory; // r1+0x8
+    s32 blockMemory; // r21
+    s32* chunkMemory; // r1+0x2020
+    s32* anCode; // r23
+    s32 nAddress; // r1+0x201C
+    struct cpu_function* pFunction; // r1+0x2018
+    struct __anon_0x3DE78 aJump[1024]; // r1+0x18
+}
+
+// Range: 0x8003EE04 -> 0x80068238
+static s32 cpuGetPPC(struct _CPU* pCPU, s32* pnAddress, struct cpu_function* pFunction, s32* anCode, s32* piCode,
+                     s32 bSlot) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* pnAddress; // r18
+    // struct cpu_function* pFunction; // r27
+    // s32* anCode; // r31
+    // s32* piCode; // r16
+    // s32 bSlot; // r1+0x8C
+
+    // Local variables
+    s32 nSize; // r1+0x88
+    s32 iHack; // r1+0x8
+    s32 bInterpret; // r22
+    s32 iCode; // r1+0x84
+    s32 iJump; // r23
+    s32 nAddress; // r29
+    s32 nDeltaAddress; // r21
+    s32 bFlag; // r15
+    s32 nAddressJump; // r6
+    s32 nOffset; // r25
+    u32 nOpcode; // r28
+    u32 nOpcodePrev; // r23
+    u32 nOpcodeNext; // r24
+    u32* pnOpcode; // r1+0x7C
+    s32 prev; // r19
+    s32 iRegisterA; // r1+0x8
+    s32 iRegisterB; // r9
+    s32 iRegisterC; // r7
+    s32 nTemp1; // r1+0x8
+    s32 nTemp2; // r1+0x8
+    s32 nTemp3; // r3
+    s32 update; // r14
+    s32 iUpdate; // r1+0x90
+    s32 nTarget; // r3
+
+    // References
+    // -> s32 ganMapGPR[32];
+    // -> static s32 cpuCompile_SDC_function;
+    // -> static s32 cpuCompile_SW_function;
+    // -> static s32 cpuCompile_LDC_function;
+    // -> static s32 cpuCompile_LW_function;
+    // -> struct __anon_0x3DB14* gpSystem;
+    // -> static s32 cpuCompile_SH_function;
+    // -> static s32 cpuCompile_SB_function;
+    // -> static s32 cpuCompile_LWR_function;
+    // -> static s32 cpuCompile_LHU_function;
+    // -> static s32 cpuCompile_LBU_function;
+    // -> static s32 cpuCompile_LWL_function;
+    // -> static s32 cpuCompile_LH_function;
+    // -> static s32 cpuCompile_LB_function;
+    // -> static s32 cpuCompile_L_CVT_SD_function;
+    // -> static s32 cpuCompile_W_CVT_SD_function;
+    // -> static s32 cpuCompile_TRUNC_W_function;
+    // -> static s32 cpuCompile_FLOOR_W_function;
+    // -> static s32 cpuCompile_CEIL_W_function;
+    // -> static s32 cpuCompile_ROUND_W_function;
+    // -> static s32 cpuCompile_D_SQRT_function;
+    // -> static s32 cpuCompile_S_SQRT_function;
+    // -> static s32 cpuCompile_DSUBU_function;
+    // -> static s32 cpuCompile_DSUB_function;
+    // -> static s32 cpuCompile_DADDU_function;
+    // -> static s32 cpuCompile_DADD_function;
+    // -> static s32 cpuCompile_DDIVU_function;
+    // -> static s32 cpuCompile_DDIV_function;
+    // -> static s32 cpuCompile_DMULTU_function;
+    // -> static s32 cpuCompile_DMULT_function;
+    // -> static s32 cpuCompile_DSRAV_function;
+    // -> static s32 cpuCompile_DSRLV_function;
+    // -> static s32 cpuCompile_DSLLV_function;
+}
+
+// Erased
+static s32 cpuRecompileFunction(struct _CPU* pCPU, struct cpu_function* pFunction, s32 nAddressN64) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // struct cpu_function* pFunction; // r1+0xC
+    // s32 nAddressN64; // r5
+}
+
+// Erased
+static void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
+    // Parameters
+    // s32* anCode; // r1+0x0
+    // s32* iCode; // r1+0x4
+    // s32 number; // r5
+}
+
+// Range: 0x80068238 -> 0x80068368
+static s32 cpuCheckDelaySlot(u32 opcode) {
+    // Parameters
+    // u32 opcode; // r1+0x0
+
+    // Local variables
+    s32 flag; // r5
+}
+
+// Erased
+static s32 cpuFindBranchOffset(struct cpu_function* pFunction, s32* pnOffset, s32 nAddress, s32* anCode) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x4
+    // s32* pnOffset; // r1+0x8
+    // s32 nAddress; // r1+0xC
+    // s32* anCode; // r1+0x10
+
+    // Local variables
+    s32 iJump; // r8
+}

--- a/debug/Fire/_frameGCN.c
+++ b/debug/Fire/_frameGCN.c
@@ -1,721 +1,1162 @@
-﻿// Local to compilation unit
-static int frameEvent(Frame_Class_t *pFrame, int nEvent)
-{
-	// References: gpSystem (0x561380)
-	// References: gnCountMapHack (0x801356C0)
-	// References: gbFrameValid (0x80135688)
-	// References: gbFrameBegin (0x8013568C)
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_frameGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80021204 -> 0x8002CA14
+*/
+
+#include "types.h"
+
+// Range: 0x80021204 -> 0x80021588
+static s32 frameEvent(struct __anon_0x24C38* pFrame, s32 nEvent) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32 nEvent; // r1+0xC
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static s32 gnCountMapHack;
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
 }
 
-int frameGetDepth(Frame_Class_t *pFrame, unsigned short *pnData, int nAddress)
-{
-	unsigned int nX;
-	unsigned int nY;
-	unsigned int nOffset;
-	long n64CalcValue;
-	int exp;
-	int mantissa;
-	long compare;
-	long val;
-	__anon_0x285E5 z_format[8];
-	// References: sTempZBuf (0x801085C0)
+// Range: 0x80021588 -> 0x800217F8
+s32 frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // u16* pnData; // r1+0xC
+    // s32 nAddress; // r1+0x10
+
+    // Local variables
+    u32 nX; // r7
+    u32 nY; // r8
+    u32 nOffset; // r1+0x8
+    s32 n64CalcValue; // r6
+    s32 exp; // r7
+    s32 mantissa; // r1+0x8
+    s32 compare; // r3
+    s32 val; // r7
+    struct __anon_0x285E5 z_format[8]; // r1+0x14
+
+    // References
+    // -> static u16 sTempZBuf[4800][4][4];
 }
 
-int frameHackCIMG_Panel(__anon_0x2865F *pRDP, Frame_Class_t *pFrame, __anon_0x23B9E *pBuffer, unsigned long long **ppnGBI)
-{
-	__anon_0x297E0 *pRSP;
-	unsigned long long *pnGBI;
-	int count;
-	int nAddress;
-	int sizeX;
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	unsigned short *BG;
-	unsigned short *FR;
-	unsigned short *pLUT;
-	unsigned short *pBitmap16;
-	unsigned char *pBitmap8;
-	int iTile;
-	int nCount;
-	__anon_0x247BF *pTile;
-	int iTile;
-	int nCount;
-	int iTile;
-	int nCount;
-	__anon_0x2ACA3 bg;
-	__anon_0x2B091 objTxtr;
-	unsigned int nLoadType;
-	__anon_0x23B9E *pBG;
-	// References: GBIcode2D2$1906 (0x800EAAB4)
-	// References: GBIcode3D2$1908 (0x800EAAE4)
-	// References: GBIcode3D1$1907 (0x800EAAD0)
+// Range: 0x800217F8 -> 0x8002303C
+s32 frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer,
+                        u64** ppnGBI) {
+    // Parameters
+    // struct __anon_0x2865F* pRDP; // r29
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x23B9E* pBuffer; // r17
+    // u64** ppnGBI; // r14
+
+    // Local variables
+    struct __anon_0x297E0* pRSP; // r17
+    u64* pnGBI; // r20
+    s32 count; // r8
+    s32 nAddress; // r5
+    s32 sizeX; // r6
+    u32 nCommandLo; // r7
+    u32 nCommandHi; // r3
+    u16* BG; // r18
+    u16* FR; // r28
+    u16* pLUT; // r16
+    u16* pBitmap16; // r4
+    u8* pBitmap8; // r5
+    s32 iTile; // r5
+    s32 nCount; // r4
+    struct __anon_0x247BF* pTile; // r5
+    s32 iTile; // r1+0x8
+    s32 nCount; // r4
+    s32 iTile; // r5
+    s32 nCount; // r4
+    union __anon_0x2ACA3 bg; // r1+0x50
+    union __anon_0x2B091 objTxtr; // r1+0x38
+    u32 nLoadType; // r1+0x34
+    struct __anon_0x23B9E* pBG; // r18
+
+    // References
+    // -> static u32 GBIcode2D2$1906[7];
+    // -> static u32 GBIcode3D2$1908[6];
+    // -> static u32 GBIcode3D1$1907[5];
 }
 
-int frameHackTIMG_Panel(Frame_Class_t *pFrame, __anon_0x23B9E *pBuffer);
-
-void PanelDrawFR3D(unsigned short *FR, unsigned short *LUT, unsigned char *bitmap, int sizeX, int sizeY, int posX, int posY, int first)
-{
-	int i;
-	int j;
-	unsigned short color;
+// Range: 0x8002303C -> 0x800230E0
+s32 frameHackTIMG_Panel(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // struct __anon_0x23B9E* pBuffer; // r1+0x4
 }
 
-void PanelDrawBG16(unsigned short *BG, unsigned short *bitmap, int sizeX, int sizeY, int posX, int posY, int flip)
-{
-	int i;
-	int j;
-	unsigned short color;
+// Range: 0x800230E0 -> 0x80023194
+void PanelDrawFR3D(u16* FR, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 first) {
+    // Parameters
+    // u16* FR; // r1+0x8
+    // u16* LUT; // r1+0xC
+    // u8* bitmap; // r1+0x10
+    // s32 sizeX; // r1+0x14
+    // s32 sizeY; // r1+0x18
+    // s32 posX; // r1+0x1C
+    // s32 posY; // r1+0x20
+    // s32 first; // r1+0x24
+
+    // Local variables
+    s32 i; // r30
+    s32 j; // r1+0x8
+    u16 color; // r29
 }
 
-void PanelDrawBG8(unsigned short *BG, unsigned short *LUT, unsigned char *bitmap, int sizeX, int sizeY, int posX, int posY, int flip)
-{
-	int i;
-	int j;
-	unsigned short color;
+// Range: 0x80023194 -> 0x80023250
+void PanelDrawBG16(u16* BG, u16* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+    // Parameters
+    // u16* BG; // r1+0x8
+    // u16* bitmap; // r1+0xC
+    // s32 sizeX; // r1+0x10
+    // s32 sizeY; // r1+0x14
+    // s32 posX; // r1+0x18
+    // s32 posY; // r1+0x1C
+    // s32 flip; // r1+0x20
+
+    // Local variables
+    s32 i; // r29
+    s32 j; // r28
+    u16 color; // r1+0x8
 }
 
-int frameHackCIMG_Zelda2_Camera(Frame_Class_t *pFrame, __anon_0x23B9E *pBuffer, unsigned int nCommandHi, unsigned int nCommandLo);
+// Range: 0x80023250 -> 0x800232FC
+void PanelDrawBG8(u16* BG, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+    // Parameters
+    // u16* BG; // r1+0x8
+    // u16* LUT; // r1+0xC
+    // u8* bitmap; // r1+0x10
+    // s32 sizeX; // r1+0x14
+    // s32 sizeY; // r1+0x18
+    // s32 posX; // r1+0x1C
+    // s32 posY; // r1+0x20
+    // s32 flip; // r1+0x24
 
-int frameHackCIMG_Zelda2_Shrink(__anon_0x2865F *pRDP, Frame_Class_t *pFrame, unsigned long long **ppnGBI)
-{
-	unsigned long long *pnGBI;
-	int count;
-	int nAddress;
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	__anon_0x297E0 *pRSP;
-	int done;
-	__anon_0x2ACA3 bg;
-	// References: GBIcode$1816 (0x800EAAA8)
+    // Local variables
+    s32 i; // r28
+    s32 j; // r27
+    u16 color; // r1+0x8
 }
 
-int frameHackCIMG_Zelda(Frame_Class_t *pFrame, __anon_0x23B9E *pBuffer, unsigned long long *pnGBI, unsigned int nCommandLo)
-{
-	unsigned int i;
-	unsigned long low2;
-	unsigned long high2;
-	unsigned short *srcP;
-	unsigned short *val;
-	unsigned short *valEnd;
-	long tile;
-	long y;
-	long x;
-	unsigned char *val;
-	unsigned char *valEnd;
-	// References: tempLine$1785 (0x801306E0)
-	// References: sCopyFrameSyncReceived (0x801356A4)
-	// References: gNoSwapBuffer (0x801356BC)
-	// References: sNumAddr (0x801356B4)
-	// References: sConstantBufAddr (0x801085A0)
-	// References: gnCountMapHack (0x801356C0)
-	// References: sSrcBuffer (0x801356B0)
-	// References: sDestinationBuffer (0x801356AC)
-	// References: gpSystem (0x561380)
+// Range: 0x800232FC -> 0x80023430
+s32 frameHackCIMG_Zelda2_Camera(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u32 nCommandHi,
+                                u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // struct __anon_0x23B9E* pBuffer; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+    // u32 nCommandLo; // r1+0x14
 }
 
-int frameHackCIMG_Zelda2(Frame_Class_t *pFrame, __anon_0x23B9E *pBuffer, unsigned long long *pnGBI)
-{
-	unsigned int i;
-	unsigned long *pGBI;
-	// References: sCopyFrameSyncReceived (0x801356A4)
-	// References: gNoSwapBuffer (0x801356BC)
-	// References: nLastFrame$1695 (0x801356CC)
-	// References: nCopyFrame$1697 (0x801356D0)
-	// References: sCommandCodes2$1722 (0x800EAA80)
-	// References: sCommandCodes$1702 (0x58AA0E80)
+// Range: 0x80023430 -> 0x800235A4
+s32 frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, u64** ppnGBI) {
+    // Parameters
+    // struct __anon_0x2865F* pRDP; // r1+0x8
+    // struct __anon_0x24C38* pFrame; // r27
+    // u64** ppnGBI; // r28
+
+    // Local variables
+    u64* pnGBI; // r30
+    s32 count; // r8
+    s32 nAddress; // r4
+    u32 nCommandLo; // r6
+    u32 nCommandHi; // r1+0x8
+    struct __anon_0x297E0* pRSP; // r29
+    s32 done; // r3
+    union __anon_0x2ACA3 bg; // r1+0x18
+
+    // References
+    // -> static u32 GBIcode$1816[3];
 }
 
-int frameHackTIMG_Zelda(Frame_Class_t *pFrame, unsigned long long **pnGBI, unsigned int *pnCommandLo, unsigned int *pnCommandHi)
-{
-	unsigned int i;
-	// References: sDestinationBuffer (0x801356AC)
-	// References: gpSystem (0x561380)
-	// References: sSrcBuffer (0x801356B0)
-	// References: sSpecialZeldaHackON (0x801356A8)
-	// References: sCommandCodes$1679 (0x38AA0E80)
+// Range: 0x800235A4 -> 0x800239E4
+s32 frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x23B9E* pBuffer; // r28
+    // u64* pnGBI; // r1+0x10
+    // u32 nCommandLo; // r29
+
+    // Local variables
+    u32 i; // r30
+    u32 low2; // r1+0x8
+    u32 high2; // r1+0x8
+    u16* srcP; // r1+0x20
+    u16* val; // r27
+    u16* valEnd; // r29
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u8* val; // r3
+    u8* valEnd; // r4
+
+    // References
+    // -> static u16 tempLine$1785[16][4][4];
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> s32 gNoSwapBuffer;
+    // -> static u32 sNumAddr;
+    // -> static u32 sConstantBufAddr[6];
+    // -> static s32 gnCountMapHack;
+    // -> static u32 sSrcBuffer;
+    // -> static u32 sDestinationBuffer;
+    // -> struct __anon_0x26A4E* gpSystem;
 }
 
-void ZeldaDrawFrameCamera(Frame_Class_t *pFrame, void *buffer)
-{
-	float matrix[3][4];
-	_GXColor color;
-	// References: frameObj$1673 (0x801306C0)
+// Range: 0x800239E4 -> 0x8002403C
+s32 frameHackCIMG_Zelda2(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x23B9E* pBuffer; // r31
+    // u64* pnGBI; // r1+0x10
+
+    // Local variables
+    u32 i; // r7
+    u32* pGBI; // r8
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> s32 gNoSwapBuffer;
+    // -> static s32 nLastFrame$1695;
+    // -> static s32 nCopyFrame$1697;
+    // -> static u32 sCommandCodes2$1722[10];
+    // -> static u32 sCommandCodes$1702[10];
 }
 
-void ZeldaCopyCamera(unsigned short *buffer);
+// Range: 0x8002403C -> 0x80024204
+s32 frameHackTIMG_Zelda(struct __anon_0x24C38* pFrame, u64** pnGBI, u32* pnCommandLo, u32* pnCommandHi) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u64** pnGBI; // r30
+    // u32* pnCommandLo; // r31
+    // u32* pnCommandHi; // r1+0x14
 
-void ZeldaDrawFrameShrink(Frame_Class_t *pFrame, int posX, int posY, int size)
-{
-	float matrix[3][4];
-	float nX0;
-	float nX1;
-	float nY0;
-	float nY1;
-	float scale;
-	void *frameBuffer;
-	_GXColor color;
-	// References: frameObj$1663 (0x801306A0)
-	// References: DemoCurrentBuffer (0x80135A8C)
+    // Local variables
+    u32 i; // r7
+
+    // References
+    // -> static u32 sDestinationBuffer;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static u32 sSrcBuffer;
+    // -> static u8 sSpecialZeldaHackON;
+    // -> static u32 sCommandCodes$1679[8];
 }
 
-void ZeldaDrawFrameHiRes(Frame_Class_t *pFrame, void *pSrc)
-{
-	float matrix[3][4];
-	_GXColor color;
-	// References: sFrameObj$1660 (0x80061380)
+// Range: 0x80024204 -> 0x800244F8
+void ZeldaDrawFrameCamera(struct __anon_0x24C38* pFrame, void* buffer) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // void* buffer; // r29
+
+    // Local variables
+    float matrix[3][4]; // r1+0x30
+    struct _GXColor color; // r1+0x2C
+
+    // References
+    // -> static struct _GXTexObj frameObj$1673;
 }
 
-void ZeldaCopyFrameHiRes(void *pSrc)
-{
-	// References: sCopyFrameSyncReceived (0x801356A4)
+// Erased
+static void ZeldaCopyCamera(u16* buffer) {
+    // Parameters
+    // u16* buffer; // r31
 }
 
-// Local to compilation unit
-static void ZeldaGreyScaleConvert(Frame_Class_t *pFrame)
-{
-	float matrix[3][4];
-	void *dataP;
-	_GXColor color;
-	// References: sFrameObj$1647 (0x60061380)
-	// References: cAlpha$1648 (0x564E1380)
-	// References: gHackCreditsColor (0x801356B8)
-	// References: DemoCurrentBuffer (0x80135A8C)
+// Range: 0x800244F8 -> 0x80024A04
+void ZeldaDrawFrameShrink(struct __anon_0x24C38* pFrame, s32 posX, s32 posY, s32 size) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 posX; // r1+0xC
+    // s32 posY; // r1+0x10
+    // s32 size; // r1+0x14
+
+    // Local variables
+    float matrix[3][4]; // r1+0x28
+    float nX0; // f31
+    float nX1; // f30
+    float nY0; // f29
+    float nY1; // f28
+    float scale; // f4
+    void* frameBuffer; // r26
+    struct _GXColor color; // r1+0x20
+
+    // References
+    // -> static struct _GXTexObj frameObj$1663;
+    // -> void* DemoCurrentBuffer;
 }
 
-void CopyAndConvertCFB(unsigned short *srcP)
-{
-	unsigned short *dataEndP;
-	long tile;
-	long y;
-	long x;
-	unsigned short val;
-	// References: line$1630 (0x60FC1280)
-	// References: sCopyFrameSyncReceived (0x801356A4)
+// Erased
+static void ZeldaDrawFrameHiRes(struct __anon_0x24C38* pFrame, void* pSrc) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // void* pSrc; // r29
+
+    // Local variables
+    float matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1660;
 }
 
-void ConvertCFB(unsigned short *srcP)
-{
-	unsigned short *dataEndP;
-	long tile;
-	long y;
-	long x;
-	unsigned short val;
-	// References: line$1606 (0x60F21280)
+// Erased
+static void ZeldaCopyFrameHiRes(void* pSrc) {
+    // Parameters
+    // void* pSrc; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
-void CopyCFB(unsigned short *srcP)
-{
-	// References: sCopyFrameSyncReceived (0x801356A4)
+// Range: 0x80024A04 -> 0x80024D94
+static void ZeldaGreyScaleConvert(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+
+    // Local variables
+    float matrix[3][4]; // r1+0x38
+    void* dataP; // r29
+    struct _GXColor color; // r1+0x10
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1647;
+    // -> static u8 cAlpha$1648;
+    // -> static u32 gHackCreditsColor;
+    // -> void* DemoCurrentBuffer;
 }
 
-void ConvertZ(unsigned short *srcP)
-{
-	unsigned short *dataEndP;
-	long tile;
-	long y;
-	long x;
-	unsigned short val;
-	// References: line$1582 (0x60DE1280)
+// Range: 0x80024D94 -> 0x800250D8
+void CopyAndConvertCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u16 val; // r1+0x8
+
+    // References
+    // -> static u16 line$1630[80][4][4];
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
-void CopyCFBZTexture(unsigned int *srcP)
-{
-	// References: sCopyFrameSyncReceived (0x801356A4)
+// Erased
+static void ConvertCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u16 val; // r1+0x8
+
+    // References
+    // -> static u16 line$1606[80][4][4];
 }
 
-void CopyCFBAlpha(unsigned char *srcP)
-{
-	// References: sCopyFrameSyncReceived (0x801356A4)
+// Erased
+static void CopyCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
-void ZeldaDrawFrame(Frame_Class_t *pFrame, unsigned short *pData)
-{
-	float matrix[3][4];
-	_GXColor color;
-	// References: sFrameObj$1568 (0x40DE1280)
+// Erased
+static void ConvertZ(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r7
+    s32 y; // r8
+    s32 x; // r1+0x8
+    u16 val; // r9
+
+    // References
+    // -> static u32 line$1582[80][4][4];
 }
 
-void ZeldaDrawFrameBlur(Frame_Class_t *pFrame, unsigned short *pData)
-{
-	float matrix[3][4];
-	_GXColor color;
-	// References: sFrameObj$1565 (0x20DE1280)
+// Erased
+static void CopyCFBZTexture(u32* srcP) {
+    // Parameters
+    // u32* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
-void ZeldaDrawFrameNoBlend(Frame_Class_t *pFrame, unsigned short *pData)
-{
-	float matrix[3][4];
-	// References: sFrameObj$1564 (0xDE1280)
+// Erased
+static void CopyCFBAlpha(u8* srcP) {
+    // Parameters
+    // u8* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
-void ZeldaDrawFrameZTexture(Frame_Class_t *pFrame, unsigned int *pData)
-{
-	float matrix[3][4];
-	// References: sFrameObj1$1562 (0x8012DDC0)
+// Range: 0x800250D8 -> 0x800253B8
+void ZeldaDrawFrame(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // u16* pData; // r29
+
+    // Local variables
+    float matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1568;
 }
 
-int _frameDrawImage(Frame_Class_t *pFrame, unsigned short *pnImage, int nSizeX, int nSizeY, int nX0, int nY0, int bAlpha)
-{
-	int iY;
-	int iX;
-	int nSizeTargetX;
-	unsigned int *pnPixel;
-	unsigned int *aPixel;
-	unsigned int nPixelSource;
-	unsigned int nPixelTarget;
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoCurrentBuffer (0x80135A8C)
+// Range: 0x800253B8 -> 0x8002569C
+void ZeldaDrawFrameBlur(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // u16* pData; // r29
+
+    // Local variables
+    float matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1565;
 }
 
-int _frameDrawRectangle(Frame_Class_t *pFrame, unsigned int nColor, int nX, int nY, int nSizeX, int nSizeY)
-{
-	int iY;
-	int iX;
-	unsigned int *pnPixel;
-	int nSizeTargetX;
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoCurrentBuffer (0x80135A8C)
+// Range: 0x8002569C -> 0x80025890
+void ZeldaDrawFrameNoBlend(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u16* pData; // r30
+
+    // Local variables
+    float matrix[3][4]; // r1+0x30
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1564;
 }
 
-int frameEnd(Frame_Class_t *pFrame)
-{
-	_CPU *pCPU;
-	int iHint;
-	void *pData;
-	// References: gpSystem (0x561380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: sCopyFrameSyncReceived (0x801356A4)
-	// References: sTempZBuf (0x801085C0)
-	// References: gbFrameValid (0x80135688)
-	// References: gbFrameBegin (0x8013568C)
+// Erased
+static void ZeldaDrawFrameZTexture(struct __anon_0x24C38* pFrame, u32* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u32* pData; // r30
+
+    // Local variables
+    float matrix[3][4]; // r1+0x30
+
+    // References
+    // -> static struct _GXTexObj sFrameObj1$1562;
 }
 
-int frameBegin(Frame_Class_t *pFrame, int nCountVertex)
-{
-	long i;
-	float matrix[3][4];
-	// References: ganNameTexCoord (0x800EA8B8)
-	// References: ganNameTexMtx (0x800EA898)
-	// References: gbFrameValid (0x80135688)
-	// References: gbFrameBegin (0x8013568C)
+// Erased
+static s32 _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, s32 nSizeX, s32 nSizeY, s32 nX0, s32 nY0,
+                           s32 bAlpha) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // u16* pnImage; // r1+0xC
+    // s32 nSizeX; // r1+0x10
+    // s32 nSizeY; // r1+0x14
+    // s32 nX0; // r1+0x18
+    // s32 nY0; // r1+0x1C
+    // s32 bAlpha; // r1+0x20
+
+    // Local variables
+    s32 iY; // r30
+    s32 iX; // r1+0x8
+    s32 nSizeTargetX; // r30
+    u32* pnPixel; // r3
+    u32* aPixel; // r29
+    u32 nPixelSource; // r7
+    u32 nPixelTarget; // r29
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
 }
 
-int frameBeginOK()
-{
-	// References: gbFrameValid (0x80135688)
+// Range: 0x80025890 -> 0x800259B8
+s32 _frameDrawRectangle(struct __anon_0x24C38* pFrame, u32 nColor, s32 nX, s32 nY, s32 nSizeX, s32 nSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // u32 nColor; // r1+0x4
+    // s32 nX; // r11
+    // s32 nY; // r1+0xC
+    // s32 nSizeX; // r7
+    // s32 nSizeY; // r1+0x14
+
+    // Local variables
+    s32 iY; // r10
+    s32 iX; // r11
+    u32* pnPixel; // r3
+    s32 nSizeTargetX; // r9
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
 }
 
-int frameSetColor(Frame_Class_t *pFrame, __anon_0x2D223 eType, unsigned int nRGBA);
+// Range: 0x800259B8 -> 0x80025C40
+s32 frameEnd(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
 
-int frameSetDepth(Frame_Class_t *pFrame, float rDepth, float rDelta);
+    // Local variables
+    struct _CPU* pCPU; // r31
+    s32 iHint; // r7
+    void* pData; // r29
 
-int frameGetScissor();
-
-int frameSetScissor(Frame_Class_t *pFrame, FrameRectangle *pScissor)
-{
-	int nTemp;
-	int nX0;
-	int nY0;
-	int nX1;
-	int nY1;
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> void* DemoCurrentBuffer;
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> static u16 sTempZBuf[4800][4][4];
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
 }
 
-int frameHide();
+// Range: 0x80025C40 -> 0x80025ECC
+s32 frameBegin(struct __anon_0x24C38* pFrame, s32 nCountVertex) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32 nCountVertex; // r28
 
-int frameShow();
+    // Local variables
+    s32 i; // r28
+    float matrix[3][4]; // r1+0x14
 
-void CopyZBuffer();
-
-int frameDraw();
-
-int frameTick();
-
-// Local to compilation unit
-static int frameDrawRectTexture_Setup(Frame_Class_t *pFrame, FrameRectangle *pRectangle)
-{
-	float matrix[3][4];
-	float matrixA[3][4];
-	float matrixB[3][4];
-	_FRAME_TEXTURE *pTexture[8];
-	float rScaleS;
-	float rScaleT;
-	float rSlideS;
-	float rSlideT;
-	unsigned int bFlag;
-	unsigned int nColors;
-	int iTile;
-	int firstTile;
-	int nCount;
-	int iIndex;
-	char cTempAlpha;
-	// References: bSkip$1410 (0x801356C8)
-	// References: gpSystem (0x561380)
-	// References: ganNameTexMtx (0x800EA898)
-	// References: sSpecialZeldaHackON (0x801356A8)
+    // References
+    // -> enum _GXTexCoordID ganNameTexCoord[8];
+    // -> u32 ganNameTexMtx[8];
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
 }
 
-// Local to compilation unit
-static int frameDrawRectTexture(Frame_Class_t *pFrame, FrameRectangle *pRectangle)
-{
-	int bCopy;
-	float rDepth;
-	float rDeltaT;
-	float rX0;
-	float rY0;
-	float rX1;
-	float rY1;
-	float rS0;
-	float rT0;
-	float rS1;
-	float rT1;
-	// References: gnCountMapHack (0x801356C0)
-	// References: gpSystem (0x561380)
-	// References: sSpecialZeldaHackON (0x801356A8)
-	// References: nCounter$1367 (0x801356C4)
+// Range: 0x80025ECC -> 0x80025EE8
+s32 frameBeginOK() {
+    // References
+    // -> static s32 gbFrameValid;
 }
 
-// Local to compilation unit
-static int frameDrawRectFill_Setup(Frame_Class_t *pFrame, FrameRectangle *pRectangle)
-{
-	int bFlag;
-	int nColors;
+// Range: 0x80025EE8 -> 0x80025FE4
+s32 frameSetColor(struct __anon_0x24C38* pFrame, enum __anon_0x2D223 eType, u32 nRGBA) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // enum __anon_0x2D223 eType; // r30
+    // u32 nRGBA; // r1+0x10
 }
 
-// Local to compilation unit
-static int frameDrawRectFill(Frame_Class_t *pFrame, FrameRectangle *pRectangle)
-{
-	int bFlag;
-	float rDepth;
-	float rX0;
-	float rY0;
-	float rX1;
-	float rY1;
+// Range: 0x80025FE4 -> 0x80025FF4
+s32 frameSetDepth(struct __anon_0x24C38* pFrame, float rDepth, float rDelta) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // float rDepth; // r1+0x4
+    // float rDelta; // r1+0x8
 }
 
-// Local to compilation unit
-static int frameDrawLine_Setup(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int bFlag;
-	int nColors;
-	// References: gapfDrawLine (0x800EA9B4)
+// Erased
+static s32 frameGetScissor() {}
+
+// Range: 0x80025FF4 -> 0x8002611C
+s32 frameSetScissor(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pScissor) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x2D2B6* pScissor; // r1+0xC
+
+    // Local variables
+    s32 nTemp; // r1+0x8
+    s32 nX0; // r3
+    s32 nY0; // r4
+    s32 nX1; // r5
+    s32 nY1; // r6
 }
 
-// Local to compilation unit
-static int frameDrawLine_C2T2(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Erased
+static s32 frameHide() {}
+
+// Range: 0x8002611C -> 0x80026124
+s32 frameShow() {}
+
+// Erased
+static void CopyZBuffer() {}
+
+// Erased
+static s32 frameDraw() {}
+
+// Erased
+static s32 frameTick() {}
+
+// Range: 0x80026124 -> 0x80026514
+static s32 frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r22
+    // struct __anon_0x2D2B6* pRectangle; // r23
+
+    // Local variables
+    float matrix[3][4]; // r1+0x98
+    float matrixA[3][4]; // r1+0x68
+    float matrixB[3][4]; // r1+0x38
+    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x18
+    float rScaleS; // f29
+    float rScaleT; // f28
+    float rSlideS; // f2
+    float rSlideT; // r1+0x8
+    u32 bFlag; // r1+0x14
+    u32 nColors; // r1+0x10
+    s32 iTile; // r25
+    s32 firstTile; // r3
+    s32 nCount; // r24
+    s32 iIndex; // r6
+    char cTempAlpha; // r20
+
+    // References
+    // -> static s32 bSkip$1410;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> u32 ganNameTexMtx[8];
+    // -> static u8 sSpecialZeldaHackON;
 }
 
-// Local to compilation unit
-static int frameDrawLine_C1T2(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
-	__anon_0x23FC4 *pVertexColor;
+// Range: 0x80026514 -> 0x800269EC
+static s32 frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D2B6* pRectangle; // r31
+
+    // Local variables
+    s32 bCopy; // r11
+    float rDepth; // f31
+    float rDeltaT; // f5
+    float rX0; // f30
+    float rY0; // f29
+    float rX1; // f28
+    float rY1; // f27
+    float rS0; // f26
+    float rT0; // f25
+    float rS1; // f24
+    float rT1; // f23
+
+    // References
+    // -> static s32 gnCountMapHack;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static u8 sSpecialZeldaHackON;
+    // -> static s32 nCounter$1367;
 }
 
-// Local to compilation unit
-static int frameDrawLine_C0T2(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x800269EC -> 0x80026A9C
+static s32 frameDrawRectFill_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D2B6* pRectangle; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
 }
 
-// Local to compilation unit
-static int frameDrawLine_C2T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x80026A9C -> 0x80026D30
+static s32 frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x2D2B6* pRectangle; // r1+0xC
+
+    // Local variables
+    s32 bFlag; // r8
+    float rDepth; // f31
+    float rX0; // f30
+    float rY0; // f29
+    float rX1; // f28
+    float rY1; // f27
 }
 
-// Local to compilation unit
-static int frameDrawLine_C1T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
-	__anon_0x23FC4 *pVertexColor;
+// Range: 0x80026D30 -> 0x80026E0C
+static s32 frameDrawLine_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
+
+    // References
+    // -> static s32 (* gapfDrawLine[6])(void*, void*);
 }
 
-// Local to compilation unit
-static int frameDrawLine_C0T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x80026E0C -> 0x80027028
+static s32 frameDrawLine_C2T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r8
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r9
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_Setup(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int bFlag;
-	int nColors;
-	// References: gapfDrawTriangle (0x800EA994)
+// Range: 0x80027028 -> 0x80027234
+static s32 frameDrawLine_C1T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C3T3(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	float *pMatrix[4];
-	// References: gHackCreditsColor (0x801356B8)
-	// References: gpSystem (0x561380)
+// Range: 0x80027234 -> 0x800273EC
+static s32 frameDrawLine_C0T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r3
 }
 
-// Local to compilation unit
-static int frameCheckTriangleDivide(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 aNewVertArray[8];
-	float fInterp;
-	float fTempColor1;
-	float fTempColor2;
-	unsigned int nNewVertCount;
-	unsigned int bInFront;
-	unsigned int bBehind;
+// Range: 0x800273EC -> 0x800275C4
+static s32 frameDrawLine_C2T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r8
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r9
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C1T3(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
-	__anon_0x23FC4 *pVertexColor;
+// Range: 0x800275C4 -> 0x8002778C
+static s32 frameDrawLine_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C0T3(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x8002778C -> 0x80027900
+static s32 frameDrawLine_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r3
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C3T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x80027900 -> 0x800279DC
+static s32 frameDrawTriangle_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
+
+    // References
+    // -> static s32 (* gapfDrawTriangle[8])(void*, void*);
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C1T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
-	__anon_0x23FC4 *pVertexColor;
+// Range: 0x800279DC -> 0x80027B80
+static s32 frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    float(*pMatrix)[4]; // r3
+
+    // References
+    // -> static u32 gHackCreditsColor;
+    // -> struct __anon_0x26A4E* gpSystem;
 }
 
-// Local to compilation unit
-static int frameDrawTriangle_C0T0(Frame_Class_t *pFrame, FramePrimitive *pPrimitive)
-{
-	int iData;
-	unsigned char *anData;
-	__anon_0x23FC4 *pVertex;
+// Range: 0x80027B80 -> 0x80028A44
+static s32 frameCheckTriangleDivide(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r22
+    // struct __anon_0x2D45B* pPrimitive; // r23
+
+    // Local variables
+    s32 iData; // r25
+    u8* anData; // r24
+    struct __anon_0x23FC4 aNewVertArray[8]; // r1+0x184
+    float fInterp; // r1+0x8
+    float fTempColor1; // f2
+    float fTempColor2; // f3
+    u32 nNewVertCount; // r5
+    u32 bInFront; // r7
+    u32 bBehind; // r8
 }
 
-// Local to compilation unit
-static int frameDrawSetupDP(Frame_Class_t *pFrame, int *pnColors, int *pbFlag)
-{
-	unsigned int nMode;
-	long numCycles;
-	unsigned long mode;
-	unsigned long cycle;
-	// References: gpSystem (0x561380)
+// Range: 0x80028A44 -> 0x80028C34
+static s32 frameDrawTriangle_C1T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r11
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
 }
 
-// Local to compilation unit
-static int frameGetCombineAlpha(_GXTevAlphaArg *pnAlphaTEV, int nAlphaN64);
+// Range: 0x80028C34 -> 0x80028DC0
+static s32 frameDrawTriangle_C0T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
 
-// Local to compilation unit
-static int frameGetCombineColor(_GXTevColorArg *pnColorTEV, int nColorN64);
-
-// Local to compilation unit
-static int frameDrawSetupSP(Frame_Class_t *pFrame, int *pnColors, int *pbFlag, int nVertexCount)
-{
-	float rValue23;
-	int bTextureGen;
-	float rNear;
-	float rFar;
-	float rScaleS;
-	float rScaleT;
-	float rSlideS;
-	float rSlideT;
-	_FRAME_TEXTURE *pTexture[8];
-	int nColors;
-	int bFlag;
-	int iTile;
-	int iHint;
-	float matrix[3][4];
-	float matrixA[3][4];
-	float matrixB[3][4];
-	float matrix44[4][4];
-	float matrixProjection[4][4];
-	_GXProjectionType eTypeProjection;
-	float scale;
-	int nCount;
-	int iIndex;
-	// References: ganNameTexMtx (0x800EA898)
-	// References: snScissorChanged (0x80135690)
-	// References: snScissorWidth (0x8013569C)
-	// References: snScissorHeight (0x801356A0)
-	// References: snScissorYOrig (0x80135698)
-	// References: snScissorXOrig (0x80135694)
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r7
+    struct __anon_0x23FC4* pVertex; // r3
 }
 
-int frameDrawSetup2D(Frame_Class_t *pFrame)
-{
-	float matrix44[4][4];
-	// References: snScissorChanged (0x80135690)
-	// References: snScissorHeight (0x801356A0)
-	// References: snScissorWidth (0x8013569C)
-	// References: snScissorYOrig (0x80135698)
-	// References: snScissorXOrig (0x80135694)
+// Range: 0x80028DC0 -> 0x80028F7C
+static s32 frameDrawTriangle_C3T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r9
+    u8* anData; // r10
+    struct __anon_0x23FC4* pVertex; // r8
 }
 
-// Local to compilation unit
-static int frameLoadTexture(Frame_Class_t *pFrame, _FRAME_TEXTURE *pTexture, int iTextureCode, __anon_0x247BF *pTile)
-{
-	void *pData;
-	int iName;
-	int nFilter;
-	_GXTexWrapMode eWrapS;
-	_GXTexWrapMode eWrapT;
-	// References: ganNamePixel (0x78A80E80)
-	// References: ganNameColor (0x58A80E80)
+// Range: 0x80028F7C -> 0x80029118
+static s32 frameDrawTriangle_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r11
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
 }
 
-int frameFreePixels(Frame_Class_t *pFrame, _FRAME_TEXTURE *pTexture);
+// Range: 0x80029118 -> 0x80029250
+static s32 frameDrawTriangle_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
 
-// Local to compilation unit
-static int frameMakePixels(Frame_Class_t *pFrame, _FRAME_TEXTURE *pTexture, __anon_0x247BF *pTile, int bReload)
-{
-	void *aPixel;
-	int nSizeLine;
-	int nFlip;
-	int nSize;
-	int nCount;
-	int nMode;
-	int nSizeX;
-	int nSizeY;
-	int nSource;
-	int nTarget;
-	int iPixelX;
-	int iPixelY;
-	int iTarget;
-	unsigned char nData8;
-	unsigned short nData16;
-	unsigned int nData32;
-	int nSizeTextureX;
-	int nSizeTextureY;
-	long lineX;
-	long lineY;
-	long linePixX;
-	long lineStep;
-	long tmemStart;
-	long tmemEnd;
-	int __nSizeX;
-	int __nSizeY;
-	unsigned int rgb[3];
-	unsigned int yuv[3];
-	// References: sRemapI$746 (0x80134DD8)
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r7
+    struct __anon_0x23FC4* pVertex; // r3
 }
 
-int frameFreeTLUT(Frame_Class_t *pFrame, _FRAME_TEXTURE *pTexture);
+// Range: 0x80029250 -> 0x800297BC
+static s32 frameDrawSetupDP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32* pnColors; // r1+0xC
+    // s32* pbFlag; // r1+0x10
 
-// Local to compilation unit
-static int frameMakeTLUT(Frame_Class_t *pFrame, _FRAME_TEXTURE *pTexture, int nCount, int nOffsetTMEM, int bReload)
-{
-	int iColor;
-	unsigned short *anColor;
-	unsigned short nData16;
+    // Local variables
+    u32 nMode; // r1+0x8
+    s32 numCycles; // r30
+    u32 mode; // r1+0x8
+    u32 cycle; // r4
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
 }
 
-void __DEMODoneRender()
-{
-	// References: DemoCurrentBuffer (0x80135A8C)
+// Range: 0x800297BC -> 0x8002984C
+static s32 frameGetCombineAlpha(enum _GXTevAlphaArg* pnAlphaTEV, s32 nAlphaN64) {
+    // Parameters
+    // enum _GXTevAlphaArg* pnAlphaTEV; // r1+0x4
+    // s32 nAlphaN64; // r1+0x8
 }
 
-void *DeallocateWrapper(void *dataP);
-
-void *AllocateWrapper(unsigned long size)
-{
-	void *tempP;
+// Range: 0x8002984C -> 0x80029948
+static s32 frameGetCombineColor(enum _GXTevColorArg* pnColorTEV, s32 nColorN64) {
+    // Parameters
+    // enum _GXTevColorArg* pnColorTEV; // r1+0x4
+    // s32 nColorN64; // r1+0x8
 }
 
-// Local to compilation unit
-static void frameDrawDone()
-{
-	// References: gNoSwapBuffer (0x801356BC)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: gbFrameValid (0x80135688)
+// Range: 0x80029948 -> 0x8002A2FC
+static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag, s32 nVertexCount) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r28
+    // s32* pnColors; // r29
+    // s32* pbFlag; // r30
+    // s32 nVertexCount; // r31
+
+    // Local variables
+    float rValue23; // f1
+    s32 bTextureGen; // r22
+    float rNear; // f24
+    float rFar; // f4
+    float rScaleS; // f25
+    float rScaleT; // f24
+    float rSlideS; // f4
+    float rSlideT; // f2
+    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x12C
+    s32 nColors; // r21
+    s32 bFlag; // r20
+    s32 iTile; // r19
+    s32 iHint; // r1+0x8
+    float matrix[3][4]; // r1+0xFC
+    float matrixA[3][4]; // r1+0xCC
+    float matrixB[3][4]; // r1+0x9C
+    float matrix44[4][4]; // r1+0x5C
+    float matrixProjection[4][4]; // r1+0x1C
+    enum _GXProjectionType eTypeProjection; // r4
+    float scale; // r1+0x8
+    s32 nCount; // r18
+    s32 iIndex; // r6
+
+    // References
+    // -> u32 ganNameTexMtx[8];
+    // -> static s32 snScissorChanged;
+    // -> static u32 snScissorWidth;
+    // -> static u32 snScissorHeight;
+    // -> static u32 snScissorYOrig;
+    // -> static u32 snScissorXOrig;
 }
 
-int frameSetVertexArray();
+// Range: 0x8002A2FC -> 0x8002A4A8
+s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
 
-// Local to compilation unit
-static void frameDrawSyncCallback(unsigned short nToken)
-{
-	// References: sCopyFrameSyncReceived (0x801356A4)
+    // Local variables
+    float matrix44[4][4]; // r1+0x10
+
+    // References
+    // -> static s32 snScissorChanged;
+    // -> static u32 snScissorHeight;
+    // -> static u32 snScissorWidth;
+    // -> static u32 snScissorYOrig;
+    // -> static u32 snScissorXOrig;
 }
 
-// Local to compilation unit
-static int frameDrawSetupFog_Default(Frame_Class_t *pFrame)
-{
-	int iHint;
-	float rNear;
-	float rFar;
-	float rFOVY;
-	float matrixProjection[4][4];
-	_GXFogAdjTable fogTable;
-	float rMax;
-	float rMin;
-	float rIntpV;
-	float rMinimum;
-	float rMultiplier;
-	float rOffset;
+// Range: 0x8002A4A8 -> 0x8002A784
+static s32 frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 iTextureCode,
+                            struct __anon_0x247BF* pTile) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r26
+    // struct _FRAME_TEXTURE* pTexture; // r27
+    // s32 iTextureCode; // r1+0x18
+    // struct __anon_0x247BF* pTile; // r1+0x1C
+
+    // Local variables
+    void* pData; // r4
+    s32 iName; // r30
+    s32 nFilter; // r4
+    enum _GXTexWrapMode eWrapS; // r29
+    enum _GXTexWrapMode eWrapT; // r28
+
+    // References
+    // -> enum _GXTexMapID ganNamePixel[8];
+    // -> u32 ganNameColor[8];
 }
 
-// Local to compilation unit
-static int frameDrawSetupFog_Zelda1(Frame_Class_t *pFrame)
-{
-	_GXFogType nFogType;
-	float rNear;
-	float rFar;
-	unsigned int nMode;
-	unsigned int iHint;
-	float rFogNear;
-	float rFogFar;
-	float rFogMin;
-	float rFogMax;
-	float rMultiplier;
-	float rOffset;
-	float rMinimum;
-	float rMaximum;
-	float dplane;
-	float dplane;
-	float dplane;
-	float dplane;
-	float dplane;
-	float rFarScale;
-	float rNearScale;
-	// References: gpSystem (0x561380)
+// Erased
+static s32 frameFreePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct _FRAME_TEXTURE* pTexture; // r31
 }
 
-int frameSetProjection(Frame_Class_t *pFrame, int iHint)
-{
-	__anon_0x24A81 *pHint;
+// Range: 0x8002A784 -> 0x8002C178
+static s32 frameMakePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, struct __anon_0x247BF* pTile,
+                           s32 bReload) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r19
+    // struct _FRAME_TEXTURE* pTexture; // r16
+    // struct __anon_0x247BF* pTile; // r26
+    // s32 bReload; // r17
+
+    // Local variables
+    void* aPixel; // r24
+    s32 nSizeLine; // r18
+    s32 nFlip; // r9
+    s32 nSize; // r1+0x40
+    s32 nCount; // r1+0x8
+    s32 nMode; // r1+0x8
+    s32 nSizeX; // r30
+    s32 nSizeY; // r15
+    s32 nSource; // r10
+    s32 nTarget; // r11
+    s32 iPixelX; // r3
+    s32 iPixelY; // r20
+    s32 iTarget; // r1+0x8
+    u8 nData8; // r31
+    u16 nData16; // r31
+    u32 nData32; // r31
+    s32 nSizeTextureX; // r1+0x8
+    s32 nSizeTextureY; // r26
+    s32 lineX; // r1+0x8
+    s32 lineY; // r1+0x8
+    s32 linePixX; // r4
+    s32 lineStep; // r5
+    s32 tmemStart; // r21
+    s32 tmemEnd; // r23
+    s32 __nSizeX; // r5
+    s32 __nSizeY; // r6
+    u32 rgb[3]; // r1+0x24
+    u32 yuv[3]; // r1+0x18
+
+    // References
+    // -> static u8 sRemapI$746[8];
 }
 
+// Erased
+static s32 frameFreeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // struct _FRAME_TEXTURE* pTexture; // r1+0x4
+}
+
+// Range: 0x8002C178 -> 0x8002C2E4
+static s32 frameMakeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 nCount, s32 nOffsetTMEM,
+                         s32 bReload) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct _FRAME_TEXTURE* pTexture; // r28
+    // s32 nCount; // r30
+    // s32 nOffsetTMEM; // r31
+    // s32 bReload; // r1+0x18
+
+    // Local variables
+    s32 iColor; // r5
+    u16* anColor; // r3
+    u16 nData16; // r1+0x8
+}
+
+// Erased
+static void __DEMODoneRender() {
+    // References
+    // -> void* DemoCurrentBuffer;
+}
+
+// Erased
+static void* DeallocateWrapper(void* dataP) {
+    // Parameters
+    // void* dataP; // r1+0x8
+}
+
+// Erased
+static void* AllocateWrapper(u32 size) {
+    // Parameters
+    // u32 size; // r1+0x8
+
+    // Local variables
+    void* tempP; // r1+0xC
+}
+
+// Range: 0x8002C2E4 -> 0x8002C360
+static void frameDrawDone() {
+    // References
+    // -> s32 gNoSwapBuffer;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> static s32 gbFrameValid;
+}
+
+// Erased
+static s32 frameSetVertexArray() {}
+
+// Range: 0x8002C360 -> 0x8002C378
+static void frameDrawSyncCallback(u16 nToken) {
+    // Parameters
+    // u16 nToken; // r1+0x0
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Range: 0x8002C378 -> 0x8002C67C
+static s32 frameDrawSetupFog_Default(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+
+    // Local variables
+    s32 iHint; // r6
+    float rNear; // f31
+    float rFar; // f30
+    float rFOVY; // f29
+    float matrixProjection[4][4]; // r1+0x34
+    struct _GXFogAdjTable fogTable; // r1+0x20
+    float rMax; // f2
+    float rMin; // r1+0x8
+    float rIntpV; // f4
+    float rMinimum; // r1+0x8
+    float rMultiplier; // f3
+    float rOffset; // r1+0x8
+}
+
+// Range: 0x8002C67C -> 0x8002CA14
+static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+
+    // Local variables
+    enum _GXFogType nFogType; // r5
+    float rNear; // r1+0x8
+    float rFar; // f2
+    u32 nMode; // r1+0x8
+    u32 iHint; // r8
+    float rFogNear; // f3
+    float rFogFar; // f4
+    float rFogMin; // f1
+    float rFogMax; // f2
+    float rMultiplier; // f6
+    float rOffset; // f7
+    float rMinimum; // f1
+    float rMaximum; // f9
+    float dplane; // f6
+    float dplane; // f5
+    float dplane; // f5
+    float dplane; // f5
+    float dplane; // f5
+    float rFarScale; // f8
+    float rNearScale; // f10
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+}
+
+// Erased
+static s32 frameSetProjection(struct __anon_0x24C38* pFrame, s32 iHint) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 iHint; // r1+0xC
+
+    // Local variables
+    struct __anon_0x24A81* pHint; // r1+0x8
+}

--- a/debug/Fire/_frameGCNcc.c
+++ b/debug/Fire/_frameGCNcc.c
@@ -7,7 +7,7 @@
 
 #include "types.h"
 
-enum _GXTevColorArg {
+typedef enum _GXTevColorArg {
     GX_CC_CPREV = 0,
     GX_CC_APREV = 1,
     GX_CC_C0 = 2,
@@ -28,12 +28,12 @@ enum _GXTevColorArg {
     GX_CC_TEXGGG = 17,
     GX_CC_TEXBBB = 18,
     GX_CC_QUARTER = 14,
-};
+} __anon_0x84A0A;
 
 // size = 0x40, address = 0x800F0158
 enum _GXTevColorArg gCombinedColor[16];
 
-enum _GXTevAlphaArg {
+typedef enum _GXTevAlphaArg {
     GX_CA_APREV = 0,
     GX_CA_A0 = 1,
     GX_CA_A1 = 2,
@@ -43,12 +43,12 @@ enum _GXTevAlphaArg {
     GX_CA_KONST = 6,
     GX_CA_ZERO = 7,
     GX_CA_ONE = 6,
-};
+} __anon_0x84BAC;
 
 // size = 0x20, address = 0x800F0198
 enum _GXTevAlphaArg gCombinedAlpha[8];
 
-enum _GXTevStageID {
+typedef enum _GXTevStageID {
     GX_TEVSTAGE0 = 0,
     GX_TEVSTAGE1 = 1,
     GX_TEVSTAGE2 = 2,
@@ -66,7 +66,7 @@ enum _GXTevStageID {
     GX_TEVSTAGE14 = 14,
     GX_TEVSTAGE15 = 15,
     GX_MAX_TEVSTAGE = 16,
-};
+} __anon_0x84CA5;
 
 // size = 0x40, address = 0x800F01B8
 static enum _GXTevStageID ganNameTevStage[16];
@@ -74,7 +74,7 @@ static enum _GXTevStageID ganNameTevStage[16];
 // size = 0x5, address = 0x80135370
 static u8 sOrder[5];
 
-enum _GXTevOp {
+typedef enum _GXTevOp {
     GX_TEV_ADD = 0,
     GX_TEV_SUB = 1,
     GX_TEV_COMP_R8_GT = 8,
@@ -87,38 +87,38 @@ enum _GXTevOp {
     GX_TEV_COMP_RGB8_EQ = 15,
     GX_TEV_COMP_A8_GT = 14,
     GX_TEV_COMP_A8_EQ = 15,
-};
+} __anon_0x84E8A;
 
-enum _GXTevBias {
+typedef enum _GXTevBias {
     GX_TB_ZERO = 0,
     GX_TB_ADDHALF = 1,
     GX_TB_SUBHALF = 2,
     GX_MAX_TEVBIAS = 3,
-};
+} __anon_0x84FB5;
 
-enum _GXTevScale {
+typedef enum _GXTevScale {
     GX_CS_SCALE_1 = 0,
     GX_CS_SCALE_2 = 1,
     GX_CS_SCALE_4 = 2,
     GX_CS_DIVIDE_2 = 3,
     GX_MAX_TEVSCALE = 4,
-};
+} __anon_0x85020;
 
-enum _GXTevRegID {
+typedef enum _GXTevRegID {
     GX_TEVPREV = 0,
     GX_TEVREG0 = 1,
     GX_TEVREG1 = 2,
     GX_TEVREG2 = 3,
     GX_MAX_TEVREG = 4,
-};
+} __anon_0x850A3;
 
-struct TevColorOp {
+typedef struct TevColorOp {
     /* 0x00 */ enum _GXTevOp op;
     /* 0x04 */ enum _GXTevBias bias;
     /* 0x08 */ enum _GXTevScale scale;
     /* 0x0C */ u8 clamp;
     /* 0x10 */ enum _GXTevRegID out_reg;
-}; // size = 0x14
+} __anon_0x85117; // size = 0x14
 
 // size = 0x64, address = 0x800F01F8
 static struct TevColorOp sTevColorOp[5];
@@ -158,20 +158,20 @@ static void UpdateRenderModeList(u32 renderMode, u32 cycle) {
     // -> static u8 sMemShift$301[2][4];
 }
 
-enum __anon_0x8573D {
+typedef enum __anon_0x8573D {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x8573D;
 
-struct __anon_0x857A7 {
+typedef struct __anon_0x857A7 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x857A7; // size = 0x10
 
-enum __anon_0x85858 {
+typedef enum __anon_0x85858 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -186,9 +186,9 @@ enum __anon_0x85858 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x85858;
 
-enum __anon_0x8598C {
+typedef enum __anon_0x8598C {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -207,9 +207,9 @@ enum __anon_0x8598C {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x8598C;
 
-struct __anon_0x85ACF {
+typedef struct __anon_0x85ACF {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -221,33 +221,33 @@ struct __anon_0x85ACF {
     /* 0x70 */ enum __anon_0x8598C storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x85ACF; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x85ACF* gpSystem;
 
-struct __anon_0x85D00 {
+typedef struct __anon_0x85D00 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x85D00; // size = 0x10
 
-struct __anon_0x85D9A {
+typedef struct __anon_0x85D9A {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x85D9A; // size = 0x14
 
-struct __anon_0x85EDB {
+typedef struct __anon_0x85EDB {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x85EDB; // size = 0xC
 
-struct __anon_0x85F4B {
+typedef struct __anon_0x85F4B {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x85EDB rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -262,36 +262,36 @@ struct __anon_0x85F4B {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x85F4B; // size = 0x3C
 
-struct __anon_0x8617B {
+typedef struct __anon_0x8617B {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x85EDB rS;
     /* 0x10 */ struct __anon_0x85EDB rT;
     /* 0x1C */ struct __anon_0x85EDB rSRaw;
     /* 0x28 */ struct __anon_0x85EDB rTRaw;
-}; // size = 0x34
+} __anon_0x8617B; // size = 0x34
 
-struct __anon_0x86264 {
+typedef struct __anon_0x86264 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x85EDB vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x86264; // size = 0x1C
 
-union __anon_0x863C3 {
+typedef union __anon_0x863C3 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x863C3;
 
-struct __anon_0x86460 {
+typedef struct __anon_0x86460 {
     /* 0x0 */ union __anon_0x863C3 data;
-}; // size = 0x1000
+} __anon_0x86460; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -318,24 +318,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x864F9;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x866BB; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x86722; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x86768;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -355,9 +355,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x867D1; // size = 0x6C
 
-struct __anon_0x86B2E {
+typedef struct __anon_0x86B2E {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -374,15 +374,15 @@ struct __anon_0x86B2E {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x86B2E; // size = 0x2C
 
-enum __anon_0x86E10 {
+typedef enum __anon_0x86E10 {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x86E10;
 
-struct __anon_0x86E99 {
+typedef struct __anon_0x86E99 {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -392,9 +392,9 @@ struct __anon_0x86E99 {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x86E10 eProjection;
-}; // size = 0x24
+} __anon_0x86E99; // size = 0x24
 
-struct __anon_0x87050 {
+typedef struct __anon_0x87050 {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -485,9 +485,9 @@ struct __anon_0x87050 {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x87050; // size = 0x3D150
 
-enum _GXTexCoordID {
+typedef enum _GXTexCoordID {
     GX_TEXCOORD0 = 0,
     GX_TEXCOORD1 = 1,
     GX_TEXCOORD2 = 2,
@@ -498,9 +498,9 @@ enum _GXTexCoordID {
     GX_TEXCOORD7 = 7,
     GX_MAX_TEXCOORD = 8,
     GX_TEXCOORD_NULL = 255,
-};
+} __anon_0x87EDC;
 
-enum _GXTexMapID {
+typedef enum _GXTexMapID {
     GX_TEXMAP0 = 0,
     GX_TEXMAP1 = 1,
     GX_TEXMAP2 = 2,
@@ -512,9 +512,9 @@ enum _GXTexMapID {
     GX_MAX_TEXMAP = 8,
     GX_TEXMAP_NULL = 255,
     GX_TEX_DISABLE = 256,
-};
+} __anon_0x87FB5;
 
-enum _GXChannelID {
+typedef enum _GXChannelID {
     GX_COLOR0 = 0,
     GX_COLOR1 = 1,
     GX_ALPHA0 = 2,
@@ -525,15 +525,15 @@ enum _GXChannelID {
     GX_ALPHA_BUMP = 7,
     GX_ALPHA_BUMPN = 8,
     GX_COLOR_NULL = 255,
-};
+} __anon_0x8808B;
 
-struct TevOrder {
+typedef struct TevOrder {
     /* 0x0 */ enum _GXTexCoordID coordID;
     /* 0x4 */ enum _GXTexMapID mapID;
     /* 0x8 */ enum _GXChannelID chanID;
-}; // size = 0xC
+} __anon_0x88153; // size = 0xC
 
-struct CombineModeTev {
+typedef struct CombineModeTev {
     /* 0x000 */ u32 ccCodes[2][2];
     /* 0x010 */ u8 numCycles;
     /* 0x011 */ u8 numStages;
@@ -544,7 +544,7 @@ struct CombineModeTev {
     /* 0x078 */ struct TevColorOp tevColorOpP[8][2];
     /* 0x1B8 */ enum _GXTevColorArg tevColorArg[8][4];
     /* 0x238 */ enum _GXTevAlphaArg tevAlphaArg[8][4];
-}; // size = 0x2B8
+} __anon_0x882D1; // size = 0x2B8
 
 // Range: 0x80097D9C -> 0x80097E5C
 s32 SetTevStageTable(struct __anon_0x87050* pFrame, s32 numCycles) {
@@ -655,12 +655,12 @@ static void OutputCCMode(s32 cycle, u32 tempColor, u32 tempAlpha) {
     // -> static char* sColorNames[16];
 }
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x88E4A; // size = 0x4
 
 // Range: 0x800983A0 -> 0x800986A4
 static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeTev* ctP) {

--- a/debug/Fire/_frameGCNcc.c
+++ b/debug/Fire/_frameGCNcc.c
@@ -1,735 +1,682 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_frameGCNcc.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80097D9C -> 0x800986A4
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
-
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
-
-// size: 0x4
-enum _GXTevColorArg
-{
-	GX_CC_CPREV = 0,
-	GX_CC_APREV = 1,
-	GX_CC_C0 = 2,
-	GX_CC_A0 = 3,
-	GX_CC_C1 = 4,
-	GX_CC_A1 = 5,
-	GX_CC_C2 = 6,
-	GX_CC_A2 = 7,
-	GX_CC_TEXC = 8,
-	GX_CC_TEXA = 9,
-	GX_CC_RASC = 10,
-	GX_CC_RASA = 11,
-	GX_CC_ONE = 12,
-	GX_CC_HALF = 13,
-	GX_CC_KONST = 14,
-	GX_CC_ZERO = 15,
-	GX_CC_TEXRRR = 16,
-	GX_CC_TEXGGG = 17,
-	GX_CC_TEXBBB = 18,
-	GX_CC_QUARTER = 14
+enum _GXTevColorArg {
+    GX_CC_CPREV = 0,
+    GX_CC_APREV = 1,
+    GX_CC_C0 = 2,
+    GX_CC_A0 = 3,
+    GX_CC_C1 = 4,
+    GX_CC_A1 = 5,
+    GX_CC_C2 = 6,
+    GX_CC_A2 = 7,
+    GX_CC_TEXC = 8,
+    GX_CC_TEXA = 9,
+    GX_CC_RASC = 10,
+    GX_CC_RASA = 11,
+    GX_CC_ONE = 12,
+    GX_CC_HALF = 13,
+    GX_CC_KONST = 14,
+    GX_CC_ZERO = 15,
+    GX_CC_TEXRRR = 16,
+    GX_CC_TEXGGG = 17,
+    GX_CC_TEXBBB = 18,
+    GX_CC_QUARTER = 14,
 };
 
-// Location: 0x58010F80
-_GXTevColorArg gCombinedColor[16];
+// size = 0x40, address = 0x800F0158
+enum _GXTevColorArg gCombinedColor[16];
 
-// size: 0x4
-enum _GXTevAlphaArg
-{
-	GX_CA_APREV = 0,
-	GX_CA_A0 = 1,
-	GX_CA_A1 = 2,
-	GX_CA_A2 = 3,
-	GX_CA_TEXA = 4,
-	GX_CA_RASA = 5,
-	GX_CA_KONST = 6,
-	GX_CA_ZERO = 7,
-	GX_CA_ONE = 6
+enum _GXTevAlphaArg {
+    GX_CA_APREV = 0,
+    GX_CA_A0 = 1,
+    GX_CA_A1 = 2,
+    GX_CA_A2 = 3,
+    GX_CA_TEXA = 4,
+    GX_CA_RASA = 5,
+    GX_CA_KONST = 6,
+    GX_CA_ZERO = 7,
+    GX_CA_ONE = 6,
 };
 
-// Location: 0x800F0198
-_GXTevAlphaArg gCombinedAlpha[8];
+// size = 0x20, address = 0x800F0198
+enum _GXTevAlphaArg gCombinedAlpha[8];
 
-// size: 0x4
-enum _GXTevStageID
-{
-	GX_TEVSTAGE0 = 0,
-	GX_TEVSTAGE1 = 1,
-	GX_TEVSTAGE2 = 2,
-	GX_TEVSTAGE3 = 3,
-	GX_TEVSTAGE4 = 4,
-	GX_TEVSTAGE5 = 5,
-	GX_TEVSTAGE6 = 6,
-	GX_TEVSTAGE7 = 7,
-	GX_TEVSTAGE8 = 8,
-	GX_TEVSTAGE9 = 9,
-	GX_TEVSTAGE10 = 10,
-	GX_TEVSTAGE11 = 11,
-	GX_TEVSTAGE12 = 12,
-	GX_TEVSTAGE13 = 13,
-	GX_TEVSTAGE14 = 14,
-	GX_TEVSTAGE15 = 15,
-	GX_MAX_TEVSTAGE = 16
+enum _GXTevStageID {
+    GX_TEVSTAGE0 = 0,
+    GX_TEVSTAGE1 = 1,
+    GX_TEVSTAGE2 = 2,
+    GX_TEVSTAGE3 = 3,
+    GX_TEVSTAGE4 = 4,
+    GX_TEVSTAGE5 = 5,
+    GX_TEVSTAGE6 = 6,
+    GX_TEVSTAGE7 = 7,
+    GX_TEVSTAGE8 = 8,
+    GX_TEVSTAGE9 = 9,
+    GX_TEVSTAGE10 = 10,
+    GX_TEVSTAGE11 = 11,
+    GX_TEVSTAGE12 = 12,
+    GX_TEVSTAGE13 = 13,
+    GX_TEVSTAGE14 = 14,
+    GX_TEVSTAGE15 = 15,
+    GX_MAX_TEVSTAGE = 16,
 };
 
-// Local to compilation unit
-// Location: 0x800F01B8
-static _GXTevStageID ganNameTevStage[16];
+// size = 0x40, address = 0x800F01B8
+static enum _GXTevStageID ganNameTevStage[16];
 
-// Local to compilation unit
-// Location: 0x70531380
-static unsigned char sOrder[5];
+// size = 0x5, address = 0x80135370
+static u8 sOrder[5];
 
-// size: 0x4
-enum _GXTevOp
-{
-	GX_TEV_ADD = 0,
-	GX_TEV_SUB = 1,
-	GX_TEV_COMP_R8_GT = 8,
-	GX_TEV_COMP_R8_EQ = 9,
-	GX_TEV_COMP_GR16_GT = 10,
-	GX_TEV_COMP_GR16_EQ = 11,
-	GX_TEV_COMP_BGR24_GT = 12,
-	GX_TEV_COMP_BGR24_EQ = 13,
-	GX_TEV_COMP_RGB8_GT = 14,
-	GX_TEV_COMP_RGB8_EQ = 15,
-	GX_TEV_COMP_A8_GT = 14,
-	GX_TEV_COMP_A8_EQ = 15
+enum _GXTevOp {
+    GX_TEV_ADD = 0,
+    GX_TEV_SUB = 1,
+    GX_TEV_COMP_R8_GT = 8,
+    GX_TEV_COMP_R8_EQ = 9,
+    GX_TEV_COMP_GR16_GT = 10,
+    GX_TEV_COMP_GR16_EQ = 11,
+    GX_TEV_COMP_BGR24_GT = 12,
+    GX_TEV_COMP_BGR24_EQ = 13,
+    GX_TEV_COMP_RGB8_GT = 14,
+    GX_TEV_COMP_RGB8_EQ = 15,
+    GX_TEV_COMP_A8_GT = 14,
+    GX_TEV_COMP_A8_EQ = 15,
 };
 
-// size: 0x4
-enum _GXTevBias
-{
-	GX_TB_ZERO = 0,
-	GX_TB_ADDHALF = 1,
-	GX_TB_SUBHALF = 2,
-	GX_MAX_TEVBIAS = 3
+enum _GXTevBias {
+    GX_TB_ZERO = 0,
+    GX_TB_ADDHALF = 1,
+    GX_TB_SUBHALF = 2,
+    GX_MAX_TEVBIAS = 3,
 };
 
-// size: 0x4
-enum _GXTevScale
-{
-	GX_CS_SCALE_1 = 0,
-	GX_CS_SCALE_2 = 1,
-	GX_CS_SCALE_4 = 2,
-	GX_CS_DIVIDE_2 = 3,
-	GX_MAX_TEVSCALE = 4
+enum _GXTevScale {
+    GX_CS_SCALE_1 = 0,
+    GX_CS_SCALE_2 = 1,
+    GX_CS_SCALE_4 = 2,
+    GX_CS_DIVIDE_2 = 3,
+    GX_MAX_TEVSCALE = 4,
 };
 
-// size: 0x4
-enum _GXTevRegID
-{
-	GX_TEVPREV = 0,
-	GX_TEVREG0 = 1,
-	GX_TEVREG1 = 2,
-	GX_TEVREG2 = 3,
-	GX_MAX_TEVREG = 4
+enum _GXTevRegID {
+    GX_TEVPREV = 0,
+    GX_TEVREG0 = 1,
+    GX_TEVREG1 = 2,
+    GX_TEVREG2 = 3,
+    GX_MAX_TEVREG = 4,
 };
 
-// size: 0x14
-struct TevColorOp
-{
-	_GXTevOp op; // 0x0
-	_GXTevBias bias; // 0x4
-	_GXTevScale scale; // 0x8
-	unsigned char clamp; // 0xC
-	_GXTevRegID out_reg; // 0x10
-};
+struct TevColorOp {
+    /* 0x00 */ enum _GXTevOp op;
+    /* 0x04 */ enum _GXTevBias bias;
+    /* 0x08 */ enum _GXTevScale scale;
+    /* 0x0C */ u8 clamp;
+    /* 0x10 */ enum _GXTevRegID out_reg;
+}; // size = 0x14
 
-// Local to compilation unit
-// Location: 0x800F01F8
-static TevColorOp sTevColorOp[5];
+// size = 0x64, address = 0x800F01F8
+static struct TevColorOp sTevColorOp[5];
 
-// Local to compilation unit
-// Location: 0x78531380
-static unsigned char sReplace[5];
+// size = 0x5, address = 0x80135378
+static u8 sReplace[5];
 
-// Local to compilation unit
-// Location: 0x5C020F80
-static _GXTevColorArg sTevColorArg[5][4];
+// size = 0x50, address = 0x800F025C
+static enum _GXTevColorArg sTevColorArg[5][4];
 
-// Local to compilation unit
-// Location: 0x800F02AC
-static _GXTevAlphaArg sTevAlphaArg[5][4];
+// size = 0x50, address = 0x800F02AC
+static enum _GXTevAlphaArg sTevAlphaArg[5][4];
 
-// Location: 0x0
-unsigned long sCurCCMode;
+// size = 0x40, address = 0x800F0390
+static char* sColorNames[16];
 
-// Location: 0x0
-unsigned long sPrevCCModes[100][2][2];
+// size = 0x40, address = 0x800F03D0
+static char* sAlphaNames[2][8];
 
-// Local to compilation unit
-// Location: 0x800F0390
-static char  *sColorNames[16];
+// size = 0x40, address = 0x800F0410
+static char* strings$288[4][4];
 
-// Local to compilation unit
-// Location: 0x800F03D0
-static char  *sAlphaNames[2][8];
+// Erased
+static void UpdateRenderModeList(u32 renderMode, u32 cycle) {
+    // Parameters
+    // u32 renderMode; // r1+0x8
+    // u32 cycle; // r23
 
-// Location: 0x0
-unsigned long sFoundRenderModes$277[100];
+    // Local variables
+    s32 i; // r5
+    u32 p[2][4]; // r1+0x10
 
-// Location: 0x0
-long sCurRenderMode$278;
-
-// Local to compilation unit
-// Location: 0x10040F80
-static char  *strings$288[4][4];
-
-// Location: 0x0
-unsigned char sMemShift$301[2][4];
-
-void UpdateRenderModeList(unsigned long renderMode, unsigned long cycle)
-{
-	long i;
-	unsigned long p[2][4];
-	// References: sCurRenderMode$278 (0x0)
-	// References: sFoundRenderModes$277 (0x0)
-	// References: strings$288 (0x10040F80)
-	// References: sMemShift$301 (0x0)
+    // References
+    // -> static s32 sCurRenderMode$278;
+    // -> static u32 sFoundRenderModes$277[100];
+    // -> static char* strings$288[4][4];
+    // -> static u8 sMemShift$301[2][4];
 }
 
-// size: 0x4
-enum __anon_0x8573D
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
+enum __anon_0x8573D {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// size: 0x10
-struct __anon_0x857A7
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+struct __anon_0x857A7 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x85858 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x4
-enum __anon_0x85858
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
+enum __anon_0x8598C {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum __anon_0x8598C
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
+struct __anon_0x85ACF {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x8573D eMode;
+    /* 0x10 */ struct __anon_0x857A7 romCopy;
+    /* 0x20 */ enum __anon_0x85858 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x8598C storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x85ACF* gpSystem;
+
+struct __anon_0x85D00 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x85D9A {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x85EDB {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x85F4B {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x85EDB rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x8617B {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x85EDB rS;
+    /* 0x10 */ struct __anon_0x85EDB rT;
+    /* 0x1C */ struct __anon_0x85EDB rSRaw;
+    /* 0x28 */ struct __anon_0x85EDB rTRaw;
+}; // size = 0x34
+
+struct __anon_0x86264 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x85EDB vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x863C3 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
 };
 
-// size: 0x88
-struct __anon_0x85ACF
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x8573D eMode; // 0xC
-	__anon_0x857A7 romCopy; // 0x10
-	__anon_0x85858 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x8598C storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
+struct __anon_0x86460 {
+    /* 0x0 */ union __anon_0x863C3 data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
 };
 
-// Location: 0x561380
-__anon_0x85ACF *gpSystem;
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
 
-// size: 0x10
-struct __anon_0x85D00
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// size: 0x14
-struct __anon_0x85D9A
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x86B2E {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x86E10 {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
 };
 
-// size: 0xC
-struct __anon_0x85EDB
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
+struct __anon_0x86E99 {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x86E10 eProjection;
+}; // size = 0x24
+
+struct __anon_0x87050 {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x85D00 viewport;
+    /* 0x000C8 */ struct __anon_0x85D9A aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x85F4B aLight[8];
+    /* 0x00320 */ struct __anon_0x8617B lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x86264 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x86460 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x86B2E aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x86E10 eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x86E99 aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+enum _GXTexCoordID {
+    GX_TEXCOORD0 = 0,
+    GX_TEXCOORD1 = 1,
+    GX_TEXCOORD2 = 2,
+    GX_TEXCOORD3 = 3,
+    GX_TEXCOORD4 = 4,
+    GX_TEXCOORD5 = 5,
+    GX_TEXCOORD6 = 6,
+    GX_TEXCOORD7 = 7,
+    GX_MAX_TEXCOORD = 8,
+    GX_TEXCOORD_NULL = 255,
 };
 
-// size: 0x3C
-struct __anon_0x85F4B
-{
-	int bTransformed; // 0x0
-	__anon_0x85EDB rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
+enum _GXTexMapID {
+    GX_TEXMAP0 = 0,
+    GX_TEXMAP1 = 1,
+    GX_TEXMAP2 = 2,
+    GX_TEXMAP3 = 3,
+    GX_TEXMAP4 = 4,
+    GX_TEXMAP5 = 5,
+    GX_TEXMAP6 = 6,
+    GX_TEXMAP7 = 7,
+    GX_MAX_TEXMAP = 8,
+    GX_TEXMAP_NULL = 255,
+    GX_TEX_DISABLE = 256,
 };
 
-// size: 0x34
-struct __anon_0x8617B
-{
-	int bTransformed; // 0x0
-	__anon_0x85EDB rS; // 0x4
-	__anon_0x85EDB rT; // 0x10
-	__anon_0x85EDB rSRaw; // 0x1C
-	__anon_0x85EDB rTRaw; // 0x28
+enum _GXChannelID {
+    GX_COLOR0 = 0,
+    GX_COLOR1 = 1,
+    GX_ALPHA0 = 2,
+    GX_ALPHA1 = 3,
+    GX_COLOR0A0 = 4,
+    GX_COLOR1A1 = 5,
+    GX_COLOR_ZERO = 6,
+    GX_ALPHA_BUMP = 7,
+    GX_ALPHA_BUMPN = 8,
+    GX_COLOR_NULL = 255,
 };
 
-// size: 0x1C
-struct __anon_0x86264
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x85EDB vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
+struct TevOrder {
+    /* 0x0 */ enum _GXTexCoordID coordID;
+    /* 0x4 */ enum _GXTexMapID mapID;
+    /* 0x8 */ enum _GXChannelID chanID;
+}; // size = 0xC
 
-// size: 0x1000
-union __anon_0x863C3
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
+struct CombineModeTev {
+    /* 0x000 */ u32 ccCodes[2][2];
+    /* 0x010 */ u8 numCycles;
+    /* 0x011 */ u8 numStages;
+    /* 0x012 */ u8 numTexGen;
+    /* 0x013 */ u8 numChan;
+    /* 0x014 */ u32 flags;
+    /* 0x018 */ struct TevOrder tevOrder[8];
+    /* 0x078 */ struct TevColorOp tevColorOpP[8][2];
+    /* 0x1B8 */ enum _GXTevColorArg tevColorArg[8][4];
+    /* 0x238 */ enum _GXTevAlphaArg tevAlphaArg[8][4];
+}; // size = 0x2B8
 
-// size: 0x1000
-struct __anon_0x86460
-{
-	__anon_0x863C3 data; // 0x0
-};
+// Range: 0x80097D9C -> 0x80097E5C
+s32 SetTevStageTable(struct __anon_0x87050* pFrame, s32 numCycles) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r31
+    // s32 numCycles; // r7
 
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
+    // Local variables
+    u32 tempColor1; // r3
+    u32 tempAlpha1; // r4
+    u32 tempColor2; // r5
+    u32 tempAlpha2; // r6
+    struct CombineModeTev* ctP; // r4
 
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x86B2E
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x86E10
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x86E99
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x86E10 eProjection; // 0x20
-};
-
-// size: 0x3D150
-struct __anon_0x87050
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x85D00 viewport; // 0xB8
-	__anon_0x85D9A aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x85F4B aLight[8]; // 0x140
-	__anon_0x8617B lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x86264 aVertex[80]; // 0x358
-	__anon_0x86460 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x86B2E aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x86E10 eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x86E99 aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-// size: 0x4
-enum _GXTexCoordID
-{
-	GX_TEXCOORD0 = 0,
-	GX_TEXCOORD1 = 1,
-	GX_TEXCOORD2 = 2,
-	GX_TEXCOORD3 = 3,
-	GX_TEXCOORD4 = 4,
-	GX_TEXCOORD5 = 5,
-	GX_TEXCOORD6 = 6,
-	GX_TEXCOORD7 = 7,
-	GX_MAX_TEXCOORD = 8,
-	GX_TEXCOORD_NULL = 255
-};
-
-// size: 0x4
-enum _GXTexMapID
-{
-	GX_TEXMAP0 = 0,
-	GX_TEXMAP1 = 1,
-	GX_TEXMAP2 = 2,
-	GX_TEXMAP3 = 3,
-	GX_TEXMAP4 = 4,
-	GX_TEXMAP5 = 5,
-	GX_TEXMAP6 = 6,
-	GX_TEXMAP7 = 7,
-	GX_MAX_TEXMAP = 8,
-	GX_TEXMAP_NULL = 255,
-	GX_TEX_DISABLE = 256
-};
-
-// size: 0x4
-enum _GXChannelID
-{
-	GX_COLOR0 = 0,
-	GX_COLOR1 = 1,
-	GX_ALPHA0 = 2,
-	GX_ALPHA1 = 3,
-	GX_COLOR0A0 = 4,
-	GX_COLOR1A1 = 5,
-	GX_COLOR_ZERO = 6,
-	GX_ALPHA_BUMP = 7,
-	GX_ALPHA_BUMPN = 8,
-	GX_COLOR_NULL = 255
-};
-
-// size: 0xC
-struct TevOrder
-{
-	_GXTexCoordID coordID; // 0x0
-	_GXTexMapID mapID; // 0x4
-	_GXChannelID chanID; // 0x8
-};
-
-// size: 0x2B8
-struct CombineModeTev
-{
-	unsigned long ccCodes[2][2]; // 0x0
-	unsigned char numCycles; // 0x10
-	unsigned char numStages; // 0x11
-	unsigned char numTexGen; // 0x12
-	unsigned char numChan; // 0x13
-	unsigned long flags; // 0x14
-	TevOrder tevOrder[8]; // 0x18
-	TevColorOp tevColorOpP[8][2]; // 0x78
-	_GXTevColorArg tevColorArg[8][4]; // 0x1B8
-	_GXTevAlphaArg tevAlphaArg[8][4]; // 0x238
-};
-
-long SetTevStageTable(__anon_0x87050 *pFrame, long numCycles)
-{
-	unsigned long tempColor1;
-	unsigned long tempAlpha1;
-	unsigned long tempColor2;
-	unsigned long tempAlpha2;
-	CombineModeTev *ctP;
-	// References: gpSystem (0x561380)
+    // References
+    // -> struct __anon_0x85ACF* gpSystem;
 }
 
-// Location: 0x800EA8B8
-_GXTexCoordID ganNameTexCoord[];
+// size = 0x0, address = 0x800EA8B8
+enum _GXTexCoordID ganNameTexCoord[];
 
-// Location: 0x78A80E80
-_GXTexMapID ganNamePixel[];
+// size = 0x0, address = 0x800EA878
+enum _GXTexMapID ganNamePixel[];
 
-void SetTevStages(__anon_0x87050 *pFrame, int cycle)
-{
-	unsigned char nColor[4];
-	unsigned char nAlpha[4];
-	unsigned int tempColor;
-	unsigned int tempAlpha;
-	_GXTevColorArg colorArg[4];
-	_GXTevAlphaArg alphaArg[4];
-	_GXTevStageID tevStages[5];
-	TevColorOp *tP;
-	long j;
-	_GXTevColorArg *cArgP;
-	_GXTevAlphaArg *aArgP;
-	long i;
-	long order;
-	// References: sTevAlphaArg (0x800F02AC)
-	// References: sTevColorArg (0x5C020F80)
-	// References: sTevColorOp (0x800F01F8)
-	// References: sOrder (0x70531380)
-	// References: sReplace (0x78531380)
-	// References: gCombinedAlpha (0x800F0198)
-	// References: gCombinedColor (0x58010F80)
-	// References: ganNamePixel (0x78A80E80)
-	// References: ganNameTexCoord (0x800EA8B8)
-	// References: ganNameTevStage (0x800F01B8)
+// Range: 0x80097E5C -> 0x800981E0
+void SetTevStages(struct __anon_0x87050* pFrame, s32 cycle) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r1+0x8
+    // s32 cycle; // r17
+
+    // Local variables
+    u8 nColor[4]; // r1+0x5C
+    u8 nAlpha[4]; // r1+0x58
+    u32 tempColor; // r6
+    u32 tempAlpha; // r9
+    enum _GXTevColorArg colorArg[4]; // r1+0x48
+    enum _GXTevAlphaArg alphaArg[4]; // r1+0x38
+    enum _GXTevStageID tevStages[5]; // r1+0x24
+    struct TevColorOp* tP; // r1+0x8
+    s32 j; // r1+0x8
+    enum _GXTevColorArg* cArgP; // r21
+    enum _GXTevAlphaArg* aArgP; // r20
+    s32 i; // r19
+    s32 order; // r18
+
+    // References
+    // -> static enum _GXTevAlphaArg sTevAlphaArg[5][4];
+    // -> static enum _GXTevColorArg sTevColorArg[5][4];
+    // -> static struct TevColorOp sTevColorOp[5];
+    // -> static u8 sOrder[5];
+    // -> static u8 sReplace[5];
+    // -> enum _GXTevAlphaArg gCombinedAlpha[8];
+    // -> enum _GXTevColorArg gCombinedColor[16];
+    // -> enum _GXTexMapID ganNamePixel[];
+    // -> enum _GXTexCoordID ganNameTexCoord[];
+    // -> static enum _GXTevStageID ganNameTevStage[16];
 }
 
-void SetNumTexGensChans(__anon_0x87050 *pFrame, int numCycles)
-{
-	unsigned char nColor[4];
-	unsigned char nAlpha[4];
-	unsigned long tempColor;
-	unsigned long tempAlpha;
-	long i;
-	long j;
-	long numGens;
-	long numChans;
+// Range: 0x800981E0 -> 0x800983A0
+void SetNumTexGensChans(struct __anon_0x87050* pFrame, s32 numCycles) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r1+0x8
+    // s32 numCycles; // r1+0xC
+
+    // Local variables
+    u8 nColor[4]; // r1+0x14
+    u8 nAlpha[4]; // r1+0x10
+    u32 tempColor; // r5
+    u32 tempAlpha; // r7
+    s32 i; // r8
+    s32 j; // r1+0x8
+    s32 numGens; // r9
+    s32 numChans; // r1+0x8
 }
 
-void CheckNewCCMode(__anon_0x87050 *pFrame, long numCycles)
-{
-	long i;
-	unsigned long tempColor1;
-	unsigned long tempAlpha1;
-	unsigned long tempColor2;
-	unsigned long tempAlpha2;
-	// References: sCurCCMode (0x0)
-	// References: sPrevCCModes (0x0)
+// Erased
+static void CheckNewCCMode(struct __anon_0x87050* pFrame, s32 numCycles) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r1+0x8
+    // s32 numCycles; // r29
+
+    // Local variables
+    s32 i; // r3
+    u32 tempColor1; // r8
+    u32 tempAlpha1; // r5
+    u32 tempColor2; // r31
+    u32 tempAlpha2; // r30
+
+    // References
+    // -> static u32 sCurCCMode;
+    // -> static u32 sPrevCCModes[100][2][2];
 }
 
-void OutputCCMode(int cycle, unsigned long tempColor, unsigned long tempAlpha)
-{
-	long i;
-	unsigned char nColor[4];
-	unsigned char nAlpha[4];
-	// References: sAlphaNames (0x800F03D0)
-	// References: sColorNames (0x800F0390)
+// Erased
+static void OutputCCMode(s32 cycle, u32 tempColor, u32 tempAlpha) {
+    // Parameters
+    // s32 cycle; // r1+0x8
+    // u32 tempColor; // r1+0xC
+    // u32 tempAlpha; // r1+0x10
+
+    // Local variables
+    s32 i; // r1+0x8
+    u8 nColor[4]; // r1+0x18
+    u8 nAlpha[4]; // r1+0x14
+
+    // References
+    // -> static char* sAlphaNames[2][8];
+    // -> static char* sColorNames[16];
 }
 
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
 
-// Local to compilation unit
-static void SetTableTevStages(__anon_0x87050 *pFrame, CombineModeTev *ctP)
-{
-	long i;
-	int iStart;
-	_GXColor color;
-	TevOrder *toP;
-	TevColorOp *tcP;
-	_GXTevColorArg *cArgP;
-	_GXTevAlphaArg *aArgP;
-	// References: ganNameTevStage (0x800F01B8)
+// Range: 0x800983A0 -> 0x800986A4
+static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeTev* ctP) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r30
+    // struct CombineModeTev* ctP; // r31
+
+    // Local variables
+    s32 i; // r23
+    s32 iStart; // r1+0x8
+    struct _GXColor color; // r1+0x30
+    struct TevOrder* toP; // r6
+    struct TevColorOp* tcP; // r22
+    enum _GXTevColorArg* cArgP; // r21
+    enum _GXTevAlphaArg* aArgP; // r20
+
+    // References
+    // -> static enum _GXTevStageID ganNameTevStage[16];
 }
-

--- a/debug/Fire/_gspF3DEX.c
+++ b/debug/Fire/_gspF3DEX.c
@@ -1,177 +1,214 @@
-﻿// Local to compilation unit
-static int rspParseGBI_F3DEX2(__anon_0x5845E *pRSP, unsigned long long **ppnGBI, int *pbDone)
-{
-	int iVertex;
-	int bDone;
-	float matrix[4][4];
-	__anon_0x5EBE0 primitive;
-	unsigned long long *pnGBI;
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	__anon_0x5A89F *pFrame;
-	unsigned int nData;
-	unsigned int nSize;
-	unsigned int nMove;
-	unsigned int nData;
-	unsigned int nSize;
-	unsigned int nMove;
-	unsigned int nValue;
-	__anon_0x575BD *pTask;
-	int nAddress;
-	int nAddress;
-	int nLength;
-	int nOffset;
-	int nId;
-	int nFlag;
-	int nAddress;
-	void *pData;
-	unsigned short *pnData16;
-	signed short nFogStart;
-	signed short nFogEnd;
-	int nDelta;
-	int nStart;
-	char *pLight;
-	unsigned int iIndex;
-	int bFound;
-	void *pData;
-	int nAddress;
-	void *pData;
-	int iLight;
-	int nAddress;
-	int nAddress;
-	unsigned int nSid;
-	int nLight;
-	int nAddress;
-	int nMode;
-	int nAddress;
-	int nSet;
-	int nClr;
-	int iMatrix;
-	int nCount;
-	int nVertices;
-	int nSrcAdrs;
-	int nDestAdrs;
-	int iCount;
-	int bFound;
-	unsigned int iVtxIndex;
-	__anon_0x5EC3E destVtx;
-	int nAddress;
-	char *pBuffer;
-	int nCount;
-	int iVertex0;
-	int nAddress;
-	int nAddress;
-	int iVertex;
-	int nVal;
-	unsigned int nVertexStart;
-	unsigned int nVertexEnd;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	__anon_0x5F2FB bg;
-	__anon_0x5F2FB bg;
-	char cTempAlpha;
-	int nAddress;
-	char cTempAlpha;
-	int bPush;
-	unsigned char nSid2D;
-	unsigned int nDLAdrs;
-	unsigned int nFlag2D;
-	// References: gpSystem (0x561380)
-	// References: flagBilerp (0x80135790)
-	// References: scissorY1 (0x801352D6)
-	// References: scissorX1 (0x801352D4)
-	// References: scissorY0 (0x8013578E)
-	// References: scissorX0 (0x8013578C)
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_gspF3DEX.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80074454 -> 0x80077850
+*/
+
+#include "types.h"
+
+// Range: 0x80074454 -> 0x80076024
+static s32 rspParseGBI_F3DEX2(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u64** ppnGBI; // r27
+    // s32* pbDone; // r25
+
+    // Local variables
+    s32 iVertex; // r4
+    s32 bDone; // r25
+    float matrix[4][4]; // r1+0x410
+    struct __anon_0x5EBE0 primitive; // r1+0x10C
+    u64* pnGBI; // r28
+    u32 nCommandLo; // r6
+    u32 nCommandHi; // r1+0x8
+    struct __anon_0x5A89F* pFrame; // r30
+    u32 nData; // r1+0x8
+    u32 nSize; // r6
+    u32 nMove; // r5
+    u32 nData; // r1+0x8
+    u32 nSize; // r6
+    u32 nMove; // r5
+    u32 nValue; // r1+0x8
+    struct __anon_0x575BD* pTask; // r4
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    s32 nLength; // r27
+    s32 nOffset; // r28
+    s32 nId; // r25
+    s32 nFlag; // r26
+    s32 nAddress; // r29
+    void* pData; // r1+0x104
+    u16* pnData16; // r3
+    s16 nFogStart; // r1+0x8
+    s16 nFogEnd; // r1+0x8
+    s32 nDelta; // r3
+    s32 nStart; // r4
+    char* pLight; // r1+0x100
+    u32 iIndex; // r25
+    s32 bFound; // r5
+    void* pData; // r1+0xFC
+    s32 nAddress; // r5
+    void* pData; // r1+0xF4
+    s32 iLight; // r25
+    s32 nAddress; // r5
+    s32 nAddress; // r25
+    u32 nSid; // r1+0x8
+    s32 nLight; // r1+0x8
+    s32 nAddress; // r5
+    s32 nMode; // r25
+    s32 nAddress; // r27
+    s32 nSet; // r4
+    s32 nClr; // r5
+    s32 iMatrix; // r25
+    s32 nCount; // r26
+    s32 nVertices; // r26
+    s32 nSrcAdrs; // r1+0x8
+    s32 nDestAdrs; // r27
+    s32 iCount; // r28
+    s32 bFound; // r9
+    u32 iVtxIndex; // r10
+    struct __anon_0x5EC3E destVtx; // r1+0x9C
+    s32 nAddress; // r5
+    char* pBuffer; // r1+0x94
+    s32 nCount; // r25
+    s32 iVertex0; // r26
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    s32 iVertex; // r4
+    s32 nVal; // r1+0x8
+    u32 nVertexStart; // r4
+    u32 nVertexEnd; // r5
+    s32 nAddress; // r5
+    s32 nAddress; // r25
+    s32 nAddress; // r25
+    s32 nAddress; // r25
+    s32 nAddress; // r25
+    union __anon_0x5F2FB bg; // r1+0x68
+    union __anon_0x5F2FB bg; // r1+0x40
+    char cTempAlpha; // r25
+    s32 nAddress; // r5
+    char cTempAlpha; // r25
+    s32 bPush; // r27
+    u8 nSid2D; // r1+0x8
+    u32 nDLAdrs; // r6
+    u32 nFlag2D; // r1+0x8
+
+    // References
+    // -> struct __anon_0x5E98D* gpSystem;
+    // -> static u8 flagBilerp;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
 }
 
-// Local to compilation unit
-static int rspGeometryMode(__anon_0x5845E *pRSP, int nSet, int nClr)
-{
-	int nMode;
+// Range: 0x80076024 -> 0x8007610C
+static s32 rspGeometryMode(struct __anon_0x5845E* pRSP, s32 nSet, s32 nClr) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nSet; // r1+0xC
+    // s32 nClr; // r1+0x10
+
+    // Local variables
+    s32 nMode; // r6
 }
 
-// Local to compilation unit
-static int rspParseGBI_F3DEX1(__anon_0x5845E *pRSP, unsigned long long **ppnGBI, int *pbDone)
-{
-	float matrix[4][4];
-	__anon_0x5EBE0 primitive;
-	unsigned int iVertex;
-	unsigned int bDone;
-	unsigned long long *pnGBI;
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	__anon_0x5A89F *pFrame;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	int bPush;
-	unsigned char nSid2D;
-	unsigned int nDLAdrs;
-	unsigned int nFlag2D;
-	__anon_0x5F2FB bg;
-	int nAddress;
-	int nMode;
-	int nAddress;
-	int nMode;
-	int nAddress;
-	int nAddress;
-	void *pData;
-	int nAddress;
-	void *pData;
-	int nAddress;
-	void *pData;
-	int nAddress;
-	char *pData;
-	int iLight;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	void *pBuffer;
-	int nCount;
-	int iVertex0;
-	int nAddress;
-	int nAddress;
-	int nAddress;
-	unsigned int nVertexStart;
-	unsigned int nVertexEnd;
-	int nWhere;
-	int nData1;
-	int nData2;
-	int iRow;
-	int iCol;
-	unsigned int nSid;
-	int nLight;
-	unsigned int nData;
-	unsigned int nSize;
-	unsigned int nMove;
-	unsigned int nData;
-	unsigned int nSize;
-	unsigned int nMove;
-	unsigned int nValue;
-	__anon_0x575BD *pTask;
-	int nAddress;
-	int iVertex;
-	int nVal;
-	// References: flagBilerp (0x80135790)
-	// References: scissorY1 (0x801352D6)
-	// References: scissorX1 (0x801352D4)
-	// References: scissorY0 (0x8013578E)
-	// References: scissorX0 (0x8013578C)
+// Range: 0x8007610C -> 0x80077790
+static s32 rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u64** ppnGBI; // r27
+    // s32* pbDone; // r24
+
+    // Local variables
+    float matrix[4][4]; // r1+0x3B0
+    struct __anon_0x5EBE0 primitive; // r1+0xAC
+    u32 iVertex; // r4
+    u32 bDone; // r24
+    u64* pnGBI; // r28
+    u32 nCommandLo; // r6
+    u32 nCommandHi; // r7
+    struct __anon_0x5A89F* pFrame; // r30
+    s32 nAddress; // r5
+    s32 nAddress; // r24
+    s32 nAddress; // r24
+    s32 nAddress; // r24
+    s32 bPush; // r24
+    u8 nSid2D; // r1+0x8
+    u32 nDLAdrs; // r7
+    u32 nFlag2D; // r1+0x8
+    union __anon_0x5F2FB bg; // r1+0x80
+    s32 nAddress; // r4
+    s32 nMode; // r24
+    s32 nAddress; // r26
+    s32 nMode; // r1+0x78
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    void* pData; // r1+0x74
+    s32 nAddress; // r5
+    void* pData; // r1+0x6C
+    s32 nAddress; // r5
+    void* pData; // r1+0x68
+    s32 nAddress; // r5
+    char* pData; // r1+0x64
+    s32 iLight; // r24
+    s32 nAddress; // r5
+    s32 nAddress; // r24
+    s32 nAddress; // r5
+    void* pBuffer; // r1+0x60
+    s32 nCount; // r6
+    s32 iVertex0; // r5
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    u32 nVertexStart; // r4
+    u32 nVertexEnd; // r5
+    s32 nWhere; // r1+0x8
+    s32 nData1; // r8
+    s32 nData2; // r1+0x8
+    s32 iRow; // r3
+    s32 iCol; // r4
+    u32 nSid; // r1+0x8
+    s32 nLight; // r1+0x8
+    u32 nData; // r1+0x8
+    u32 nSize; // r3
+    u32 nMove; // r5
+    u32 nData; // r1+0x8
+    u32 nSize; // r3
+    u32 nMove; // r5
+    u32 nValue; // r1+0x8
+    struct __anon_0x575BD* pTask; // r4
+    s32 nAddress; // r5
+    s32 iVertex; // r4
+    s32 nVal; // r1+0x8
+
+    // References
+    // -> static u8 flagBilerp;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
 }
 
-// Local to compilation unit
-static int rspSetGeometryMode1(__anon_0x5845E *pRSP, int nMode)
-{
-	int nModeFrame;
+// Range: 0x80077790 -> 0x80077850
+static s32 rspSetGeometryMode1(struct __anon_0x5845E* pRSP, s32 nMode) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nMode; // r1+0xC
+
+    // Local variables
+    s32 nModeFrame; // r5
 }
 
-int MulMatrices(float *aOutMatrix[4], float *aLeftMatrix[4], float *aRightMatrix[4])
-{
-	int i;
-	int j;
-}
+// Erased
+static s32 MulMatrices(float (*aOutMatrix)[4], float (*aLeftMatrix)[4], float (*aRightMatrix)[4]) {
+    // Parameters
+    // float (* aOutMatrix)[4]; // r3
+    // float (* aLeftMatrix)[4]; // r4
+    // float (* aRightMatrix)[4]; // r5
 
+    // Local variables
+    s32 i; // r8
+    s32 j; // r1+0x0
+}

--- a/debug/Fire/_gspJPEG.c
+++ b/debug/Fire/_gspJPEG.c
@@ -1,211 +1,348 @@
-﻿// Local to compilation unit
-static int rspParseJPEG_DecodeZ(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	int y;
-	signed short *temp;
-	signed short *temp2;
-	unsigned long long *system_imb;
-	unsigned int *infoStruct;
-	int size;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_gspJPEG.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x8007AC6C -> 0x80080AA4
+*/
+
+#include "types.h"
+
+// Range: 0x8007AC6C -> 0x8007AD68
+static s32 rspParseJPEG_DecodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r4
+
+    // Local variables
+    s32 y; // r31
+    s16* temp; // r1+0x8
+    s16* temp2; // r30
+    u64* system_imb; // r1+0x20
+    u32* infoStruct; // r1+0x1C
+    s32 size; // r29
 }
 
-// Local to compilation unit
-static int rspParseJPEG_EncodeZ(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	int y;
-	signed short *temp;
-	signed short *temp2;
-	unsigned long long *system_imb;
-	unsigned int *infoStruct;
-	int size;
+// Range: 0x8007AD68 -> 0x8007AE64
+static s32 rspParseJPEG_EncodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r4
+
+    // Local variables
+    s32 y; // r31
+    s16* temp; // r1+0x8
+    s16* temp2; // r30
+    u64* system_imb; // r1+0x20
+    u32* infoStruct; // r1+0x1C
+    s32 size; // r29
 }
 
-int rspRecon420Z(__anon_0x5845E *pRSP, signed short *imgBuf)
-{
-	int i;
-	int j;
-	int r;
-	int g;
-	int b;
-	int y;
-	int u;
-	int v;
+// Range: 0x8007AE64 -> 0x8007B244
+s32 rspRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* imgBuf; // r1+0xC
+
+    // Local variables
+    s32 i; // r1+0x10
+    s32 j; // r26
+    s32 r; // r10
+    s32 g; // r7
+    s32 b; // r11
+    s32 y; // r6
+    s32 u; // r9
+    s32 v; // r1+0x8
 }
 
-int rspLoadColorBufferZ(int *r, int *g, int *b, signed short *imgBuf, int index);
-
-int rspUndoRecon420Z(__anon_0x5845E *pRSP, signed short *imgBuf)
-{
-	int i;
-	int j;
-	int r;
-	int g;
-	int b;
-	int y;
-	int u;
-	int v;
+// Erased
+static s32 rspLoadColorBufferZ(s32* r, s32* g, s32* b, s16* imgBuf, s32 index) {
+    // Parameters
+    // s32* r; // r1+0x4
+    // s32* g; // r1+0x8
+    // s32* b; // r1+0xC
+    // s16* imgBuf; // r1+0x10
+    // s32 index; // r1+0x14
 }
 
-int rspUndoLoadColorBufferZ(int r, int g, int b, signed short *imgBuf, int index);
+// Range: 0x8007B244 -> 0x8007B64C
+s32 rspUndoRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s16* imgBuf; // r29
 
-void rspUndoDCTZ(__anon_0x5845E *pRSP)
-{
-	int c;
-	int i;
-	int j;
-	int dd;
-	signed short t[8][8];
+    // Local variables
+    s32 i; // r1+0x8
+    s32 j; // r24
+    s32 r; // r1+0x8
+    s32 g; // r1+0x8
+    s32 b; // r1+0x8
+    s32 y; // r7
+    s32 u; // r5
+    s32 v; // r1+0x8
 }
 
-void rspUndoZigzagDataZ(__anon_0x5845E *pRSP, signed short *dataBuf)
-{
-	int c;
+// Range: 0x8007B64C -> 0x8007B6E0
+s32 rspUndoLoadColorBufferZ(s32 r, s32 g, s32 b, s16* imgBuf, s32 index) {
+    // Parameters
+    // s32 r; // r3
+    // s32 g; // r1+0x8
+    // s32 b; // r4
+    // s16* imgBuf; // r1+0x10
+    // s32 index; // r1+0x14
 }
 
-void rspUndoQuantizeZ(__anon_0x5845E *pRSP, signed short *dataBuf)
-{
-	int c;
-	int i;
+// Range: 0x8007B6E0 -> 0x8007B9B0
+void rspUndoDCTZ(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r5
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
 }
 
-void rspZigzagDataZ(__anon_0x5845E *pRSP, signed short *dataBuf)
-{
-	int c;
+// Range: 0x8007B9B0 -> 0x8007BDD8
+void rspUndoZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r4
+
+    // Local variables
+    s32 c; // r1+0x8
 }
 
-// Local to compilation unit
-static void rspQuantizeZ(__anon_0x5845E *pRSP, signed short *dataBuf)
-{
-	int c;
-	int i;
+// Range: 0x8007BDD8 -> 0x8007C3A4
+void rspUndoQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r1+0xC
+
+    // Local variables
+    s32 c; // r12
+    s32 i; // r1+0x8
 }
 
-// Local to compilation unit
-static void rspDCTZ(__anon_0x5845E *pRSP)
-{
-	int c;
-	int i;
-	int j;
-	int dd;
-	signed short t[8][8];
+// Range: 0x8007C3A4 -> 0x8007C8CC
+void rspZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r4
+
+    // Local variables
+    s32 c; // r1+0x8
 }
 
-int rspDestroyJPEGArraysZ();
+// Range: 0x8007C8CC -> 0x8007CEF8
+static void rspQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r1+0xC
 
-// Local to compilation unit
-static int rspCreateJPEGArraysZ(__anon_0x5845E *pRSP, int qYAddress, int qCbAddress, int qCrAddress);
-
-// Local to compilation unit
-static int rspParseJPEG_Decode(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	int i;
-	int y;
-	unsigned char *temp;
-	unsigned char *temp2;
-	unsigned long long *system_imb;
-	int size;
-	int scale;
+    // Local variables
+    s32 c; // r12
+    s32 i; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspParseJPEG_Encode(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	unsigned char *temp;
-	unsigned char *temp2;
-	int i;
-	int j;
-	int x;
-	int y;
-	unsigned char *system_imb;
-	unsigned char *system_cfb;
-	int scale;
+// Range: 0x8007CEF8 -> 0x8007D1C8
+static void rspDCTZ(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r1+0x8
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
 }
 
-void rspFormatYUV(__anon_0x5845E *pRSP, char *imgBuf)
-{
-	int i;
-	int j;
+// Erased
+static s32 rspDestroyJPEGArraysZ() {}
+
+// Range: 0x8007D1C8 -> 0x8007D4C0
+static s32 rspCreateJPEGArraysZ(struct __anon_0x5845E* pRSP, s32 qYAddress, s32 qCbAddress, s32 qCrAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r24
+    // s32 qYAddress; // r4
+    // s32 qCbAddress; // r25
+    // s32 qCrAddress; // r26
 }
 
-void rspUndoYUVtoDCTBuf(__anon_0x5845E *pRSP)
-{
-	int i;
-	int j;
+// Range: 0x8007D4C0 -> 0x8007DD0C
+static s32 rspParseJPEG_Decode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r20
+
+    // Local variables
+    s32 i; // r3
+    s32 y; // r25
+    u8* temp; // r31
+    u8* temp2; // r26
+    u64* system_imb; // r1+0x1C
+    s32 size; // r21
+    s32 scale; // r22
 }
 
-void rspUndoDCT(__anon_0x5845E *pRSP)
-{
-	int c;
-	int i;
-	int j;
-	int dd;
-	signed short t[8][8];
+// Range: 0x8007DD0C -> 0x8007E744
+static s32 rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r19
+    // struct __anon_0x575BD* pTask; // r16
+
+    // Local variables
+    u8* temp; // r24
+    u8* temp2; // r23
+    s32 i; // r10
+    s32 j; // r11
+    s32 x; // r22
+    s32 y; // r21
+    u8* system_imb; // r1+0x30
+    u8* system_cfb; // r1+0x2C
+    s32 scale; // r20
 }
 
-void rspUndoQuantize(__anon_0x5845E *pRSP, int scale)
-{
-	int c;
-	int i;
-	int j;
-	signed short q;
-	signed short s;
+// Range: 0x8007E744 -> 0x8007E8F4
+void rspFormatYUV(struct __anon_0x5845E* pRSP, char* imgBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // char* imgBuf; // r4
+
+    // Local variables
+    s32 i; // r10
+    s32 j; // r11
 }
 
-void rspUndoZigzagData(__anon_0x5845E *pRSP, unsigned char **databuf, int n, int *preDc)
-{
-	signed short Dc;
-	signed short Ac;
-	int i;
-	int z;
+// Range: 0x8007E8F4 -> 0x8007F07C
+void rspUndoYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 i; // r1+0x8
+    s32 j; // r1+0x8
 }
 
-void rspZigzagData(__anon_0x5845E *pRSP, unsigned char **databuf, int n, int *preDc)
-{
-	signed short Ac;
-	int i;
-	int z;
+// Range: 0x8007F07C -> 0x8007F368
+void rspUndoDCT(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r5
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
 }
 
-// Local to compilation unit
-static void rspQuantize(__anon_0x5845E *pRSP, int scale)
-{
-	int c;
-	int i;
-	int j;
-	signed short q;
-	signed short s;
+// Range: 0x8007F368 -> 0x8007F4EC
+void rspUndoQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 scale; // r1+0xC
+
+    // Local variables
+    s32 c; // r29
+    s32 i; // r28
+    s32 j; // r27
+    s16 q; // r6
+    s16 s; // r1+0x8
 }
 
-// Local to compilation unit
-static void rspDCT(__anon_0x5845E *pRSP)
-{
-	int c;
-	int i;
-	int j;
-	int dd;
-	signed short t[8][8];
+// Erased
+static void rspUndoZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u8** databuf; // r1+0xC
+    // s32 n; // r1+0x10
+    // s32* preDc; // r1+0x14
+
+    // Local variables
+    s16 Dc; // r12
+    s16 Ac; // r12
+    s32 i; // r7
+    s32 z; // r31
 }
 
-// Local to compilation unit
-static void rspYUVtoDCTBuf(__anon_0x5845E *pRSP)
-{
-	int i;
+// Erased
+static void rspZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u8** databuf; // r1+0xC
+    // s32 n; // r1+0x10
+    // s32* preDc; // r1+0x14
+
+    // Local variables
+    s16 Ac; // r30
+    s32 i; // r6
+    s32 z; // r7
 }
 
-// Local to compilation unit
-static void rspConvertRGBAtoYUV(__anon_0x5845E *pRSP)
-{
-	int i;
-	int j;
-	long Y;
-	long U;
-	long V;
+// Range: 0x8007F4EC -> 0x8007F668
+static void rspQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 scale; // r1+0xC
+
+    // Local variables
+    s32 c; // r29
+    s32 i; // r28
+    s32 j; // r27
+    s16 q; // r6
+    s16 s; // r1+0x8
 }
 
-void rspConvertBufferToRGBA(unsigned char *buf, __anon_0x58360 *rgba);
+// Range: 0x8007F668 -> 0x8007F938
+static void rspDCT(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
 
-int rspDestroyJPEGArrays();
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r1+0x8
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
+}
 
-// Local to compilation unit
-static int rspCreateJPEGArrays(__anon_0x5845E *pRSP);
+// Range: 0x8007F938 -> 0x80080028
+static void rspYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
 
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Range: 0x80080028 -> 0x800801C0
+static void rspConvertRGBAtoYUV(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 i; // r30
+    s32 j; // r1+0x8
+    s32 Y; // r20
+    s32 U; // r20
+    s32 V; // r12
+}
+
+// Erased
+static void rspConvertBufferToRGBA(u8* buf, struct __anon_0x58360* rgba) {
+    // Parameters
+    // u8* buf; // r1+0x4
+    // struct __anon_0x58360* rgba; // r1+0x8
+}
+
+// Erased
+static s32 rspDestroyJPEGArrays() {}
+
+// Range: 0x800801C0 -> 0x80080AA4
+static s32 rspCreateJPEGArrays(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+}

--- a/debug/Fire/_gspS2DEX.c
+++ b/debug/Fire/_gspS2DEX.c
@@ -1,303 +1,507 @@
-﻿// Local to compilation unit
-static int rspSetupS2DEX(__anon_0x5845E *pRSP)
-{
-	float fL;
-	float fR;
-	float fB;
-	float fT;
-	__anon_0x5A89F *pFrame;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\_gspS2DEX.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x80077850 -> 0x8007AC6C
+*/
+
+#include "types.h"
+
+// Range: 0x80077850 -> 0x800779B0
+static s32 rspSetupS2DEX(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+
+    // Local variables
+    float fL; // f31
+    float fR; // f30
+    float fB; // f29
+    float fT; // f28
+    struct __anon_0x5A89F* pFrame; // r4
 }
 
-// Local to compilation unit
-static int rspObjMatrix(__anon_0x5845E *pRSP, int nAddress)
-{
-	unsigned int *pnData32;
-	unsigned short *pnData16;
-	unsigned char *pObjMtx;
-	unsigned short nBaseScaleX;
-	unsigned short nBaseScaleY;
-	int nA;
-	int nB;
-	int nC;
-	int nD;
-	signed short nY;
+// Range: 0x800779B0 -> 0x80077B18
+static s32 rspObjMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // s32 nAddress; // r5
+
+    // Local variables
+    u32* pnData32; // r1+0x8
+    u16* pnData16; // r1+0x8
+    u8* pObjMtx; // r1+0x18
+    u16 nBaseScaleX; // r6
+    u16 nBaseScaleY; // r8
+    s32 nA; // r5
+    s32 nB; // r4
+    s32 nC; // r1+0x8
+    s32 nD; // r9
+    s16 nY; // r1+0x8
 }
 
-int rspObjSubMatrix(__anon_0x5845E *pRSP, int nAddress)
-{
-	unsigned short *pnData16;
-	unsigned char *pObjSubMtx;
-	unsigned short nBaseScaleX;
-	unsigned short nBaseScaleY;
-	signed short nY;
+// Erased
+static s32 rspObjSubMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16* pnData16; // r6
+    u8* pObjSubMtx; // r1+0x18
+    u16 nBaseScaleX; // r7
+    u16 nBaseScaleY; // r5
+    s16 nY; // r1+0x8
 }
 
-int rspBgRectCopy(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress)
-{
-	__anon_0x5F2FB bg;
-	__anon_0x5F2FB bgScale;
-	unsigned int nOldMode1;
-	unsigned int nOldMode2;
-	// References: flagBilerp (0x80135790)
-	// References: scissorY1 (0x801352D6)
-	// References: scissorX1 (0x801352D4)
-	// References: scissorY0 (0x8013578E)
-	// References: scissorX0 (0x8013578C)
+// Range: 0x80077B18 -> 0x80077CB8
+s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x5A89F* pFrame; // r31
+    // s32 nAddress; // r5
+
+    // Local variables
+    union __anon_0x5F2FB bg; // r1+0x48
+    union __anon_0x5F2FB bgScale; // r1+0x20
+    u32 nOldMode1; // r1+0x18
+    u32 nOldMode2; // r1+0x14
+
+    // References
+    // -> static u8 flagBilerp;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
 }
 
-int rspObjLoadTxSprite(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress);
-
-int rspObjLoadTxRectR(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress);
-
-int rspObjLoadTxRect(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress);
-
-// Local to compilation unit
-static int rspObjRectangleR(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress)
-{
-	unsigned short nSizLineBytes;
-	float fLeft;
-	float fRight;
-	float fTop;
-	float fBottom;
-	float fTexRight;
-	float fTexBottom;
-	float fTexLeft;
-	float fTexTop;
-	int nTexTrim2;
-	int nTexTrim5;
-	float fSpriteWidth;
-	float fSpriteHeight;
-	int nClampSetting;
-	__anon_0x5F63B objSprite;
-	__anon_0x5A2EC *pTile;
-	__anon_0x5EBE0 primitive;
-	float mtxTransL[3][4];
-	float mtxTransW[3][4];
-	float mtxScale[3][4];
-	float mtxTemp[3][4];
-	float mtxOut[3][4];
-	__anon_0x5F6E9 vecIn;
-	__anon_0x5F6E9 vecOut;
+// Erased
+static s32 rspObjLoadTxSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
 }
 
-// Local to compilation unit
-static int rspObjSprite(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress)
-{
-	unsigned short nSizLineBytes;
-	float fLeft;
-	float fRight;
-	float fTop;
-	float fBottom;
-	float fTexRight;
-	float fTexBottom;
-	float fTexLeft;
-	float fTexTop;
-	float fScaleX;
-	float fScaleY;
-	float fSpriteWidth;
-	float fSpriteHeight;
-	int nTexTrim2;
-	int nTexTrim5;
-	int nClampSetting;
-	__anon_0x5F63B objSprite;
-	__anon_0x5A2EC *pTile;
-	__anon_0x5EBE0 primitive;
-	float mtxTransL[3][4];
-	float mtxTransW[3][4];
-	float mtxScale[3][4];
-	float mtxTemp[3][4];
-	float mtxOut[3][4];
-	__anon_0x5F6E9 vecIn;
-	__anon_0x5F6E9 vecOut;
+// Erased
+static s32 rspObjLoadTxRectR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
 }
 
-// Local to compilation unit
-static int rspObjRectangle(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress)
-{
-	unsigned short nSizLineBytes;
-	float fDeltaS;
-	float fDeltaT;
-	__anon_0x5F63B objSprite;
-	__anon_0x5A2EC *pTile;
-	__anon_0x5F759 primitive;
-	int nClampSetting;
-	int nTexTrim2;
-	int nTexTrim5;
+// Erased
+static s32 rspObjLoadTxRect(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
 }
 
-// Local to compilation unit
-static int rspObjLoadTxtr(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, int nAddress)
-{
-	unsigned int nSizDefine;
-	unsigned int nLoadType;
-	int nAddr;
-	__anon_0x5A2EC *pTile;
-	__anon_0x59558 *pBuffer;
-	__anon_0x5FC1B objTxtr;
+// Range: 0x80077CB8 -> 0x8007876C
+static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    float fLeft; // f30
+    float fRight; // f29
+    float fTop; // f28
+    float fBottom; // f27
+    float fTexRight; // f26
+    float fTexBottom; // f25
+    float fTexLeft; // f24
+    float fTexTop; // f23
+    s32 nTexTrim2; // r28
+    s32 nTexTrim5; // r27
+    float fSpriteWidth; // f22
+    float fSpriteHeight; // f1
+    s32 nClampSetting; // r1+0x8
+    union __anon_0x5F63B objSprite; // r1+0x438
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5EBE0 primitive; // r1+0x12C
+    float mtxTransL[3][4]; // r1+0xFC
+    float mtxTransW[3][4]; // r1+0xCC
+    float mtxScale[3][4]; // r1+0x9C
+    float mtxTemp[3][4]; // r1+0x6C
+    float mtxOut[3][4]; // r1+0x3C
+    struct __anon_0x5F6E9 vecIn; // r1+0x30
+    struct __anon_0x5F6E9 vecOut; // r1+0x24
 }
 
-int rspFillObjTxtr(__anon_0x5845E *pRSP, int nAddress, __anon_0x5FC1B *pTxtr, unsigned int *pLoadType)
-{
-	unsigned int *pnData32;
-	unsigned short *pnData16;
-	unsigned char *pTxtrBlock;
-	unsigned int nLoadType;
+// Range: 0x8007876C -> 0x80079234
+static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    float fLeft; // f29
+    float fRight; // r1+0x8
+    float fTop; // f28
+    float fBottom; // r1+0x8
+    float fTexRight; // f27
+    float fTexBottom; // f26
+    float fTexLeft; // f25
+    float fTexTop; // f24
+    float fScaleX; // f23
+    float fScaleY; // f22
+    float fSpriteWidth; // f2
+    float fSpriteHeight; // f4
+    s32 nTexTrim2; // r28
+    s32 nTexTrim5; // r27
+    s32 nClampSetting; // r1+0x8
+    union __anon_0x5F63B objSprite; // r1+0x438
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5EBE0 primitive; // r1+0x12C
+    float mtxTransL[3][4]; // r1+0xFC
+    float mtxTransW[3][4]; // r1+0xCC
+    float mtxScale[3][4]; // r1+0x9C
+    float mtxTemp[3][4]; // r1+0x6C
+    float mtxOut[3][4]; // r1+0x3C
+    struct __anon_0x5F6E9 vecIn; // r1+0x30
+    struct __anon_0x5F6E9 vecOut; // r1+0x24
 }
 
-// Local to compilation unit
-static int guS2DEmuBgRect1Cyc(__anon_0x5845E *pRSP, __anon_0x5A89F *pFrame, __anon_0x5F2FB *pBG)
-{
-	signed short frameX0;
-	signed short frameX1;
-	signed short framePtrY0;
-	signed short frameRemain;
-	signed short imageX0;
-	signed short imageY0;
-	signed short imageSliceW;
-	signed short imageW;
-	int imageYorig;
-	signed short scaleW;
-	signed short scaleH;
-	signed short imageSrcW;
-	signed short imageSrcH;
-	signed short imageSliceLines;
-	int frameSliceLines;
-	int frameSliceCount;
-	unsigned short imageS;
-	unsigned short imageT;
-	unsigned int imagePtr;
-	signed short imageISliceL0;
-	signed short imageIY0;
-	int frameLSliceL0;
-	signed short pixX0;
-	signed short pixY0;
-	signed short pixX1;
-	signed short pixY1;
-	signed short frameY0;
-	signed short frameW;
-	signed short frameH;
-	int frameWmax;
-	int frameHmax;
-	signed short tmemSize;
-	signed short tmemMask;
-	signed short tmemShift;
-	int imageNumSlice;
-	int imageSliceWmax;
-	int imageLYoffset;
-	int frameLYoffset;
-	int imageLHidden;
-	int frameLHidden;
-	int frameLYslice;
-	signed short imageRemain;
-	signed short imageSliceH;
-	signed short frameSliceH;
-	__anon_0x5F759 primitive;
-	signed short nT;
-	signed short framePtrY1;
-	// References: flagBilerp (0x80135790)
-	// References: tmemSrcLines (0x801357A8)
-	// References: imageSrcWsize (0x8013579E)
-	// References: imageTop (0x801357A4)
-	// References: imagePtrX0 (0x801357A2)
-	// References: tmemSliceWmax (0x8013579C)
-	// References: rdpSetTile_w0 (0x80135798)
-	// References: rdpSetTimg_w0 (0x80135794)
-	// References: TMEMSHIFT$3465 (0x801352E0)
-	// References: TMEMMASK$3464 (0x801352D8)
-	// References: TMEMSIZE$3463 (0x70E20E80)
-	// References: flagSplit (0x801357A0)
-	// References: scissorY1 (0x801352D6)
-	// References: scissorX1 (0x801352D4)
-	// References: scissorY0 (0x8013578E)
-	// References: scissorX0 (0x8013578C)
+// Range: 0x80079234 -> 0x800797D0
+static s32 rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    float fDeltaS; // f3
+    float fDeltaT; // f4
+    union __anon_0x5F63B objSprite; // r1+0x48
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5F759 primitive; // r1+0x1C
+    s32 nClampSetting; // r1+0x8
+    s32 nTexTrim2; // r29
+    s32 nTexTrim5; // r28
 }
 
-// Local to compilation unit
-static int tmemLoad(__anon_0x5A89F *pFrame, __anon_0x5845E *pRSP, unsigned int *imagePtr, signed short *imageRemain, signed short drawLines, signed short flagBilerp)
-{
-	signed short loadLines;
-	signed short iLoadable;
-	signed short SubSliceL2;
-	signed short SubSliceD2;
-	signed short SubSliceY2;
-	unsigned int imageTopSeg;
-	unsigned int imagePtr2;
-	unsigned int imagePtr1A;
-	unsigned int imagePtr1B;
-	signed short SubSliceY1;
-	signed short SubSliceL1;
-	signed short tmemSH_A;
-	signed short tmemSH_B;
-	// References: imageSrcWsize (0x8013579E)
-	// References: imageTop (0x801357A4)
-	// References: imagePtrX0 (0x801357A2)
-	// References: tmemSrcLines (0x801357A8)
-	// References: tmemSliceWmax (0x8013579C)
-	// References: flagSplit (0x801357A0)
+// Range: 0x800797D0 -> 0x80079C1C
+static s32 rspObjLoadTxtr(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x5A89F* pFrame; // r29
+    // s32 nAddress; // r5
+
+    // Local variables
+    u32 nSizDefine; // r26
+    u32 nLoadType; // r1+0x30
+    s32 nAddr; // r5
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x59558* pBuffer; // r30
+    union __anon_0x5FC1B objTxtr; // r1+0x18
 }
 
-// Local to compilation unit
-static int tmemLoad_A(__anon_0x5A89F *pFrame, __anon_0x5845E *pRSP, unsigned int imagePtr, signed short loadLines, signed short tmemAdrs, signed short tmemSH)
-{
-	// References: tmemSliceWmax (0x8013579C)
+// Range: 0x80079C1C -> 0x80079D7C
+s32 rspFillObjTxtr(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5FC1B* pTxtr, u32* pLoadType) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5FC1B* pTxtr; // r30
+    // u32* pLoadType; // r31
+
+    // Local variables
+    u32* pnData32; // r1+0x8
+    u16* pnData16; // r1+0x8
+    u8* pTxtrBlock; // r1+0x18
+    u32 nLoadType; // r1+0x8
 }
 
-// Local to compilation unit
-static int tmemLoad_B(__anon_0x5A89F *pFrame, __anon_0x5845E *pRSP, unsigned int imagePtr, signed short loadLines, signed short tmemSH)
-{
-	__anon_0x59558 *pBuffer;
-	int nAddr;
-	// References: imageSrcWsize (0x8013579E)
+// Range: 0x80079D7C -> 0x8007A4B8
+static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, union __anon_0x5F2FB* pBG) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r15
+    // struct __anon_0x5A89F* pFrame; // r29
+    // union __anon_0x5F2FB* pBG; // r26
+
+    // Local variables
+    s16 frameX0; // r4
+    s16 frameX1; // r1+0x50
+    s16 framePtrY0; // r23
+    s16 frameRemain; // r31
+    s16 imageX0; // r3
+    s16 imageY0; // r4
+    s16 imageSliceW; // r9
+    s16 imageW; // r21
+    s32 imageYorig; // r5
+    s16 scaleW; // r1+0x8
+    s16 scaleH; // r1+0x8
+    s16 imageSrcW; // r6
+    s16 imageSrcH; // r7
+    s16 imageSliceLines; // r25
+    s32 frameSliceLines; // r22
+    s32 frameSliceCount; // r28
+    u16 imageS; // r18
+    u16 imageT; // r24
+    u32 imagePtr; // r1+0x44
+    s16 imageISliceL0; // r20
+    s16 imageIY0; // r1+0x8
+    s32 frameLSliceL0; // r7
+    s16 pixX0; // r3
+    s16 pixY0; // r4
+    s16 pixX1; // r1+0x8
+    s16 pixY1; // r8
+    s16 frameY0; // r5
+    s16 frameW; // r3
+    s16 frameH; // r7
+    s32 frameWmax; // r1+0x8
+    s32 frameHmax; // r7
+    s16 tmemSize; // r1+0x8
+    s16 tmemMask; // r18
+    s16 tmemShift; // r10
+    s32 imageNumSlice; // r1+0x8
+    s32 imageSliceWmax; // r6
+    s32 imageLYoffset; // r4
+    s32 frameLYoffset; // r4
+    s32 imageLHidden; // r4
+    s32 frameLHidden; // r6
+    s32 frameLYslice; // r6
+    s16 imageRemain; // r1+0x40
+    s16 imageSliceH; // r1+0x8
+    s16 frameSliceH; // r30
+    struct __anon_0x5F759 primitive; // r1+0x18
+    s16 nT; // r3
+    s16 framePtrY1; // r30
+
+    // References
+    // -> static u8 flagBilerp;
+    // -> static s16 tmemSrcLines;
+    // -> static u16 imageSrcWsize;
+    // -> static u32 imageTop;
+    // -> static u16 imagePtrX0;
+    // -> static u16 tmemSliceWmax;
+    // -> static u32 rdpSetTile_w0;
+    // -> static u32 rdpSetTimg_w0;
+    // -> static s16 TMEMSHIFT$3465[4];
+    // -> static s16 TMEMMASK$3464[4];
+    // -> static s16 TMEMSIZE$3463[5];
+    // -> static u16 flagSplit;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
 }
 
-int guS2DEmuSetScissor(unsigned int ulx, unsigned int uly, unsigned int lrx, unsigned int lry, unsigned char flag)
-{
-	// References: flagBilerp (0x80135790)
-	// References: scissorY1 (0x801352D6)
-	// References: scissorX1 (0x801352D4)
-	// References: scissorY0 (0x8013578E)
-	// References: scissorX0 (0x8013578C)
+// Range: 0x8007A4B8 -> 0x8007A728
+static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32* imagePtr, s16* imageRemain,
+                    s16 drawLines, s16 flagBilerp) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r21
+    // struct __anon_0x5845E* pRSP; // r22
+    // u32* imagePtr; // r23
+    // s16* imageRemain; // r24
+    // s16 drawLines; // r25
+    // s16 flagBilerp; // r1+0x1A
+
+    // Local variables
+    s16 loadLines; // r6
+    s16 iLoadable; // r29
+    s16 SubSliceL2; // r6
+    s16 SubSliceD2; // r28
+    s16 SubSliceY2; // r7
+    u32 imageTopSeg; // r30
+    u32 imagePtr2; // r5
+    u32 imagePtr1A; // r27
+    u32 imagePtr1B; // r5
+    s16 SubSliceY1; // r4
+    s16 SubSliceL1; // r26
+    s16 tmemSH_A; // r20
+    s16 tmemSH_B; // r8
+
+    // References
+    // -> static u16 imageSrcWsize;
+    // -> static u32 imageTop;
+    // -> static u16 imagePtrX0;
+    // -> static s16 tmemSrcLines;
+    // -> static u16 tmemSliceWmax;
+    // -> static u16 flagSplit;
 }
 
-int rspSetTileSize(__anon_0x5A89F *pFrame, __anon_0x5A2EC *pTile, int nX0, int nY0, int nX1, int nY1);
+// Range: 0x8007A728 -> 0x8007A7D4
+static s32 tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+                      s16 tmemAdrs, s16 tmemSH) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r27
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 imagePtr; // r29
+    // s16 loadLines; // r30
+    // s16 tmemAdrs; // r1+0x16
+    // s16 tmemSH; // r31
 
-int rspLoadTile(__anon_0x5A89F *pFrame, __anon_0x5A2EC *pTile, int nX0, int nY0, int nX1, int nY1);
-
-int rspLoadBlock(__anon_0x5A89F *pFrame, __anon_0x5A2EC *pTile, int nX0, int nY0, int nX1, int nY1);
-
-int rspSetImage(__anon_0x5A89F *pFrame, __anon_0x5845E *pRSP, int nFormat, int nWidth, int nSize, int nImage)
-{
-	int addr;
-	__anon_0x59558 *pBuffer;
+    // References
+    // -> static u16 tmemSliceWmax;
 }
 
-int rspSetTile(__anon_0x5A89F *pFrame, __anon_0x5A2EC *pTile, int nSize, int nTmem, int nTLUT, int nFormat, int nMaskS, int nMaskT, int nModeS, int nModeT, int nShiftS, int nShiftT);
+// Range: 0x8007A7D4 -> 0x8007A8E8
+static s32 tmemLoad_B(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+                      s16 tmemSH) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r30
+    // struct __anon_0x5845E* pRSP; // r1+0xC
+    // u32 imagePtr; // r1+0x10
+    // s16 loadLines; // r31
+    // s16 tmemSH; // r28
 
-int rspFillObjBg(__anon_0x5845E *pRSP, int nAddress, __anon_0x5F2FB *pBg)
-{
-	unsigned char *pnData8;
-	unsigned char *pObjBg;
-	unsigned short *pnData16;
+    // Local variables
+    struct __anon_0x59558* pBuffer; // r8
+    s32 nAddr; // r5
+
+    // References
+    // -> static u16 imageSrcWsize;
 }
 
-int rspFillObjBgScale(__anon_0x5845E *pRSP, int nAddress, __anon_0x5F2FB *pBg)
-{
-	unsigned char *pnData8;
-	unsigned char *pObjBg;
-	unsigned short *pnData16;
-	unsigned int *pnData32;
+// Erased
+static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
+    // Parameters
+    // u32 ulx; // r1+0x0
+    // u32 uly; // r1+0x4
+    // u32 lrx; // r1+0x8
+    // u32 lry; // r1+0xC
+    // u8 flag; // r1+0x10
+
+    // References
+    // -> static u8 flagBilerp;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
 }
 
-// Local to compilation unit
-static int rspFillObjSprite(__anon_0x5845E *pRSP, int nAddress, __anon_0x5F63B *pSprite)
-{
-	unsigned short *pnData16;
-	unsigned char *pnData8;
-	unsigned char *pObjSprite;
+// Erased
+static s32 rspSetTileSize(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                          s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
 }
 
-// Local to compilation unit
-static int Matrix4by4Identity(float *matrix4b4[4]);
+// Erased
+static s32 rspLoadTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                       s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
+}
 
-int frameFillVertex(__anon_0x5A89F *pFrame, int nIndex, signed short nX, signed short nY, signed short nZ, float rS, float rT);
+// Erased
+static s32 rspLoadBlock(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                        s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
+}
 
+// Range: 0x8007A8E8 -> 0x8007A97C
+s32 rspSetImage(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, s32 nFormat, s32 nWidth, s32 nSize,
+                s32 nImage) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r31
+    // struct __anon_0x5845E* pRSP; // r1+0xC
+    // s32 nFormat; // r1+0x10
+    // s32 nWidth; // r1+0x14
+    // s32 nSize; // r1+0x18
+    // s32 nImage; // r1+0x1C
+
+    // Local variables
+    s32 addr; // r5
+    struct __anon_0x59558* pBuffer; // r9
+}
+
+// Erased
+static s32 rspSetTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nSize, s32 nTmem, s32 nTLUT,
+                      s32 nFormat, s32 nMaskS, s32 nMaskT, s32 nModeS, s32 nModeT, s32 nShiftS, s32 nShiftT) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nSize; // r1+0x10
+    // s32 nTmem; // r1+0x14
+    // s32 nTLUT; // r1+0x18
+    // s32 nFormat; // r1+0x20
+    // s32 nMaskS; // r1+0x24
+    // s32 nMaskT; // r1+0x8
+    // s32 nModeS; // r8
+    // s32 nModeT; // r6
+    // s32 nShiftS; // r9
+    // s32 nShiftT; // r8
+}
+
+// Range: 0x8007A97C -> 0x8007AA74
+s32 rspFillObjBg(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F2FB* pBg; // r31
+
+    // Local variables
+    u8* pnData8; // r1+0x8
+    u8* pObjBg; // r1+0x18
+    u16* pnData16; // r1+0x8
+}
+
+// Range: 0x8007AA74 -> 0x8007AB54
+s32 rspFillObjBgScale(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F2FB* pBg; // r31
+
+    // Local variables
+    u8* pnData8; // r1+0x8
+    u8* pObjBg; // r1+0x14
+    u16* pnData16; // r1+0x8
+    u32* pnData32; // r1+0x8
+}
+
+// Range: 0x8007AB54 -> 0x8007AC1C
+static s32 rspFillObjSprite(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F63B* pSprite) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F63B* pSprite; // r31
+
+    // Local variables
+    u16* pnData16; // r1+0x8
+    u8* pnData8; // r1+0x8
+    u8* pObjSprite; // r1+0x14
+}
+
+// Range: 0x8007AC1C -> 0x8007AC6C
+static s32 Matrix4by4Identity(float (*matrix4b4)[4]) {
+    // Parameters
+    // float (* matrix4b4)[4]; // r1+0x0
+}
+
+// Erased
+static s32 frameFillVertex(struct __anon_0x5A89F* pFrame, s32 nIndex, s16 nX, s16 nY, s16 nZ, float rS, float rT) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r1+0x8
+    // s32 nIndex; // r1+0xC
+    // s16 nX; // r1+0x10
+    // s16 nY; // r1+0x12
+    // s16 nZ; // r1+0x14
+    // float rS; // r1+0x18
+    // float rT; // r1+0x1C
+}

--- a/debug/Fire/audio.c
+++ b/debug/Fire/audio.c
@@ -7,17 +7,17 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x752F4; // size = 0x10
 
 // size = 0x10, address = 0x800EE778
 struct _XL_OBJECTTYPE gClassAudio;
 
-struct __anon_0x753E7 {
+typedef struct __anon_0x753E7 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 bEnable;
     /* 0x08 */ void* pHost;
@@ -26,7 +26,7 @@ struct __anon_0x753E7 {
     /* 0x14 */ s32 nRateBit;
     /* 0x18 */ s32 nRateDAC;
     /* 0x1C */ s32 nStatus;
-}; // size = 0x20
+} __anon_0x753E7; // size = 0x20
 
 // Range: 0x8008E4A8 -> 0x8008E5C8
 s32 audioEvent(struct __anon_0x753E7* pAudio, s32 nEvent, void* pArgument) {

--- a/debug/Fire/audio.c
+++ b/debug/Fire/audio.c
@@ -1,60 +1,81 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\audio.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008E4A8 -> 0x8008E8A0
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE778
+struct _XL_OBJECTTYPE gClassAudio;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x753E7 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 bEnable;
+    /* 0x08 */ void* pHost;
+    /* 0x0C */ s32 nControl;
+    /* 0x10 */ s32 nAddress;
+    /* 0x14 */ s32 nRateBit;
+    /* 0x18 */ s32 nRateDAC;
+    /* 0x1C */ s32 nStatus;
+}; // size = 0x20
 
-// Location: 0x78E70E80
-_XL_OBJECTTYPE gClassAudio;
-
-// size: 0x20
-struct __anon_0x753E7
-{
-	int nSize; // 0x0
-	int bEnable; // 0x4
-	void *pHost; // 0x8
-	int nControl; // 0xC
-	int nAddress; // 0x10
-	int nRateBit; // 0x14
-	int nRateDAC; // 0x18
-	int nStatus; // 0x1C
-};
-
-int audioEvent(__anon_0x753E7 *pAudio, int nEvent, void *pArgument);
-
-int audioEnable(__anon_0x753E7 *pAudio, int bEnable);
-
-int audioGet64();
-
-int audioGet32(__anon_0x753E7 *pAudio, unsigned int nAddress, int *pData);
-
-int audioGet16();
-
-int audioGet8();
-
-int audioPut64();
-
-int audioPut32(__anon_0x753E7 *pAudio, unsigned int nAddress, int *pData)
-{
-	void *pBuffer;
+// Range: 0x8008E4A8 -> 0x8008E5C8
+s32 audioEvent(struct __anon_0x753E7* pAudio, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int audioPut16();
+// Range: 0x8008E5C8 -> 0x8008E620
+s32 audioEnable(struct __anon_0x753E7* pAudio, s32 bEnable) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r3
+    // s32 bEnable; // r1+0xC
+}
 
-int audioPut8();
+// Range: 0x8008E620 -> 0x8008E628
+s32 audioGet64() {}
 
+// Range: 0x8008E628 -> 0x8008E730
+s32 audioGet32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r31
+}
+
+// Range: 0x8008E730 -> 0x8008E738
+s32 audioGet16() {}
+
+// Range: 0x8008E738 -> 0x8008E740
+s32 audioGet8() {}
+
+// Range: 0x8008E740 -> 0x8008E748
+s32 audioPut64() {}
+
+// Range: 0x8008E748 -> 0x8008E890
+s32 audioPut32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r31
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    void* pBuffer; // r1+0x14
+}
+
+// Range: 0x8008E890 -> 0x8008E898
+s32 audioPut16() {}
+
+// Range: 0x8008E898 -> 0x8008E8A0
+s32 audioPut8() {}

--- a/debug/Fire/codeGCN.c
+++ b/debug/Fire/codeGCN.c
@@ -1,152 +1,125 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\codeGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8001C444 -> 0x8001C498
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EA7C8
+struct _XL_OBJECTTYPE gClassCode;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+enum __anon_0x1F980 {
+    XLFT_NONE = -1,
+    XLFT_TEXT = 0,
+    XLFT_BINARY = 1,
 };
 
-// Location: 0x800EA7C8
-_XL_OBJECTTYPE gClassCode;
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
 
-// size: 0x4
-enum __anon_0x1F980
-{
-	XLFT_NONE = 4294967295,
-	XLFT_TEXT = 0,
-	XLFT_BINARY = 1
-};
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
+struct tXL_FILE {
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ enum __anon_0x1F980 eType;
+    /* 0x1C */ struct DVDFileInfo info;
+}; // size = 0x58
 
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
+// size = 0x4, address = 0x80135680
+static void* gpBufferFunction;
 
-// size: 0x58
-struct tXL_FILE
-{
-	int iBuffer; // 0x0
-	void *pData; // 0x4
-	void *pBuffer; // 0x8
-	int nAttributes; // 0xC
-	int nSize; // 0x10
-	int nOffset; // 0x14
-	__anon_0x1F980 eType; // 0x18
-	DVDFileInfo info; // 0x1C
-};
+// size = 0x4, address = 0x80135684
+static u32* ganDataCode;
 
-// Location: 0x0
-tXL_FILE *gpFileCode;
+struct _CODE_CACHE_NODE {
+    /* 0x0 */ s32 checksum;
+    /* 0x4 */ s32 length;
+    /* 0x8 */ struct _CODE_CACHE_NODE* next;
+    /* 0xC */ struct _CODE_CACHE_NODE* child;
+}; // size = 0x10
 
-// Location: 0x0
-unsigned int gnSizeCode;
+// Range: 0x8001C444 -> 0x8001C498
+s32 codeEvent(s32 nEvent) {
+    // Parameters
+    // s32 nEvent; // r1+0x4
 
-// Local to compilation unit
-// Location: 0x80135680
-static void *gpBufferFunction;
-
-// Location: 0x0
-char gpBufferFunctionCache[65536];
-
-// Local to compilation unit
-// Location: 0x80135684
-static unsigned int *ganDataCode;
-
-// Location: 0x0
-unsigned int gnCountFunction;
-
-// Location: 0x0
-unsigned int gnLastCountFunction;
-
-// Location: 0x0
-int gSizeInARAM;
-
-// size: 0x10
-struct _CODE_CACHE_NODE
-{
-	int checksum; // 0x0
-	int length; // 0x4
-	_CODE_CACHE_NODE *next; // 0x8
-	_CODE_CACHE_NODE *child; // 0xC
-};
-
-// Location: 0x0
-_CODE_CACHE_NODE gCodeCacheHead;
-
-int codeEvent(int nEvent)
-{
-	// References: ganDataCode (0x80135684)
-	// References: gpBufferFunction (0x80135680)
+    // References
+    // -> static u32* ganDataCode;
+    // -> static void* gpBufferFunction;
 }
 
-// Location: 0x0
-int gCatalogLoaded;
+// Erased
+static s32 codeCheckCatalog(s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // s32 nAddress0; // r4
+    // s32 nAddress1; // r5
 
-int codeCheckCatalog(int nAddress0, int nAddress1)
-{
-	int iFunction;
-	int instruction;
-	unsigned int checksum;
-	// References: gnCountFunction (0x0)
-	// References: ganDataCode (0x80135684)
-	// References: gCatalogLoaded (0x0)
+    // Local variables
+    s32 iFunction; // r1+0x8
+    s32 instruction; // r31
+    u32 checksum; // r1+0x14
+
+    // References
+    // -> static u32 gnCountFunction;
+    // -> static u32* ganDataCode;
+    // -> static s32 gCatalogLoaded;
 }
 
-int codeSendFilePart();
+// Erased
+static s32 codeSendFilePart() {}
 
-int hioInit();
+// Erased
+static s32 hioInit() {}
 
-int hioSendBuffer();
+// Erased
+static s32 hioSendBuffer() {}
 
-void hioCallback();
+// Erased
+static void hioCallback() {}
 
-int hioCallbackDevice();
+// Erased
+static s32 hioCallbackDevice() {}
 
-int hioInitSend();
-
+// Erased
+static s32 hioInitSend() {}

--- a/debug/Fire/codeGCN.c
+++ b/debug/Fire/codeGCN.c
@@ -7,23 +7,23 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x1F88E; // size = 0x10
 
 // size = 0x10, address = 0x800EA7C8
 struct _XL_OBJECTTYPE gClassCode;
 
-enum __anon_0x1F980 {
+typedef enum __anon_0x1F980 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
-};
+} __anon_0x1F980;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -31,9 +31,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x1FA38; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -46,16 +46,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x1FBA8; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x1FDCE; // size = 0x3C
 
-struct tXL_FILE {
+typedef struct tXL_FILE {
     /* 0x00 */ s32 iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
@@ -64,7 +64,7 @@ struct tXL_FILE {
     /* 0x14 */ s32 nOffset;
     /* 0x18 */ enum __anon_0x1F980 eType;
     /* 0x1C */ struct DVDFileInfo info;
-}; // size = 0x58
+} __anon_0x1FE86; // size = 0x58
 
 // size = 0x4, address = 0x80135680
 static void* gpBufferFunction;
@@ -72,12 +72,12 @@ static void* gpBufferFunction;
 // size = 0x4, address = 0x80135684
 static u32* ganDataCode;
 
-struct _CODE_CACHE_NODE {
+typedef struct _CODE_CACHE_NODE {
     /* 0x0 */ s32 checksum;
     /* 0x4 */ s32 length;
     /* 0x8 */ struct _CODE_CACHE_NODE* next;
     /* 0xC */ struct _CODE_CACHE_NODE* child;
-}; // size = 0x10
+} __anon_0x20141; // size = 0x10
 
 // Range: 0x8001C444 -> 0x8001C498
 s32 codeEvent(s32 nEvent) {

--- a/debug/Fire/cpu.c
+++ b/debug/Fire/cpu.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x3CBBE; // size = 0x10
 
 // size = 0x10, address = 0x800EB658
 struct _XL_OBJECTTYPE gClassCPU;
@@ -158,20 +158,20 @@ static s32 cpuCompile_LWR_function;
 // size = 0x1F4, address = 0x80130A58
 u32 aHeapTreeFlag[125];
 
-enum __anon_0x3D79A {
+typedef enum __anon_0x3D79A {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x3D79A;
 
-struct __anon_0x3D7FC {
+typedef struct __anon_0x3D7FC {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x3D7FC; // size = 0x10
 
-enum __anon_0x3D8AD {
+typedef enum __anon_0x3D8AD {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -186,9 +186,9 @@ enum __anon_0x3D8AD {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x3D8AD;
 
-enum __anon_0x3D9D9 {
+typedef enum __anon_0x3D9D9 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -207,9 +207,9 @@ enum __anon_0x3D9D9 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x3D9D9;
 
-struct __anon_0x3DB14 {
+typedef struct __anon_0x3DB14 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -221,7 +221,7 @@ struct __anon_0x3DB14 {
     /* 0x70 */ enum __anon_0x3D9D9 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x3DB14; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x3DB14* gpSystem;
@@ -244,17 +244,17 @@ static s32 cpuUpdateDiskChecksum(u32* checksum, s32 startAddress, s32 endAddress
     // -> struct __anon_0x3DB14* gpSystem;
 }
 
-struct __anon_0x3DE78 {
+typedef struct __anon_0x3DE78 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x3DE78; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x3DEDE; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -273,9 +273,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x3DF51; // size = 0x48
 
-union __anon_0x3E22D {
+typedef union __anon_0x3E22D {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -306,9 +306,9 @@ union __anon_0x3E22D {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x3E22D;
 
-union __anon_0x3E641 {
+typedef union __anon_0x3E641 {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -318,9 +318,9 @@ union __anon_0x3E641 {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x3E641;
 
-struct __anon_0x3EB4F {
+typedef struct __anon_0x3EB4F {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -334,9 +334,9 @@ struct __anon_0x3EB4F {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x3EB4F; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -351,15 +351,15 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x3EE1D; // size = 0x84
 
-struct __anon_0x3F080 {
+typedef struct __anon_0x3F080 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x3F080; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -375,9 +375,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x3F1AB; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -385,9 +385,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x3F402; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -398,9 +398,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x3F51D; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -444,7 +444,7 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x3F6CA; // size = 0x12090
 
 // Erased
 static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instruction) {
@@ -458,7 +458,7 @@ static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instructi
     u32* opcode; // r1+0x14
 }
 
-struct cpu_disk_node {
+typedef struct cpu_disk_node {
     /* 0x00 */ u32 functionLength;
     /* 0x04 */ u32 checksum;
     /* 0x08 */ s32 startAddress;
@@ -475,7 +475,7 @@ struct cpu_disk_node {
     /* 0x34 */ struct cpu_disk_node* left;
     /* 0x38 */ struct cpu_disk_node* right;
     /* 0x3C */ struct cpu_disk_node* same;
-}; // size = 0x40
+} __anon_0x3FE5C; // size = 0x40
 
 // Erased
 static s32 cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, s32 start) {
@@ -1073,11 +1073,11 @@ static s32 cpuSetCP0(struct _CPU* pCPU, s32* anRegister) {
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
-enum __anon_0x42F73 {
+typedef enum __anon_0x42F73 {
     CS_NONE = -1,
     CS_32BIT = 0,
     CS_64BIT = 1,
-};
+} __anon_0x42F73;
 
 // Erased
 static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
@@ -1238,29 +1238,29 @@ s32 cpuMapObject(struct _CPU* pCPU, void* pObject, u32 nAddress0, u32 nAddress1,
 // Erased
 static s32 cpuGetOpcodeText() {}
 
-enum __anon_0x43B0A {
+typedef enum __anon_0x43B0A {
     RLM_NONE = -1,
     RLM_PART = 0,
     RLM_FULL = 1,
     RLM_COUNT_ = 2,
-};
+} __anon_0x43B0A;
 
-struct __anon_0x43B69 {
+typedef struct __anon_0x43B69 {
     /* 0x0 */ s32 iCache;
     /* 0x4 */ u32 nSize;
     /* 0x8 */ u32 nTickUsed;
     /* 0xC */ char keep;
-}; // size = 0x10
+} __anon_0x43B69; // size = 0x10
 
-struct __anon_0x43C7D {
+typedef struct __anon_0x43C7D {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 (*pCallback)();
     /* 0x08 */ u8* pTarget;
     /* 0x0C */ u32 nSize;
     /* 0x10 */ u32 nOffset;
-}; // size = 0x14
+} __anon_0x43C7D; // size = 0x14
 
-struct __anon_0x43D5D {
+typedef struct __anon_0x43D5D {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 bDone;
     /* 0x08 */ s32 nResult;
@@ -1273,9 +1273,9 @@ struct __anon_0x43D5D {
     /* 0x24 */ u32 nOffset1;
     /* 0x28 */ u32 nSize;
     /* 0x2C */ u32 nSizeRead;
-}; // size = 0x30
+} __anon_0x43D5D; // size = 0x30
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -1283,9 +1283,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x43FA8; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -1298,16 +1298,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x44118; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x4433E; // size = 0x3C
 
-struct __anon_0x443F6 {
+typedef struct __anon_0x443F6 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
     /* 0x00008 */ s32 bFlip;
@@ -1329,7 +1329,7 @@ struct __anon_0x443F6 {
     /* 0x10EB4 */ s32 nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
     /* 0x10EF4 */ s32 offsetToRom;
-}; // size = 0x10EF8
+} __anon_0x443F6; // size = 0x10EF8
 
 // size = 0x0, address = 0x800F3E78
 s32 __float_nan[];
@@ -1343,10 +1343,10 @@ float fTickScale;
 // size = 0x4, address = 0x80134E60
 u32 nTickMultiplier;
 
-enum __anon_0x44829 {
+typedef enum __anon_0x44829 {
     RUM_NONE = 0,
     RUM_IDLE = 1,
-};
+} __anon_0x44829;
 
 // Range: 0x80035218 -> 0x8003522C
 s32 __cpuBreak(struct _CPU* pCPU) {
@@ -1388,12 +1388,12 @@ s32 cpuSetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64 nData) {
     // -> static s64 ganMaskSetCP0[32];
 }
 
-enum __anon_0x44AE9 {
+typedef enum __anon_0x44AE9 {
     CM_NONE = -1,
     CM_USER = 0,
     CM_SUPER = 1,
     CM_KERNEL = 2,
-};
+} __anon_0x44AE9;
 
 // Range: 0x8003573C -> 0x800357D0
 static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
@@ -1578,7 +1578,7 @@ static s32 cpuMakeDevice(struct _CPU* pCPU, s32* piDevice, void* pObject, s32 nO
     s32 iDevice; // r31
 }
 
-enum __anon_0x45AE1 {
+typedef enum __anon_0x45AE1 {
     CEC_NONE = -1,
     CEC_INTERRUPT = 0,
     CEC_TLB_MODIFICATION = 1,
@@ -1613,7 +1613,7 @@ enum __anon_0x45AE1 {
     CEC_RESERVED_30 = 30,
     CEC_VCE_DATA = 31,
     CEC_COUNT = 32,
-};
+} __anon_0x45AE1;
 
 // Range: 0x8003604C -> 0x8003630C
 s32 cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, s32 nMaskIP) {
@@ -1637,11 +1637,11 @@ s32 cpuTestInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
     // s32 nMaskIP; // r31
 }
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x45F28; // size = 0xC
 
 // Range: 0x800363E8 -> 0x800365C4
 static s32 cpuFindCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressHost) {

--- a/debug/Fire/cpu.c
+++ b/debug/Fire/cpu.c
@@ -1,1309 +1,1727 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\cpu.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80030E70 -> 0x80036870
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EB658
+struct _XL_OBJECTTYPE gClassCPU;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+// size = 0x80, address = 0x800EB668
+static char* gaszNameGPR[32];
+
+// size = 0x80, address = 0x800EB6E8
+static char* gaszNameFPR[32];
+
+// size = 0x80, address = 0x800EB850
+static char* gaszNameCP0[32];
+
+// size = 0x80, address = 0x800EBB04
+static char* gaszNameCP1[32];
+
+// size = 0x100, address = 0x800EBB88
+static s64 ganMaskGetCP0[32];
+
+// size = 0x100, address = 0x800EBC88
+static s64 ganMaskSetCP0[32];
+
+// size = 0x40, address = 0x800EBD88
+static u8 Opcode[64];
+
+// size = 0x40, address = 0x800EBDC8
+static u8 SpecialOpcode[64];
+
+// size = 0x20, address = 0x800EBE08
+static u8 RegimmOpcode[32];
+
+// size = 0x4, address = 0x801356E0
+void* gHeapTree;
+
+// size = 0x14, address = 0x800EBE28
+static u32 ganOpcodeSaveFP1[5];
+
+// size = 0x14, address = 0x800EBE3C
+static u32 ganOpcodeSaveFP2_0[5];
+
+// size = 0xC, address = 0x800EBE50
+static u32 ganOpcodeSaveFP2_1[3];
+
+// size = 0x14, address = 0x800EBE5C
+static u32 ganOpcodeLoadFP[5];
+
+// size = 0x80, address = 0x800EBE70
+s32 ganMapGPR[32];
+
+// size = 0x4, address = 0x801356E4
+static s32 cpuCompile_DSLLV_function;
+
+// size = 0x4, address = 0x801356E8
+static s32 cpuCompile_DSRLV_function;
+
+// size = 0x4, address = 0x801356EC
+static s32 cpuCompile_DSRAV_function;
+
+// size = 0x4, address = 0x801356F0
+static s32 cpuCompile_DMULT_function;
+
+// size = 0x4, address = 0x801356F4
+static s32 cpuCompile_DMULTU_function;
+
+// size = 0x4, address = 0x801356F8
+static s32 cpuCompile_DDIV_function;
+
+// size = 0x4, address = 0x801356FC
+static s32 cpuCompile_DDIVU_function;
+
+// size = 0x4, address = 0x80135700
+static s32 cpuCompile_DADD_function;
+
+// size = 0x4, address = 0x80135704
+static s32 cpuCompile_DADDU_function;
+
+// size = 0x4, address = 0x80135708
+static s32 cpuCompile_DSUB_function;
+
+// size = 0x4, address = 0x8013570C
+static s32 cpuCompile_DSUBU_function;
+
+// size = 0x4, address = 0x80135710
+static s32 cpuCompile_S_SQRT_function;
+
+// size = 0x4, address = 0x80135714
+static s32 cpuCompile_D_SQRT_function;
+
+// size = 0x4, address = 0x80135718
+static s32 cpuCompile_W_CVT_SD_function;
+
+// size = 0x4, address = 0x8013571C
+static s32 cpuCompile_L_CVT_SD_function;
+
+// size = 0x4, address = 0x80135720
+static s32 cpuCompile_CEIL_W_function;
+
+// size = 0x4, address = 0x80135724
+static s32 cpuCompile_FLOOR_W_function;
+
+// size = 0x4, address = 0x80135728
+static s32 cpuCompile_ROUND_W_function;
+
+// size = 0x4, address = 0x8013572C
+static s32 cpuCompile_TRUNC_W_function;
+
+// size = 0x4, address = 0x80135730
+static s32 cpuCompile_LB_function;
+
+// size = 0x4, address = 0x80135734
+static s32 cpuCompile_LH_function;
+
+// size = 0x4, address = 0x80135738
+static s32 cpuCompile_LW_function;
+
+// size = 0x4, address = 0x8013573C
+static s32 cpuCompile_LBU_function;
+
+// size = 0x4, address = 0x80135740
+static s32 cpuCompile_LHU_function;
+
+// size = 0x4, address = 0x80135744
+static s32 cpuCompile_SB_function;
+
+// size = 0x4, address = 0x80135748
+static s32 cpuCompile_SH_function;
+
+// size = 0x4, address = 0x8013574C
+static s32 cpuCompile_SW_function;
+
+// size = 0x4, address = 0x80135750
+static s32 cpuCompile_LDC_function;
+
+// size = 0x4, address = 0x80135754
+static s32 cpuCompile_SDC_function;
+
+// size = 0x4, address = 0x80135758
+static s32 cpuCompile_LWL_function;
+
+// size = 0x4, address = 0x8013575C
+static s32 cpuCompile_LWR_function;
+
+// size = 0x1F4, address = 0x80130A58
+u32 aHeapTreeFlag[125];
+
+enum __anon_0x3D79A {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// Location: 0x58B60E80
-_XL_OBJECTTYPE gClassCPU;
+struct __anon_0x3D7FC {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
 
-// Local to compilation unit
-// Location: 0x68B60E80
-static char  *gaszNameGPR[32];
-
-// Local to compilation unit
-// Location: 0x800EB6E8
-static char  *gaszNameFPR[32];
-
-// Local to compilation unit
-// Location: 0x50B80E80
-static char  *gaszNameCP0[32];
-
-// Local to compilation unit
-// Location: 0x4BB0E80
-static char  *gaszNameCP1[32];
-
-// Local to compilation unit
-// Location: 0x800EBB88
-static signed long long ganMaskGetCP0[32];
-
-// Local to compilation unit
-// Location: 0x800EBC88
-static signed long long ganMaskSetCP0[32];
-
-// Local to compilation unit
-// Location: 0x800EBD88
-static unsigned char Opcode[64];
-
-// Local to compilation unit
-// Location: 0x800EBDC8
-static unsigned char SpecialOpcode[64];
-
-// Local to compilation unit
-// Location: 0x8BE0E80
-static unsigned char RegimmOpcode[32];
-
-// Location: 0x801356E0
-void *gHeapTree;
-
-// Local to compilation unit
-// Location: 0x28BE0E80
-static unsigned int ganOpcodeSaveFP1[5];
-
-// Local to compilation unit
-// Location: 0x3CBE0E80
-static unsigned int ganOpcodeSaveFP2_0[5];
-
-// Local to compilation unit
-// Location: 0x50BE0E80
-static unsigned int ganOpcodeSaveFP2_1[3];
-
-// Local to compilation unit
-// Location: 0x5CBE0E80
-static unsigned int ganOpcodeLoadFP[5];
-
-// Location: 0x70BE0E80
-int ganMapGPR[32];
-
-// Local to compilation unit
-// Location: 0x801356E4
-static int cpuCompile_DSLLV_function;
-
-// Local to compilation unit
-// Location: 0x801356E8
-static int cpuCompile_DSRLV_function;
-
-// Local to compilation unit
-// Location: 0x801356EC
-static int cpuCompile_DSRAV_function;
-
-// Local to compilation unit
-// Location: 0x801356F0
-static int cpuCompile_DMULT_function;
-
-// Local to compilation unit
-// Location: 0x801356F4
-static int cpuCompile_DMULTU_function;
-
-// Local to compilation unit
-// Location: 0x801356F8
-static int cpuCompile_DDIV_function;
-
-// Local to compilation unit
-// Location: 0x801356FC
-static int cpuCompile_DDIVU_function;
-
-// Local to compilation unit
-// Location: 0x571380
-static int cpuCompile_DADD_function;
-
-// Local to compilation unit
-// Location: 0x4571380
-static int cpuCompile_DADDU_function;
-
-// Local to compilation unit
-// Location: 0x8571380
-static int cpuCompile_DSUB_function;
-
-// Local to compilation unit
-// Location: 0xC571380
-static int cpuCompile_DSUBU_function;
-
-// Local to compilation unit
-// Location: 0x10571380
-static int cpuCompile_S_SQRT_function;
-
-// Local to compilation unit
-// Location: 0x14571380
-static int cpuCompile_D_SQRT_function;
-
-// Local to compilation unit
-// Location: 0x18571380
-static int cpuCompile_W_CVT_SD_function;
-
-// Local to compilation unit
-// Location: 0x1C571380
-static int cpuCompile_L_CVT_SD_function;
-
-// Local to compilation unit
-// Location: 0x20571380
-static int cpuCompile_CEIL_W_function;
-
-// Local to compilation unit
-// Location: 0x24571380
-static int cpuCompile_FLOOR_W_function;
-
-// Local to compilation unit
-// Location: 0x28571380
-static int cpuCompile_ROUND_W_function;
-
-// Local to compilation unit
-// Location: 0x2C571380
-static int cpuCompile_TRUNC_W_function;
-
-// Local to compilation unit
-// Location: 0x30571380
-static int cpuCompile_LB_function;
-
-// Local to compilation unit
-// Location: 0x34571380
-static int cpuCompile_LH_function;
-
-// Local to compilation unit
-// Location: 0x38571380
-static int cpuCompile_LW_function;
-
-// Local to compilation unit
-// Location: 0x3C571380
-static int cpuCompile_LBU_function;
-
-// Local to compilation unit
-// Location: 0x40571380
-static int cpuCompile_LHU_function;
-
-// Local to compilation unit
-// Location: 0x44571380
-static int cpuCompile_SB_function;
-
-// Local to compilation unit
-// Location: 0x48571380
-static int cpuCompile_SH_function;
-
-// Local to compilation unit
-// Location: 0x4C571380
-static int cpuCompile_SW_function;
-
-// Local to compilation unit
-// Location: 0x50571380
-static int cpuCompile_LDC_function;
-
-// Local to compilation unit
-// Location: 0x54571380
-static int cpuCompile_SDC_function;
-
-// Local to compilation unit
-// Location: 0x58571380
-static int cpuCompile_LWL_function;
-
-// Local to compilation unit
-// Location: 0x5C571380
-static int cpuCompile_LWR_function;
-
-// Location: 0x580A1380
-unsigned int aHeapTreeFlag[125];
-
-// size: 0x4
-enum __anon_0x3D79A
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
+enum __anon_0x3D8AD {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x10
-struct __anon_0x3D7FC
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+enum __anon_0x3D9D9 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum __anon_0x3D8AD
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
+struct __anon_0x3DB14 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x3D79A eMode;
+    /* 0x10 */ struct __anon_0x3D7FC romCopy;
+    /* 0x20 */ enum __anon_0x3D8AD eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x3D9D9 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x3DB14* gpSystem;
+
+// Erased
+static s32 cpuUpdateDiskChecksum(u32* checksum, s32 startAddress, s32 endAddress) {
+    // Parameters
+    // u32* checksum; // r29
+    // s32 startAddress; // r4
+    // s32 endAddress; // r1+0x10
+
+    // Local variables
+    s32 count; // r31
+    s32 instruction; // r30
+    s32 check; // r1+0x8
+    u32* opcode; // r1+0x14
+    u32 part; // r27
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+struct __anon_0x3DE78 {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x3DE78* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x3E22D {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x4
-enum __anon_0x3D9D9
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
+union __anon_0x3E641 {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x88
-struct __anon_0x3DB14
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x3D79A eMode; // 0xC
-	__anon_0x3D7FC romCopy; // 0x10
-	__anon_0x3D8AD eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x3D9D9 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
+struct __anon_0x3EB4F {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
+
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
+
+struct __anon_0x3F080 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
+
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
+
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
+
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
+
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x3E22D aGPR[32];
+    /* 0x00140 */ union __anon_0x3E641 aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x3EB4F* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x3F080 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
+
+// Erased
+static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instruction) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 startAddress; // r30
+    // s32 instruction; // r31
+
+    // Local variables
+    s32 iHack; // r1+0x8
+    u32* opcode; // r1+0x14
+}
+
+struct cpu_disk_node {
+    /* 0x00 */ u32 functionLength;
+    /* 0x04 */ u32 checksum;
+    /* 0x08 */ s32 startAddress;
+    /* 0x0C */ s32 endAddress;
+    /* 0x10 */ u32 specialFlag;
+    /* 0x14 */ u32 frequency;
+    /* 0x18 */ u32 inCatalog;
+    /* 0x1C */ u32* length;
+    /* 0x20 */ u32 size;
+    /* 0x24 */ u32 GCNsize;
+    /* 0x28 */ u32* N64code;
+    /* 0x2C */ u32* GCNcode;
+    /* 0x30 */ struct cpu_disk_node* prev;
+    /* 0x34 */ struct cpu_disk_node* left;
+    /* 0x38 */ struct cpu_disk_node* right;
+    /* 0x3C */ struct cpu_disk_node* same;
+}; // size = 0x40
+
+// Erased
+static s32 cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, s32 start) {
+    // Parameters
+    // struct cpu_disk_node* pDisk; // r30
+    // s32 start; // r4
+
+    // Local variables
+    s32 count; // r1+0x8
+    s32 instruction; // r1+0x8
+    u32* last; // r31
+    u32* current; // r1+0x10
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+// Range: 0x80030E70 -> 0x80030F84
+static s32 cpuOpcodeChecksum(u32 opcode) {
+    // Parameters
+    // u32 opcode; // r1+0x0
+
+    // Local variables
+    s32 flag; // r5
+}
+
+// Erased
+static s32 treeMemory(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80030F84 -> 0x80031168
+static s32 treePrintNode(struct _CPU* pCPU, struct cpu_function* tree, s32 print_flag, s32* left, s32* right) {
+    // Parameters
+    // struct _CPU* pCPU; // r21
+    // struct cpu_function* tree; // r22
+    // s32 print_flag; // r1+0x10
+    // s32* left; // r23
+    // s32* right; // r24
+
+    // Local variables
+    struct cpu_function* current; // r27
+    s32 flag; // r26
+    s32 level; // r25
+
+    // References
+    // -> s32 ganMapGPR[32];
+}
+
+// Erased
+static s32 treePrint(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 left; // r1+0x10
+    s32 right; // r1+0xC
+}
+
+// Range: 0x80031168 -> 0x8003133C
+static s32 treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, s32 kill_limit) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // struct cpu_function* tree; // r1+0xC
+    // s32 kill_limit; // r29
+
+    // Local variables
+    struct cpu_function* current; // r31
+    struct cpu_function* kill; // r30
+}
+
+// Erased
+static s32 treeForceCleanUp(struct _CPU* pCPU, struct cpu_function* node, s32 kill_value) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // struct cpu_function* node; // r1+0xC
+    // s32 kill_value; // r5
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+}
+
+// Range: 0x8003133C -> 0x8003161C
+static s32 treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+    // struct cpu_function* top; // r1+0xC
+
+    // Local variables
+    struct cpu_function** current; // r30
+    struct cpu_function* kill; // r29
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 kill_limit; // r28
+}
+
+// Range: 0x8003161C -> 0x8003174C
+static s32 treeCleanUp(struct _CPU* pCPU, struct cpu_treeRoot* root) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_treeRoot* root; // r31
+
+    // Local variables
+    s32 done; // r3
+    s32 complete; // r30
+}
+
+// Erased
+static s32 treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_function* node; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+}
+
+// Range: 0x8003174C -> 0x80031860
+static s32 treeTimerCheck(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 begin; // r1+0x10
+    s32 end; // r1+0xC
+}
+
+// Range: 0x80031860 -> 0x800318F0
+static s32 treeKillReason(struct _CPU* pCPU, s32* value) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32* value; // r1+0x4
+}
+
+// Range: 0x800318F0 -> 0x80032088
+static s32 treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // struct cpu_function* tree; // r24
+    // s32 start; // r25
+    // s32 end; // r26
+
+    // Local variables
+    struct cpu_treeRoot* root; // r29
+    struct cpu_function* node1; // r1+0x3C
+    struct cpu_function* node2; // r1+0x38
+    struct cpu_function* save1; // r3
+    struct cpu_function* save2; // r4
+    struct cpu_function* connect; // r5
+    s32 update; // r28
+    s32 count; // r27
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80032088 -> 0x800320EC
+static s32 treeSearchNode(struct cpu_function* tree, s32 target, struct cpu_function** node) {
+    // Parameters
+    // struct cpu_function* tree; // r3
+    // s32 target; // r1+0x4
+    // struct cpu_function** node; // r1+0x8
+
+    // Local variables
+    struct cpu_function* current; // r3
+}
+
+// Erased
+static s32 treeSearch(struct _CPU* pCPU, s32 target, struct cpu_function** node) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 target; // r4
+    // struct cpu_function** node; // r5
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 flag; // r3
+}
+
+// Range: 0x800320EC -> 0x800322D8
+static s32 treeAdjustRoot(struct _CPU* pCPU, s32 new_end) {
+    // Parameters
+    // struct _CPU* pCPU; // r23
+    // s32 new_end; // r24
+
+    // Local variables
+    s32 old_root; // r1+0x8
+    s32 new_root; // r30
+    s32 kill_start; // r29
+    s32 check1; // r1+0x8
+    s32 check2; // r28
+    u16 total; // r27
+    s32 total_memory; // r26
+    s32 address; // r22
+    struct cpu_treeRoot* root; // r25
+    struct cpu_function* node; // r1+0x18
+    struct cpu_function* change; // r1+0x14
+}
+
+// Range: 0x800322D8 -> 0x80032470
+static s32 treeBalance(struct cpu_treeRoot* root) {
+    // Parameters
+    // struct cpu_treeRoot* root; // r1+0x0
+
+    // Local variables
+    struct cpu_function* tree; // r8
+    struct cpu_function* current; // r4
+    struct cpu_function* save; // r6
+    s32 total; // r9
+    s32 count; // r7
+}
+
+// Range: 0x80032470 -> 0x80032558
+static s32 treeInsertNode(struct cpu_function** tree, s32 start, s32 end, struct cpu_function** ppFunction) {
+    // Parameters
+    // struct cpu_function** tree; // r31
+    // s32 start; // r8
+    // s32 end; // r7
+    // struct cpu_function** ppFunction; // r30
+
+    // Local variables
+    struct cpu_function** current; // r31
+    struct cpu_function* prev; // r4
+}
+
+// Range: 0x80032558 -> 0x80032674
+s32 treeInsert(struct _CPU* pCPU, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 start; // r29
+    // s32 end; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+    struct cpu_function* current; // r1+0x14
+    s32 flag; // r3
+}
+
+// Erased
+static s32 treeInsertAndReturn(struct _CPU* pCPU, s32 start, s32 end, struct cpu_function** ppFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 start; // r28
+    // s32 end; // r29
+    // struct cpu_function** ppFunction; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+    s32 flag; // r3
+}
+
+// Erased
+static s32 treeRebuild(struct _CPU* pCPU, s32 start_address, struct cpu_function** node) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 start_address; // r30
+    // struct cpu_function** node; // r31
+}
+
+// Range: 0x80032674 -> 0x800329D4
+static s32 treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct cpu_function* kill) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // struct cpu_function** top; // r1+0xC
+    // struct cpu_function* kill; // r31
+
+    // Local variables
+    struct cpu_treeRoot* root; // r3
+    struct cpu_function* save1; // r5
+    struct cpu_function* save2; // r8
+    struct cpu_function* connect; // r1+0x8
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x800329D4 -> 0x80032C84
+static s32 treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // struct cpu_function* tree; // r25
+
+    // Local variables
+    struct cpu_function* current; // r27
+    struct cpu_function* kill; // r28
+    s32 count; // r26
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80032C84 -> 0x80032F2C
+static s32 treeKill(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 count; // r29
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80032F2C -> 0x80033048
+static s32 treeInitNode(struct cpu_function** tree, struct cpu_function* prev, s32 start, s32 end) {
+    // Parameters
+    // struct cpu_function** tree; // r30
+    // struct cpu_function* prev; // r31
+    // s32 start; // r28
+    // s32 end; // r29
+
+    // Local variables
+    struct cpu_function* node; // r1+0x1C
+    s32 where; // r1+0x18
+}
+
+// Range: 0x80033048 -> 0x800330A0
+static s32 treeInit(struct _CPU* pCPU, s32 root_address) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 root_address; // r1+0x4
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x0
+}
+
+// Range: 0x800330A0 -> 0x800331A4
+static s32 treeCallerCheck(struct _CPU* pCPU, struct cpu_function* tree, s32 flag, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // struct cpu_function* tree; // r25
+    // s32 flag; // r26
+    // s32 nAddress0; // r27
+    // s32 nAddress1; // r28
+
+    // Local variables
+    s32 count; // r30
+    s32 saveGCN; // r6
+    s32 saveN64; // r1+0x8
+    s32* addr_function; // r1+0x8
+    s32* addr_call; // r29
+}
+
+// Erased
+static s32 treeCallerKill(struct _CPU* pCPU, struct cpu_function* kill) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_function* kill; // r30
+
+    // Local variables
+    s32 left; // r1+0x14
+    s32 right; // r1+0x10
+    struct cpu_treeRoot* root; // r31
+}
+
+// Erased
+static void treeCallerInit(struct cpu_callerID* block, s32 total) {
+    // Parameters
+    // struct cpu_callerID* block; // r3
+    // s32 total; // r1+0x4
+
+    // Local variables
+    s32 count; // r6
+}
+
+// Range: 0x800331A4 -> 0x80033304
+static s32 cpuDMAUpdateFunction(struct _CPU* pCPU, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 start; // r29
+    // s32 end; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 count; // r1+0x8
+    s32 cancel; // r5
+}
+
+// Range: 0x80033304 -> 0x80033E88
+s32 cpuFindFunction(struct _CPU* pCPU, s32 theAddress, struct cpu_function** tree_node) {
+    // Parameters
+    // struct _CPU* pCPU; // r22
+    // s32 theAddress; // r1+0x38
+    // struct cpu_function** tree_node; // r28
+
+    // Local variables
+    struct __anon_0x3EB4F** apDevice; // r26
+    u8* aiDevice; // r27
+    u32 opcode; // r1+0x34
+    u8 follow; // r1+0x3D
+    u8 valid; // r16
+    u8 check; // r1+0x3C
+    u8 end_flag; // r18
+    u8 save_restore; // r14
+    u8 alert; // r15
+    s32 beginAddress; // r21
+    s32 cheat_address; // r17
+    s32 current_address; // r31
+    s32 temp_address; // r30
+    s32 branch; // r1+0x8
+
+    // References
+    // -> static u8 Opcode[64];
+    // -> static u8 RegimmOpcode[32];
+    // -> static u8 SpecialOpcode[64];
+}
+
+// Erased
+static s32 cpuTreeFree(struct cpu_function* pFunction) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x0
+
+    // Local variables
+    u32* anPack; // r1+0x0
+    s32 iPack; // r1+0x0
+    u32 nMask; // r5
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80033E88 -> 0x80033F3C
+static s32 cpuTreeTake(void* heap, s32* where) {
+    // Parameters
+    // void* heap; // r1+0x0
+    // s32* where; // r1+0x4
+
+    // Local variables
+    s32 done; // r5
+    s32 nOffset; // r8
+    s32 nCount; // r1+0x0
+    s32 iPack; // r1+0x0
+    u32 nPack; // r9
+    u32 nMask; // r10
+    u32 nMask0; // r1+0x0
+
+    // References
+    // -> void* gHeapTree;
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80033F3C -> 0x80034028
+s32 cpuHeapFree(struct _CPU* pCPU, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // struct cpu_function* pFunction; // r4
+
+    // Local variables
+    u32* anPack; // r8
+    s32 iPack; // r1+0x8
+    u32 nMask; // r6
+}
+
+// Range: 0x80034028 -> 0x80034288
+s32 cpuHeapTake(void* heap, struct _CPU* pCPU, struct cpu_function* pFunction, s32 memory_size) {
+    // Parameters
+    // void* heap; // r3
+    // struct _CPU* pCPU; // r1+0xC
+    // struct cpu_function* pFunction; // r1+0x10
+    // s32 memory_size; // r6
+
+    // Local variables
+    s32 done; // r12
+    s32 second; // r7
+    u32* anPack; // r8
+    s32 nPackCount; // r9
+    s32 nBlockCount; // r10
+    s32 nOffset; // r27
+    s32 nCount; // r26
+    s32 iPack; // r1+0x8
+    u32 nPack; // r25
+    u32 nMask; // r24
+    u32 nMask0; // r23
+}
+
+// Range: 0x80034288 -> 0x80034324
+static s32 cpuHeapReset(u32* array, s32 count) {
+    // Parameters
+    // u32* array; // r3
+    // s32 count; // r1+0x4
+
+    // Local variables
+    s32 i; // r6
+}
+
+// Range: 0x80034324 -> 0x80034564
+s32 cpuGetFunctionChecksum(struct _CPU* pCPU, u32* pnChecksum, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // u32* pnChecksum; // r30
+    // struct cpu_function* pFunction; // r31
+
+    // Local variables
+    s32 nSize; // r10
+    u32* pnBuffer; // r1+0x18
+    u32 nChecksum; // r11
+    u32 nData; // r12
+}
+
+// Range: 0x80034564 -> 0x800345F0
+s32 cpuInvalidateCache(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nAddress0; // r30
+    // s32 nAddress1; // r31
+}
+
+// Range: 0x800345F0 -> 0x80034780
+s32 cpuGetOffsetAddress(struct _CPU* pCPU, u32* anAddress, s32* pnCount, u32 nOffset, u32 nSize) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u32* anAddress; // r1+0xC
+    // s32* pnCount; // r1+0x10
+    // u32 nOffset; // r1+0x14
+    // u32 nSize; // r1+0x18
+
+    // Local variables
+    s32 iEntry; // r1+0x8
+    s32 iAddress; // r7
+    u32 nAddress; // r1+0x8
+    u32 nMask; // r1+0x8
+    u32 nSizeMapped; // r26
+}
+
+// Range: 0x80034780 -> 0x800347F8
+s32 cpuGetAddressBuffer(struct _CPU* pCPU, void* ppBuffer, u32 nAddress) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // void* ppBuffer; // r4
+    // u32 nAddress; // r5
+
+    // Local variables
+    struct __anon_0x3EB4F* pDevice; // r1+0x8
+}
+
+// Range: 0x800347F8 -> 0x80034864
+s32 cpuGetAddressOffset(struct _CPU* pCPU, s32* pnOffset, u32 nAddress) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32* pnOffset; // r1+0x4
+    // u32 nAddress; // r1+0x8
+
+    // Local variables
+    s32 iDevice; // r1+0x0
+}
+
+// Range: 0x80034864 -> 0x80034A6C
+s32 cpuEvent(struct _CPU* pCPU, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r1+0x10
+}
+
+// Erased
+static s32 cpuSetFCR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetFPR(struct _CPU* pCPU, double* arRegister, s32 bDouble) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // double* arRegister; // r30
+    // s32 bDouble; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetCP0(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+enum __anon_0x42F73 {
+    CS_NONE = -1,
+    CS_32BIT = 0,
+    CS_64BIT = 1,
 };
 
-// Location: 0x561380
-__anon_0x3DB14 *gpSystem;
+// Erased
+static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
 
-int cpuUpdateDiskChecksum(unsigned int *checksum, int startAddress, int endAddress)
-{
-	int count;
-	int instruction;
-	int check;
-	unsigned int *opcode;
-	unsigned int part;
-	// References: gpSystem (0x561380)
+    // Local variables
+    s32 iRegister; // r1+0x8
+    enum __anon_0x42F73 eSize; // r1+0x18
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
-// size: 0x8
-struct __anon_0x3DE78
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
+// Range: 0x80034A6C -> 0x80034AE8
+s32 cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
+    // Parameters
+    // struct _CPU* pCPU; // r26
+    // s64 nPC; // r0
+    // s64 nLo; // r29
+    // s64 nHi; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetFCR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetFPR(struct _CPU* pCPU, double* arRegister, s32 bDouble) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // double* arRegister; // r30
+    // s32 bDouble; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetCP0(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetGPR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+    enum __anon_0x42F73 eSize; // r1+0x18
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetXPC(struct _CPU* pCPU, s32* pnPC, s32* pnLo, s32* pnHi) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32* pnPC; // r29
+    // s32* pnLo; // r30
+    // s32* pnHi; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Range: 0x80034AE8 -> 0x80034FCC
+s32 cpuReset(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+    s32 iTLB; // r1+0x8
+
+    // References
+    // -> void* gHeapTree;
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80034FCC -> 0x80035038
+s32 cpuSetCodeHack(struct _CPU* pCPU, s32 nAddress, s32 nOpcodeOld, s32 nOpcodeNew) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 nAddress; // r1+0x4
+    // s32 nOpcodeOld; // r1+0x8
+    // s32 nOpcodeNew; // r1+0xC
+
+    // Local variables
+    s32 iHack; // r9
+}
+
+// Range: 0x80035038 -> 0x80035050
+s32 cpuSetDevicePut(struct __anon_0x3EB4F* pDevice, s32 (*pfPut8)(void*, u32, char*), s32 (*pfPut16)(void*, u32, s16*),
+                    s32 (*pfPut32)(void*, u32, s32*), s32 (*pfPut64)(void*, u32, s64*)) {
+    // Parameters
+    // struct __anon_0x3EB4F* pDevice; // r1+0x4
+    // s32 (* pfPut8)(void*, u32, char*); // r1+0x8
+    // s32 (* pfPut16)(void*, u32, s16*); // r1+0xC
+    // s32 (* pfPut32)(void*, u32, s32*); // r1+0x10
+    // s32 (* pfPut64)(void*, u32, s64*); // r1+0x14
+}
+
+// Range: 0x80035050 -> 0x80035068
+s32 cpuSetDeviceGet(struct __anon_0x3EB4F* pDevice, s32 (*pfGet8)(void*, u32, char*), s32 (*pfGet16)(void*, u32, s16*),
+                    s32 (*pfGet32)(void*, u32, s32*), s32 (*pfGet64)(void*, u32, s64*)) {
+    // Parameters
+    // struct __anon_0x3EB4F* pDevice; // r1+0x4
+    // s32 (* pfGet8)(void*, u32, char*); // r1+0x8
+    // s32 (* pfGet16)(void*, u32, s16*); // r1+0xC
+    // s32 (* pfGet32)(void*, u32, s32*); // r1+0x10
+    // s32 (* pfGet64)(void*, u32, s64*); // r1+0x14
+}
+
+// Range: 0x80035068 -> 0x80035218
+s32 cpuMapObject(struct _CPU* pCPU, void* pObject, u32 nAddress0, u32 nAddress1, s32 nType) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // void* pObject; // r27
+    // u32 nAddress0; // r28
+    // u32 nAddress1; // r29
+    // s32 nType; // r30
+
+    // Local variables
+    s32 iDevice; // r1+0x24
+    s32 iAddress; // r4
+    u32 nAddressVirtual0; // r5
+    u32 nAddressVirtual1; // r6
+}
+
+// Erased
+static s32 cpuGetOpcodeText() {}
+
+enum __anon_0x43B0A {
+    RLM_NONE = -1,
+    RLM_PART = 0,
+    RLM_FULL = 1,
+    RLM_COUNT_ = 2,
 };
 
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
-};
-
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x3DE78 *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
-};
-
-// size: 0x8
-union __anon_0x3E22D
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x8
-union __anon_0x3E641
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x34
-struct __anon_0x3EB4F
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
-};
-
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
-};
-
-// size: 0xC
-struct __anon_0x3F080
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
-};
-
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
-
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
-
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
-
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x3E22D aGPR[32]; // 0x40
-	__anon_0x3E641 aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x3EB4F *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x3F080 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
-
-int cpuCheckOpcodeHack(_CPU *pCPU, int startAddress, int instruction)
-{
-	int iHack;
-	unsigned int *opcode;
-}
-
-// size: 0x40
-struct cpu_disk_node
-{
-	unsigned int functionLength; // 0x0
-	unsigned int checksum; // 0x4
-	int startAddress; // 0x8
-	int endAddress; // 0xC
-	unsigned int specialFlag; // 0x10
-	unsigned int frequency; // 0x14
-	unsigned int inCatalog; // 0x18
-	unsigned int *length; // 0x1C
-	unsigned int size; // 0x20
-	unsigned int GCNsize; // 0x24
-	unsigned int *N64code; // 0x28
-	unsigned int *GCNcode; // 0x2C
-	cpu_disk_node *prev; // 0x30
-	cpu_disk_node *left; // 0x34
-	cpu_disk_node *right; // 0x38
-	cpu_disk_node *same; // 0x3C
-};
-
-int cpuDoubleCheckSameChecksum(cpu_disk_node *pDisk, int start)
-{
-	int count;
-	int instruction;
-	unsigned int *last;
-	unsigned int *current;
-	// References: gpSystem (0x561380)
-}
-
-// Local to compilation unit
-static int cpuOpcodeChecksum(unsigned int opcode)
-{
-	int flag;
-}
-
-int treeMemory(_CPU *pCPU);
-
-// Local to compilation unit
-static int treePrintNode(_CPU *pCPU, cpu_function *tree, int print_flag, int *left, int *right)
-{
-	cpu_function *current;
-	int flag;
-	int level;
-	// References: ganMapGPR (0x70BE0E80)
-}
-
-int treePrint(_CPU *pCPU)
-{
-	cpu_treeRoot *root;
-	int left;
-	int right;
-}
-
-// Local to compilation unit
-static int treeForceCleanNodes(_CPU *pCPU, cpu_function *tree, int kill_limit)
-{
-	cpu_function *current;
-	cpu_function *kill;
-}
-
-int treeForceCleanUp(_CPU *pCPU, cpu_function *node, int kill_value)
-{
-	cpu_treeRoot *root;
-}
-
-// Local to compilation unit
-static int treeCleanNodes(_CPU *pCPU, cpu_function *top)
-{
-	cpu_function **current;
-	cpu_function *kill;
-	cpu_treeRoot *root;
-	int kill_limit;
-}
-
-// Local to compilation unit
-static int treeCleanUp(_CPU *pCPU, cpu_treeRoot *root)
-{
-	int done;
-	int complete;
-}
-
-int treeCleanUpCheck(_CPU *pCPU, cpu_function *node)
-{
-	cpu_treeRoot *root;
-}
-
-// Local to compilation unit
-static int treeTimerCheck(_CPU *pCPU)
-{
-	cpu_treeRoot *root;
-	int begin;
-	int end;
-}
-
-// Local to compilation unit
-static int treeKillReason(_CPU *pCPU, int *value);
-
-// Local to compilation unit
-static int treeKillRange(_CPU *pCPU, cpu_function *tree, int start, int end)
-{
-	cpu_treeRoot *root;
-	cpu_function *node1;
-	cpu_function *node2;
-	cpu_function *save1;
-	cpu_function *save2;
-	cpu_function *connect;
-	int update;
-	int count;
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-// Local to compilation unit
-static int treeSearchNode(cpu_function *tree, int target, cpu_function **node)
-{
-	cpu_function *current;
-}
-
-int treeSearch(_CPU *pCPU, int target, cpu_function **node)
-{
-	cpu_treeRoot *root;
-	int flag;
-}
-
-// Local to compilation unit
-static int treeAdjustRoot(_CPU *pCPU, int new_end)
-{
-	int old_root;
-	int new_root;
-	int kill_start;
-	int check1;
-	int check2;
-	unsigned short total;
-	int total_memory;
-	int address;
-	cpu_treeRoot *root;
-	cpu_function *node;
-	cpu_function *change;
-}
-
-// Local to compilation unit
-static int treeBalance(cpu_treeRoot *root)
-{
-	cpu_function *tree;
-	cpu_function *current;
-	cpu_function *save;
-	int total;
-	int count;
-}
-
-// Local to compilation unit
-static int treeInsertNode(cpu_function **tree, int start, int end, cpu_function **ppFunction)
-{
-	cpu_function **current;
-	cpu_function *prev;
-}
-
-int treeInsert(_CPU *pCPU, int start, int end)
-{
-	cpu_treeRoot *root;
-	cpu_function *current;
-	int flag;
-}
-
-int treeInsertAndReturn(_CPU *pCPU, int start, int end, cpu_function **ppFunction)
-{
-	cpu_treeRoot *root;
-	int flag;
-}
-
-int treeRebuild(_CPU *pCPU, int start_address, cpu_function **node);
-
-// Local to compilation unit
-static int treeDeleteNode(_CPU *pCPU, cpu_function **top, cpu_function *kill)
-{
-	cpu_treeRoot *root;
-	cpu_function *save1;
-	cpu_function *save2;
-	cpu_function *connect;
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-// Local to compilation unit
-static int treeKillNodes(_CPU *pCPU, cpu_function *tree)
-{
-	cpu_function *current;
-	cpu_function *kill;
-	int count;
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-// Local to compilation unit
-static int treeKill(_CPU *pCPU)
-{
-	cpu_treeRoot *root;
-	int count;
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-// Local to compilation unit
-static int treeInitNode(cpu_function **tree, cpu_function *prev, int start, int end)
-{
-	cpu_function *node;
-	int where;
-}
-
-// Local to compilation unit
-static int treeInit(_CPU *pCPU, int root_address)
-{
-	cpu_treeRoot *root;
-}
-
-// Local to compilation unit
-static int treeCallerCheck(_CPU *pCPU, cpu_function *tree, int flag, int nAddress0, int nAddress1)
-{
-	int count;
-	int saveGCN;
-	int saveN64;
-	int *addr_function;
-	int *addr_call;
-}
-
-int treeCallerKill(_CPU *pCPU, cpu_function *kill)
-{
-	int left;
-	int right;
-	cpu_treeRoot *root;
-}
-
-void treeCallerInit(cpu_callerID *block, int total)
-{
-	int count;
-}
-
-// Local to compilation unit
-static int cpuDMAUpdateFunction(_CPU *pCPU, int start, int end)
-{
-	cpu_treeRoot *root;
-	int count;
-	int cancel;
-}
-
-int cpuFindFunction(_CPU *pCPU, int theAddress, cpu_function **tree_node)
-{
-	__anon_0x3EB4F **apDevice;
-	unsigned char *aiDevice;
-	unsigned int opcode;
-	unsigned char follow;
-	unsigned char valid;
-	unsigned char check;
-	unsigned char end_flag;
-	unsigned char save_restore;
-	unsigned char alert;
-	int beginAddress;
-	int cheat_address;
-	int current_address;
-	int temp_address;
-	int branch;
-	// References: Opcode (0x800EBD88)
-	// References: RegimmOpcode (0x8BE0E80)
-	// References: SpecialOpcode (0x800EBDC8)
-}
-
-int cpuTreeFree(cpu_function *pFunction)
-{
-	unsigned int *anPack;
-	int iPack;
-	unsigned int nMask;
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-// Local to compilation unit
-static int cpuTreeTake(void *heap, int *where)
-{
-	int done;
-	int nOffset;
-	int nCount;
-	int iPack;
-	unsigned int nPack;
-	unsigned int nMask;
-	unsigned int nMask0;
-	// References: gHeapTree (0x801356E0)
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-int cpuHeapFree(_CPU *pCPU, cpu_function *pFunction)
-{
-	unsigned int *anPack;
-	int iPack;
-	unsigned int nMask;
-}
-
-int cpuHeapTake(void *heap, _CPU *pCPU, cpu_function *pFunction, int memory_size)
-{
-	int done;
-	int second;
-	unsigned int *anPack;
-	int nPackCount;
-	int nBlockCount;
-	int nOffset;
-	int nCount;
-	int iPack;
-	unsigned int nPack;
-	unsigned int nMask;
-	unsigned int nMask0;
-}
-
-// Local to compilation unit
-static int cpuHeapReset(unsigned int *array, int count)
-{
-	int i;
-}
-
-int cpuGetFunctionChecksum(_CPU *pCPU, unsigned int *pnChecksum, cpu_function *pFunction)
-{
-	int nSize;
-	unsigned int *pnBuffer;
-	unsigned int nChecksum;
-	unsigned int nData;
-}
-
-int cpuInvalidateCache(_CPU *pCPU, int nAddress0, int nAddress1);
-
-int cpuGetOffsetAddress(_CPU *pCPU, unsigned int *anAddress, int *pnCount, unsigned int nOffset, unsigned int nSize)
-{
-	int iEntry;
-	int iAddress;
-	unsigned int nAddress;
-	unsigned int nMask;
-	unsigned int nSizeMapped;
-}
-
-int cpuGetAddressBuffer(_CPU *pCPU, void *ppBuffer, unsigned int nAddress)
-{
-	__anon_0x3EB4F *pDevice;
-}
-
-int cpuGetAddressOffset(_CPU *pCPU, int *pnOffset, unsigned int nAddress)
-{
-	int iDevice;
-}
-
-int cpuEvent(_CPU *pCPU, int nEvent, void *pArgument);
-
-int cpuSetFCR(_CPU *pCPU, int *anRegister)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuSetFPR(_CPU *pCPU, long float *arRegister, int bDouble)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuSetCP0(_CPU *pCPU, signed long long *anRegister)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-// size: 0x4
-enum __anon_0x42F73
-{
-	CS_NONE = 4294967295,
-	CS_32BIT = 0,
-	CS_64BIT = 1
-};
-
-int cpuSetGPR(_CPU *pCPU, signed long long *anRegister)
-{
-	int iRegister;
-	__anon_0x42F73 eSize;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuSetXPC(_CPU *pCPU, signed long long nPC, signed long long nLo, signed long long nHi)
-{
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuGetFCR(_CPU *pCPU, int *anRegister)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuGetFPR(_CPU *pCPU, long float *arRegister, int bDouble)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuGetCP0(_CPU *pCPU, signed long long *anRegister)
-{
-	int iRegister;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuGetGPR(_CPU *pCPU, signed long long *anRegister)
-{
-	int iRegister;
-	__anon_0x42F73 eSize;
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuGetXPC(_CPU *pCPU, signed long long *pnPC, signed long long *pnLo, signed long long *pnHi)
-{
-	// References: gClassCPU (0x58B60E80)
-}
-
-int cpuReset(_CPU *pCPU)
-{
-	int iRegister;
-	int iTLB;
-	// References: gHeapTree (0x801356E0)
-	// References: aHeapTreeFlag (0x580A1380)
-}
-
-int cpuSetCodeHack(_CPU *pCPU, int nAddress, int nOpcodeOld, int nOpcodeNew)
-{
-	int iHack;
-}
-
-int cpuSetDevicePut(__anon_0x3EB4F *pDevice, int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */), int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */), int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */), int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */));
-
-int cpuSetDeviceGet(__anon_0x3EB4F *pDevice, int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */), int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */), int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */), int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */));
-
-int cpuMapObject(_CPU *pCPU, void *pObject, unsigned int nAddress0, unsigned int nAddress1, int nType)
-{
-	int iDevice;
-	int iAddress;
-	unsigned int nAddressVirtual0;
-	unsigned int nAddressVirtual1;
-}
-
-int cpuGetOpcodeText();
-
-// size: 0x4
-enum __anon_0x43B0A
-{
-	RLM_NONE = 4294967295,
-	RLM_PART = 0,
-	RLM_FULL = 1,
-	RLM_COUNT_ = 2
-};
-
-// size: 0x10
-struct __anon_0x43B69
-{
-	int iCache; // 0x0
-	unsigned int nSize; // 0x4
-	unsigned int nTickUsed; // 0x8
-	char keep; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x43C7D
-{
-	int bWait; // 0x0
-	int (*pCallback)(); // 0x4
-	unsigned char *pTarget; // 0x8
-	unsigned int nSize; // 0xC
-	unsigned int nOffset; // 0x10
-};
-
-// size: 0x30
-struct __anon_0x43D5D
-{
-	int bWait; // 0x0
-	int bDone; // 0x4
-	int nResult; // 0x8
-	unsigned char *anData; // 0xC
-	int (*pCallback)(); // 0x10
-	int iCache; // 0x14
-	int iBlock; // 0x18
-	int nOffset; // 0x1C
-	unsigned int nOffset0; // 0x20
-	unsigned int nOffset1; // 0x24
-	unsigned int nSize; // 0x28
-	unsigned int nSizeRead; // 0x2C
-};
-
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
-
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// size: 0x10EF8
-struct __anon_0x443F6
-{
-	void *pHost; // 0x0
-	void *pBuffer; // 0x4
-	int bFlip; // 0x8
-	int bLoad; // 0xC
-	char acNameFile[513]; // 0x10
-	unsigned int nSize; // 0x214
-	__anon_0x43B0A eModeLoad; // 0x218
-	__anon_0x43B69 aBlock[4096]; // 0x21C
-	unsigned int nTick; // 0x1021C
-	unsigned char *pCacheRAM; // 0x10220
-	unsigned char anBlockCachedRAM[1024]; // 0x10224
-	unsigned char anBlockCachedARAM[2046]; // 0x10624
-	__anon_0x43C7D copy; // 0x10E24
-	__anon_0x43D5D load; // 0x10E38
-	int nCountBlockRAM; // 0x10E68
-	int nSizeCacheRAM; // 0x10E6C
-	unsigned char acHeader[64]; // 0x10E70
-	unsigned int *anOffsetBlock; // 0x10EB0
-	int nCountOffsetBlocks; // 0x10EB4
-	DVDFileInfo fileInfo; // 0x10EB8
-	int offsetToRom; // 0x10EF4
-};
-
-// Location: 0x783E0F80
-int __float_nan[];
-
-// Location: 0x7C3E0F80
-int __float_huge[];
-
-// Location: 0x644E1380
+struct __anon_0x43B69 {
+    /* 0x0 */ s32 iCache;
+    /* 0x4 */ u32 nSize;
+    /* 0x8 */ u32 nTickUsed;
+    /* 0xC */ char keep;
+}; // size = 0x10
+
+struct __anon_0x43C7D {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 (*pCallback)();
+    /* 0x08 */ u8* pTarget;
+    /* 0x0C */ u32 nSize;
+    /* 0x10 */ u32 nOffset;
+}; // size = 0x14
+
+struct __anon_0x43D5D {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 bDone;
+    /* 0x08 */ s32 nResult;
+    /* 0x0C */ u8* anData;
+    /* 0x10 */ s32 (*pCallback)();
+    /* 0x14 */ s32 iCache;
+    /* 0x18 */ s32 iBlock;
+    /* 0x1C */ s32 nOffset;
+    /* 0x20 */ u32 nOffset0;
+    /* 0x24 */ u32 nOffset1;
+    /* 0x28 */ u32 nSize;
+    /* 0x2C */ u32 nSizeRead;
+}; // size = 0x30
+
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+struct __anon_0x443F6 {
+    /* 0x00000 */ void* pHost;
+    /* 0x00004 */ void* pBuffer;
+    /* 0x00008 */ s32 bFlip;
+    /* 0x0000C */ s32 bLoad;
+    /* 0x00010 */ char acNameFile[513];
+    /* 0x00214 */ u32 nSize;
+    /* 0x00218 */ enum __anon_0x43B0A eModeLoad;
+    /* 0x0021C */ struct __anon_0x43B69 aBlock[4096];
+    /* 0x1021C */ u32 nTick;
+    /* 0x10220 */ u8* pCacheRAM;
+    /* 0x10224 */ u8 anBlockCachedRAM[1024];
+    /* 0x10624 */ u8 anBlockCachedARAM[2046];
+    /* 0x10E24 */ struct __anon_0x43C7D copy;
+    /* 0x10E38 */ struct __anon_0x43D5D load;
+    /* 0x10E68 */ s32 nCountBlockRAM;
+    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E70 */ u8 acHeader[64];
+    /* 0x10EB0 */ u32* anOffsetBlock;
+    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB8 */ struct DVDFileInfo fileInfo;
+    /* 0x10EF4 */ s32 offsetToRom;
+}; // size = 0x10EF8
+
+// size = 0x0, address = 0x800F3E78
+s32 __float_nan[];
+
+// size = 0x0, address = 0x800F3E7C
+s32 __float_huge[];
+
+// size = 0x4, address = 0x80134E64
 float fTickScale;
 
-// Location: 0x604E1380
-unsigned int nTickMultiplier;
+// size = 0x4, address = 0x80134E60
+u32 nTickMultiplier;
 
-// size: 0x4
-enum __anon_0x44829
-{
-	RUM_NONE = 0,
-	RUM_IDLE = 1
+enum __anon_0x44829 {
+    RUM_NONE = 0,
+    RUM_IDLE = 1,
 };
 
-int __cpuBreak(_CPU *pCPU);
-
-int __cpuERET(_CPU *pCPU);
-
-int cpuGetRegisterCP0(_CPU *pCPU, int iRegister, signed long long *pnData)
-{
-	int bFlag;
-	// References: ganMaskGetCP0 (0x800EBB88)
+// Range: 0x80035218 -> 0x8003522C
+s32 __cpuBreak(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
 }
 
-int cpuSetRegisterCP0(_CPU *pCPU, int iRegister, signed long long nData)
-{
-	int bFlag;
-	// References: ganMaskSetCP0 (0x800EBC88)
+// Range: 0x8003522C -> 0x800352C8
+s32 __cpuERET(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
 }
 
-// size: 0x4
-enum __anon_0x44AE9
-{
-	CM_NONE = 4294967295,
-	CM_USER = 0,
-	CM_SUPER = 1,
-	CM_KERNEL = 2
+// Range: 0x800352C8 -> 0x80035570
+s32 cpuGetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64* pnData) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 iRegister; // r1+0xC
+    // s64* pnData; // r1+0x10
+
+    // Local variables
+    s32 bFlag; // r1+0x8
+
+    // References
+    // -> static s64 ganMaskGetCP0[32];
+}
+
+// Range: 0x80035570 -> 0x8003573C
+s32 cpuSetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64 nData) {
+    // Parameters
+    // struct _CPU* pCPU; // r26
+    // s32 iRegister; // r27
+    // s64 nData; // r29
+
+    // Local variables
+    s32 bFlag; // r30
+
+    // References
+    // -> static s64 ganMaskSetCP0[32];
+}
+
+enum __anon_0x44AE9 {
+    CM_NONE = -1,
+    CM_USER = 0,
+    CM_SUPER = 1,
+    CM_KERNEL = 2,
 };
 
-// Local to compilation unit
-static int cpuSetCP0_Status(_CPU *pCPU, unsigned long long nStatus)
-{
-	__anon_0x44AE9 eMode;
-	__anon_0x44AE9 eModeLast;
-	__anon_0x42F73 eSize;
-	__anon_0x42F73 eSizeLast;
+// Range: 0x8003573C -> 0x800357D0
+static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // u64 nStatus; // r31
+
+    // Local variables
+    enum __anon_0x44AE9 eMode; // r1+0x28
+    enum __anon_0x44AE9 eModeLast; // r1+0x24
+    enum __anon_0x42F73 eSize; // r1+0x20
+    enum __anon_0x42F73 eSizeLast; // r1+0x1C
 }
 
-int cpuSetCP0_Config(_CPU *pCPU, unsigned int nConfig);
-
-// Local to compilation unit
-static int cpuGetSize(unsigned long long nStatus, __anon_0x42F73 *peSize, __anon_0x44AE9 *peMode)
-{
-	__anon_0x44AE9 eMode;
+// Erased
+static s32 cpuSetCP0_Config(struct _CPU* pCPU, u32 nConfig) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // u32 nConfig; // r1+0x4
 }
 
-// Local to compilation unit
-static int cpuGetMode(unsigned long long nStatus, __anon_0x44AE9 *peMode);
+// Range: 0x800357D0 -> 0x80035914
+static s32 cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44AE9* peMode) {
+    // Parameters
+    // u64 nStatus; // r29
+    // enum __anon_0x42F73* peSize; // r30
+    // enum __anon_0x44AE9* peMode; // r31
 
-int cpuVirtualToPhysical_Kernel64(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuVirtualToPhysical_Kernel32(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuVirtualToPhysical_Super64(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuVirtualToPhysical_Super32(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuVirtualToPhysical_User64(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuVirtualToPhysical_User32(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical);
-
-int cpuFindTLB(_CPU *pCPU, unsigned long long nAddressVirtual, unsigned int *pnAddressPhysical)
-{
-	int iEntry;
-	unsigned int nMask;
-	unsigned int nVirtual;
+    // Local variables
+    enum __anon_0x44AE9 eMode; // r1+0x18
 }
 
-int cpuGetTLB(_CPU *pCPU, int iEntry);
-
-// Local to compilation unit
-static int cpuSetTLB(_CPU *pCPU, int iEntry)
-{
-	int iDevice;
-	unsigned int nMask;
-	unsigned int nVirtual;
-	unsigned int nPhysical;
+// Range: 0x80035914 -> 0x800359EC
+static s32 cpuGetMode(u64 nStatus, enum __anon_0x44AE9* peMode) {
+    // Parameters
+    // u64 nStatus; // r1+0x0
+    // enum __anon_0x44AE9* peMode; // r1+0x8
 }
 
-int cpuCountTLB(_CPU *pCPU, int *pnCount)
-{
-	int iEntry;
-	int nCount;
+// Erased
+static s32 cpuVirtualToPhysical_Kernel64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // u64 nAddressVirtual; // r30
+    // u32* pnAddressPhysical; // r31
 }
 
-// Local to compilation unit
-static int cpuMapAddress(_CPU *pCPU, int *piDevice, unsigned int nVirtual, unsigned int nPhysical, int nSize)
-{
-	int iDeviceTarget;
-	int iDeviceSource;
-	unsigned int nAddressVirtual0;
-	unsigned int nAddressVirtual1;
+// Erased
+static s32 cpuVirtualToPhysical_Kernel32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
 }
 
-int cpuWipeDevices(_CPU *pCPU, int bFree)
-{
-	int iDevice;
+// Erased
+static s32 cpuVirtualToPhysical_Super64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
 }
 
-// Local to compilation unit
-static int cpuFreeDevice(_CPU *pCPU, int iDevice)
-{
-	int iAddress;
+// Erased
+static s32 cpuVirtualToPhysical_Super32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
 }
 
-// Local to compilation unit
-static int cpuMakeDevice(_CPU *pCPU, int *piDevice, void *pObject, int nOffset, unsigned int nAddress0, unsigned int nAddress1, int nType)
-{
-	__anon_0x3EB4F *pDevice;
-	int iDevice;
+// Erased
+static s32 cpuVirtualToPhysical_User64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
 }
 
-// size: 0x4
-enum __anon_0x45AE1
-{
-	CEC_NONE = 4294967295,
-	CEC_INTERRUPT = 0,
-	CEC_TLB_MODIFICATION = 1,
-	CEC_TLB_LOAD = 2,
-	CEC_TLB_STORE = 3,
-	CEC_ADDRESS_LOAD = 4,
-	CEC_ADDRESS_STORE = 5,
-	CEC_BUS_INSTRUCTION = 6,
-	CEC_BUS_DATA = 7,
-	CEC_SYSCALL = 8,
-	CEC_BREAK = 9,
-	CEC_RESERVED = 10,
-	CEC_COPROCESSOR = 11,
-	CEC_OVERFLOW = 12,
-	CEC_TRAP = 13,
-	CEC_VCE_INSTRUCTION = 14,
-	CEC_FLOAT = 15,
-	CEC_RESERVED_16 = 16,
-	CEC_RESERVED_17 = 17,
-	CEC_RESERVED_18 = 18,
-	CEC_RESERVED_19 = 19,
-	CEC_RESERVED_20 = 20,
-	CEC_RESERVED_21 = 21,
-	CEC_RESERVED_22 = 22,
-	CEC_WATCH = 23,
-	CEC_RESERVED_24 = 24,
-	CEC_RESERVED_25 = 25,
-	CEC_RESERVED_26 = 26,
-	CEC_RESERVED_27 = 27,
-	CEC_RESERVED_28 = 28,
-	CEC_RESERVED_29 = 29,
-	CEC_RESERVED_30 = 30,
-	CEC_VCE_DATA = 31,
-	CEC_COUNT = 32
+// Erased
+static s32 cpuVirtualToPhysical_User32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuFindTLB(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+
+    // Local variables
+    s32 iEntry; // r12
+    u32 nMask; // r1+0x0
+    u32 nVirtual; // r1+0x0
+}
+
+// Erased
+static s32 cpuGetTLB(struct _CPU* pCPU, s32 iEntry) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 iEntry; // r1+0x4
+}
+
+// Range: 0x800359EC -> 0x80035CD0
+static s32 cpuSetTLB(struct _CPU* pCPU, s32 iEntry) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 iEntry; // r1+0xC
+
+    // Local variables
+    s32 iDevice; // r1+0x10
+    u32 nMask; // r1+0x8
+    u32 nVirtual; // r27
+    u32 nPhysical; // r30
+}
+
+// Erased
+static s32 cpuCountTLB(struct _CPU* pCPU, s32* pnCount) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32* pnCount; // r1+0x4
+
+    // Local variables
+    s32 iEntry; // r8
+    s32 nCount; // r9
+}
+
+// Range: 0x80035CD0 -> 0x80035E98
+static s32 cpuMapAddress(struct _CPU* pCPU, s32* piDevice, u32 nVirtual, u32 nPhysical, s32 nSize) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* piDevice; // r31
+    // u32 nVirtual; // r28
+    // u32 nPhysical; // r6
+    // s32 nSize; // r29
+
+    // Local variables
+    s32 iDeviceTarget; // r1+0x1C
+    s32 iDeviceSource; // r5
+    u32 nAddressVirtual0; // r5
+    u32 nAddressVirtual1; // r6
+}
+
+// Erased
+static s32 cpuWipeDevices(struct _CPU* pCPU, s32 bFree) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 bFree; // r29
+
+    // Local variables
+    s32 iDevice; // r30
+}
+
+// Range: 0x80035E98 -> 0x80035F3C
+static s32 cpuFreeDevice(struct _CPU* pCPU, s32 iDevice) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 iDevice; // r30
+
+    // Local variables
+    s32 iAddress; // r4
+}
+
+// Range: 0x80035F3C -> 0x8003604C
+static s32 cpuMakeDevice(struct _CPU* pCPU, s32* piDevice, void* pObject, s32 nOffset, u32 nAddress0, u32 nAddress1,
+                         s32 nType) {
+    // Parameters
+    // struct _CPU* pCPU; // r25
+    // s32* piDevice; // r1+0xC
+    // void* pObject; // r26
+    // s32 nOffset; // r27
+    // u32 nAddress0; // r28
+    // u32 nAddress1; // r29
+    // s32 nType; // r30
+
+    // Local variables
+    struct __anon_0x3EB4F* pDevice; // r1+0x28
+    s32 iDevice; // r31
+}
+
+enum __anon_0x45AE1 {
+    CEC_NONE = -1,
+    CEC_INTERRUPT = 0,
+    CEC_TLB_MODIFICATION = 1,
+    CEC_TLB_LOAD = 2,
+    CEC_TLB_STORE = 3,
+    CEC_ADDRESS_LOAD = 4,
+    CEC_ADDRESS_STORE = 5,
+    CEC_BUS_INSTRUCTION = 6,
+    CEC_BUS_DATA = 7,
+    CEC_SYSCALL = 8,
+    CEC_BREAK = 9,
+    CEC_RESERVED = 10,
+    CEC_COPROCESSOR = 11,
+    CEC_OVERFLOW = 12,
+    CEC_TRAP = 13,
+    CEC_VCE_INSTRUCTION = 14,
+    CEC_FLOAT = 15,
+    CEC_RESERVED_16 = 16,
+    CEC_RESERVED_17 = 17,
+    CEC_RESERVED_18 = 18,
+    CEC_RESERVED_19 = 19,
+    CEC_RESERVED_20 = 20,
+    CEC_RESERVED_21 = 21,
+    CEC_RESERVED_22 = 22,
+    CEC_WATCH = 23,
+    CEC_RESERVED_24 = 24,
+    CEC_RESERVED_25 = 25,
+    CEC_RESERVED_26 = 26,
+    CEC_RESERVED_27 = 27,
+    CEC_RESERVED_28 = 28,
+    CEC_RESERVED_29 = 29,
+    CEC_RESERVED_30 = 30,
+    CEC_VCE_DATA = 31,
+    CEC_COUNT = 32,
 };
 
-int cpuException(_CPU *pCPU, __anon_0x45AE1 eCode, int nMaskIP);
-
-int cpuResetInterrupt(_CPU *pCPU, int nMaskIP);
-
-int cpuTestInterrupt(_CPU *pCPU, int nMaskIP);
-
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
-};
-
-// Local to compilation unit
-static int cpuFindCachedAddress(_CPU *pCPU, int nAddressN64, int *pnAddressHost)
-{
-	int iAddress;
-	cpu_function *pFunction;
-	_CPU_ADDRESS addressFound;
-	_CPU_ADDRESS *aAddressCache;
+// Range: 0x8003604C -> 0x8003630C
+s32 cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+    // enum __anon_0x45AE1 eCode; // r28
+    // s32 nMaskIP; // r29
 }
 
-int cpuFreeCachedAddress(_CPU *pCPU, int nAddress0, int nAddress1)
-{
-	int iAddress;
-	int iAddressNext;
-	int nAddressN64;
-	_CPU_ADDRESS *aAddressCache;
+// Erased
+static s32 cpuResetInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nMaskIP; // r1+0x4
 }
 
-int cpuMakeCachedAddress(_CPU *pCPU, int nAddressN64, int nAddressHost, cpu_function *pFunction)
-{
-	int iAddress;
-	_CPU_ADDRESS *aAddressCache;
+// Range: 0x8003630C -> 0x800363E8
+s32 cpuTestInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 nMaskIP; // r31
 }
 
-// Location: 0x800ED6C8
-_XL_OBJECTTYPE gClassRAM;
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
 
-// Local to compilation unit
-static int cpuHackHandler(_CPU *pCPU)
-{
-	unsigned int nSize;
-	unsigned int *pnCode;
-	int iCode;
-	int iSave1;
-	int iSave2;
-	int iLoad;
-	// References: ganOpcodeLoadFP (0x5CBE0E80)
-	// References: ganOpcodeSaveFP2_1 (0x50BE0E80)
-	// References: ganOpcodeSaveFP2_0 (0x3CBE0E80)
-	// References: ganOpcodeSaveFP1 (0x28BE0E80)
-	// References: gClassRAM (0x800ED6C8)
+// Range: 0x800363E8 -> 0x800365C4
+static s32 cpuFindCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressHost) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 nAddressN64; // r1+0xC
+    // s32* pnAddressHost; // r1+0x10
+
+    // Local variables
+    s32 iAddress; // r10
+    struct cpu_function* pFunction; // r1+0x8
+    struct _CPU_ADDRESS addressFound; // r1+0x14
+    struct _CPU_ADDRESS* aAddressCache; // r6
 }
 
-int cpuHackCacheInstruction(_CPU *pCPU)
-{
-	unsigned int *pnCode;
+// Range: 0x800365C4 -> 0x80036658
+s32 cpuFreeCachedAddress(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nAddress0; // r1+0x4
+    // s32 nAddress1; // r1+0x8
+
+    // Local variables
+    s32 iAddress; // r10
+    s32 iAddressNext; // r11
+    s32 nAddressN64; // r1+0x0
+    struct _CPU_ADDRESS* aAddressCache; // r12
 }
 
-int cpuHackIdle(_CPU *pCPU)
-{
-	__anon_0x3DB14 *pSystem;
+// Erased
+static s32 cpuMakeCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressHost, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nAddressN64; // r1+0x4
+    // s32 nAddressHost; // r1+0x8
+    // struct cpu_function* pFunction; // r1+0xC
+
+    // Local variables
+    s32 iAddress; // r7
+    struct _CPU_ADDRESS* aAddressCache; // r9
 }
 
+// size = 0x10, address = 0x800ED6C8
+struct _XL_OBJECTTYPE gClassRAM;
+
+// Range: 0x80036658 -> 0x80036870
+static s32 cpuHackHandler(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+
+    // Local variables
+    u32 nSize; // r1+0x10
+    u32* pnCode; // r1+0xC
+    s32 iCode; // r3
+    s32 iSave1; // r30
+    s32 iSave2; // r29
+    s32 iLoad; // r28
+
+    // References
+    // -> static u32 ganOpcodeLoadFP[5];
+    // -> static u32 ganOpcodeSaveFP2_1[3];
+    // -> static u32 ganOpcodeSaveFP2_0[5];
+    // -> static u32 ganOpcodeSaveFP1[5];
+    // -> struct _XL_OBJECTTYPE gClassRAM;
+}
+
+// Erased
+static s32 cpuHackCacheInstruction(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    u32* pnCode; // r1+0x10
+}
+
+// Erased
+static s32 cpuHackIdle(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+
+    // Local variables
+    struct __anon_0x3DB14* pSystem; // r3
+}

--- a/debug/Fire/disk.c
+++ b/debug/Fire/disk.c
@@ -7,19 +7,19 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x73A37; // size = 0x10
 
 // size = 0x10, address = 0x800EE748
 struct _XL_OBJECTTYPE gClassDisk;
 
-struct __anon_0x73B29 {
+typedef struct __anon_0x73B29 {
     /* 0x0 */ void* pHost;
-}; // size = 0x4
+} __anon_0x73B29; // size = 0x4
 
 // Range: 0x8008D788 -> 0x8008D924
 s32 diskEvent(struct __anon_0x73B29* pDisk, s32 nEvent, void* pArgument) {

--- a/debug/Fire/disk.c
+++ b/debug/Fire/disk.c
@@ -1,80 +1,97 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\disk.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008D788 -> 0x8008DA1C
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE748
+struct _XL_OBJECTTYPE gClassDisk;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x73B29 {
+    /* 0x0 */ void* pHost;
+}; // size = 0x4
 
-// Location: 0x48E70E80
-_XL_OBJECTTYPE gClassDisk;
+// Range: 0x8008D788 -> 0x8008D924
+s32 diskEvent(struct __anon_0x73B29* pDisk, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x73B29* pDisk; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}
 
-// size: 0x4
-struct __anon_0x73B29
-{
-	void *pHost; // 0x0
-};
+// Range: 0x8008D924 -> 0x8008D92C
+static s32 diskGetDrive64() {}
 
-int diskEvent(__anon_0x73B29 *pDisk, int nEvent, void *pArgument);
+// Range: 0x8008D92C -> 0x8008D964
+static s32 diskGetDrive32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int diskGetDrive64();
+// Range: 0x8008D964 -> 0x8008D96C
+static s32 diskGetDrive16() {}
 
-// Local to compilation unit
-static int diskGetDrive32(unsigned int nAddress, int *pData);
+// Range: 0x8008D96C -> 0x8008D974
+static s32 diskGetDrive8() {}
 
-// Local to compilation unit
-static int diskGetDrive16();
+// Range: 0x8008D974 -> 0x8008D97C
+static s32 diskPutDrive64() {}
 
-// Local to compilation unit
-static int diskGetDrive8();
+// Range: 0x8008D97C -> 0x8008D9A8
+static s32 diskPutDrive32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
-// Local to compilation unit
-static int diskPutDrive64();
+// Range: 0x8008D9A8 -> 0x8008D9B0
+static s32 diskPutDrive16() {}
 
-// Local to compilation unit
-static int diskPutDrive32(unsigned int nAddress);
+// Range: 0x8008D9B0 -> 0x8008D9B8
+static s32 diskPutDrive8() {}
 
-// Local to compilation unit
-static int diskPutDrive16();
+// Range: 0x8008D9B8 -> 0x8008D9CC
+static s32 diskGetROM64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int diskPutDrive8();
+// Range: 0x8008D9CC -> 0x8008D9DC
+static s32 diskGetROM32(s32* pData) {
+    // Parameters
+    // s32* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int diskGetROM64(signed long long *pData);
+// Range: 0x8008D9DC -> 0x8008D9EC
+static s32 diskGetROM16(s16* pData) {
+    // Parameters
+    // s16* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int diskGetROM32(int *pData);
+// Range: 0x8008D9EC -> 0x8008D9FC
+static s32 diskGetROM8(char* pData) {
+    // Parameters
+    // char* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int diskGetROM16(signed short *pData);
+// Range: 0x8008D9FC -> 0x8008DA04
+static s32 diskPutROM64() {}
 
-// Local to compilation unit
-static int diskGetROM8(char *pData);
+// Range: 0x8008DA04 -> 0x8008DA0C
+static s32 diskPutROM32() {}
 
-// Local to compilation unit
-static int diskPutROM64();
+// Range: 0x8008DA0C -> 0x8008DA14
+static s32 diskPutROM16() {}
 
-// Local to compilation unit
-static int diskPutROM32();
-
-// Local to compilation unit
-static int diskPutROM16();
-
-// Local to compilation unit
-static int diskPutROM8();
-
+// Range: 0x8008DA14 -> 0x8008DA1C
+static s32 diskPutROM8() {}

--- a/debug/Fire/flash.c
+++ b/debug/Fire/flash.c
@@ -7,22 +7,22 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x7419C; // size = 0x10
 
 // size = 0x10, address = 0x800EE758
 struct _XL_OBJECTTYPE gClassFlash;
 
-struct __anon_0x7428F {
+typedef struct __anon_0x7428F {
     /* 0x0 */ void* pHost;
     /* 0x4 */ s32 flashCommand;
     /* 0x8 */ char* flashBuffer;
     /* 0xC */ s32 flashStatus;
-}; // size = 0x10
+} __anon_0x7428F; // size = 0x10
 
 // Range: 0x8008DA1C -> 0x8008DB3C
 s32 flashEvent(struct __anon_0x7428F* pFLASH, s32 nEvent, void* pArgument) {

--- a/debug/Fire/flash.c
+++ b/debug/Fire/flash.c
@@ -1,74 +1,93 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\flash.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008DA1C -> 0x8008E138
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE758
+struct _XL_OBJECTTYPE gClassFlash;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x7428F {
+    /* 0x0 */ void* pHost;
+    /* 0x4 */ s32 flashCommand;
+    /* 0x8 */ char* flashBuffer;
+    /* 0xC */ s32 flashStatus;
+}; // size = 0x10
 
-// Location: 0x58E70E80
-_XL_OBJECTTYPE gClassFlash;
-
-// size: 0x10
-struct __anon_0x7428F
-{
-	void *pHost; // 0x0
-	int flashCommand; // 0x4
-	char *flashBuffer; // 0x8
-	int flashStatus; // 0xC
-};
-
-int flashEvent(__anon_0x7428F *pFLASH, int nEvent, void *pArgument);
-
-// Local to compilation unit
-static int flashGet64();
-
-// Local to compilation unit
-static int flashGet32(__anon_0x7428F *pFLASH, int *pData);
-
-// Local to compilation unit
-static int flashGet16();
-
-// Local to compilation unit
-static int flashGet8();
-
-// Local to compilation unit
-static int flashPut64();
-
-// Local to compilation unit
-static int flashPut32(__anon_0x7428F *pFLASH, int *pData)
-{
-	int i;
-	char buffer[128];
+// Range: 0x8008DA1C -> 0x8008DB3C
+s32 flashEvent(struct __anon_0x7428F* pFLASH, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-// Local to compilation unit
-static int flashPut16();
+// Range: 0x8008DB3C -> 0x8008DB44
+static s32 flashGet64() {}
 
-// Local to compilation unit
-static int flashPut8();
-
-int flashTransferFLASH(__anon_0x7428F *pFLASH, int nOffsetRAM, int nSize)
-{
-	void *pTarget;
-	int i;
+// Range: 0x8008DB44 -> 0x8008DBE8
+static s32 flashGet32(struct __anon_0x7428F* pFLASH, s32* pData) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r1+0x0
+    // s32* pData; // r1+0x8
 }
 
-int flashCopyFLASH(__anon_0x7428F *pFLASH, int nOffsetRAM, int nOffsetFLASH, int nSize)
-{
-	void *pTarget;
+// Range: 0x8008DBE8 -> 0x8008DBF0
+static s32 flashGet16() {}
+
+// Range: 0x8008DBF0 -> 0x8008DBF8
+static s32 flashGet8() {}
+
+// Range: 0x8008DBF8 -> 0x8008DC00
+static s32 flashPut64() {}
+
+// Range: 0x8008DC00 -> 0x8008DED0
+static s32 flashPut32(struct __anon_0x7428F* pFLASH, s32* pData) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r30
+    // s32* pData; // r31
+
+    // Local variables
+    s32 i; // r1+0x8
+    char buffer[128]; // r1+0x1C
 }
 
+// Range: 0x8008DED0 -> 0x8008DED8
+static s32 flashPut16() {}
+
+// Range: 0x8008DED8 -> 0x8008DEE0
+static s32 flashPut8() {}
+
+// Range: 0x8008DEE0 -> 0x8008DFF4
+s32 flashTransferFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nSize) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r31
+    // s32 nOffsetRAM; // r4
+    // s32 nSize; // r1+0x14
+
+    // Local variables
+    void* pTarget; // r1+0x18
+    s32 i; // r4
+}
+
+// Range: 0x8008DFF4 -> 0x8008E138
+s32 flashCopyFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nOffsetFLASH, s32 nSize) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r30
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetFLASH; // r31
+    // s32 nSize; // r1+0x14
+
+    // Local variables
+    void* pTarget; // r1+0x18
+}

--- a/debug/Fire/frame.c
+++ b/debug/Fire/frame.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x22648; // size = 0x10
 
 // size = 0x10, address = 0x800EA848
 struct _XL_OBJECTTYPE gClassFrame;
@@ -68,7 +68,7 @@ u32 ganNameColor[8];
 // size = 0x8, address = 0x80134DD8
 static u8 sRemapI$746[8];
 
-enum _GXTexMapID {
+typedef enum _GXTexMapID {
     GX_TEXMAP0 = 0,
     GX_TEXMAP1 = 1,
     GX_TEXMAP2 = 2,
@@ -80,7 +80,7 @@ enum _GXTexMapID {
     GX_MAX_TEXMAP = 8,
     GX_TEXMAP_NULL = 255,
     GX_TEX_DISABLE = 256,
-};
+} __anon_0x22A94;
 
 // size = 0x20, address = 0x800EA878
 enum _GXTexMapID ganNamePixel[8];
@@ -88,7 +88,7 @@ enum _GXTexMapID ganNamePixel[8];
 // size = 0x20, address = 0x800EA898
 u32 ganNameTexMtx[8];
 
-enum _GXTexCoordID {
+typedef enum _GXTexCoordID {
     GX_TEXCOORD0 = 0,
     GX_TEXCOORD1 = 1,
     GX_TEXCOORD2 = 2,
@@ -99,7 +99,7 @@ enum _GXTexCoordID {
     GX_TEXCOORD7 = 7,
     GX_MAX_TEXCOORD = 8,
     GX_TEXCOORD_NULL = 255,
-};
+} __anon_0x22C01;
 
 // size = 0x20, address = 0x800EA8B8
 enum _GXTexCoordID ganNameTexCoord[8];
@@ -134,9 +134,9 @@ static u32 sZBufShift[8][2];
 // size = 0x14, address = 0x800EAA24
 static char* gaszNameColorType[5];
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x2311A; // size = 0x20
 
 // size = 0x20, address = 0x8012DDC0
 static struct _GXTexObj sFrameObj1$1562;
@@ -219,11 +219,11 @@ u32 anRenderModeDatabaseFill[100];
 // size = 0x190, address = 0x800EAFAC
 u32 anRenderModeDatabaseCycle1[100];
 
-struct __anon_0x239BA {
+typedef struct __anon_0x239BA {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x239BA; // size = 0xC
 
 // Range: 0x8001D34C -> 0x8001D39C
 void PSMTX44MultVecNoW(float (*m)[4], struct __anon_0x239BA* src, struct __anon_0x239BA* dst) {
@@ -233,22 +233,22 @@ void PSMTX44MultVecNoW(float (*m)[4], struct __anon_0x239BA* src, struct __anon_
     // struct __anon_0x239BA* dst; // r5
 }
 
-struct __anon_0x23B04 {
+typedef struct __anon_0x23B04 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x23B04; // size = 0x10
 
-struct __anon_0x23B9E {
+typedef struct __anon_0x23B9E {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x23B9E; // size = 0x14
 
-struct __anon_0x23CAB {
+typedef struct __anon_0x23CAB {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x274AD rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -263,36 +263,36 @@ struct __anon_0x23CAB {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x23CAB; // size = 0x3C
 
-struct __anon_0x23EDB {
+typedef struct __anon_0x23EDB {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x274AD rS;
     /* 0x10 */ struct __anon_0x274AD rT;
     /* 0x1C */ struct __anon_0x274AD rSRaw;
     /* 0x28 */ struct __anon_0x274AD rTRaw;
-}; // size = 0x34
+} __anon_0x23EDB; // size = 0x34
 
-struct __anon_0x23FC4 {
+typedef struct __anon_0x23FC4 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x274AD vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x23FC4; // size = 0x1C
 
-union __anon_0x24123 {
+typedef union __anon_0x24123 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x24123;
 
-struct __anon_0x241C0 {
+typedef struct __anon_0x241C0 {
     /* 0x0 */ union __anon_0x24123 data;
-}; // size = 0x1000
+} __anon_0x241C0; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -319,13 +319,13 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x24259;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x2441B; // size = 0xC
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -345,9 +345,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x24462; // size = 0x6C
 
-struct __anon_0x247BF {
+typedef struct __anon_0x247BF {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -364,9 +364,9 @@ struct __anon_0x247BF {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x247BF; // size = 0x2C
 
-struct __anon_0x24A81 {
+typedef struct __anon_0x24A81 {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -376,9 +376,9 @@ struct __anon_0x24A81 {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x25D5E eProjection;
-}; // size = 0x24
+} __anon_0x24A81; // size = 0x24
 
-struct __anon_0x24C38 {
+typedef struct __anon_0x24C38 {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -469,12 +469,12 @@ struct __anon_0x24C38 {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x24C38; // size = 0x3D150
 
-struct __anon_0x25A82 {
+typedef struct __anon_0x25A82 {
     /* 0x0 */ s32 nSizeTextures;
     /* 0x4 */ s32 nCountTextures;
-}; // size = 0x8
+} __anon_0x25A82; // size = 0x8
 
 // Range: 0x8001D39C -> 0x8001D4B8
 s32 frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
@@ -503,11 +503,11 @@ s32 frameInvalidateCache(struct __anon_0x24C38* pFrame, s32 nOffset0, s32 nOffse
     struct _FRAME_TEXTURE* pTextureNext; // r26
 }
 
-enum __anon_0x25D5E {
+typedef enum __anon_0x25D5E {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x25D5E;
 
 // Range: 0x8001D624 -> 0x8001D740
 s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, s32 nAddressFloat,
@@ -550,14 +550,14 @@ s32 frameFixMatrixHint(struct __anon_0x24C38* pFrame, s32 nAddressFloat, s32 nAd
     s32 iHintTest; // r9
 }
 
-enum __anon_0x2614E {
+typedef enum __anon_0x2614E {
     FBT_NONE = -1,
     FBT_DEPTH = 0,
     FBT_IMAGE = 1,
     FBT_COLOR_SHOW = 2,
     FBT_COLOR_DRAW = 3,
     FBT_COUNT = 4,
-};
+} __anon_0x2614E;
 
 // Range: 0x8001D7F8 -> 0x8001D830
 s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
@@ -566,11 +566,11 @@ s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
     // enum __anon_0x2614E eType; // r1+0x4
 }
 
-enum __anon_0x2625D {
+typedef enum __anon_0x2625D {
     FRT_NONE = -1,
     FRT_COLD = 0,
     FRT_WARM = 1,
-};
+} __anon_0x2625D;
 
 // Range: 0x8001D830 -> 0x8001D8E0
 s32 frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
@@ -622,20 +622,20 @@ s32 frameSetLightCount(struct __anon_0x24C38* pFrame, s32 nCount) {
     // s32 nCount; // r1+0x4
 }
 
-enum __anon_0x266CE {
+typedef enum __anon_0x266CE {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x266CE;
 
-struct __anon_0x26732 {
+typedef struct __anon_0x26732 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x26732; // size = 0x10
 
-enum __anon_0x267E3 {
+typedef enum __anon_0x267E3 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -650,9 +650,9 @@ enum __anon_0x267E3 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x267E3;
 
-enum __anon_0x26911 {
+typedef enum __anon_0x26911 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -671,9 +671,9 @@ enum __anon_0x26911 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x26911;
 
-struct __anon_0x26A4E {
+typedef struct __anon_0x26A4E {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -685,16 +685,16 @@ struct __anon_0x26A4E {
     /* 0x70 */ enum __anon_0x26911 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x26A4E; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x26A4E* gpSystem;
 
-enum __anon_0x26C3F {
+typedef enum __anon_0x26C3F {
     FLT_NONE = -1,
     FLT_TILE = 0,
     FLT_BLOCK = 1,
-};
+} __anon_0x26C3F;
 
 // Range: 0x8001DC58 -> 0x8001EBA0
 s32 frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, s32 iTile) {
@@ -770,11 +770,11 @@ s32 __float_nan[];
 // size = 0x0, address = 0x800F3E7C
 s32 __float_huge[];
 
-struct __anon_0x274AD {
+typedef struct __anon_0x274AD {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x274AD; // size = 0xC
 
 // Range: 0x8001EDCC -> 0x8001F850
 s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
@@ -835,10 +835,10 @@ static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, float*
     struct __anon_0x23FC4* pVertex; // r8
 }
 
-enum __anon_0x27B8C {
+typedef enum __anon_0x27B8C {
     FMT_MODELVIEW = 0,
     FMT_PROJECTION = 1,
-};
+} __anon_0x27B8C;
 
 // Range: 0x8001F850 -> 0x8001F970
 s32 frameGetMatrix(struct __anon_0x24C38* pFrame, float (*matrix)[4], enum __anon_0x27B8C eType, s32 bPull) {
@@ -869,7 +869,7 @@ s32 frameSetMatrix(struct __anon_0x24C38* pFrame, float (*matrix)[4], enum __ano
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
-enum __anon_0x27E96 {
+typedef enum __anon_0x27E96 {
     FMT_NONE = -1,
     FMT_FOG = 0,
     FMT_GEOMETRY = 1,
@@ -882,7 +882,7 @@ enum __anon_0x27E96 {
     FMT_COMBINE_ALPHA1 = 8,
     FMT_COMBINE_ALPHA2 = 9,
     FMT_COUNT = 10,
-};
+} __anon_0x27E96;
 
 // Range: 0x8001FFFC -> 0x80020014
 s32 frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32* pnMode) {
@@ -904,12 +904,12 @@ s32 frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32 n
     u32 nModeChanged; // r9
 }
 
-enum __anon_0x2813A {
+typedef enum __anon_0x2813A {
     FS_NONE = -1,
     FS_SOURCE = 0,
     FS_TARGET = 1,
     FS_COUNT = 2,
-};
+} __anon_0x2813A;
 
 // Erased
 static s32 frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32* pnSizeX, s32* pnSizeY) {
@@ -964,12 +964,12 @@ s32 frameDrawReset(struct __anon_0x24C38* pFrame, s32 nFlag) {
     // s32 nFlag; // r1+0x4
 }
 
-struct __anon_0x285E5 {
+typedef struct __anon_0x285E5 {
     /* 0x0 */ s32 shift;
     /* 0x4 */ s32 add;
-}; // size = 0x8
+} __anon_0x285E5; // size = 0x8
 
-struct __anon_0x2865F {
+typedef struct __anon_0x2865F {
     /* 0x00 */ s32 nBIST;
     /* 0x04 */ s32 nStatus;
     /* 0x08 */ void* pHost;
@@ -982,9 +982,9 @@ struct __anon_0x2865F {
     /* 0x24 */ s32 nClockCmd;
     /* 0x28 */ s32 nClockPipe;
     /* 0x2C */ s32 nClockTMEM;
-}; // size = 0x30
+} __anon_0x2865F; // size = 0x30
 
-struct __anon_0x28835 {
+typedef struct __anon_0x28835 {
     /* 0x00 */ s32 nType;
     /* 0x04 */ s32 nFlag;
     /* 0x08 */ s32 nOffsetBoot;
@@ -1001,9 +1001,9 @@ struct __anon_0x28835 {
     /* 0x34 */ s32 nLengthMBI;
     /* 0x38 */ s32 nOffsetYield;
     /* 0x3C */ s32 nLengthYield;
-}; // size = 0x40
+} __anon_0x28835; // size = 0x40
 
-enum __anon_0x28AC5 {
+typedef enum __anon_0x28AC5 {
     RUT_NONE = -1,
     RUT_TURBO = 0,
     RUT_SPRITE2D = 1,
@@ -1019,9 +1019,9 @@ enum __anon_0x28AC5 {
     RUT_AUDIO1 = 11,
     RUT_AUDIO2 = 12,
     RUT_JPEG = 13,
-};
+} __anon_0x28AC5;
 
-struct __anon_0x28C10 {
+typedef struct __anon_0x28C10 {
     /* 0x00 */ s32 iDL;
     /* 0x04 */ s32 bValid;
     /* 0x08 */ struct __anon_0x28835 task;
@@ -1031,80 +1031,80 @@ struct __anon_0x28C10 {
     /* 0x54 */ u32 nVersionUCode;
     /* 0x58 */ s32 anBaseSegment[16];
     /* 0x98 */ u64* apDL[16];
-}; // size = 0xD8
+} __anon_0x28C10; // size = 0xD8
 
-struct __anon_0x28E31 {
+typedef struct __anon_0x28E31 {
     /* 0x00 */ float aRotations[2][2];
     /* 0x10 */ float fX;
     /* 0x14 */ float fY;
     /* 0x18 */ float fBaseScaleX;
     /* 0x1C */ float fBaseScaleY;
-}; // size = 0x20
+} __anon_0x28E31; // size = 0x20
 
-struct __anon_0x28F3E {
+typedef struct __anon_0x28F3E {
     /* 0x0 */ float rS;
     /* 0x4 */ float rT;
     /* 0x8 */ s16 nX;
     /* 0xA */ s16 nY;
     /* 0xC */ s16 nZ;
     /* 0xE */ u8 anData[4];
-}; // size = 0x14
+} __anon_0x28F3E; // size = 0x14
 
-struct __anon_0x29056 {
+typedef struct __anon_0x29056 {
     /* 0x0 */ char anNormal[3];
-}; // size = 0x3
+} __anon_0x29056; // size = 0x3
 
-struct __anon_0x290D5 {
+typedef struct __anon_0x290D5 {
     /* 0x0 */ u8 anMaterial[4];
-}; // size = 0x4
+} __anon_0x290D5; // size = 0x4
 
-struct __anon_0x29178 {
+typedef struct __anon_0x29178 {
     /* 0x0 */ float aMatrix[4][4];
-}; // size = 0x40
+} __anon_0x29178; // size = 0x40
 
-struct __anon_0x291D6 {
+typedef struct __anon_0x291D6 {
     /* 0x0 */ u8 nRed;
     /* 0x1 */ u8 nGreen;
     /* 0x2 */ u8 nBlue;
     /* 0x3 */ char rVectorX;
     /* 0x4 */ char rVectorY;
     /* 0x5 */ char rVectorZ;
-}; // size = 0x6
+} __anon_0x291D6; // size = 0x6
 
-struct __anon_0x29487 {
+typedef struct __anon_0x29487 {
     /* 0x0 */ s16 anSlice[8];
-}; // size = 0x10
+} __anon_0x29487; // size = 0x10
 
-enum __anon_0x29567 {
+typedef enum __anon_0x29567 {
     RUT_NOCODE = -1,
     RUT_ABI1 = 0,
     RUT_ABI2 = 1,
     RUT_ABI3 = 2,
     RUT_ABI4 = 3,
     RUT_UNKNOWN = 4,
-};
+} __anon_0x29567;
 
-struct tXL_LIST {
+typedef struct tXL_LIST {
     /* 0x0 */ s32 nItemSize;
     /* 0x4 */ s32 nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
-}; // size = 0x10
+} __anon_0x295E5; // size = 0x10
 
-struct __anon_0x296E2 {
+typedef struct __anon_0x296E2 {
     /* 0x0 */ s16 r;
     /* 0x2 */ s16 g;
     /* 0x4 */ s16 b;
     /* 0x6 */ s16 a;
-}; // size = 0x8
+} __anon_0x296E2; // size = 0x8
 
-struct __anon_0x29770 {
+typedef struct __anon_0x29770 {
     /* 0x0 */ s16 y;
     /* 0x2 */ s16 u;
     /* 0x4 */ s16 v;
-}; // size = 0x6
+} __anon_0x29770; // size = 0x6
 
-struct __anon_0x297E0 {
+typedef struct __anon_0x297E0 {
     /* 0x0000 */ s32 nMode;
     /* 0x0004 */ struct __anon_0x28C10 yield;
     /* 0x00DC */ u32 nTickLast;
@@ -1200,9 +1200,9 @@ struct __anon_0x297E0 {
     /* 0x39C0 */ struct __anon_0x296E2* rgbaBuf;
     /* 0x39C4 */ struct __anon_0x29770* yuvBuf;
     /* 0x39C8 */ s32* dctBuf;
-}; // size = 0x39CC
+} __anon_0x297E0; // size = 0x39CC
 
-struct __anon_0x2A6F7 {
+typedef struct __anon_0x2A6F7 {
     /* 0x00 */ u16 imageX;
     /* 0x02 */ u16 imageW;
     /* 0x04 */ s16 frameX;
@@ -1223,9 +1223,9 @@ struct __anon_0x2A6F7 {
     /* 0x22 */ u16 tmemLoadTH;
     /* 0x24 */ u16 tmemSizeW;
     /* 0x26 */ u16 tmemSize;
-}; // size = 0x28
+} __anon_0x2A6F7; // size = 0x28
 
-struct __anon_0x2AA02 {
+typedef struct __anon_0x2AA02 {
     /* 0x00 */ u16 imageX;
     /* 0x02 */ u16 imageW;
     /* 0x04 */ s16 frameX;
@@ -1244,15 +1244,15 @@ struct __anon_0x2AA02 {
     /* 0x1E */ u16 scaleH;
     /* 0x20 */ s32 imageYorig;
     /* 0x24 */ u8 padding[4];
-}; // size = 0x28
+} __anon_0x2AA02; // size = 0x28
 
-union __anon_0x2ACA3 {
+typedef union __anon_0x2ACA3 {
     /* 0x0 */ struct __anon_0x2A6F7 b;
     /* 0x0 */ struct __anon_0x2AA02 s;
     /* 0x0 */ s64 force_structure_alignment;
-};
+} __anon_0x2ACA3;
 
-struct __anon_0x2AD2F {
+typedef struct __anon_0x2AD2F {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 tmem;
@@ -1261,9 +1261,9 @@ struct __anon_0x2AD2F {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x2AD2F; // size = 0x18
 
-struct __anon_0x2AE4F {
+typedef struct __anon_0x2AE4F {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 tmem;
@@ -1272,9 +1272,9 @@ struct __anon_0x2AE4F {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x2AE4F; // size = 0x18
 
-struct __anon_0x2AF72 {
+typedef struct __anon_0x2AF72 {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 phead;
@@ -1283,21 +1283,21 @@ struct __anon_0x2AF72 {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x2AF72; // size = 0x18
 
-union __anon_0x2B091 {
+typedef union __anon_0x2B091 {
     /* 0x0 */ struct __anon_0x2AD2F block;
     /* 0x0 */ struct __anon_0x2AE4F tile;
     /* 0x0 */ struct __anon_0x2AF72 tlut;
     /* 0x0 */ s64 force_structure_alignment;
-};
+} __anon_0x2B091;
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x2B189; // size = 0x4
 
 // size = 0x4, address = 0x80135A8C
 void* DemoCurrentBuffer;
@@ -1308,17 +1308,17 @@ void* DemoFrameBuffer1;
 // size = 0x4, address = 0x80135A90
 void* DemoFrameBuffer2;
 
-struct __anon_0x2B2A7 {
+typedef struct __anon_0x2B2A7 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x2B2A7; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x2B30D; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -1337,9 +1337,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x2B380; // size = 0x48
 
-union __anon_0x2B65C {
+typedef union __anon_0x2B65C {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -1370,9 +1370,9 @@ union __anon_0x2B65C {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x2B65C;
 
-union __anon_0x2BA70 {
+typedef union __anon_0x2BA70 {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -1382,9 +1382,9 @@ union __anon_0x2BA70 {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x2BA70;
 
-struct __anon_0x2BF7E {
+typedef struct __anon_0x2BF7E {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -1398,9 +1398,9 @@ struct __anon_0x2BF7E {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x2BF7E; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -1415,21 +1415,21 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x2C24C; // size = 0x84
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x2C48D; // size = 0xC
 
-struct __anon_0x2C542 {
+typedef struct __anon_0x2C542 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x2C542; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -1445,9 +1445,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x2C66D; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -1455,9 +1455,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x2C8C4; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -1468,9 +1468,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x2C9DF; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -1514,9 +1514,9 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x2CB8C; // size = 0x12090
 
-enum __anon_0x2D223 {
+typedef enum __anon_0x2D223 {
     FCT_NONE = -1,
     FCT_FOG = 0,
     FCT_FILL = 1,
@@ -1524,9 +1524,9 @@ enum __anon_0x2D223 {
     FCT_PRIMITIVE = 3,
     FCT_ENVIRONMENT = 4,
     FCT_COUNT = 5,
-};
+} __anon_0x2D223;
 
-struct __anon_0x2D2B6 {
+typedef struct __anon_0x2D2B6 {
     /* 0x00 */ s32 bFlip;
     /* 0x04 */ s32 iTile;
     /* 0x08 */ s32 nX0;
@@ -1537,14 +1537,14 @@ struct __anon_0x2D2B6 {
     /* 0x1C */ float rT;
     /* 0x20 */ float rDeltaS;
     /* 0x24 */ float rDeltaT;
-}; // size = 0x28
+} __anon_0x2D2B6; // size = 0x28
 
-struct __anon_0x2D45B {
+typedef struct __anon_0x2D45B {
     /* 0x0 */ s32 nCount;
     /* 0x4 */ u8 anData[768];
-}; // size = 0x304
+} __anon_0x2D45B; // size = 0x304
 
-enum _GXTevAlphaArg {
+typedef enum _GXTevAlphaArg {
     GX_CA_APREV = 0,
     GX_CA_A0 = 1,
     GX_CA_A1 = 2,
@@ -1554,9 +1554,9 @@ enum _GXTevAlphaArg {
     GX_CA_KONST = 6,
     GX_CA_ZERO = 7,
     GX_CA_ONE = 6,
-};
+} __anon_0x2D4FB;
 
-enum _GXTevColorArg {
+typedef enum _GXTevColorArg {
     GX_CC_CPREV = 0,
     GX_CC_APREV = 1,
     GX_CC_C0 = 2,
@@ -1577,25 +1577,25 @@ enum _GXTevColorArg {
     GX_CC_TEXGGG = 17,
     GX_CC_TEXBBB = 18,
     GX_CC_QUARTER = 14,
-};
+} __anon_0x2D5A6;
 
-enum _GXProjectionType {
+typedef enum _GXProjectionType {
     GX_PERSPECTIVE = 0,
     GX_ORTHOGRAPHIC = 1,
-};
+} __anon_0x2D741;
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x2D794;
 
-struct _GXFogAdjTable {
+typedef struct _GXFogAdjTable {
     /* 0x0 */ u16 r[10];
-}; // size = 0x14
+} __anon_0x2D85D; // size = 0x14
 
-enum _GXFogType {
+typedef enum _GXFogType {
     GX_FOG_NONE = 0,
     GX_FOG_PERSP_LIN = 2,
     GX_FOG_PERSP_EXP = 4,
@@ -1612,7 +1612,7 @@ enum _GXFogType {
     GX_FOG_EXP2 = 5,
     GX_FOG_REVEXP = 6,
     GX_FOG_REVEXP2 = 7,
-};
+} __anon_0x2D8A4;
 
 // Erased
 static s32 frameUpdateTrackBuffer() {}

--- a/debug/Fire/frame.c
+++ b/debug/Fire/frame.c
@@ -1,1772 +1,1787 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\frame.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8001D34C -> 0x80021204
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EA848
+struct _XL_OBJECTTYPE gClassFrame;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+// size = 0x4, address = 0x80135688
+static s32 gbFrameValid;
+
+// size = 0x4, address = 0x8013568C
+static s32 gbFrameBegin;
+
+// size = 0x4, address = 0x80135690
+static s32 snScissorChanged;
+
+// size = 0x4, address = 0x80135694
+static u32 snScissorXOrig;
+
+// size = 0x4, address = 0x80135698
+static u32 snScissorYOrig;
+
+// size = 0x4, address = 0x8013569C
+static u32 snScissorWidth;
+
+// size = 0x4, address = 0x801356A0
+static u32 snScissorHeight;
+
+// size = 0x4, address = 0x801356A4
+static s32 sCopyFrameSyncReceived;
+
+// size = 0x1, address = 0x801356A8
+static u8 sSpecialZeldaHackON;
+
+// size = 0x4, address = 0x801356AC
+static u32 sDestinationBuffer;
+
+// size = 0x4, address = 0x801356B0
+static u32 sSrcBuffer;
+
+// size = 0x18, address = 0x801085A0
+static u32 sConstantBufAddr[6];
+
+// size = 0x4, address = 0x801356B4
+static u32 sNumAddr;
+
+// size = 0x4, address = 0x801356B8
+static u32 gHackCreditsColor;
+
+// size = 0x4, address = 0x801356BC
+s32 gNoSwapBuffer;
+
+// size = 0x20, address = 0x800EA858
+u32 ganNameColor[8];
+
+// size = 0x8, address = 0x80134DD8
+static u8 sRemapI$746[8];
+
+enum _GXTexMapID {
+    GX_TEXMAP0 = 0,
+    GX_TEXMAP1 = 1,
+    GX_TEXMAP2 = 2,
+    GX_TEXMAP3 = 3,
+    GX_TEXMAP4 = 4,
+    GX_TEXMAP5 = 5,
+    GX_TEXMAP6 = 6,
+    GX_TEXMAP7 = 7,
+    GX_MAX_TEXMAP = 8,
+    GX_TEXMAP_NULL = 255,
+    GX_TEX_DISABLE = 256,
 };
 
-// Location: 0x48A80E80
-_XL_OBJECTTYPE gClassFrame;
+// size = 0x20, address = 0x800EA878
+enum _GXTexMapID ganNamePixel[8];
 
-// Local to compilation unit
-// Location: 0x80135688
-static int gbFrameValid;
+// size = 0x20, address = 0x800EA898
+u32 ganNameTexMtx[8];
 
-// Local to compilation unit
-// Location: 0x8013568C
-static int gbFrameBegin;
-
-// Local to compilation unit
-// Location: 0x80135690
-static int snScissorChanged;
-
-// Local to compilation unit
-// Location: 0x80135694
-static unsigned long snScissorXOrig;
-
-// Local to compilation unit
-// Location: 0x80135698
-static unsigned long snScissorYOrig;
-
-// Local to compilation unit
-// Location: 0x8013569C
-static unsigned long snScissorWidth;
-
-// Local to compilation unit
-// Location: 0x801356A0
-static unsigned long snScissorHeight;
-
-// Local to compilation unit
-// Location: 0x801356A4
-static int sCopyFrameSyncReceived;
-
-// Local to compilation unit
-// Location: 0x801356A8
-static unsigned char sSpecialZeldaHackON;
-
-// Local to compilation unit
-// Location: 0x801356AC
-static unsigned int sDestinationBuffer;
-
-// Local to compilation unit
-// Location: 0x801356B0
-static unsigned int sSrcBuffer;
-
-// Local to compilation unit
-// Location: 0x801085A0
-static unsigned int sConstantBufAddr[6];
-
-// Local to compilation unit
-// Location: 0x801356B4
-static unsigned int sNumAddr;
-
-// Location: 0x0
-unsigned int sZBufIdx;
-
-// Local to compilation unit
-// Location: 0x801356B8
-static unsigned int gHackCreditsColor;
-
-// Location: 0x801356BC
-int gNoSwapBuffer;
-
-// Location: 0x58A80E80
-unsigned long ganNameColor[8];
-
-// Local to compilation unit
-// Location: 0x80134DD8
-static unsigned char sRemapI$746[8];
-
-// size: 0x4
-enum _GXTexMapID
-{
-	GX_TEXMAP0 = 0,
-	GX_TEXMAP1 = 1,
-	GX_TEXMAP2 = 2,
-	GX_TEXMAP3 = 3,
-	GX_TEXMAP4 = 4,
-	GX_TEXMAP5 = 5,
-	GX_TEXMAP6 = 6,
-	GX_TEXMAP7 = 7,
-	GX_MAX_TEXMAP = 8,
-	GX_TEXMAP_NULL = 255,
-	GX_TEX_DISABLE = 256
+enum _GXTexCoordID {
+    GX_TEXCOORD0 = 0,
+    GX_TEXCOORD1 = 1,
+    GX_TEXCOORD2 = 2,
+    GX_TEXCOORD3 = 3,
+    GX_TEXCOORD4 = 4,
+    GX_TEXCOORD5 = 5,
+    GX_TEXCOORD6 = 6,
+    GX_TEXCOORD7 = 7,
+    GX_MAX_TEXCOORD = 8,
+    GX_TEXCOORD_NULL = 255,
 };
 
-// Location: 0x78A80E80
-_GXTexMapID ganNamePixel[8];
-
-// Location: 0x800EA898
-unsigned long ganNameTexMtx[8];
-
-// size: 0x4
-enum _GXTexCoordID
-{
-	GX_TEXCOORD0 = 0,
-	GX_TEXCOORD1 = 1,
-	GX_TEXCOORD2 = 2,
-	GX_TEXCOORD3 = 3,
-	GX_TEXCOORD4 = 4,
-	GX_TEXCOORD5 = 5,
-	GX_TEXCOORD6 = 6,
-	GX_TEXCOORD7 = 7,
-	GX_MAX_TEXCOORD = 8,
-	GX_TEXCOORD_NULL = 255
-};
-
-// Location: 0x800EA8B8
-_GXTexCoordID ganNameTexCoord[8];
-
-// Local to compilation unit
-// Location: 0x20A90E80
-static char  *gaszNameColor[20];
-
-// Local to compilation unit
-// Location: 0x70A90E80
-static char  *gaszNameAlpha[9];
-
-// Local to compilation unit
-// Location: 0x800EA994
-static int (*gapfDrawTriangle[8])(void */* unknown0 */, void */* unknown1 */);
-
-// Local to compilation unit
-// Location: 0x800EA9B4
-static int (*gapfDrawLine[6])(void */* unknown0 */, void */* unknown1 */);
-
-// Local to compilation unit
-// Location: 0x801356C0
-static int gnCountMapHack;
-
-// Local to compilation unit
-// Location: 0x801356C4
-static int nCounter$1367;
-
-// Local to compilation unit
-// Location: 0x801356C8
-static int bSkip$1410;
-
-// Local to compilation unit
-// Location: 0x801085C0
-static unsigned short sTempZBuf[4800][4][4];
-
-// Local to compilation unit
-// Location: 0x800EA9CC
-static unsigned long sZBufShift[8][2];
-
-// Local to compilation unit
-// Location: 0x24AA0E80
-static char  *gaszNameColorType[5];
-
-// Location: 0x0
-void *pSrc$1492;
-
-// Location: 0x0
-signed long long lastTime$1493;
-
-// Location: 0x0
-signed long long curTime$1494;
-
-// Location: 0x0
-signed long long diffTime$1495;
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// Local to compilation unit
-// Location: 0x8012DDC0
-static _GXTexObj sFrameObj1$1562;
-
-// Local to compilation unit
-// Location: 0x8012DDE0
-static _GXTexObj sFrameObj2$1563;
-
-// Local to compilation unit
-// Location: 0xDE1280
-static _GXTexObj sFrameObj$1564;
-
-// Local to compilation unit
-// Location: 0x20DE1280
-static _GXTexObj sFrameObj$1565;
-
-// Local to compilation unit
-// Location: 0x40DE1280
-static _GXTexObj sFrameObj$1568;
+// size = 0x20, address = 0x800EA8B8
+enum _GXTexCoordID ganNameTexCoord[8];
 
-// Local to compilation unit
-// Location: 0x60DE1280
-static unsigned long line$1582[80][4][4];
+// size = 0x50, address = 0x800EA920
+static char* gaszNameColor[20];
 
-// Local to compilation unit
-// Location: 0x60F21280
-static unsigned short line$1606[80][4][4];
+// size = 0x24, address = 0x800EA970
+static char* gaszNameAlpha[9];
 
-// Local to compilation unit
-// Location: 0x60FC1280
-static unsigned short line$1630[80][4][4];
-
-// Local to compilation unit
-// Location: 0x60061380
-static _GXTexObj sFrameObj$1647;
-
-// Local to compilation unit
-// Location: 0x564E1380
-static unsigned char cAlpha$1648;
-
-// Local to compilation unit
-// Location: 0x80061380
-static _GXTexObj sFrameObj$1660;
-
-// Local to compilation unit
-// Location: 0x801306A0
-static _GXTexObj frameObj$1663;
-
-// Local to compilation unit
-// Location: 0x801306C0
-static _GXTexObj frameObj$1673;
-
-// Local to compilation unit
-// Location: 0x38AA0E80
-static unsigned long sCommandCodes$1679[8];
-
-// Local to compilation unit
-// Location: 0x801356CC
-static int nLastFrame$1695;
-
-// Location: 0x0
-int nLensThisFrame$1696;
-
-// Local to compilation unit
-// Location: 0x801356D0
-static int nCopyFrame$1697;
-
-// Local to compilation unit
-// Location: 0x58AA0E80
-static unsigned long sCommandCodes$1702[10];
-
-// Local to compilation unit
-// Location: 0x800EAA80
-static unsigned long sCommandCodes2$1722[10];
-
-// Local to compilation unit
-// Location: 0x801306E0
-static unsigned short tempLine$1785[16][4][4];
-
-// Local to compilation unit
-// Location: 0x800EAAA8
-static unsigned int GBIcode$1816[3];
-
-// Local to compilation unit
-// Location: 0x800EAAB4
-static unsigned int GBIcode2D2$1906[7];
-
-// Local to compilation unit
-// Location: 0x800EAAD0
-static unsigned int GBIcode3D1$1907[5];
-
-// Local to compilation unit
-// Location: 0x800EAAE4
-static unsigned int GBIcode3D2$1908[6];
-
-// Location: 0x800EAAFC
-unsigned int anRenderModeDatabaseCycle2[100];
-
-// Location: 0x800EAC8C
-unsigned int anRenderModeDatabaseCopy[100];
-
-// Location: 0x1CAE0E80
-unsigned int anRenderModeDatabaseFill[100];
-
-// Location: 0x800EAFAC
-unsigned int anRenderModeDatabaseCycle1[100];
-
-// Location: 0x0
-unsigned int nTotal$2284;
-
-// Location: 0x0
-unsigned int nTimesCalled$2285;
-
-// size: 0xC
-struct __anon_0x239BA
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-void PSMTX44MultVecNoW(float *m[4], __anon_0x239BA *src, __anon_0x239BA *dst);
-
-// size: 0x10
-struct __anon_0x23B04
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x23B9E
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
-};
-
-// size: 0x3C
-struct __anon_0x23CAB
-{
-	int bTransformed; // 0x0
-	__anon_0x274AD rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
-
-// size: 0x34
-struct __anon_0x23EDB
-{
-	int bTransformed; // 0x0
-	__anon_0x274AD rS; // 0x4
-	__anon_0x274AD rT; // 0x10
-	__anon_0x274AD rSRaw; // 0x1C
-	__anon_0x274AD rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x23FC4
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x274AD vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x24123
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x241C0
-{
-	__anon_0x24123 data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x247BF
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x24
-struct __anon_0x24A81
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x25D5E eProjection; // 0x20
-};
-
-// size: 0x3D150
-struct __anon_0x24C38
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x23B04 viewport; // 0xB8
-	__anon_0x23B9E aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x23CAB aLight[8]; // 0x140
-	__anon_0x23EDB lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x23FC4 aVertex[80]; // 0x358
-	__anon_0x241C0 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x247BF aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x25D5E eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x24A81 aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-// size: 0x8
-struct __anon_0x25A82
-{
-	int nSizeTextures; // 0x0
-	int nCountTextures; // 0x4
-};
-
-int frameGetTextureInfo(__anon_0x24C38 *pFrame, __anon_0x25A82 *pInfo)
-{
-	_FRAME_TEXTURE *pTexture;
-	int iTexture;
-	int nCount;
-	int nSize;
+// size = 0x20, address = 0x800EA994
+static s32 (*gapfDrawTriangle[8])(void*, void*);
+
+// size = 0x18, address = 0x800EA9B4
+static s32 (*gapfDrawLine[6])(void*, void*);
+
+// size = 0x4, address = 0x801356C0
+static s32 gnCountMapHack;
+
+// size = 0x4, address = 0x801356C4
+static s32 nCounter$1367;
+
+// size = 0x4, address = 0x801356C8
+static s32 bSkip$1410;
+
+// size = 0x25800, address = 0x801085C0
+static u16 sTempZBuf[4800][4][4];
+
+// size = 0x40, address = 0x800EA9CC
+static u32 sZBufShift[8][2];
+
+// size = 0x14, address = 0x800EAA24
+static char* gaszNameColorType[5];
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+// size = 0x20, address = 0x8012DDC0
+static struct _GXTexObj sFrameObj1$1562;
+
+// size = 0x20, address = 0x8012DDE0
+static struct _GXTexObj sFrameObj2$1563;
+
+// size = 0x20, address = 0x8012DE00
+static struct _GXTexObj sFrameObj$1564;
+
+// size = 0x20, address = 0x8012DE20
+static struct _GXTexObj sFrameObj$1565;
+
+// size = 0x20, address = 0x8012DE40
+static struct _GXTexObj sFrameObj$1568;
+
+// size = 0x1400, address = 0x8012DE60
+static u32 line$1582[80][4][4];
+
+// size = 0xA00, address = 0x8012F260
+static u16 line$1606[80][4][4];
+
+// size = 0xA00, address = 0x8012FC60
+static u16 line$1630[80][4][4];
+
+// size = 0x20, address = 0x80130660
+static struct _GXTexObj sFrameObj$1647;
+
+// size = 0x1, address = 0x80134E56
+static u8 cAlpha$1648;
+
+// size = 0x20, address = 0x80130680
+static struct _GXTexObj sFrameObj$1660;
+
+// size = 0x20, address = 0x801306A0
+static struct _GXTexObj frameObj$1663;
+
+// size = 0x20, address = 0x801306C0
+static struct _GXTexObj frameObj$1673;
+
+// size = 0x20, address = 0x800EAA38
+static u32 sCommandCodes$1679[8];
+
+// size = 0x4, address = 0x801356CC
+static s32 nLastFrame$1695;
+
+// size = 0x4, address = 0x801356D0
+static s32 nCopyFrame$1697;
+
+// size = 0x28, address = 0x800EAA58
+static u32 sCommandCodes$1702[10];
+
+// size = 0x28, address = 0x800EAA80
+static u32 sCommandCodes2$1722[10];
+
+// size = 0x200, address = 0x801306E0
+static u16 tempLine$1785[16][4][4];
+
+// size = 0xC, address = 0x800EAAA8
+static u32 GBIcode$1816[3];
+
+// size = 0x1C, address = 0x800EAAB4
+static u32 GBIcode2D2$1906[7];
+
+// size = 0x14, address = 0x800EAAD0
+static u32 GBIcode3D1$1907[5];
+
+// size = 0x18, address = 0x800EAAE4
+static u32 GBIcode3D2$1908[6];
+
+// size = 0x190, address = 0x800EAAFC
+u32 anRenderModeDatabaseCycle2[100];
+
+// size = 0x190, address = 0x800EAC8C
+u32 anRenderModeDatabaseCopy[100];
+
+// size = 0x190, address = 0x800EAE1C
+u32 anRenderModeDatabaseFill[100];
+
+// size = 0x190, address = 0x800EAFAC
+u32 anRenderModeDatabaseCycle1[100];
+
+struct __anon_0x239BA {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+// Range: 0x8001D34C -> 0x8001D39C
+void PSMTX44MultVecNoW(float (*m)[4], struct __anon_0x239BA* src, struct __anon_0x239BA* dst) {
+    // Parameters
+    // float (* m)[4]; // r3
+    // struct __anon_0x239BA* src; // r4
+    // struct __anon_0x239BA* dst; // r5
 }
 
-int frameInvalidateCache(__anon_0x24C38 *pFrame, int nOffset0, int nOffset1)
-{
-	int iTexture0;
-	int iTexture1;
-	_FRAME_TEXTURE *pTexture;
-	_FRAME_TEXTURE *pTextureNext;
+struct __anon_0x23B04 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x23B9E {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x23CAB {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x274AD rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x23EDB {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x274AD rS;
+    /* 0x10 */ struct __anon_0x274AD rT;
+    /* 0x1C */ struct __anon_0x274AD rSRaw;
+    /* 0x28 */ struct __anon_0x274AD rTRaw;
+}; // size = 0x34
+
+struct __anon_0x23FC4 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x274AD vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x24123 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
+};
+
+struct __anon_0x241C0 {
+    /* 0x0 */ union __anon_0x24123 data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
+};
+
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x247BF {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+struct __anon_0x24A81 {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x25D5E eProjection;
+}; // size = 0x24
+
+struct __anon_0x24C38 {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x23B04 viewport;
+    /* 0x000C8 */ struct __anon_0x23B9E aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x23CAB aLight[8];
+    /* 0x00320 */ struct __anon_0x23EDB lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x23FC4 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x241C0 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x247BF aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x25D5E eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x24A81 aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+struct __anon_0x25A82 {
+    /* 0x0 */ s32 nSizeTextures;
+    /* 0x4 */ s32 nCountTextures;
+}; // size = 0x8
+
+// Range: 0x8001D39C -> 0x8001D4B8
+s32 frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // struct __anon_0x25A82* pInfo; // r1+0xC
+
+    // Local variables
+    struct _FRAME_TEXTURE* pTexture; // r10
+    s32 iTexture; // r5
+    s32 nCount; // r6
+    s32 nSize; // r1+0x8
 }
 
-// size: 0x4
-enum __anon_0x25D5E
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
+// Range: 0x8001D4B8 -> 0x8001D624
+s32 frameInvalidateCache(struct __anon_0x24C38* pFrame, s32 nOffset0, s32 nOffset1) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r25
+    // s32 nOffset0; // r1+0xC
+    // s32 nOffset1; // r1+0x10
 
-int frameSetMatrixHint(__anon_0x24C38 *pFrame, __anon_0x25D5E eProjection, int nAddressFloat, int nAddressFixed, float rNear, float rFar, float rFOVY, float rAspect, float rScale)
-{
-	int iHint;
+    // Local variables
+    s32 iTexture0; // r28
+    s32 iTexture1; // r27
+    struct _FRAME_TEXTURE* pTexture; // r23
+    struct _FRAME_TEXTURE* pTextureNext; // r26
 }
 
-int frameGetMatrixHint(__anon_0x24C38 *pFrame, unsigned int nAddress, int *piHint)
-{
-	int iHint;
+enum __anon_0x25D5E {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
+};
+
+// Range: 0x8001D624 -> 0x8001D740
+s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, s32 nAddressFloat,
+                       s32 nAddressFixed, float rNear, float rFar, float rFOVY, float rAspect, float rScale) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // enum __anon_0x25D5E eProjection; // r1+0x4
+    // s32 nAddressFloat; // r5
+    // s32 nAddressFixed; // r6
+    // float rNear; // f1
+    // float rFar; // r1+0x14
+    // float rFOVY; // r1+0x18
+    // float rAspect; // r1+0x1C
+    // float rScale; // r1+0x20
+
+    // Local variables
+    s32 iHint; // r10
 }
 
-int frameFixMatrixHint(__anon_0x24C38 *pFrame, int nAddressFloat, int nAddressFixed)
-{
-	int iHint;
-	int iHintTest;
+// Erased
+static s32 frameGetMatrixHint(struct __anon_0x24C38* pFrame, u32 nAddress, s32* piHint) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u32 nAddress; // r1+0x4
+    // s32* piHint; // r1+0x8
+
+    // Local variables
+    s32 iHint; // r8
 }
 
-// size: 0x4
-enum __anon_0x2614E
-{
-	FBT_NONE = 4294967295,
-	FBT_DEPTH = 0,
-	FBT_IMAGE = 1,
-	FBT_COLOR_SHOW = 2,
-	FBT_COLOR_DRAW = 3,
-	FBT_COUNT = 4
-};
+// Range: 0x8001D740 -> 0x8001D7F8
+s32 frameFixMatrixHint(struct __anon_0x24C38* pFrame, s32 nAddressFloat, s32 nAddressFixed) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // s32 nAddressFloat; // r1+0x4
+    // s32 nAddressFixed; // r1+0x8
 
-int frameSetBuffer(__anon_0x24C38 *pFrame, __anon_0x2614E eType);
-
-// size: 0x4
-enum __anon_0x2625D
-{
-	FRT_NONE = 4294967295,
-	FRT_COLD = 0,
-	FRT_WARM = 1
-};
-
-int frameResetUCode(__anon_0x24C38 *pFrame, __anon_0x2625D eType)
-{
-	int iMode;
+    // Local variables
+    s32 iHint; // r8
+    s32 iHintTest; // r9
 }
 
-int frameSetViewport(__anon_0x24C38 *pFrame, signed short *pData)
-{
-	int iScale;
-	float rY;
-	float rSizeX;
-	float rSizeY;
-	float arScale[3];
+enum __anon_0x2614E {
+    FBT_NONE = -1,
+    FBT_DEPTH = 0,
+    FBT_IMAGE = 1,
+    FBT_COLOR_SHOW = 2,
+    FBT_COLOR_DRAW = 3,
+    FBT_COUNT = 4,
+};
+
+// Range: 0x8001D7F8 -> 0x8001D830
+s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2614E eType; // r1+0x4
 }
 
-int frameSetLookAt(__anon_0x24C38 *pFrame, int iLookAt, char *pData);
+enum __anon_0x2625D {
+    FRT_NONE = -1,
+    FRT_COLD = 0,
+    FRT_WARM = 1,
+};
 
-int frameSetLight(__anon_0x24C38 *pFrame, int iLight, char *pData)
-{
-	__anon_0x23CAB *pLight;
+// Range: 0x8001D830 -> 0x8001D8E0
+s32 frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2625D eType; // r1+0x4
+
+    // Local variables
+    s32 iMode; // r6
 }
 
-int frameSetLightCount(__anon_0x24C38 *pFrame, int nCount);
+// Range: 0x8001D8E0 -> 0x8001DA74
+s32 frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // s16* pData; // r1+0xC
 
-// size: 0x4
-enum __anon_0x266CE
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
-
-// size: 0x10
-struct __anon_0x26732
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
-};
-
-// size: 0x4
-enum __anon_0x267E3
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
-
-// size: 0x4
-enum __anon_0x26911
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
-
-// size: 0x88
-struct __anon_0x26A4E
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x266CE eMode; // 0xC
-	__anon_0x26732 romCopy; // 0x10
-	__anon_0x267E3 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x26911 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
-
-// Location: 0x561380
-__anon_0x26A4E *gpSystem;
-
-// size: 0x4
-enum __anon_0x26C3F
-{
-	FLT_NONE = 4294967295,
-	FLT_TILE = 0,
-	FLT_BLOCK = 1
-};
-
-int frameLoadTMEM(__anon_0x24C38 *pFrame, __anon_0x26C3F eType, int iTile)
-{
-	int bFlip;
-	int iTMEM;
-	int nSize;
-	int nStep;
-	int nDelta;
-	int iScan;
-	int nOffset;
-	__anon_0x247BF *pTile;
-	unsigned char nData8;
-	unsigned short nData16;
-	unsigned int nData32;
-	unsigned int nSum;
-	unsigned long long *pSource;
-	int nCount;
-	int nScanFull;
-	int nScanPart;
-	unsigned char *pSource8;
-	unsigned short *pSource16;
-	unsigned int *pSource32;
-	// References: gpSystem (0x561380)
+    // Local variables
+    s32 iScale; // r1+0x8
+    float rY; // f1
+    float rSizeX; // f3
+    float rSizeY; // r1+0x8
+    float arScale[3]; // r1+0x28
 }
 
-int frameLoadTLUT(__anon_0x24C38 *pFrame, int nCount, int iTile)
-{
-	int iTMEM;
-	int nSize;
-	unsigned int nSum;
-	unsigned long long nData64;
-	unsigned short nData16;
-	unsigned short *pSource;
-	long tileNum;
+// Range: 0x8001DA74 -> 0x8001DB24
+s32 frameSetLookAt(struct __anon_0x24C38* pFrame, s32 iLookAt, char* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 iLookAt; // r1+0x4
+    // char* pData; // r1+0x8
 }
 
-int frameCullDL(__anon_0x24C38 *pFrame, int nVertexStart, int nVertexEnd)
-{
-	float rX;
-	float rY;
-	float rZ;
-	float rW;
-	float *matrix[4];
-	__anon_0x23FC4 *vtxP;
-	__anon_0x23FC4 *endVtxP;
-	int nCode;
-	int nCodeFull;
+// Range: 0x8001DB24 -> 0x8001DC4C
+s32 frameSetLight(struct __anon_0x24C38* pFrame, s32 iLight, char* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // s32 iLight; // r1+0xC
+    // char* pData; // r1+0x10
+
+    // Local variables
+    struct __anon_0x23CAB* pLight; // r6
 }
 
-// Location: 0x783E0F80
-int __float_nan[];
-
-// Location: 0x7C3E0F80
-int __float_huge[];
-
-// size: 0xC
-struct __anon_0x274AD
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-int frameLoadVertex(__anon_0x24C38 *pFrame, void *pBuffer, int iVertex0, int nCount)
-{
-	float mag;
-	int iLight;
-	int nLight;
-	int nTexGen;
-	float colorS;
-	float colorT;
-	float rS;
-	float rT;
-	float arNormal[3];
-	float arPosition[3];
-	__anon_0x23FC4 *pVertex;
-	unsigned int nData32;
-	__anon_0x23CAB *aLight;
-	__anon_0x23CAB *pLight;
-	int iVertex1;
-	float rScale;
-	float rScaleST;
-	char *pnData8;
-	signed short *pnData16;
-	float *matrixView[4];
-	float *matrixModel[4];
-	float rColorR;
-	float rColorG;
-	float rColorB;
-	float rDiffuse;
-	float rInverseW;
-	float rInverseLength;
-	__anon_0x274AD vec;
-	float distance;
-	// References: gpSystem (0x561380)
-	// References: __float_huge (0x7C3E0F80)
-	// References: __float_nan (0x783E0F80)
+// Range: 0x8001DC4C -> 0x8001DC58
+s32 frameSetLightCount(struct __anon_0x24C38* pFrame, s32 nCount) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nCount; // r1+0x4
 }
 
-int frameProjectVertex(__anon_0x24C38 *pFrame, int iVertex, float *prX, float *prY, float *prZ)
-{
-	float rW;
-	__anon_0x23FC4 *pVertex;
+enum __anon_0x266CE {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
+
+struct __anon_0x26732 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x267E3 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
+};
+
+enum __anon_0x26911 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
+};
+
+struct __anon_0x26A4E {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x266CE eMode;
+    /* 0x10 */ struct __anon_0x26732 romCopy;
+    /* 0x20 */ enum __anon_0x267E3 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x26911 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x26A4E* gpSystem;
+
+enum __anon_0x26C3F {
+    FLT_NONE = -1,
+    FLT_TILE = 0,
+    FLT_BLOCK = 1,
+};
+
+// Range: 0x8001DC58 -> 0x8001EBA0
+s32 frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, s32 iTile) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // enum __anon_0x26C3F eType; // r30
+    // s32 iTile; // r31
+
+    // Local variables
+    s32 bFlip; // r10
+    s32 iTMEM; // r5
+    s32 nSize; // r6
+    s32 nStep; // r11
+    s32 nDelta; // r12
+    s32 iScan; // r12
+    s32 nOffset; // r7
+    struct __anon_0x247BF* pTile; // r1+0x8
+    u8 nData8; // r30
+    u16 nData16; // r30
+    u32 nData32; // r30
+    u32 nSum; // r1+0x8
+    u64* pSource; // r4
+    s32 nCount; // r6
+    s32 nScanFull; // r7
+    s32 nScanPart; // r8
+    u8* pSource8; // r31
+    u16* pSource16; // r31
+    u32* pSource32; // r31
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
 }
 
-// size: 0x4
-enum __anon_0x27B8C
-{
-	FMT_MODELVIEW = 0,
-	FMT_PROJECTION = 1
-};
+// Range: 0x8001EBA0 -> 0x8001EC80
+s32 frameLoadTLUT(struct __anon_0x24C38* pFrame, s32 nCount, s32 iTile) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 nCount; // r1+0xC
+    // s32 iTile; // r1+0x10
 
-int frameGetMatrix(__anon_0x24C38 *pFrame, float *matrix[4], __anon_0x27B8C eType, int bPull);
-
-int frameSetMatrix(__anon_0x24C38 *pFrame, float *matrix[4], __anon_0x27B8C eType, int bLoad, int bPush, int nAddressN64)
-{
-	int bFlag;
-	float *matrixTarget[4];
-	float matrixResult[4][4];
-	// References: gpSystem (0x561380)
+    // Local variables
+    s32 iTMEM; // r28
+    s32 nSize; // r27
+    u32 nSum; // r26
+    u64 nData64; // r25
+    u16 nData16; // r3
+    u16* pSource; // r31
+    s32 tileNum; // r4
 }
 
-// size: 0x4
-enum __anon_0x27E96
-{
-	FMT_NONE = 4294967295,
-	FMT_FOG = 0,
-	FMT_GEOMETRY = 1,
-	FMT_TEXTURE1 = 2,
-	FMT_TEXTURE2 = 3,
-	FMT_OTHER0 = 4,
-	FMT_OTHER1 = 5,
-	FMT_COMBINE_COLOR1 = 6,
-	FMT_COMBINE_COLOR2 = 7,
-	FMT_COMBINE_ALPHA1 = 8,
-	FMT_COMBINE_ALPHA2 = 9,
-	FMT_COUNT = 10
-};
+// Range: 0x8001EC80 -> 0x8001EDCC
+s32 frameCullDL(struct __anon_0x24C38* pFrame, s32 nVertexStart, s32 nVertexEnd) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nVertexStart; // r1+0x4
+    // s32 nVertexEnd; // r1+0x8
 
-int frameGetMode(__anon_0x24C38 *pFrame, __anon_0x27E96 eType, unsigned int *pnMode);
-
-int frameSetMode(__anon_0x24C38 *pFrame, __anon_0x27E96 eType, unsigned int nMode)
-{
-	unsigned int nFlag;
-	unsigned int nModeChanged;
+    // Local variables
+    float rX; // r1+0x0
+    float rY; // f2
+    float rZ; // f1
+    float rW; // r1+0x0
+    float(*matrix)[4]; // r5
+    struct __anon_0x23FC4* vtxP; // r6
+    struct __anon_0x23FC4* endVtxP; // r4
+    s32 nCode; // r1+0x0
+    s32 nCodeFull; // r7
 }
 
-// size: 0x4
-enum __anon_0x2813A
-{
-	FS_NONE = 4294967295,
-	FS_SOURCE = 0,
-	FS_TARGET = 1,
-	FS_COUNT = 2
-};
+// size = 0x0, address = 0x800F3E78
+s32 __float_nan[];
 
-int frameGetSize(__anon_0x24C38 *pFrame, __anon_0x2813A eSize, int *pnSizeX, int *pnSizeY);
+// size = 0x0, address = 0x800F3E7C
+s32 __float_huge[];
 
-int frameSetSize(__anon_0x24C38 *pFrame, __anon_0x2813A eSize, int nSizeX, int nSizeY);
+struct __anon_0x274AD {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
 
-int frameGetWire(__anon_0x24C38 *pFrame, int *pbWire);
+// Range: 0x8001EDCC -> 0x8001F850
+s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // void* pBuffer; // r4
+    // s32 iVertex0; // r20
+    // s32 nCount; // r31
 
-int frameSetWire(__anon_0x24C38 *pFrame, int bWire);
+    // Local variables
+    float mag; // f5
+    s32 iLight; // r29
+    s32 nLight; // r28
+    s32 nTexGen; // r27
+    float colorS; // f7
+    float colorT; // f6
+    float rS; // f8
+    float rT; // f9
+    float arNormal[3]; // r1+0x40
+    float arPosition[3]; // r1+0x34
+    struct __anon_0x23FC4* pVertex; // r8
+    u32 nData32; // r12
+    struct __anon_0x23CAB* aLight; // r26
+    struct __anon_0x23CAB* pLight; // r25
+    s32 iVertex1; // r1+0x8
+    float rScale; // r1+0x8
+    float rScaleST; // r1+0x8
+    char* pnData8; // r24
+    s16* pnData16; // r23
+    float(*matrixView)[4]; // r22
+    float(*matrixModel)[4]; // r21
+    float rColorR; // f7
+    float rColorG; // f8
+    float rColorB; // f9
+    float rDiffuse; // f27
+    float rInverseW; // f6
+    float rInverseLength; // r1+0x8
+    struct __anon_0x274AD vec; // r1+0x28
+    float distance; // r1+0x8
 
-int frameGetFill(__anon_0x24C38 *pFrame, int *pbFill);
-
-int frameSetFill(__anon_0x24C38 *pFrame, int bFill);
-
-int frameDrawReset(__anon_0x24C38 *pFrame, int nFlag);
-
-// size: 0x8
-struct __anon_0x285E5
-{
-	int shift; // 0x0
-	long add; // 0x4
-};
-
-// size: 0x30
-struct __anon_0x2865F
-{
-	int nBIST; // 0x0
-	int nStatus; // 0x4
-	void *pHost; // 0x8
-	int nModeTest; // 0xC
-	int nDataTest; // 0x10
-	int nAddressTest; // 0x14
-	int nAddress0; // 0x18
-	int nAddress1; // 0x1C
-	int nClock; // 0x20
-	int nClockCmd; // 0x24
-	int nClockPipe; // 0x28
-	int nClockTMEM; // 0x2C
-};
-
-// size: 0x40
-struct __anon_0x28835
-{
-	int nType; // 0x0
-	int nFlag; // 0x4
-	int nOffsetBoot; // 0x8
-	int nLengthBoot; // 0xC
-	int nOffsetCode; // 0x10
-	int nLengthCode; // 0x14
-	int nOffsetData; // 0x18
-	int nLengthData; // 0x1C
-	int nOffsetStack; // 0x20
-	int nLengthStack; // 0x24
-	int nOffsetBuffer; // 0x28
-	int nLengthBuffer; // 0x2C
-	int nOffsetMBI; // 0x30
-	int nLengthMBI; // 0x34
-	int nOffsetYield; // 0x38
-	int nLengthYield; // 0x3C
-};
-
-// size: 0x4
-enum __anon_0x28AC5
-{
-	RUT_NONE = 4294967295,
-	RUT_TURBO = 0,
-	RUT_SPRITE2D = 1,
-	RUT_FAST3D = 2,
-	RUT_ZSORT = 3,
-	RUT_LINE3D = 4,
-	RUT_F3DEX1 = 5,
-	RUT_F3DEX2 = 6,
-	RUT_S2DEX1 = 7,
-	RUT_S2DEX2 = 8,
-	RUT_L3DEX1 = 9,
-	RUT_L3DEX2 = 10,
-	RUT_AUDIO1 = 11,
-	RUT_AUDIO2 = 12,
-	RUT_JPEG = 13
-};
-
-// size: 0xD8
-struct __anon_0x28C10
-{
-	int iDL; // 0x0
-	int bValid; // 0x4
-	__anon_0x28835 task; // 0x8
-	int nCountVertex; // 0x48
-	__anon_0x28AC5 eTypeUCode; // 0x4C
-	unsigned int n2TriMult; // 0x50
-	unsigned int nVersionUCode; // 0x54
-	int anBaseSegment[16]; // 0x58
-	unsigned long long  *apDL[16]; // 0x98
-};
-
-// size: 0x20
-struct __anon_0x28E31
-{
-	float aRotations[2][2]; // 0x0
-	float fX; // 0x10
-	float fY; // 0x14
-	float fBaseScaleX; // 0x18
-	float fBaseScaleY; // 0x1C
-};
-
-// size: 0x14
-struct __anon_0x28F3E
-{
-	float rS; // 0x0
-	float rT; // 0x4
-	signed short nX; // 0x8
-	signed short nY; // 0xA
-	signed short nZ; // 0xC
-	unsigned char anData[4]; // 0xE
-};
-
-// size: 0x3
-struct __anon_0x29056
-{
-	char anNormal[3]; // 0x0
-};
-
-// size: 0x4
-struct __anon_0x290D5
-{
-	unsigned char anMaterial[4]; // 0x0
-};
-
-// size: 0x40
-struct __anon_0x29178
-{
-	float aMatrix[4][4]; // 0x0
-};
-
-// size: 0x6
-struct __anon_0x291D6
-{
-	unsigned char nRed; // 0x0
-	unsigned char nGreen; // 0x1
-	unsigned char nBlue; // 0x2
-	char rVectorX; // 0x3
-	char rVectorY; // 0x4
-	char rVectorZ; // 0x5
-};
-
-// size: 0x10
-struct __anon_0x29487
-{
-	signed short anSlice[8]; // 0x0
-};
-
-// size: 0x4
-enum __anon_0x29567
-{
-	RUT_NOCODE = 4294967295,
-	RUT_ABI1 = 0,
-	RUT_ABI2 = 1,
-	RUT_ABI3 = 2,
-	RUT_ABI4 = 3,
-	RUT_UNKNOWN = 4
-};
-
-// size: 0x10
-struct tXL_LIST
-{
-	int nItemSize; // 0x0
-	int nItemCount; // 0x4
-	void *pNodeHead; // 0x8
-	void *pNodeNext; // 0xC
-};
-
-// size: 0x8
-struct __anon_0x296E2
-{
-	signed short r; // 0x0
-	signed short g; // 0x2
-	signed short b; // 0x4
-	signed short a; // 0x6
-};
-
-// size: 0x6
-struct __anon_0x29770
-{
-	signed short y; // 0x0
-	signed short u; // 0x2
-	signed short v; // 0x4
-};
-
-// size: 0x39CC
-struct __anon_0x297E0
-{
-	int nMode; // 0x0
-	__anon_0x28C10 yield; // 0x4
-	unsigned int nTickLast; // 0xDC
-	int (*pfUpdateWaiting)(); // 0xE0
-	unsigned int n2TriMult; // 0xE4
-	int aStatus[4]; // 0xE8
-	float aMatrixOrtho[4][4]; // 0xF8
-	unsigned int nMode2D; // 0x138
-	__anon_0x28E31 twoDValues; // 0x13C
-	int nPass; // 0x15C
-	unsigned int nZSortSubDL; // 0x160
-	unsigned int nStatusSubDL; // 0x164
-	unsigned int nNumZSortLights; // 0x168
-	int aLightAddresses[8]; // 0x16C
-	int nAmbientLightAddress; // 0x18C
-	__anon_0x28F3E aZSortVertex[128]; // 0x190
-	__anon_0x29056 aZSortNormal[128]; // 0xB90
-	__anon_0x290D5 aZSortMaterial[128]; // 0xD10
-	__anon_0x29178 aZSortMatrix[128]; // 0xF10
-	__anon_0x291D6 aZSortLight[8]; // 0x2F10
-	int aZSortInvW[128]; // 0x2F40
-	signed short aZSortWiVal[128]; // 0x3140
-	unsigned int nNumZSortMatrices; // 0x3240
-	unsigned int nNumZSortVertices; // 0x3244
-	unsigned int nTotalZSortVertices; // 0x3248
-	unsigned int nNumZSortNormals; // 0x324C
-	unsigned int nNumZSortMaterials; // 0x3250
-	int anAudioBaseSegment[16]; // 0x3254
-	signed short *anAudioBuffer; // 0x3294
-	signed short anADPCMCoef[5][2][8]; // 0x3298
-	unsigned short nAudioDMOutR[2]; // 0x3338
-	unsigned short nAudioDMauxL[2]; // 0x333C
-	unsigned short nAudioDMauxR[2]; // 0x3340
-	unsigned short nAudioCount[2]; // 0x3344
-	unsigned short nAudioFlags; // 0x3348
-	unsigned short nAudioDMEMIn[2]; // 0x334A
-	unsigned short nAudioDMEMOut[2]; // 0x334E
-	unsigned int nAudioLoopAddress; // 0x3354
-	unsigned int nAudioDryAmt; // 0x3358
-	unsigned int nAudioWetAmt; // 0x335C
-	unsigned int nAudioVolL; // 0x3360
-	unsigned int nAudioVolR; // 0x3364
-	unsigned int nAudioVolTGTL; // 0x3368
-	unsigned int nAudioVolRateLM; // 0x336C
-	unsigned int nAudioVolRateLL; // 0x3370
-	unsigned int nAudioVolTGTR; // 0x3374
-	unsigned int nAudioVolRateRM; // 0x3378
-	unsigned int nAudioVolRateRL; // 0x337C
-	__anon_0x29487 vParams; // 0x3380
-	signed short stepF; // 0x3390
-	signed short stepL; // 0x3392
-	signed short stepR; // 0x3394
-	int anGenReg[32]; // 0x3398
-	__anon_0x29487 aVectorReg[32]; // 0x3418
-	int anCP0Reg[32]; // 0x3618
-	__anon_0x29487 anCP2Reg[32]; // 0x3698
-	signed short anAcc[24]; // 0x3898
-	signed short nVCC; // 0x38C8
-	signed short nVC0; // 0x38CA
-	char nVCE; // 0x38CC
-	__anon_0x29567 eTypeAudioUCode; // 0x38D0
-	unsigned short nAudioMemOffset; // 0x38D4
-	unsigned short nAudioADPCMOffset; // 0x38D6
-	unsigned short nAudioScratchOffset; // 0x38D8
-	unsigned short nAudioParBase; // 0x38DA
-	int nPC; // 0x38DC
-	int iDL; // 0x38E0
-	int nBIST; // 0x38E4
-	void *pHost; // 0x38E8
-	void *pDMEM; // 0x38EC
-	void *pIMEM; // 0x38F0
-	int nStatus; // 0x38F4
-	int nFullDMA; // 0x38F8
-	int nBusyDMA; // 0x38FC
-	int nSizeGet; // 0x3900
-	int nSizePut; // 0x3904
-	int nSemaphore; // 0x3908
-	int nAddressSP; // 0x390C
-	int nGeometryMode; // 0x3910
-	int nAddressRDRAM; // 0x3914
-	tXL_LIST *pListUCode; // 0x3918
-	int nCountVertex; // 0x391C
-	__anon_0x28AC5 eTypeUCode; // 0x3920
-	unsigned int nVersionUCode; // 0x3924
-	int anBaseSegment[16]; // 0x3928
-	unsigned long long  *apDL[16]; // 0x3968
-	int *Coeff; // 0x39A8
-	signed short *QTable; // 0x39AC
-	signed short *QYTable; // 0x39B0
-	signed short *QCbTable; // 0x39B4
-	signed short *QCrTable; // 0x39B8
-	int *Zigzag; // 0x39BC
-	__anon_0x296E2 *rgbaBuf; // 0x39C0
-	__anon_0x29770 *yuvBuf; // 0x39C4
-	int *dctBuf; // 0x39C8
-};
-
-// size: 0x28
-struct __anon_0x2A6F7
-{
-	unsigned short imageX; // 0x0
-	unsigned short imageW; // 0x2
-	signed short frameX; // 0x4
-	unsigned short frameW; // 0x6
-	unsigned short imageY; // 0x8
-	unsigned short imageH; // 0xA
-	signed short frameY; // 0xC
-	unsigned short frameH; // 0xE
-	unsigned int imagePtr; // 0x10
-	unsigned short imageLoad; // 0x14
-	unsigned char imageFmt; // 0x16
-	unsigned char imageSiz; // 0x17
-	unsigned short imagePal; // 0x18
-	unsigned short imageFlip; // 0x1A
-	unsigned short tmemW; // 0x1C
-	unsigned short tmemH; // 0x1E
-	unsigned short tmemLoadSH; // 0x20
-	unsigned short tmemLoadTH; // 0x22
-	unsigned short tmemSizeW; // 0x24
-	unsigned short tmemSize; // 0x26
-};
-
-// size: 0x28
-struct __anon_0x2AA02
-{
-	unsigned short imageX; // 0x0
-	unsigned short imageW; // 0x2
-	signed short frameX; // 0x4
-	unsigned short frameW; // 0x6
-	unsigned short imageY; // 0x8
-	unsigned short imageH; // 0xA
-	signed short frameY; // 0xC
-	unsigned short frameH; // 0xE
-	unsigned int imagePtr; // 0x10
-	unsigned short imageLoad; // 0x14
-	unsigned char imageFmt; // 0x16
-	unsigned char imageSiz; // 0x17
-	unsigned short imagePal; // 0x18
-	unsigned short imageFlip; // 0x1A
-	unsigned short scaleW; // 0x1C
-	unsigned short scaleH; // 0x1E
-	int imageYorig; // 0x20
-	unsigned char padding[4]; // 0x24
-};
-
-// size: 0x28
-union __anon_0x2ACA3
-{
-	__anon_0x2A6F7 b; // 0x0
-	__anon_0x2AA02 s; // 0x0
-	signed long long force_structure_alignment; // 0x0
-};
-
-// size: 0x18
-struct __anon_0x2AD2F
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short tmem; // 0x8
-	unsigned short tsize; // 0xA
-	unsigned short tline; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-struct __anon_0x2AE4F
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short tmem; // 0x8
-	unsigned short twidth; // 0xA
-	unsigned short theight; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-struct __anon_0x2AF72
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short phead; // 0x8
-	unsigned short pnum; // 0xA
-	unsigned short zero; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-union __anon_0x2B091
-{
-	__anon_0x2AD2F block; // 0x0
-	__anon_0x2AE4F tile; // 0x0
-	__anon_0x2AF72 tlut; // 0x0
-	signed long long force_structure_alignment; // 0x0
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// Location: 0x80135A8C
-void *DemoCurrentBuffer;
-
-// Location: 0x80135A94
-void *DemoFrameBuffer1;
-
-// Location: 0x80135A90
-void *DemoFrameBuffer2;
-
-// size: 0x8
-struct __anon_0x2B2A7
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
-};
-
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
-};
-
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x2B2A7 *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
-};
-
-// size: 0x8
-union __anon_0x2B65C
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x8
-union __anon_0x2BA70
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x34
-struct __anon_0x2BF7E
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
-};
-
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
-};
-
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
-};
-
-// size: 0xC
-struct __anon_0x2C542
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
-};
-
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
-
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
-
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
-
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x2B65C aGPR[32]; // 0x40
-	__anon_0x2BA70 aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x2BF7E *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x2C542 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
-
-// size: 0x4
-enum __anon_0x2D223
-{
-	FCT_NONE = 4294967295,
-	FCT_FOG = 0,
-	FCT_FILL = 1,
-	FCT_BLEND = 2,
-	FCT_PRIMITIVE = 3,
-	FCT_ENVIRONMENT = 4,
-	FCT_COUNT = 5
-};
-
-// size: 0x28
-struct __anon_0x2D2B6
-{
-	int bFlip; // 0x0
-	int iTile; // 0x4
-	int nX0; // 0x8
-	int nY0; // 0xC
-	int nX1; // 0x10
-	int nY1; // 0x14
-	float rS; // 0x18
-	float rT; // 0x1C
-	float rDeltaS; // 0x20
-	float rDeltaT; // 0x24
-};
-
-// size: 0x304
-struct __anon_0x2D45B
-{
-	int nCount; // 0x0
-	unsigned char anData[768]; // 0x4
-};
-
-// size: 0x4
-enum _GXTevAlphaArg
-{
-	GX_CA_APREV = 0,
-	GX_CA_A0 = 1,
-	GX_CA_A1 = 2,
-	GX_CA_A2 = 3,
-	GX_CA_TEXA = 4,
-	GX_CA_RASA = 5,
-	GX_CA_KONST = 6,
-	GX_CA_ZERO = 7,
-	GX_CA_ONE = 6
-};
-
-// size: 0x4
-enum _GXTevColorArg
-{
-	GX_CC_CPREV = 0,
-	GX_CC_APREV = 1,
-	GX_CC_C0 = 2,
-	GX_CC_A0 = 3,
-	GX_CC_C1 = 4,
-	GX_CC_A1 = 5,
-	GX_CC_C2 = 6,
-	GX_CC_A2 = 7,
-	GX_CC_TEXC = 8,
-	GX_CC_TEXA = 9,
-	GX_CC_RASC = 10,
-	GX_CC_RASA = 11,
-	GX_CC_ONE = 12,
-	GX_CC_HALF = 13,
-	GX_CC_KONST = 14,
-	GX_CC_ZERO = 15,
-	GX_CC_TEXRRR = 16,
-	GX_CC_TEXGGG = 17,
-	GX_CC_TEXBBB = 18,
-	GX_CC_QUARTER = 14
-};
-
-// size: 0x4
-enum _GXProjectionType
-{
-	GX_PERSPECTIVE = 0,
-	GX_ORTHOGRAPHIC = 1
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x14
-struct _GXFogAdjTable
-{
-	unsigned short r[10]; // 0x0
-};
-
-// size: 0x4
-enum _GXFogType
-{
-	GX_FOG_NONE = 0,
-	GX_FOG_PERSP_LIN = 2,
-	GX_FOG_PERSP_EXP = 4,
-	GX_FOG_PERSP_EXP2 = 5,
-	GX_FOG_PERSP_REVEXP = 6,
-	GX_FOG_PERSP_REVEXP2 = 7,
-	GX_FOG_ORTHO_LIN = 10,
-	GX_FOG_ORTHO_EXP = 12,
-	GX_FOG_ORTHO_EXP2 = 13,
-	GX_FOG_ORTHO_REVEXP = 14,
-	GX_FOG_ORTHO_REVEXP2 = 15,
-	GX_FOG_LIN = 2,
-	GX_FOG_EXP = 4,
-	GX_FOG_EXP2 = 5,
-	GX_FOG_REVEXP = 6,
-	GX_FOG_REVEXP2 = 7
-};
-
-int frameUpdateTrackBuffer();
-
-int frameCheckTrackBuffer();
-
-int frameSetupTrackBuffer();
-
-// Local to compilation unit
-static int frameLoadTile(__anon_0x24C38 *pFrame, _FRAME_TEXTURE **ppTexture, int iTileCode)
-{
-	int bFlag;
-	__anon_0x247BF *pTile;
-	_FRAME_TEXTURE *pTexture;
-	_FRAME_TEXTURE *pTextureLast;
-	unsigned int nData0;
-	unsigned int nData1;
-	unsigned int nData2;
-	unsigned int nData3;
-	int iTexture;
-	int nShift;
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> s32 __float_huge[];
+    // -> s32 __float_nan[];
 }
 
-int frameMultiTexture(__anon_0x24C38 *pFrame)
-{
-	int iMode;
-	int iType;
-	int nMode;
-	int nUsed;
+// Erased
+static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, float* prX, float* prY, float* prZ) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 iVertex; // r1+0x4
+    // float* prX; // r1+0x8
+    // float* prY; // r1+0xC
+    // float* prZ; // r1+0x10
+
+    // Local variables
+    float rW; // r1+0x0
+    struct __anon_0x23FC4* pVertex; // r8
 }
 
-// Local to compilation unit
-static int frameUpdateCache(__anon_0x24C38 *pFrame)
-{
-	int nCount;
-	int nCountFree;
-	unsigned int nMask;
-	int nFrameCount;
-	int nFrameDelta;
-	int iTexture;
-	int iTextureUsed;
-	int iTextureCached;
-	_FRAME_TEXTURE *pTexture;
-	_FRAME_TEXTURE *pTextureCached;
-	_FRAME_TEXTURE *pTextureLast;
+enum __anon_0x27B8C {
+    FMT_MODELVIEW = 0,
+    FMT_PROJECTION = 1,
+};
+
+// Range: 0x8001F850 -> 0x8001F970
+s32 frameGetMatrix(struct __anon_0x24C38* pFrame, float (*matrix)[4], enum __anon_0x27B8C eType, s32 bPull) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // float (* matrix)[4]; // r7
+    // enum __anon_0x27B8C eType; // r1+0x10
+    // s32 bPull; // r31
 }
 
-int frameResetCache(__anon_0x24C38 *pFrame);
+// Range: 0x8001F970 -> 0x8001FFFC
+s32 frameSetMatrix(struct __anon_0x24C38* pFrame, float (*matrix)[4], enum __anon_0x27B8C eType, s32 bLoad, s32 bPush,
+                   s32 nAddressN64) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // float (* matrix)[4]; // r30
+    // enum __anon_0x27B8C eType; // r26
+    // s32 bLoad; // r28
+    // s32 bPush; // r27
+    // s32 nAddressN64; // r31
 
-// Local to compilation unit
-static int frameSetupCache(__anon_0x24C38 *pFrame)
-{
-	int iTexture;
+    // Local variables
+    s32 bFlag; // r28
+    float(*matrixTarget)[4]; // r3
+    float matrixResult[4][4]; // r1+0x48
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
 }
 
-int frameFreeTexture(__anon_0x24C38 *pFrame, _FRAME_TEXTURE *pTexture)
-{
-	int iTexture;
+enum __anon_0x27E96 {
+    FMT_NONE = -1,
+    FMT_FOG = 0,
+    FMT_GEOMETRY = 1,
+    FMT_TEXTURE1 = 2,
+    FMT_TEXTURE2 = 3,
+    FMT_OTHER0 = 4,
+    FMT_OTHER1 = 5,
+    FMT_COMBINE_COLOR1 = 6,
+    FMT_COMBINE_COLOR2 = 7,
+    FMT_COMBINE_ALPHA1 = 8,
+    FMT_COMBINE_ALPHA2 = 9,
+    FMT_COUNT = 10,
+};
+
+// Range: 0x8001FFFC -> 0x80020014
+s32 frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32* pnMode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x27E96 eType; // r1+0x4
+    // u32* pnMode; // r1+0x8
 }
 
-// Local to compilation unit
-static int frameMakeTexture(__anon_0x24C38 *pFrame, _FRAME_TEXTURE **ppTexture)
-{
-	unsigned int nMask;
-	int iTexture;
-	int iTextureUsed;
+// Range: 0x80020014 -> 0x800201A8
+s32 frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32 nMode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x27E96 eType; // r1+0x4
+    // u32 nMode; // r1+0x8
+
+    // Local variables
+    u32 nFlag; // r8
+    u32 nModeChanged; // r9
 }
 
-int packReset(unsigned int *anPack, int nPackCount)
-{
-	int iPack;
+enum __anon_0x2813A {
+    FS_NONE = -1,
+    FS_SOURCE = 0,
+    FS_TARGET = 1,
+    FS_COUNT = 2,
+};
+
+// Erased
+static s32 frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32* pnSizeX, s32* pnSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2813A eSize; // r1+0x4
+    // s32* pnSizeX; // r1+0x8
+    // s32* pnSizeY; // r1+0xC
 }
 
-// Local to compilation unit
-static int packFreeBlocks(int *piPack, unsigned int *anPack)
-{
-	int iPack;
-	unsigned int nMask;
+// Range: 0x800201A8 -> 0x800202D0
+s32 frameSetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32 nSizeX, s32 nSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // enum __anon_0x2813A eSize; // r1+0xC
+    // s32 nSizeX; // r1+0x10
+    // s32 nSizeY; // r1+0x14
 }
 
-// Local to compilation unit
-static int packTakeBlocks(int *piPack, unsigned int *anPack, int nPackCount, int nBlockCount)
-{
-	int nOffset;
-	int nCount;
-	int iPack;
-	unsigned int nPack;
-	unsigned int nMask;
-	unsigned int nMask0;
+// Erased
+static s32 frameGetWire(struct __anon_0x24C38* pFrame, s32* pbWire) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32* pbWire; // r1+0x4
 }
 
-// Local to compilation unit
-static int frameConvertYUVtoRGB(unsigned int *YUV, unsigned int *RGB)
-{
-	long Yl;
-	int R;
-	int G;
-	int B;
+// Erased
+static s32 frameSetWire(struct __anon_0x24C38* pFrame, s32 bWire) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 bWire; // r1+0x4
 }
 
-int frameConcatenateMatrix(float *matrixResult[4], float *matrixA[4], float *matrixB[4]);
+// Erased
+static s32 frameGetFill(struct __anon_0x24C38* pFrame, s32* pbFill) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32* pbFill; // r1+0x4
+}
 
-int frameScaleMatrix(float *matrixResult[4], float *matrix[4], float rScale);
+// Range: 0x800202D0 -> 0x800202FC
+s32 frameSetFill(struct __anon_0x24C38* pFrame, s32 bFill) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 bFill; // r1+0x4
+}
 
-int frameVectorTimesMatrix(float *fOutVector, float *fInVector, float *matrix[4]);
+// Range: 0x800202FC -> 0x80020340
+s32 frameDrawReset(struct __anon_0x24C38* pFrame, s32 nFlag) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nFlag; // r1+0x4
+}
 
+struct __anon_0x285E5 {
+    /* 0x0 */ s32 shift;
+    /* 0x4 */ s32 add;
+}; // size = 0x8
+
+struct __anon_0x2865F {
+    /* 0x00 */ s32 nBIST;
+    /* 0x04 */ s32 nStatus;
+    /* 0x08 */ void* pHost;
+    /* 0x0C */ s32 nModeTest;
+    /* 0x10 */ s32 nDataTest;
+    /* 0x14 */ s32 nAddressTest;
+    /* 0x18 */ s32 nAddress0;
+    /* 0x1C */ s32 nAddress1;
+    /* 0x20 */ s32 nClock;
+    /* 0x24 */ s32 nClockCmd;
+    /* 0x28 */ s32 nClockPipe;
+    /* 0x2C */ s32 nClockTMEM;
+}; // size = 0x30
+
+struct __anon_0x28835 {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ s32 nFlag;
+    /* 0x08 */ s32 nOffsetBoot;
+    /* 0x0C */ s32 nLengthBoot;
+    /* 0x10 */ s32 nOffsetCode;
+    /* 0x14 */ s32 nLengthCode;
+    /* 0x18 */ s32 nOffsetData;
+    /* 0x1C */ s32 nLengthData;
+    /* 0x20 */ s32 nOffsetStack;
+    /* 0x24 */ s32 nLengthStack;
+    /* 0x28 */ s32 nOffsetBuffer;
+    /* 0x2C */ s32 nLengthBuffer;
+    /* 0x30 */ s32 nOffsetMBI;
+    /* 0x34 */ s32 nLengthMBI;
+    /* 0x38 */ s32 nOffsetYield;
+    /* 0x3C */ s32 nLengthYield;
+}; // size = 0x40
+
+enum __anon_0x28AC5 {
+    RUT_NONE = -1,
+    RUT_TURBO = 0,
+    RUT_SPRITE2D = 1,
+    RUT_FAST3D = 2,
+    RUT_ZSORT = 3,
+    RUT_LINE3D = 4,
+    RUT_F3DEX1 = 5,
+    RUT_F3DEX2 = 6,
+    RUT_S2DEX1 = 7,
+    RUT_S2DEX2 = 8,
+    RUT_L3DEX1 = 9,
+    RUT_L3DEX2 = 10,
+    RUT_AUDIO1 = 11,
+    RUT_AUDIO2 = 12,
+    RUT_JPEG = 13,
+};
+
+struct __anon_0x28C10 {
+    /* 0x00 */ s32 iDL;
+    /* 0x04 */ s32 bValid;
+    /* 0x08 */ struct __anon_0x28835 task;
+    /* 0x48 */ s32 nCountVertex;
+    /* 0x4C */ enum __anon_0x28AC5 eTypeUCode;
+    /* 0x50 */ u32 n2TriMult;
+    /* 0x54 */ u32 nVersionUCode;
+    /* 0x58 */ s32 anBaseSegment[16];
+    /* 0x98 */ u64* apDL[16];
+}; // size = 0xD8
+
+struct __anon_0x28E31 {
+    /* 0x00 */ float aRotations[2][2];
+    /* 0x10 */ float fX;
+    /* 0x14 */ float fY;
+    /* 0x18 */ float fBaseScaleX;
+    /* 0x1C */ float fBaseScaleY;
+}; // size = 0x20
+
+struct __anon_0x28F3E {
+    /* 0x0 */ float rS;
+    /* 0x4 */ float rT;
+    /* 0x8 */ s16 nX;
+    /* 0xA */ s16 nY;
+    /* 0xC */ s16 nZ;
+    /* 0xE */ u8 anData[4];
+}; // size = 0x14
+
+struct __anon_0x29056 {
+    /* 0x0 */ char anNormal[3];
+}; // size = 0x3
+
+struct __anon_0x290D5 {
+    /* 0x0 */ u8 anMaterial[4];
+}; // size = 0x4
+
+struct __anon_0x29178 {
+    /* 0x0 */ float aMatrix[4][4];
+}; // size = 0x40
+
+struct __anon_0x291D6 {
+    /* 0x0 */ u8 nRed;
+    /* 0x1 */ u8 nGreen;
+    /* 0x2 */ u8 nBlue;
+    /* 0x3 */ char rVectorX;
+    /* 0x4 */ char rVectorY;
+    /* 0x5 */ char rVectorZ;
+}; // size = 0x6
+
+struct __anon_0x29487 {
+    /* 0x0 */ s16 anSlice[8];
+}; // size = 0x10
+
+enum __anon_0x29567 {
+    RUT_NOCODE = -1,
+    RUT_ABI1 = 0,
+    RUT_ABI2 = 1,
+    RUT_ABI3 = 2,
+    RUT_ABI4 = 3,
+    RUT_UNKNOWN = 4,
+};
+
+struct tXL_LIST {
+    /* 0x0 */ s32 nItemSize;
+    /* 0x4 */ s32 nItemCount;
+    /* 0x8 */ void* pNodeHead;
+    /* 0xC */ void* pNodeNext;
+}; // size = 0x10
+
+struct __anon_0x296E2 {
+    /* 0x0 */ s16 r;
+    /* 0x2 */ s16 g;
+    /* 0x4 */ s16 b;
+    /* 0x6 */ s16 a;
+}; // size = 0x8
+
+struct __anon_0x29770 {
+    /* 0x0 */ s16 y;
+    /* 0x2 */ s16 u;
+    /* 0x4 */ s16 v;
+}; // size = 0x6
+
+struct __anon_0x297E0 {
+    /* 0x0000 */ s32 nMode;
+    /* 0x0004 */ struct __anon_0x28C10 yield;
+    /* 0x00DC */ u32 nTickLast;
+    /* 0x00E0 */ s32 (*pfUpdateWaiting)();
+    /* 0x00E4 */ u32 n2TriMult;
+    /* 0x00E8 */ s32 aStatus[4];
+    /* 0x00F8 */ float aMatrixOrtho[4][4];
+    /* 0x0138 */ u32 nMode2D;
+    /* 0x013C */ struct __anon_0x28E31 twoDValues;
+    /* 0x015C */ s32 nPass;
+    /* 0x0160 */ u32 nZSortSubDL;
+    /* 0x0164 */ u32 nStatusSubDL;
+    /* 0x0168 */ u32 nNumZSortLights;
+    /* 0x016C */ s32 aLightAddresses[8];
+    /* 0x018C */ s32 nAmbientLightAddress;
+    /* 0x0190 */ struct __anon_0x28F3E aZSortVertex[128];
+    /* 0x0B90 */ struct __anon_0x29056 aZSortNormal[128];
+    /* 0x0D10 */ struct __anon_0x290D5 aZSortMaterial[128];
+    /* 0x0F10 */ struct __anon_0x29178 aZSortMatrix[128];
+    /* 0x2F10 */ struct __anon_0x291D6 aZSortLight[8];
+    /* 0x2F40 */ s32 aZSortInvW[128];
+    /* 0x3140 */ s16 aZSortWiVal[128];
+    /* 0x3240 */ u32 nNumZSortMatrices;
+    /* 0x3244 */ u32 nNumZSortVertices;
+    /* 0x3248 */ u32 nTotalZSortVertices;
+    /* 0x324C */ u32 nNumZSortNormals;
+    /* 0x3250 */ u32 nNumZSortMaterials;
+    /* 0x3254 */ s32 anAudioBaseSegment[16];
+    /* 0x3294 */ s16* anAudioBuffer;
+    /* 0x3298 */ s16 anADPCMCoef[5][2][8];
+    /* 0x3338 */ u16 nAudioDMOutR[2];
+    /* 0x333C */ u16 nAudioDMauxL[2];
+    /* 0x3340 */ u16 nAudioDMauxR[2];
+    /* 0x3344 */ u16 nAudioCount[2];
+    /* 0x3348 */ u16 nAudioFlags;
+    /* 0x334A */ u16 nAudioDMEMIn[2];
+    /* 0x334E */ u16 nAudioDMEMOut[2];
+    /* 0x3354 */ u32 nAudioLoopAddress;
+    /* 0x3358 */ u32 nAudioDryAmt;
+    /* 0x335C */ u32 nAudioWetAmt;
+    /* 0x3360 */ u32 nAudioVolL;
+    /* 0x3364 */ u32 nAudioVolR;
+    /* 0x3368 */ u32 nAudioVolTGTL;
+    /* 0x336C */ u32 nAudioVolRateLM;
+    /* 0x3370 */ u32 nAudioVolRateLL;
+    /* 0x3374 */ u32 nAudioVolTGTR;
+    /* 0x3378 */ u32 nAudioVolRateRM;
+    /* 0x337C */ u32 nAudioVolRateRL;
+    /* 0x3380 */ struct __anon_0x29487 vParams;
+    /* 0x3390 */ s16 stepF;
+    /* 0x3392 */ s16 stepL;
+    /* 0x3394 */ s16 stepR;
+    /* 0x3398 */ s32 anGenReg[32];
+    /* 0x3418 */ struct __anon_0x29487 aVectorReg[32];
+    /* 0x3618 */ s32 anCP0Reg[32];
+    /* 0x3698 */ struct __anon_0x29487 anCP2Reg[32];
+    /* 0x3898 */ s16 anAcc[24];
+    /* 0x38C8 */ s16 nVCC;
+    /* 0x38CA */ s16 nVC0;
+    /* 0x38CC */ char nVCE;
+    /* 0x38D0 */ enum __anon_0x29567 eTypeAudioUCode;
+    /* 0x38D4 */ u16 nAudioMemOffset;
+    /* 0x38D6 */ u16 nAudioADPCMOffset;
+    /* 0x38D8 */ u16 nAudioScratchOffset;
+    /* 0x38DA */ u16 nAudioParBase;
+    /* 0x38DC */ s32 nPC;
+    /* 0x38E0 */ s32 iDL;
+    /* 0x38E4 */ s32 nBIST;
+    /* 0x38E8 */ void* pHost;
+    /* 0x38EC */ void* pDMEM;
+    /* 0x38F0 */ void* pIMEM;
+    /* 0x38F4 */ s32 nStatus;
+    /* 0x38F8 */ s32 nFullDMA;
+    /* 0x38FC */ s32 nBusyDMA;
+    /* 0x3900 */ s32 nSizeGet;
+    /* 0x3904 */ s32 nSizePut;
+    /* 0x3908 */ s32 nSemaphore;
+    /* 0x390C */ s32 nAddressSP;
+    /* 0x3910 */ s32 nGeometryMode;
+    /* 0x3914 */ s32 nAddressRDRAM;
+    /* 0x3918 */ struct tXL_LIST* pListUCode;
+    /* 0x391C */ s32 nCountVertex;
+    /* 0x3920 */ enum __anon_0x28AC5 eTypeUCode;
+    /* 0x3924 */ u32 nVersionUCode;
+    /* 0x3928 */ s32 anBaseSegment[16];
+    /* 0x3968 */ u64* apDL[16];
+    /* 0x39A8 */ s32* Coeff;
+    /* 0x39AC */ s16* QTable;
+    /* 0x39B0 */ s16* QYTable;
+    /* 0x39B4 */ s16* QCbTable;
+    /* 0x39B8 */ s16* QCrTable;
+    /* 0x39BC */ s32* Zigzag;
+    /* 0x39C0 */ struct __anon_0x296E2* rgbaBuf;
+    /* 0x39C4 */ struct __anon_0x29770* yuvBuf;
+    /* 0x39C8 */ s32* dctBuf;
+}; // size = 0x39CC
+
+struct __anon_0x2A6F7 {
+    /* 0x00 */ u16 imageX;
+    /* 0x02 */ u16 imageW;
+    /* 0x04 */ s16 frameX;
+    /* 0x06 */ u16 frameW;
+    /* 0x08 */ u16 imageY;
+    /* 0x0A */ u16 imageH;
+    /* 0x0C */ s16 frameY;
+    /* 0x0E */ u16 frameH;
+    /* 0x10 */ u32 imagePtr;
+    /* 0x14 */ u16 imageLoad;
+    /* 0x16 */ u8 imageFmt;
+    /* 0x17 */ u8 imageSiz;
+    /* 0x18 */ u16 imagePal;
+    /* 0x1A */ u16 imageFlip;
+    /* 0x1C */ u16 tmemW;
+    /* 0x1E */ u16 tmemH;
+    /* 0x20 */ u16 tmemLoadSH;
+    /* 0x22 */ u16 tmemLoadTH;
+    /* 0x24 */ u16 tmemSizeW;
+    /* 0x26 */ u16 tmemSize;
+}; // size = 0x28
+
+struct __anon_0x2AA02 {
+    /* 0x00 */ u16 imageX;
+    /* 0x02 */ u16 imageW;
+    /* 0x04 */ s16 frameX;
+    /* 0x06 */ u16 frameW;
+    /* 0x08 */ u16 imageY;
+    /* 0x0A */ u16 imageH;
+    /* 0x0C */ s16 frameY;
+    /* 0x0E */ u16 frameH;
+    /* 0x10 */ u32 imagePtr;
+    /* 0x14 */ u16 imageLoad;
+    /* 0x16 */ u8 imageFmt;
+    /* 0x17 */ u8 imageSiz;
+    /* 0x18 */ u16 imagePal;
+    /* 0x1A */ u16 imageFlip;
+    /* 0x1C */ u16 scaleW;
+    /* 0x1E */ u16 scaleH;
+    /* 0x20 */ s32 imageYorig;
+    /* 0x24 */ u8 padding[4];
+}; // size = 0x28
+
+union __anon_0x2ACA3 {
+    /* 0x0 */ struct __anon_0x2A6F7 b;
+    /* 0x0 */ struct __anon_0x2AA02 s;
+    /* 0x0 */ s64 force_structure_alignment;
+};
+
+struct __anon_0x2AD2F {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 tmem;
+    /* 0x0A */ u16 tsize;
+    /* 0x0C */ u16 tline;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+struct __anon_0x2AE4F {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 tmem;
+    /* 0x0A */ u16 twidth;
+    /* 0x0C */ u16 theight;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+struct __anon_0x2AF72 {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 phead;
+    /* 0x0A */ u16 pnum;
+    /* 0x0C */ u16 zero;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+union __anon_0x2B091 {
+    /* 0x0 */ struct __anon_0x2AD2F block;
+    /* 0x0 */ struct __anon_0x2AE4F tile;
+    /* 0x0 */ struct __anon_0x2AF72 tlut;
+    /* 0x0 */ s64 force_structure_alignment;
+};
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+// size = 0x4, address = 0x80135A8C
+void* DemoCurrentBuffer;
+
+// size = 0x4, address = 0x80135A94
+void* DemoFrameBuffer1;
+
+// size = 0x4, address = 0x80135A90
+void* DemoFrameBuffer2;
+
+struct __anon_0x2B2A7 {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x2B2A7* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x2B65C {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
+};
+
+union __anon_0x2BA70 {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
+};
+
+struct __anon_0x2BF7E {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
+
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
+
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
+
+struct __anon_0x2C542 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
+
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
+
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
+
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
+
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x2B65C aGPR[32];
+    /* 0x00140 */ union __anon_0x2BA70 aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x2BF7E* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x2C542 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
+
+enum __anon_0x2D223 {
+    FCT_NONE = -1,
+    FCT_FOG = 0,
+    FCT_FILL = 1,
+    FCT_BLEND = 2,
+    FCT_PRIMITIVE = 3,
+    FCT_ENVIRONMENT = 4,
+    FCT_COUNT = 5,
+};
+
+struct __anon_0x2D2B6 {
+    /* 0x00 */ s32 bFlip;
+    /* 0x04 */ s32 iTile;
+    /* 0x08 */ s32 nX0;
+    /* 0x0C */ s32 nY0;
+    /* 0x10 */ s32 nX1;
+    /* 0x14 */ s32 nY1;
+    /* 0x18 */ float rS;
+    /* 0x1C */ float rT;
+    /* 0x20 */ float rDeltaS;
+    /* 0x24 */ float rDeltaT;
+}; // size = 0x28
+
+struct __anon_0x2D45B {
+    /* 0x0 */ s32 nCount;
+    /* 0x4 */ u8 anData[768];
+}; // size = 0x304
+
+enum _GXTevAlphaArg {
+    GX_CA_APREV = 0,
+    GX_CA_A0 = 1,
+    GX_CA_A1 = 2,
+    GX_CA_A2 = 3,
+    GX_CA_TEXA = 4,
+    GX_CA_RASA = 5,
+    GX_CA_KONST = 6,
+    GX_CA_ZERO = 7,
+    GX_CA_ONE = 6,
+};
+
+enum _GXTevColorArg {
+    GX_CC_CPREV = 0,
+    GX_CC_APREV = 1,
+    GX_CC_C0 = 2,
+    GX_CC_A0 = 3,
+    GX_CC_C1 = 4,
+    GX_CC_A1 = 5,
+    GX_CC_C2 = 6,
+    GX_CC_A2 = 7,
+    GX_CC_TEXC = 8,
+    GX_CC_TEXA = 9,
+    GX_CC_RASC = 10,
+    GX_CC_RASA = 11,
+    GX_CC_ONE = 12,
+    GX_CC_HALF = 13,
+    GX_CC_KONST = 14,
+    GX_CC_ZERO = 15,
+    GX_CC_TEXRRR = 16,
+    GX_CC_TEXGGG = 17,
+    GX_CC_TEXBBB = 18,
+    GX_CC_QUARTER = 14,
+};
+
+enum _GXProjectionType {
+    GX_PERSPECTIVE = 0,
+    GX_ORTHOGRAPHIC = 1,
+};
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
+};
+
+struct _GXFogAdjTable {
+    /* 0x0 */ u16 r[10];
+}; // size = 0x14
+
+enum _GXFogType {
+    GX_FOG_NONE = 0,
+    GX_FOG_PERSP_LIN = 2,
+    GX_FOG_PERSP_EXP = 4,
+    GX_FOG_PERSP_EXP2 = 5,
+    GX_FOG_PERSP_REVEXP = 6,
+    GX_FOG_PERSP_REVEXP2 = 7,
+    GX_FOG_ORTHO_LIN = 10,
+    GX_FOG_ORTHO_EXP = 12,
+    GX_FOG_ORTHO_EXP2 = 13,
+    GX_FOG_ORTHO_REVEXP = 14,
+    GX_FOG_ORTHO_REVEXP2 = 15,
+    GX_FOG_LIN = 2,
+    GX_FOG_EXP = 4,
+    GX_FOG_EXP2 = 5,
+    GX_FOG_REVEXP = 6,
+    GX_FOG_REVEXP2 = 7,
+};
+
+// Erased
+static s32 frameUpdateTrackBuffer() {}
+
+// Erased
+static s32 frameCheckTrackBuffer() {}
+
+// Erased
+static s32 frameSetupTrackBuffer() {}
+
+// Range: 0x80020340 -> 0x80020764
+static s32 frameLoadTile(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture, s32 iTileCode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct _FRAME_TEXTURE** ppTexture; // r30
+    // s32 iTileCode; // r31
+
+    // Local variables
+    s32 bFlag; // r27
+    struct __anon_0x247BF* pTile; // r26
+    struct _FRAME_TEXTURE* pTexture; // r1+0x18
+    struct _FRAME_TEXTURE* pTextureLast; // r25
+    u32 nData0; // r24
+    u32 nData1; // r23
+    u32 nData2; // r22
+    u32 nData3; // r21
+    s32 iTexture; // r1+0x8
+    s32 nShift; // r3
+}
+
+// Erased
+static s32 frameMultiTexture(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+
+    // Local variables
+    s32 iMode; // r5
+    s32 iType; // r1+0x0
+    s32 nMode; // r1+0x0
+    s32 nUsed; // r6
+}
+
+// Range: 0x80020764 -> 0x80020958
+static s32 frameUpdateCache(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r23
+
+    // Local variables
+    s32 nCount; // r1+0x8
+    s32 nCountFree; // r1+0x8
+    u32 nMask; // r27
+    s32 nFrameCount; // r26
+    s32 nFrameDelta; // r1+0x8
+    s32 iTexture; // r1+0x8
+    s32 iTextureUsed; // r25
+    s32 iTextureCached; // r1+0x8
+    struct _FRAME_TEXTURE* pTexture; // r24
+    struct _FRAME_TEXTURE* pTextureCached; // r4
+    struct _FRAME_TEXTURE* pTextureLast; // r5
+}
+
+// Erased
+static s32 frameResetCache(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+}
+
+// Range: 0x80020958 -> 0x80020E20
+static s32 frameSetupCache(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+
+    // Local variables
+    s32 iTexture; // r1+0x8
+}
+
+// Erased
+static s32 frameFreeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // struct _FRAME_TEXTURE* pTexture; // r29
+
+    // Local variables
+    s32 iTexture; // r30
+}
+
+// Range: 0x80020E20 -> 0x80020F3C
+static s32 frameMakeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // struct _FRAME_TEXTURE** ppTexture; // r1+0xC
+
+    // Local variables
+    u32 nMask; // r5
+    s32 iTexture; // r9
+    s32 iTextureUsed; // r8
+}
+
+// Erased
+static s32 packReset(u32* anPack, s32 nPackCount) {
+    // Parameters
+    // u32* anPack; // r3
+    // s32 nPackCount; // r1+0x4
+
+    // Local variables
+    s32 iPack; // r7
+}
+
+// Range: 0x80020F3C -> 0x80020FA4
+static s32 packFreeBlocks(s32* piPack, u32* anPack) {
+    // Parameters
+    // s32* piPack; // r1+0x0
+    // u32* anPack; // r1+0x4
+
+    // Local variables
+    s32 iPack; // r1+0x0
+    u32 nMask; // r7
+}
+
+// Range: 0x80020FA4 -> 0x80021070
+static s32 packTakeBlocks(s32* piPack, u32* anPack, s32 nPackCount, s32 nBlockCount) {
+    // Parameters
+    // s32* piPack; // r1+0x0
+    // u32* anPack; // r4
+    // s32 nPackCount; // r5
+    // s32 nBlockCount; // r1+0xC
+
+    // Local variables
+    s32 nOffset; // r9
+    s32 nCount; // r10
+    s32 iPack; // r11
+    u32 nPack; // r5
+    u32 nMask; // r12
+    u32 nMask0; // r7
+}
+
+// Range: 0x80021070 -> 0x8002113C
+static s32 frameConvertYUVtoRGB(u32* YUV, u32* RGB) {
+    // Parameters
+    // u32* YUV; // r1+0x0
+    // u32* RGB; // r1+0x4
+
+    // Local variables
+    s32 Yl; // r7
+    s32 R; // r1+0x0
+    s32 G; // r5
+    s32 B; // r8
+}
+
+// Erased
+static s32 frameConcatenateMatrix(float (*matrixResult)[4], float (*matrixA)[4], float (*matrixB)[4]) {
+    // Parameters
+    // float (* matrixResult)[4]; // r1+0x8
+    // float (* matrixA)[4]; // r4
+    // float (* matrixB)[4]; // r5
+}
+
+// Range: 0x8002113C -> 0x80021204
+s32 frameScaleMatrix(float (*matrixResult)[4], float (*matrix)[4], float rScale) {
+    // Parameters
+    // float (* matrixResult)[4]; // r1+0x0
+    // float (* matrix)[4]; // r1+0x4
+    // float rScale; // r1+0x8
+}
+
+// Erased
+static s32 frameVectorTimesMatrix(float* fOutVector, float* fInVector, float (*matrix)[4]) {
+    // Parameters
+    // float* fOutVector; // r1+0x4
+    // float* fInVector; // r1+0x8
+    // float (* matrix)[4]; // r1+0xC
+}

--- a/debug/Fire/library.c
+++ b/debug/Fire/library.c
@@ -1,1476 +1,1630 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\library.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008F0F4 -> 0x8009779C
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EEB0C
+struct _XL_OBJECTTYPE gClassLibrary;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+// size = 0x100, address = 0x800EEB1C
+static u32 __osRcpImTable[64];
 
-// Location: 0xCEB0E80
-_XL_OBJECTTYPE gClassLibrary;
-
-// Local to compilation unit
-// Location: 0x1CEB0E80
-static unsigned int __osRcpImTable[64];
-
-// Local to compilation unit
-// Location: 0x28531380
+// size = 0x4, address = 0x80135328
 static float dtor$466;
 
-// Local to compilation unit
-// Location: 0x2C531380
+// size = 0x4, address = 0x8013532C
 static float dtor$480;
 
-// Local to compilation unit
-// Location: 0x30531380
-static unsigned int nAddress$605;
+// size = 0x4, address = 0x80135330
+static u32 nAddress$605;
 
-// size: 0x8
-struct __anon_0x78E87
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
+struct __anon_0x78E87 {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x78E87* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x7923C {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
+struct __anon_0x79A22 {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
+
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
+
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
+
+struct __anon_0x79FE6 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
+
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
+
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
+
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
+
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x7923C aGPR[32];
+    /* 0x00140 */ union __anon_0x7D2DB aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x79A22* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x79FE6 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
+
+struct __anon_0x7AD10 {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ void (*pfLibrary)(struct _CPU*);
+    /* 0x8 */ u32 anData[17];
+}; // size = 0x4C
+
+// size = 0x1008, address = 0x800EEF2C
+struct __anon_0x7AD10 gaFunction[54];
+
+struct __anon_0x7AE26 {
+    /* 0x00 */ s32 nFlag;
+    /* 0x04 */ void* pHost;
+    /* 0x08 */ s32 nAddStackSwap;
+    /* 0x0C */ s32 nCountFunction;
+    /* 0x10 */ s32 nAddressException;
+    /* 0x14 */ struct __anon_0x7AD10* aFunction;
+    /* 0x18 */ void* apData[10];
+    /* 0x40 */ s32 anAddress[10];
+}; // size = 0x68
+
+// Range: 0x8008F0F4 -> 0x8008F234
+s32 libraryEvent(struct __anon_0x7AE26* pLibrary, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r1+0x10
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8008F234 -> 0x8008F32C
+s32 libraryCall(struct __anon_0x7AE26* pLibrary, struct _CPU* pCPU, s32 iFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r29
+    // struct _CPU* pCPU; // r30
+    // s32 iFunction; // r31
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8008F32C -> 0x8008F420
+s32 libraryFunctionReplaced(s32 iFunction) {
+    // Parameters
+    // s32 iFunction; // r1+0x4
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Erased
+static s32 libraryUpdate(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r31
+
+    // Local variables
+    struct _CPU* pCPU; // r29
+    struct cpu_function* pFunction; // r1+0xC
+}
+
+// Range: 0x8008F420 -> 0x8008F584
+static s32 librarySearch(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r29
+    // struct cpu_function* pFunction; // r30
+}
+
+// Range: 0x8008F584 -> 0x8008FB6C
+s32 libraryTestFunction(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r30
+    // struct cpu_function* pFunction; // r26
+
+    // Local variables
+    s32 iFunction; // r31
+    s32 iData; // r24
+    s32 bFlag; // r29
+    s32 bDone; // r27
+    s32 bReturn; // r21
+    u32 iCode; // r5
+    u32* pnCode; // r1+0x1C
+    u32* pnCodeTemp; // r1+0x18
+    u32 nSizeCode; // r1+0x8
+    u32 nChecksum; // r1+0x14
+    u32 nOpcode; // r1+0x8
+    u32 nAddress; // r1+0x8
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Erased
+static s32 libraryCheckHandler(struct __anon_0x7AE26* pLibrary, s32 bException) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r31
+    // s32 bException; // r4
+}
+
+// Range: 0x8008FB6C -> 0x8009007C
+static s32 libraryFindFunctions(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r24
+
+    // Local variables
+    struct _CPU* pCPU; // r3
+    s32 iFunction; // r29
+    struct __anon_0x79A22** apDevice; // r28
+    u8* aiDevice; // r27
+    u32 nOpcode; // r1+0x10
+    u32* pnCode; // r1+0xC
+    u32 nAddress; // r29
+    u32 nAddressLast; // r31
+    u32 nAddressEnqueueThread; // r26
+    u32 nAddressDispatchThread; // r25
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8009007C -> 0x800907B0
+static s32 libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r24
+
+    // Local variables
+    struct _CPU* pCPU; // r27
+    struct __anon_0x79A22** apDevice; // r26
+    u8* aiDevice; // r25
+    u32 nAddress; // r23
+    u32 nAddressLast; // r28
+    u32 nOffset; // r1+0x28
+    u32 nOpcode; // r1+0x24
+    u32 anCode[6]; // r1+0xC
+}
+
+// Range: 0x800907B0 -> 0x80090AB0
+static s32 libraryFindException(struct __anon_0x7AE26* pLibrary, s32 bException) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r27
+    // s32 bException; // r28
+
+    // Local variables
+    struct _CPU* pCPU; // r30
+    struct __anon_0x79A22** apDevice; // r29
+    u8* aiDevice; // r31
+    u32 anCode[6]; // r1+0x10
+}
+
+// Range: 0x80090AB0 -> 0x80090AC4
+s32 zeldaLoadSZS_Exit(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80090AC4 -> 0x80090AD8
+s32 zeldaLoadSZS_Entry(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80090AD8 -> 0x80090B40
+s32 osViSwapBuffer_Entry(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+
+    // References
+    // -> static u32 nAddress$605;
+}
+
+struct __anon_0x7BB81 {
+    /* 0x0 */ float f_odd;
+    /* 0x4 */ float f_even;
+}; // size = 0x8
+
+union __anon_0x7BBDC {
+    /* 0x0 */ struct __anon_0x7BB81 f;
+    /* 0x0 */ double d;
+    /* 0x0 */ s64 u64;
 };
 
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x78E87 *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
+struct __anon_0x7BC50 {
+    /* 0x000 */ u64 at;
+    /* 0x008 */ u64 v0;
+    /* 0x010 */ u64 v1;
+    /* 0x018 */ u64 a0;
+    /* 0x020 */ u64 a1;
+    /* 0x028 */ u64 a2;
+    /* 0x030 */ u64 a3;
+    /* 0x038 */ u64 t0;
+    /* 0x040 */ u64 t1;
+    /* 0x048 */ u64 t2;
+    /* 0x050 */ u64 t3;
+    /* 0x058 */ u64 t4;
+    /* 0x060 */ u64 t5;
+    /* 0x068 */ u64 t6;
+    /* 0x070 */ u64 t7;
+    /* 0x078 */ u64 s0;
+    /* 0x080 */ u64 s1;
+    /* 0x088 */ u64 s2;
+    /* 0x090 */ u64 s3;
+    /* 0x098 */ u64 s4;
+    /* 0x0A0 */ u64 s5;
+    /* 0x0A8 */ u64 s6;
+    /* 0x0B0 */ u64 s7;
+    /* 0x0B8 */ u64 t8;
+    /* 0x0C0 */ u64 t9;
+    /* 0x0C8 */ u64 gp;
+    /* 0x0D0 */ u64 sp;
+    /* 0x0D8 */ u64 s8;
+    /* 0x0E0 */ u64 ra;
+    /* 0x0E8 */ u64 lo;
+    /* 0x0F0 */ u64 hi;
+    /* 0x0F8 */ u32 sr;
+    /* 0x0FC */ u32 pc;
+    /* 0x100 */ u32 cause;
+    /* 0x104 */ u32 badvaddr;
+    /* 0x108 */ u32 rcp;
+    /* 0x10C */ u32 fpcsr;
+    /* 0x110 */ union __anon_0x7BBDC fp0;
+    /* 0x118 */ union __anon_0x7BBDC fp2;
+    /* 0x120 */ union __anon_0x7BBDC fp4;
+    /* 0x128 */ union __anon_0x7BBDC fp6;
+    /* 0x130 */ union __anon_0x7BBDC fp8;
+    /* 0x138 */ union __anon_0x7BBDC fp10;
+    /* 0x140 */ union __anon_0x7BBDC fp12;
+    /* 0x148 */ union __anon_0x7BBDC fp14;
+    /* 0x150 */ union __anon_0x7BBDC fp16;
+    /* 0x158 */ union __anon_0x7BBDC fp18;
+    /* 0x160 */ union __anon_0x7BBDC fp20;
+    /* 0x168 */ union __anon_0x7BBDC fp22;
+    /* 0x170 */ union __anon_0x7BBDC fp24;
+    /* 0x178 */ union __anon_0x7BBDC fp26;
+    /* 0x180 */ union __anon_0x7BBDC fp28;
+    /* 0x188 */ union __anon_0x7BBDC fp30;
+}; // size = 0x190
+
+struct __OSThread_s {
+    /* 0x00 */ struct __OSThread_s* next;
+    /* 0x04 */ s32 priority;
+    /* 0x08 */ struct __OSThread_s** queue;
+    /* 0x0C */ struct __OSThread_s* tlnext;
+    /* 0x10 */ u16 state;
+    /* 0x12 */ u16 flags;
+    /* 0x14 */ s32 id;
+    /* 0x18 */ s32 fp;
+    /* 0x20 */ struct __anon_0x7BC50 context;
+}; // size = 0x1B0
+
+struct OSMesgQueue_s {
+    /* 0x00 */ struct __OSThread_s* mtqueue;
+    /* 0x04 */ struct __OSThread_s* fullqueue;
+    /* 0x08 */ s32 validCount;
+    /* 0x0C */ s32 first;
+    /* 0x10 */ s32 msgCount;
+    /* 0x14 */ void* msg;
+}; // size = 0x18
+
+struct __anon_0x7C589 {
+    /* 0x0 */ u16 type;
+    /* 0x2 */ u8 pri;
+    /* 0x3 */ u8 status;
+    /* 0x4 */ struct OSMesgQueue_s* retQueue;
+}; // size = 0x8
+
+struct __anon_0x7C62D {
+    /* 0x00 */ struct __anon_0x7C589 hdr;
+    /* 0x08 */ void* dramAddr;
+    /* 0x0C */ u32 devAddr;
+    /* 0x10 */ u32 size;
+    /* 0x14 */ void* piHandle;
+}; // size = 0x18
+
+// Range: 0x80090B40 -> 0x80090C68
+s32 dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    void* pTarget; // r1+0x18
+    struct OSMesgQueue_s* mq; // r1+0x14
+    u32* msg; // r1+0x10
+    struct __anon_0x7C62D* pIOMessage; // r1+0xC
+    s32 first; // r30
+    s32 msgCount; // r29
+    s32 validCount; // r28
+    s32 nSize; // r6
+    s32 nAddress; // r5
+    s32 nOffsetRAM; // r5
+    s32 nOffsetROM; // r5
+}
+
+// Range: 0x80090C68 -> 0x80090C78
+s32 pictureSnap_Zelda2(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80090C78 -> 0x80090DE0
+s32 starfoxCopy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r25
+
+    // Local variables
+    s32* A0; // r1+0x18
+    s32 A1; // r31
+    s32 A2; // r30
+    s32 A3; // r29
+    s32 T0; // r28
+    s32 T1; // r24
+    s32 T2; // r1+0x8
+    s32 T3; // r23
+    s32 T8; // r27
+    s32 T9; // r26
+    s16* pData16; // r1+0x14
+    char* source; // r1+0x10
+    char* target; // r1+0xC
+}
+
+// Range: 0x80090DE0 -> 0x80090E8C
+s32 osEepromLongWrite(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    s32 length; // r31
+    s32 ret; // r30
+    u8 address; // r29
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090E8C -> 0x80090F38
+s32 osEepromLongRead(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    s32 length; // r31
+    s32 ret; // r30
+    u8 address; // r29
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090F38 -> 0x80090FB0
+s32 osEepromWrite(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u8 address; // r31
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090FB0 -> 0x80091028
+s32 osEepromRead(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u8 address; // r31
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80091028 -> 0x80091100
+s32 __osEepStatus(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 ret; // r5
+    s32 nSize; // r1+0x10
+    u8* status; // r1+0xC
+}
+
+// Range: 0x80091100 -> 0x8009120C
+s32 osAiSetNextBuffer(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u32 size; // r31
+    u32 nData32; // r1+0x10
+}
+
+// Range: 0x8009120C -> 0x80091338
+s32 osAiSetFrequency(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    u32 dacRate; // r1+0x8
+    u8 bitRate; // r28
+    u32 nData32; // r1+0x10
+}
+
+struct __anon_0x7D115 {
+    /* 0x0 */ u8 col[3];
+    /* 0x3 */ char pad1;
+    /* 0x4 */ u8 colc[3];
+    /* 0x7 */ char pad2;
+    /* 0x8 */ s8 dir[3];
+    /* 0xB */ char pad3;
+}; // size = 0xC
+
+union __anon_0x7D215 {
+    /* 0x0 */ struct __anon_0x7D115 l;
+    /* 0x0 */ s64 force_structure_alignment[2];
 };
 
-// size: 0x8
-union __anon_0x7923C
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
+struct __anon_0x7D2A5 {
+    /* 0x0 */ union __anon_0x7D215 l[2];
+}; // size = 0x20
+
+union __anon_0x7D2DB {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x34
-struct __anon_0x79A22
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
+// Range: 0x80091338 -> 0x8009190C
+void guLookAtReflect(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x70
+    s32 i; // r7
+    s32 j; // r1+0x8
+    s32 e1; // r5
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x68
+    float mf[4][4]; // r1+0x28
+    u32* m; // r1+0x24
+    u32* sp; // r1+0x20
+    s32* ai; // r9
+    s32* af; // r10
+    float xEye; // f3
+    float yEye; // f4
+    float zEye; // f5
+    float xAt; // r1+0x8
+    float yAt; // r1+0x8
+    float zAt; // f1
+    float xUp; // r1+0x8
+    float yUp; // f1
+    float zUp; // f2
+    float len; // f9
+    float xLook; // f6
+    float yLook; // f7
+    float zLook; // f8
+    float xRight; // f9
+    float yRight; // f10
+    float zRight; // f11
+}
+
+// Range: 0x8009190C -> 0x80091E60
+void guLookAtReflectF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    u32* mf; // r1+0x1C
+    u32* sp; // r1+0x18
+    float xEye; // f3
+    float yEye; // f4
+    float zEye; // f5
+    float xAt; // r1+0x8
+    float yAt; // r1+0x8
+    float zAt; // f1
+    float xUp; // r1+0x8
+    float yUp; // f1
+    float zUp; // f2
+    float len; // f9
+    float xLook; // f6
+    float yLook; // f7
+    float zLook; // f8
+    float xRight; // f9
+    float yRight; // f10
+    float zRight; // f11
+}
+
+struct __anon_0x7DB47 {
+    /* 0x0 */ s32 x1;
+    /* 0x4 */ s32 y1;
+    /* 0x8 */ s32 x2;
+    /* 0xC */ s32 y2;
+}; // size = 0x10
+
+union __anon_0x7DBF9 {
+    /* 0x0 */ struct __anon_0x7DB47 h;
+    /* 0x0 */ s32 force_structure_alignment[4];
 };
 
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
+// Range: 0x80091E60 -> 0x80092834
+void guLookAtHilite(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x84
+    union __anon_0x7DBF9* h; // r1+0x80
+    s32 i; // r7
+    s32 j; // r1+0x8
+    s32 e1; // r5
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x78
+    float mf[4][4]; // r1+0x38
+    u32* m; // r1+0x34
+    u32* sp; // r1+0x30
+    s32* ai; // r9
+    s32* af; // r10
+    float len; // f5
+    float xLook; // r1+0x8
+    float yLook; // f1
+    float zLook; // f2
+    float xRight; // f3
+    float yRight; // f4
+    float zRight; // f5
+    float xHilite; // f29
+    float yHilite; // f28
+    float zHilite; // f27
+    float xEye; // f6
+    float yEye; // f7
+    float zEye; // f8
+    float xAt; // r1+0x8
+    float yAt; // f1
+    float zAt; // f2
+    float xUp; // f3
+    float yUp; // f12
+    float zUp; // f4
+    float xl1; // f27
+    float yl1; // f28
+    float zl1; // f26
+    float xl2; // f9
+    float yl2; // f10
+    float zl2; // f11
+    s32 twidth; // r6
+    s32 theight; // r7
+}
+
+// Range: 0x80092834 -> 0x80093188
+void guLookAtHiliteF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x3C
+    union __anon_0x7DBF9* h; // r1+0x38
+    union __anon_0x7D2DB data; // r1+0x30
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    float len; // f5
+    float xLook; // r1+0x8
+    float yLook; // f1
+    float zLook; // f2
+    float xRight; // f3
+    float yRight; // f4
+    float zRight; // f5
+    float xHilite; // f29
+    float yHilite; // f28
+    float zHilite; // f27
+    float xEye; // f6
+    float yEye; // f7
+    float zEye; // f8
+    float xAt; // r1+0x8
+    float yAt; // f1
+    float zAt; // f2
+    float xUp; // f3
+    float yUp; // f12
+    float zUp; // f4
+    float xl1; // f27
+    float yl1; // f28
+    float zl1; // f26
+    float xl2; // f9
+    float yl2; // f10
+    float zl2; // f11
+    s32 twidth; // r6
+    s32 theight; // r7
+}
+
+// Erased
+static s32 __float2int(float x) {
+    // Parameters
+    // float x; // r1+0x8
+}
+
+// Range: 0x80093188 -> 0x800935A0
+void guLookAt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    float mf[4][4]; // r1+0x30
+    s32* m; // r1+0x2C
+    u32* sp; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    s32* ai; // r9
+    s32* af; // r10
+    float len; // f6
+    float xLook; // f3
+    float yLook; // f4
+    float zLook; // f5
+    float xRight; // f6
+    float yRight; // f7
+    float zRight; // f8
+    float xEye; // f9
+    float yEye; // f10
+    float zEye; // f11
+    float xAt; // r1+0x8
+    float yAt; // r1+0x8
+    float zAt; // f1
+    float xUp; // r1+0x8
+    float yUp; // f1
+    float zUp; // f2
+}
+
+// Range: 0x800935A0 -> 0x8009392C
+void guLookAtF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    float len; // f9
+    float xAt; // r1+0x8
+    float yAt; // r1+0x8
+    float zAt; // f1
+    float xUp; // r1+0x8
+    float yUp; // f1
+    float zUp; // f2
+    float xEye; // f3
+    float yEye; // f4
+    float zEye; // f5
+    u32* mf; // r1+0x34
+    u32* sp; // r1+0x30
+    float xLook; // f6
+    float yLook; // f7
+    float zLook; // f8
+    float xRight; // f9
+    float yRight; // f10
+    float zRight; // f11
+    union __anon_0x7D2DB data; // r1+0x28
+    union __anon_0x7D2DB data0; // r1+0x20
+    union __anon_0x7D2DB data1; // r1+0x18
+}
+
+// Range: 0x8009392C -> 0x80093C78
+void guRotate(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32* m; // r1+0x64
+    u32* sp; // r1+0x60
+    union __anon_0x7D2DB data; // r1+0x58
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    float mf[4][4]; // r1+0x18
+    float sine; // r1+0x8
+    float cosine; // r1+0x8
+    float a; // f30
+    float x; // f29
+    float y; // f28
+    float z; // f27
+    float ab; // f13
+    float bc; // f30
+    float ca; // f29
+    float t; // f26
+    float magnitude; // f2
+    s32* ai; // r9
+    s32* af; // r10
+
+    // References
+    // -> static float dtor$480;
+}
+
+// Range: 0x80093C78 -> 0x80093F88
+void guRotateF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    float m; // f2
+    s32 i; // r8
+    s32 j; // r4
+    float a; // f31
+    float x; // f30
+    float y; // f29
+    float z; // f28
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
+    float sine; // r1+0x8
+    float cosine; // r1+0x8
+    float ab; // f27
+    float bc; // f26
+    float ca; // f25
+    float t; // f4
+
+    // References
+    // -> static float dtor$466;
+}
+
+// Range: 0x80093F88 -> 0x80094174
+void guTranslate(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32* m; // r1+0x60
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x58
+    float mf[4][4]; // r1+0x14
+    s32* ai; // r9
+    s32* af; // r10
+}
+
+// Range: 0x80094174 -> 0x80094294
+void guTranslateF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 i; // r8
+    s32 j; // r4
+    u32* mf; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
+}
+
+// Range: 0x80094294 -> 0x80094480
+void guScale(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    float mf[4][4]; // r1+0x24
+    s32* m; // r1+0x20
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x18
+    s32* ai; // r9
+    s32* af; // r10
+}
+
+// Range: 0x80094480 -> 0x800945A8
+void guScaleF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 i; // r8
+    s32 j; // r4
+    u32* mf; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
+}
+
+struct __anon_0x7F9D8 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x7FA72 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x7FBB3 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x7FC23 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x7FBB3 rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x7FE53 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x7FBB3 rS;
+    /* 0x10 */ struct __anon_0x7FBB3 rT;
+    /* 0x1C */ struct __anon_0x7FBB3 rSRaw;
+    /* 0x28 */ struct __anon_0x7FBB3 rTRaw;
+}; // size = 0x34
+
+struct __anon_0x7FF3C {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x7FBB3 vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x8009B {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
 };
 
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
+struct __anon_0x80138 {
+    /* 0x0 */ union __anon_0x8009B data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
 };
 
-// size: 0xC
-struct __anon_0x79FE6
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x80806 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x80AE8 {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
 };
 
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
+struct __anon_0x80B6D {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x80AE8 eProjection;
+}; // size = 0x24
 
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
 
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x7923C aGPR[32]; // 0x40
-	__anon_0x7D2DB aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x79A22 *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x79FE6 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
+struct __anon_0x80DBD {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x7F9D8 viewport;
+    /* 0x000C8 */ struct __anon_0x7FA72 aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x7FC23 aLight[8];
+    /* 0x00320 */ struct __anon_0x7FE53 lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x7FF3C aVertex[80];
+    /* 0x00C18 */ struct __anon_0x80138 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x80806 aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x80AE8 eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x80B6D aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
 
-// size: 0x4C
-struct __anon_0x7AD10
-{
-	char *szName; // 0x0
-	void (*pfLibrary)(_CPU */* unknown0 */); // 0x4
-	unsigned int anData[17]; // 0x8
-};
+// Range: 0x800945A8 -> 0x80094658
+void GenPerspective_1080(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
 
-// Location: 0x2CEF0E80
-__anon_0x7AD10 gaFunction[54];
-
-// size: 0x68
-struct __anon_0x7AE26
-{
-	int nFlag; // 0x0
-	void *pHost; // 0x4
-	int nAddStackSwap; // 0x8
-	int nCountFunction; // 0xC
-	int nAddressException; // 0x10
-	__anon_0x7AD10 *aFunction; // 0x14
-	void *apData[10]; // 0x18
-	int anAddress[10]; // 0x40
-};
-
-int libraryEvent(__anon_0x7AE26 *pLibrary, int nEvent, void *pArgument)
-{
-	// References: gaFunction (0x2CEF0E80)
+    // Local variables
+    union __anon_0x7D2DB data; // r1+0x18
+    u32* mf; // r1+0x10
+    u32* sp; // r1+0xC
+    float fovy; // f3
+    float aspect; // f4
+    float rNear; // f1
+    float rFar; // f2
+    struct __anon_0x80DBD* pFrame; // r31
 }
 
-int libraryCall(__anon_0x7AE26 *pLibrary, _CPU *pCPU, int iFunction)
-{
-	// References: gaFunction (0x2CEF0E80)
+// Range: 0x80094658 -> 0x8009491C
+void guPerspective(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32* m; // r1+0x60
+    float fovy; // f30
+    float aspect; // f29
+    float rNear; // f28
+    float rFar; // f27
+    float scale; // f5
+    float _cot; // f2
+    s32 i; // r6
+    s32 j; // r1+0x8
+    union __anon_0x7D2DB data; // r1+0x58
+    float mf[4][4]; // r1+0x18
+    s32 e1; // r7
+    s32 e2; // r8
+    u32* sp; // r1+0x14
+    s32* ai; // r9
+    s32* af; // r10
 }
 
-int libraryFunctionReplaced(int iFunction)
-{
-	// References: gaFunction (0x2CEF0E80)
+// Range: 0x8009491C -> 0x80094B78
+void guPerspectiveF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 i; // r8
+    s32 j; // r4
+    float cot; // f2
+    s16* perspNorm; // r1+0x30
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    union __anon_0x7D2DB data0; // r1+0x20
+    union __anon_0x7D2DB data1; // r1+0x18
+    union __anon_0x7D2DB data; // r1+0x10
+    float fovy; // f29
+    float aspect; // f28
+    float rNear; // f27
+    float rFar; // f31
+    float scale; // f5
 }
 
-int libraryUpdate(__anon_0x7AE26 *pLibrary)
-{
-	_CPU *pCPU;
-	cpu_function *pFunction;
+// Range: 0x80094B78 -> 0x80094E54
+void guOrtho(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32* m; // r1+0x60
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x58
+    float mf[4][4]; // r1+0x18
+    u32* sp; // r1+0x14
+    s32* ai; // r9
+    s32* af; // r10
+    float l; // f31
+    float r; // f30
+    float b; // f29
+    float t; // f28
+    float n; // f27
+    float f; // f26
+    float scale; // f5
 }
 
-// Local to compilation unit
-static int librarySearch(__anon_0x7AE26 *pLibrary, cpu_function *pFunction);
+// Range: 0x80094E54 -> 0x800950C4
+void guOrthoF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
 
-int libraryTestFunction(__anon_0x7AE26 *pLibrary, cpu_function *pFunction)
-{
-	int iFunction;
-	int iData;
-	int bFlag;
-	int bDone;
-	int bReturn;
-	unsigned int iCode;
-	unsigned int *pnCode;
-	unsigned int *pnCodeTemp;
-	unsigned int nSizeCode;
-	unsigned int nChecksum;
-	unsigned int nOpcode;
-	unsigned int nAddress;
-	// References: gaFunction (0x2CEF0E80)
+    // Local variables
+    s32 i; // r8
+    s32 j; // r4
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    float l; // f29
+    float r; // f28
+    float b; // f27
+    float t; // f26
+    float n; // f31
+    float f; // f30
+    float scale; // f5
+    union __anon_0x7D2DB data0; // r1+0x20
+    union __anon_0x7D2DB data1; // r1+0x18
+    union __anon_0x7D2DB data; // r1+0x10
 }
 
-int libraryCheckHandler(__anon_0x7AE26 *pLibrary, int bException);
+// Range: 0x800950C4 -> 0x80095178
+void guMtxIdent(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
 
-// Local to compilation unit
-static int libraryFindFunctions(__anon_0x7AE26 *pLibrary)
-{
-	_CPU *pCPU;
-	int iFunction;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-	unsigned int nOpcode;
-	unsigned int *pnCode;
-	unsigned int nAddress;
-	unsigned int nAddressLast;
-	unsigned int nAddressEnqueueThread;
-	unsigned int nAddressDispatchThread;
-	// References: gaFunction (0x2CEF0E80)
+    // Local variables
+    s32* m; // r1+0xC
 }
 
-// Local to compilation unit
-static int libraryFindVariables(__anon_0x7AE26 *pLibrary)
-{
-	_CPU *pCPU;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-	unsigned int nAddress;
-	unsigned int nAddressLast;
-	unsigned int nOffset;
-	unsigned int nOpcode;
-	unsigned int anCode[6];
+// Range: 0x80095178 -> 0x8009524C
+void guMtxIdentF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+
+    // Local variables
+    float* mf; // r1+0x20
+    s32 i; // r7
+    s32 j; // r1+0x8
+    union __anon_0x7D2DB data1; // r1+0x18
+    union __anon_0x7D2DB data0; // r1+0x10
 }
 
-// Local to compilation unit
-static int libraryFindException(__anon_0x7AE26 *pLibrary, int bException)
-{
-	_CPU *pCPU;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-	unsigned int anCode[6];
+// Range: 0x8009524C -> 0x80095454
+void guMtxF2L(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    float* mf; // r1+0x24
+    s32 e1; // r6
+    s32 e2; // r7
+    s32 i; // r8
+    s32 j; // r1+0x8
+    s32* m; // r1+0x20
+    union __anon_0x7D2DB data; // r1+0x18
+    s32* ai; // r9
+    s32* af; // r10
 }
 
-int zeldaLoadSZS_Exit(_CPU *pCPU);
+// Range: 0x80095454 -> 0x8009576C
+void guMtxCatF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r23
 
-int zeldaLoadSZS_Entry(_CPU *pCPU);
-
-int osViSwapBuffer_Entry(_CPU *pCPU)
-{
-	// References: nAddress$605 (0x30531380)
+    // Local variables
+    s32 i; // r9
+    s32 j; // r23
+    float temp[4][4]; // r1+0x38
+    union __anon_0x7D2DB data1; // r1+0x30
+    union __anon_0x7D2DB data2; // r1+0x28
+    u32* mf; // r1+0x24
+    u32* nf; // r1+0x20
+    u32* res; // r1+0x1C
 }
 
-// size: 0x8
-struct __anon_0x7BB81
-{
-	float f_odd; // 0x0
-	float f_even; // 0x4
-};
-
-// size: 0x8
-union __anon_0x7BBDC
-{
-	__anon_0x7BB81 f; // 0x0
-	long float d; // 0x0
-	signed long long u64; // 0x0
-};
-
-// size: 0x190
-struct __anon_0x7BC50
-{
-	unsigned long long at; // 0x0
-	unsigned long long v0; // 0x8
-	unsigned long long v1; // 0x10
-	unsigned long long a0; // 0x18
-	unsigned long long a1; // 0x20
-	unsigned long long a2; // 0x28
-	unsigned long long a3; // 0x30
-	unsigned long long t0; // 0x38
-	unsigned long long t1; // 0x40
-	unsigned long long t2; // 0x48
-	unsigned long long t3; // 0x50
-	unsigned long long t4; // 0x58
-	unsigned long long t5; // 0x60
-	unsigned long long t6; // 0x68
-	unsigned long long t7; // 0x70
-	unsigned long long s0; // 0x78
-	unsigned long long s1; // 0x80
-	unsigned long long s2; // 0x88
-	unsigned long long s3; // 0x90
-	unsigned long long s4; // 0x98
-	unsigned long long s5; // 0xA0
-	unsigned long long s6; // 0xA8
-	unsigned long long s7; // 0xB0
-	unsigned long long t8; // 0xB8
-	unsigned long long t9; // 0xC0
-	unsigned long long gp; // 0xC8
-	unsigned long long sp; // 0xD0
-	unsigned long long s8; // 0xD8
-	unsigned long long ra; // 0xE0
-	unsigned long long lo; // 0xE8
-	unsigned long long hi; // 0xF0
-	unsigned int sr; // 0xF8
-	unsigned int pc; // 0xFC
-	unsigned int cause; // 0x100
-	unsigned int badvaddr; // 0x104
-	unsigned int rcp; // 0x108
-	unsigned int fpcsr; // 0x10C
-	__anon_0x7BBDC fp0; // 0x110
-	__anon_0x7BBDC fp2; // 0x118
-	__anon_0x7BBDC fp4; // 0x120
-	__anon_0x7BBDC fp6; // 0x128
-	__anon_0x7BBDC fp8; // 0x130
-	__anon_0x7BBDC fp10; // 0x138
-	__anon_0x7BBDC fp12; // 0x140
-	__anon_0x7BBDC fp14; // 0x148
-	__anon_0x7BBDC fp16; // 0x150
-	__anon_0x7BBDC fp18; // 0x158
-	__anon_0x7BBDC fp20; // 0x160
-	__anon_0x7BBDC fp22; // 0x168
-	__anon_0x7BBDC fp24; // 0x170
-	__anon_0x7BBDC fp26; // 0x178
-	__anon_0x7BBDC fp28; // 0x180
-	__anon_0x7BBDC fp30; // 0x188
-};
-
-// size: 0x1B0
-struct __OSThread_s
-{
-	__OSThread_s *next; // 0x0
-	int priority; // 0x4
-	__OSThread_s **queue; // 0x8
-	__OSThread_s *tlnext; // 0xC
-	unsigned short state; // 0x10
-	unsigned short flags; // 0x12
-	int id; // 0x14
-	int fp; // 0x18
-	__anon_0x7BC50 context; // 0x20
-};
-
-// size: 0x18
-struct OSMesgQueue_s
-{
-	__OSThread_s *mtqueue; // 0x0
-	__OSThread_s *fullqueue; // 0x4
-	int validCount; // 0x8
-	int first; // 0xC
-	int msgCount; // 0x10
-	void *msg; // 0x14
-};
-
-// size: 0x8
-struct __anon_0x7C589
-{
-	unsigned short type; // 0x0
-	unsigned char pri; // 0x2
-	unsigned char status; // 0x3
-	OSMesgQueue_s *retQueue; // 0x4
-};
-
-// size: 0x18
-struct __anon_0x7C62D
-{
-	__anon_0x7C589 hdr; // 0x0
-	void *dramAddr; // 0x8
-	unsigned long devAddr; // 0xC
-	unsigned long size; // 0x10
-	void *piHandle; // 0x14
-};
-
-int dmaSoundRomHandler_ZELDA1(_CPU *pCPU)
-{
-	void *pTarget;
-	OSMesgQueue_s *mq;
-	unsigned int *msg;
-	__anon_0x7C62D *pIOMessage;
-	int first;
-	int msgCount;
-	int validCount;
-	int nSize;
-	int nAddress;
-	int nOffsetRAM;
-	int nOffsetROM;
+// Range: 0x8009576C -> 0x800957E0
+void osVirtualToPhysical(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
 }
 
-int pictureSnap_Zelda2(_CPU *pCPU);
-
-int starfoxCopy(_CPU *pCPU)
-{
-	int *A0;
-	int A1;
-	int A2;
-	int A3;
-	int T0;
-	int T1;
-	int T2;
-	int T3;
-	int T8;
-	int T9;
-	signed short *pData16;
-	char *source;
-	char *target;
+// Range: 0x800957E0 -> 0x800957F0
+void osPhysicalToVirtual(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
 }
 
-int osEepromLongWrite(_CPU *pCPU)
-{
-	int length;
-	int ret;
-	unsigned char address;
-	unsigned char *buffer;
+// Range: 0x800957F0 -> 0x8009584C
+void _memcpy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pSource; // r1+0x10
+    void* pTarget; // r1+0xC
 }
 
-int osEepromLongRead(_CPU *pCPU)
-{
-	int length;
-	int ret;
-	unsigned char address;
-	unsigned char *buffer;
+// Range: 0x8009584C -> 0x800958A8
+void _bcopy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pSource; // r1+0x10
+    void* pTarget; // r1+0xC
 }
 
-int osEepromWrite(_CPU *pCPU)
-{
-	unsigned char address;
-	unsigned char *buffer;
+// Range: 0x800958A8 -> 0x800958EC
+void _bzero(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pBuffer; // r1+0xC
 }
 
-int osEepromRead(_CPU *pCPU)
-{
-	unsigned char address;
-	unsigned char *buffer;
+// Range: 0x800958EC -> 0x80095920
+static void __sinf(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
 }
 
-int __osEepStatus(_CPU *pCPU)
-{
-	int ret;
-	int nSize;
-	unsigned char *status;
+// Range: 0x80095920 -> 0x80095954
+static void __cosf(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
 }
 
-int osAiSetNextBuffer(_CPU *pCPU)
-{
-	unsigned int size;
-	unsigned int nData32;
+// Range: 0x80095954 -> 0x800959A4
+static s32 __osSpSetStatus(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+
+    // Local variables
+    u32 nData32; // r1+0xC
 }
 
-int osAiSetFrequency(_CPU *pCPU)
-{
-	unsigned int dacRate;
-	unsigned char bitRate;
-	unsigned int nData32;
+// Range: 0x800959A4 -> 0x80095A30
+static s32 __osRestoreInt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    u64 nStatus; // r1+0x10
 }
 
-// size: 0xC
-struct __anon_0x7D115
-{
-	unsigned char col[3]; // 0x0
-	char pad1; // 0x3
-	unsigned char colc[3]; // 0x4
-	char pad2; // 0x7
-	signed char dir[3]; // 0x8
-	char pad3; // 0xB
-};
+// Range: 0x80095A30 -> 0x80095AC0
+static s32 __osDisableInt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
 
-// size: 0x10
-union __anon_0x7D215
-{
-	__anon_0x7D115 l; // 0x0
-	signed long long force_structure_alignment[2]; // 0x0
-};
-
-// size: 0x20
-struct __anon_0x7D2A5
-{
-	__anon_0x7D215 l[2]; // 0x0
-};
-
-// size: 0x8
-union __anon_0x7D2DB
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-void guLookAtReflect(_CPU *pCPU)
-{
-	__anon_0x7D2A5 *l;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	__anon_0x7D2DB data;
-	float mf[4][4];
-	unsigned int *m;
-	unsigned int *sp;
-	int *ai;
-	int *af;
-	float xEye;
-	float yEye;
-	float zEye;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
-	float len;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
+    // Local variables
+    u32 nStatus; // r1+0x8
+    u64 nData64; // r1+0x18
 }
 
-void guLookAtReflectF(_CPU *pCPU)
-{
-	__anon_0x7D2A5 *l;
-	__anon_0x7D2DB data;
-	unsigned int *mf;
-	unsigned int *sp;
-	float xEye;
-	float yEye;
-	float zEye;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
-	float len;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
+// Range: 0x80095AC0 -> 0x80095B48
+static s32 osInvalICache(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    u32 nAddress; // r30
+    u32 nSize; // r1+0x8
 }
 
-// size: 0x10
-struct __anon_0x7DB47
-{
-	int x1; // 0x0
-	int y1; // 0x4
-	int x2; // 0x8
-	int y2; // 0xC
-};
+// Range: 0x80095B48 -> 0x80095B9C
+static s32 osGetMemSize(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
 
-// size: 0x10
-union __anon_0x7DBF9
-{
-	__anon_0x7DB47 h; // 0x0
-	long force_structure_alignment[4]; // 0x0
-};
-
-void guLookAtHilite(_CPU *pCPU)
-{
-	__anon_0x7D2A5 *l;
-	__anon_0x7DBF9 *h;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	__anon_0x7D2DB data;
-	float mf[4][4];
-	unsigned int *m;
-	unsigned int *sp;
-	int *ai;
-	int *af;
-	float len;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
-	float xHilite;
-	float yHilite;
-	float zHilite;
-	float xEye;
-	float yEye;
-	float zEye;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
-	float xl1;
-	float yl1;
-	float zl1;
-	float xl2;
-	float yl2;
-	float zl2;
-	int twidth;
-	int theight;
+    // Local variables
+    u32 nSize; // r1+0xC
 }
 
-void guLookAtHiliteF(_CPU *pCPU)
-{
-	__anon_0x7D2A5 *l;
-	__anon_0x7DBF9 *h;
-	__anon_0x7D2DB data;
-	unsigned int *mf;
-	unsigned int *sp;
-	float len;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
-	float xHilite;
-	float yHilite;
-	float zHilite;
-	float xEye;
-	float yEye;
-	float zEye;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
-	float xl1;
-	float yl1;
-	float zl1;
-	float xl2;
-	float yl2;
-	float zl2;
-	int twidth;
-	int theight;
+// Erased
+static s32 __ptException() {}
+
+// Range: 0x80095B9C -> 0x80096140
+static s32 __osDispatchThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+
+    // Local variables
+    struct __anon_0x7AE26* pLibrary; // r29
+    u32 nAddress; // r5
+    u64 nData64; // r0
+    struct __OSThread_s* __osRunningThread; // r1+0x10
+    u32 nData32; // r1+0xC
+    u32 __OSGlobalIntMask; // r28
+    u32 nStatus; // r6
+    u32 nMask; // r6
+
+    // References
+    // -> static u32 __osRcpImTable[64];
 }
 
-int __float2int(float x);
+// Range: 0x80096140 -> 0x80096214
+static s32 __osPopThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
 
-void guLookAt(_CPU *pCPU)
-{
-	float mf[4][4];
-	int *m;
-	unsigned int *sp;
-	__anon_0x7D2DB data;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	int *ai;
-	int *af;
-	float len;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
-	float xEye;
-	float yEye;
-	float zEye;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
+    // Local variables
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
 }
 
-void guLookAtF(_CPU *pCPU)
-{
-	float len;
-	float xAt;
-	float yAt;
-	float zAt;
-	float xUp;
-	float yUp;
-	float zUp;
-	float xEye;
-	float yEye;
-	float zEye;
-	unsigned int *mf;
-	unsigned int *sp;
-	float xLook;
-	float yLook;
-	float zLook;
-	float xRight;
-	float yRight;
-	float zRight;
-	__anon_0x7D2DB data;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
+// Range: 0x80096214 -> 0x8009643C
+static s32 __osEnqueueThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
 }
 
-void guRotate(_CPU *pCPU)
-{
-	int *m;
-	unsigned int *sp;
-	__anon_0x7D2DB data;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	float mf[4][4];
-	float sine;
-	float cosine;
-	float a;
-	float x;
-	float y;
-	float z;
-	float ab;
-	float bc;
-	float ca;
-	float t;
-	float magnitude;
-	int *ai;
-	int *af;
-	// References: dtor$480 (0x2C531380)
+// Range: 0x8009643C -> 0x80096728
+static s32 __osEnqueueAndYield(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    s64 nData64; // r1+0x18
+    struct __anon_0x7AE26* pLibrary; // r3
+    struct __OSThread_s* __osRunningThread; // r1+0x10
+    u32 __OSGlobalIntMask; // r31
+    u32 nStatus; // r1+0x8
+    u32 nData32; // r5
+    u32 nMask; // r1+0xC
+    struct __anon_0x79A22** apDevice; // r6
+    u8* aiDevice; // r7
 }
 
-void guRotateF(_CPU *pCPU)
-{
-	float m;
-	int i;
-	int j;
-	float a;
-	float x;
-	float y;
-	float z;
-	unsigned int *mf;
-	unsigned int *sp;
-	__anon_0x7D2DB data;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
-	float sine;
-	float cosine;
-	float ab;
-	float bc;
-	float ca;
-	float t;
-	// References: dtor$466 (0x28531380)
+// Range: 0x80096728 -> 0x80096AB8
+static s32 send_mesg(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    struct __anon_0x7AE26* pLibrary; // r1+0x8
+    struct __anon_0x79A22** apDevice; // r30
+    u8* aiDevice; // r29
 }
 
-void guTranslate(_CPU *pCPU)
-{
-	int *m;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	__anon_0x7D2DB data;
-	float mf[4][4];
-	int *ai;
-	int *af;
+// Range: 0x80096AB8 -> 0x8009779C
+static s32 __osException(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    s32 iBit; // r3
+    struct __anon_0x7AE26* pLibrary; // r1+0x8
+    s64 nData64; // r1+0x28
+    s64 nCause; // r1+0x20
+    struct __OSThread_s* __osRunningThread; // r1+0x18
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
+    u32 nStatus; // r22
+    u32 nStatusRSP; // r1+0x14
+    u32 nData32; // r1+0x10
+    u32 __OSGlobalIntMask; // r23
+    u32 nS0; // r18
+    u32 nS1; // r17
+    u32 nMask; // r1+0xC
 }
-
-void guTranslateF(_CPU *pCPU)
-{
-	int i;
-	int j;
-	unsigned int *mf;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
-}
-
-void guScale(_CPU *pCPU)
-{
-	float mf[4][4];
-	int *m;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	__anon_0x7D2DB data;
-	int *ai;
-	int *af;
-}
-
-void guScaleF(_CPU *pCPU)
-{
-	int i;
-	int j;
-	unsigned int *mf;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
-}
-
-// size: 0x10
-struct __anon_0x7F9D8
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x7FA72
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
-};
-
-// size: 0xC
-struct __anon_0x7FBB3
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-// size: 0x3C
-struct __anon_0x7FC23
-{
-	int bTransformed; // 0x0
-	__anon_0x7FBB3 rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
-
-// size: 0x34
-struct __anon_0x7FE53
-{
-	int bTransformed; // 0x0
-	__anon_0x7FBB3 rS; // 0x4
-	__anon_0x7FBB3 rT; // 0x10
-	__anon_0x7FBB3 rSRaw; // 0x1C
-	__anon_0x7FBB3 rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x7FF3C
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x7FBB3 vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x8009B
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x80138
-{
-	__anon_0x8009B data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x80806
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x80AE8
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x80B6D
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x80AE8 eProjection; // 0x20
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x3D150
-struct __anon_0x80DBD
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x7F9D8 viewport; // 0xB8
-	__anon_0x7FA72 aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x7FC23 aLight[8]; // 0x140
-	__anon_0x7FE53 lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x7FF3C aVertex[80]; // 0x358
-	__anon_0x80138 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x80806 aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x80AE8 eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x80B6D aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-void GenPerspective_1080(_CPU *pCPU)
-{
-	__anon_0x7D2DB data;
-	unsigned int *mf;
-	unsigned int *sp;
-	float fovy;
-	float aspect;
-	float rNear;
-	float rFar;
-	__anon_0x80DBD *pFrame;
-}
-
-void guPerspective(_CPU *pCPU)
-{
-	int *m;
-	float fovy;
-	float aspect;
-	float rNear;
-	float rFar;
-	float scale;
-	float _cot;
-	int i;
-	int j;
-	__anon_0x7D2DB data;
-	float mf[4][4];
-	int e1;
-	int e2;
-	unsigned int *sp;
-	int *ai;
-	int *af;
-}
-
-void guPerspectiveF(_CPU *pCPU)
-{
-	int i;
-	int j;
-	float cot;
-	signed short *perspNorm;
-	unsigned int *mf;
-	unsigned int *sp;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
-	__anon_0x7D2DB data;
-	float fovy;
-	float aspect;
-	float rNear;
-	float rFar;
-	float scale;
-}
-
-void guOrtho(_CPU *pCPU)
-{
-	int *m;
-	int i;
-	int j;
-	int e1;
-	int e2;
-	__anon_0x7D2DB data;
-	float mf[4][4];
-	unsigned int *sp;
-	int *ai;
-	int *af;
-	float l;
-	float r;
-	float b;
-	float t;
-	float n;
-	float f;
-	float scale;
-}
-
-void guOrthoF(_CPU *pCPU)
-{
-	int i;
-	int j;
-	unsigned int *mf;
-	unsigned int *sp;
-	float l;
-	float r;
-	float b;
-	float t;
-	float n;
-	float f;
-	float scale;
-	__anon_0x7D2DB data0;
-	__anon_0x7D2DB data1;
-	__anon_0x7D2DB data;
-}
-
-void guMtxIdent(_CPU *pCPU)
-{
-	int *m;
-}
-
-void guMtxIdentF(_CPU *pCPU)
-{
-	float *mf;
-	int i;
-	int j;
-	__anon_0x7D2DB data1;
-	__anon_0x7D2DB data0;
-}
-
-void guMtxF2L(_CPU *pCPU)
-{
-	float *mf;
-	int e1;
-	int e2;
-	int i;
-	int j;
-	int *m;
-	__anon_0x7D2DB data;
-	int *ai;
-	int *af;
-}
-
-void guMtxCatF(_CPU *pCPU)
-{
-	int i;
-	int j;
-	float temp[4][4];
-	__anon_0x7D2DB data1;
-	__anon_0x7D2DB data2;
-	unsigned int *mf;
-	unsigned int *nf;
-	unsigned int *res;
-}
-
-void osVirtualToPhysical(_CPU *pCPU);
-
-void osPhysicalToVirtual(_CPU *pCPU);
-
-void _memcpy(_CPU *pCPU)
-{
-	int nSize;
-	void *pSource;
-	void *pTarget;
-}
-
-void _bcopy(_CPU *pCPU)
-{
-	int nSize;
-	void *pSource;
-	void *pTarget;
-}
-
-void _bzero(_CPU *pCPU)
-{
-	int nSize;
-	void *pBuffer;
-}
-
-// Local to compilation unit
-static void __sinf(_CPU *pCPU);
-
-// Local to compilation unit
-static void __cosf(_CPU *pCPU);
-
-// Local to compilation unit
-static int __osSpSetStatus(_CPU *pCPU)
-{
-	unsigned int nData32;
-}
-
-// Local to compilation unit
-static int __osRestoreInt(_CPU *pCPU)
-{
-	unsigned long long nStatus;
-}
-
-// Local to compilation unit
-static int __osDisableInt(_CPU *pCPU)
-{
-	unsigned int nStatus;
-	unsigned long long nData64;
-}
-
-// Local to compilation unit
-static int osInvalICache(_CPU *pCPU)
-{
-	unsigned int nAddress;
-	unsigned int nSize;
-}
-
-// Local to compilation unit
-static int osGetMemSize(_CPU *pCPU)
-{
-	unsigned int nSize;
-}
-
-int __ptException();
-
-// Local to compilation unit
-static int __osDispatchThread(_CPU *pCPU)
-{
-	__anon_0x7AE26 *pLibrary;
-	unsigned int nAddress;
-	unsigned long long nData64;
-	__OSThread_s *__osRunningThread;
-	unsigned int nData32;
-	unsigned int __OSGlobalIntMask;
-	unsigned int nStatus;
-	unsigned int nMask;
-	// References: __osRcpImTable (0x1CEB0E80)
-}
-
-// Local to compilation unit
-static int __osPopThread(_CPU *pCPU)
-{
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-}
-
-// Local to compilation unit
-static int __osEnqueueThread(_CPU *pCPU)
-{
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-}
-
-// Local to compilation unit
-static int __osEnqueueAndYield(_CPU *pCPU)
-{
-	signed long long nData64;
-	__anon_0x7AE26 *pLibrary;
-	__OSThread_s *__osRunningThread;
-	unsigned int __OSGlobalIntMask;
-	unsigned int nStatus;
-	unsigned int nData32;
-	unsigned int nMask;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-}
-
-// Local to compilation unit
-static int send_mesg(_CPU *pCPU)
-{
-	__anon_0x7AE26 *pLibrary;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-}
-
-// Local to compilation unit
-static int __osException(_CPU *pCPU)
-{
-	int iBit;
-	__anon_0x7AE26 *pLibrary;
-	signed long long nData64;
-	signed long long nCause;
-	__OSThread_s *__osRunningThread;
-	__anon_0x79A22 **apDevice;
-	unsigned char *aiDevice;
-	unsigned int nStatus;
-	unsigned int nStatusRSP;
-	unsigned int nData32;
-	unsigned int __OSGlobalIntMask;
-	unsigned int nS0;
-	unsigned int nS1;
-	unsigned int nMask;
-}
-

--- a/debug/Fire/library.c
+++ b/debug/Fire/library.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x78CD6; // size = 0x10
 
 // size = 0x10, address = 0x800EEB0C
 struct _XL_OBJECTTYPE gClassLibrary;
@@ -29,17 +29,17 @@ static float dtor$480;
 // size = 0x4, address = 0x80135330
 static u32 nAddress$605;
 
-struct __anon_0x78E87 {
+typedef struct __anon_0x78E87 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x78E87; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x78EED; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -58,9 +58,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x78F60; // size = 0x48
 
-union __anon_0x7923C {
+typedef union __anon_0x7923C {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -91,9 +91,9 @@ union __anon_0x7923C {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x7923C;
 
-struct __anon_0x79A22 {
+typedef struct __anon_0x79A22 {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -107,9 +107,9 @@ struct __anon_0x79A22 {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x79A22; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -124,21 +124,21 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x79CF0; // size = 0x84
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x79F31; // size = 0xC
 
-struct __anon_0x79FE6 {
+typedef struct __anon_0x79FE6 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x79FE6; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -154,9 +154,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x7A111; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -164,9 +164,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x7A368; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -177,9 +177,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x7A483; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -223,18 +223,18 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x7A630; // size = 0x12090
 
-struct __anon_0x7AD10 {
+typedef struct __anon_0x7AD10 {
     /* 0x0 */ char* szName;
     /* 0x4 */ void (*pfLibrary)(struct _CPU*);
     /* 0x8 */ u32 anData[17];
-}; // size = 0x4C
+} __anon_0x7AD10; // size = 0x4C
 
 // size = 0x1008, address = 0x800EEF2C
 struct __anon_0x7AD10 gaFunction[54];
 
-struct __anon_0x7AE26 {
+typedef struct __anon_0x7AE26 {
     /* 0x00 */ s32 nFlag;
     /* 0x04 */ void* pHost;
     /* 0x08 */ s32 nAddStackSwap;
@@ -243,7 +243,7 @@ struct __anon_0x7AE26 {
     /* 0x14 */ struct __anon_0x7AD10* aFunction;
     /* 0x18 */ void* apData[10];
     /* 0x40 */ s32 anAddress[10];
-}; // size = 0x68
+} __anon_0x7AE26; // size = 0x68
 
 // Range: 0x8008F0F4 -> 0x8008F234
 s32 libraryEvent(struct __anon_0x7AE26* pLibrary, s32 nEvent, void* pArgument) {
@@ -395,18 +395,18 @@ s32 osViSwapBuffer_Entry(struct _CPU* pCPU) {
     // -> static u32 nAddress$605;
 }
 
-struct __anon_0x7BB81 {
+typedef struct __anon_0x7BB81 {
     /* 0x0 */ float f_odd;
     /* 0x4 */ float f_even;
-}; // size = 0x8
+} __anon_0x7BB81; // size = 0x8
 
-union __anon_0x7BBDC {
+typedef union __anon_0x7BBDC {
     /* 0x0 */ struct __anon_0x7BB81 f;
     /* 0x0 */ double d;
     /* 0x0 */ s64 u64;
-};
+} __anon_0x7BBDC;
 
-struct __anon_0x7BC50 {
+typedef struct __anon_0x7BC50 {
     /* 0x000 */ u64 at;
     /* 0x008 */ u64 v0;
     /* 0x010 */ u64 v1;
@@ -460,9 +460,9 @@ struct __anon_0x7BC50 {
     /* 0x178 */ union __anon_0x7BBDC fp26;
     /* 0x180 */ union __anon_0x7BBDC fp28;
     /* 0x188 */ union __anon_0x7BBDC fp30;
-}; // size = 0x190
+} __anon_0x7BC50; // size = 0x190
 
-struct __OSThread_s {
+typedef struct __OSThread_s {
     /* 0x00 */ struct __OSThread_s* next;
     /* 0x04 */ s32 priority;
     /* 0x08 */ struct __OSThread_s** queue;
@@ -472,31 +472,31 @@ struct __OSThread_s {
     /* 0x14 */ s32 id;
     /* 0x18 */ s32 fp;
     /* 0x20 */ struct __anon_0x7BC50 context;
-}; // size = 0x1B0
+} __anon_0x7C319; // size = 0x1B0
 
-struct OSMesgQueue_s {
+typedef struct OSMesgQueue_s {
     /* 0x00 */ struct __OSThread_s* mtqueue;
     /* 0x04 */ struct __OSThread_s* fullqueue;
     /* 0x08 */ s32 validCount;
     /* 0x0C */ s32 first;
     /* 0x10 */ s32 msgCount;
     /* 0x14 */ void* msg;
-}; // size = 0x18
+} __anon_0x7C481; // size = 0x18
 
-struct __anon_0x7C589 {
+typedef struct __anon_0x7C589 {
     /* 0x0 */ u16 type;
     /* 0x2 */ u8 pri;
     /* 0x3 */ u8 status;
     /* 0x4 */ struct OSMesgQueue_s* retQueue;
-}; // size = 0x8
+} __anon_0x7C589; // size = 0x8
 
-struct __anon_0x7C62D {
+typedef struct __anon_0x7C62D {
     /* 0x00 */ struct __anon_0x7C589 hdr;
     /* 0x08 */ void* dramAddr;
     /* 0x0C */ u32 devAddr;
     /* 0x10 */ u32 size;
     /* 0x14 */ void* piHandle;
-}; // size = 0x18
+} __anon_0x7C62D; // size = 0x18
 
 // Range: 0x80090B40 -> 0x80090C68
 s32 dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
@@ -620,25 +620,25 @@ s32 osAiSetFrequency(struct _CPU* pCPU) {
     u32 nData32; // r1+0x10
 }
 
-struct __anon_0x7D115 {
+typedef struct __anon_0x7D115 {
     /* 0x0 */ u8 col[3];
     /* 0x3 */ char pad1;
     /* 0x4 */ u8 colc[3];
     /* 0x7 */ char pad2;
     /* 0x8 */ s8 dir[3];
     /* 0xB */ char pad3;
-}; // size = 0xC
+} __anon_0x7D115; // size = 0xC
 
-union __anon_0x7D215 {
+typedef union __anon_0x7D215 {
     /* 0x0 */ struct __anon_0x7D115 l;
     /* 0x0 */ s64 force_structure_alignment[2];
-};
+} __anon_0x7D215;
 
-struct __anon_0x7D2A5 {
+typedef struct __anon_0x7D2A5 {
     /* 0x0 */ union __anon_0x7D215 l[2];
-}; // size = 0x20
+} __anon_0x7D2A5; // size = 0x20
 
-union __anon_0x7D2DB {
+typedef union __anon_0x7D2DB {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -648,7 +648,7 @@ union __anon_0x7D2DB {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x7D2DB;
 
 // Range: 0x80091338 -> 0x8009190C
 void guLookAtReflect(struct _CPU* pCPU) {
@@ -713,17 +713,17 @@ void guLookAtReflectF(struct _CPU* pCPU) {
     float zRight; // f11
 }
 
-struct __anon_0x7DB47 {
+typedef struct __anon_0x7DB47 {
     /* 0x0 */ s32 x1;
     /* 0x4 */ s32 y1;
     /* 0x8 */ s32 x2;
     /* 0xC */ s32 y2;
-}; // size = 0x10
+} __anon_0x7DB47; // size = 0x10
 
-union __anon_0x7DBF9 {
+typedef union __anon_0x7DBF9 {
     /* 0x0 */ struct __anon_0x7DB47 h;
     /* 0x0 */ s32 force_structure_alignment[4];
-};
+} __anon_0x7DBF9;
 
 // Range: 0x80091E60 -> 0x80092834
 void guLookAtHilite(struct _CPU* pCPU) {
@@ -1002,28 +1002,28 @@ void guScaleF(struct _CPU* pCPU) {
     union __anon_0x7D2DB data1; // r1+0x10
 }
 
-struct __anon_0x7F9D8 {
+typedef struct __anon_0x7F9D8 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x7F9D8; // size = 0x10
 
-struct __anon_0x7FA72 {
+typedef struct __anon_0x7FA72 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x7FA72; // size = 0x14
 
-struct __anon_0x7FBB3 {
+typedef struct __anon_0x7FBB3 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x7FBB3; // size = 0xC
 
-struct __anon_0x7FC23 {
+typedef struct __anon_0x7FC23 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x7FBB3 rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -1038,36 +1038,36 @@ struct __anon_0x7FC23 {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x7FC23; // size = 0x3C
 
-struct __anon_0x7FE53 {
+typedef struct __anon_0x7FE53 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x7FBB3 rS;
     /* 0x10 */ struct __anon_0x7FBB3 rT;
     /* 0x1C */ struct __anon_0x7FBB3 rSRaw;
     /* 0x28 */ struct __anon_0x7FBB3 rTRaw;
-}; // size = 0x34
+} __anon_0x7FE53; // size = 0x34
 
-struct __anon_0x7FF3C {
+typedef struct __anon_0x7FF3C {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x7FBB3 vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x7FF3C; // size = 0x1C
 
-union __anon_0x8009B {
+typedef union __anon_0x8009B {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x8009B;
 
-struct __anon_0x80138 {
+typedef struct __anon_0x80138 {
     /* 0x0 */ union __anon_0x8009B data;
-}; // size = 0x1000
+} __anon_0x80138; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -1094,24 +1094,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x801D1;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x80393; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x803FA; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x80440;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -1131,9 +1131,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x804A9; // size = 0x6C
 
-struct __anon_0x80806 {
+typedef struct __anon_0x80806 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -1150,15 +1150,15 @@ struct __anon_0x80806 {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x80806; // size = 0x2C
 
-enum __anon_0x80AE8 {
+typedef enum __anon_0x80AE8 {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x80AE8;
 
-struct __anon_0x80B6D {
+typedef struct __anon_0x80B6D {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -1168,16 +1168,16 @@ struct __anon_0x80B6D {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x80AE8 eProjection;
-}; // size = 0x24
+} __anon_0x80B6D; // size = 0x24
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x80D02; // size = 0x4
 
-struct __anon_0x80DBD {
+typedef struct __anon_0x80DBD {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -1268,7 +1268,7 @@ struct __anon_0x80DBD {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x80DBD; // size = 0x3D150
 
 // Range: 0x800945A8 -> 0x80094658
 void GenPerspective_1080(struct _CPU* pCPU) {

--- a/debug/Fire/mcardGCN.c
+++ b/debug/Fire/mcardGCN.c
@@ -1,811 +1,1130 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\mcardGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80013440 -> 0x8001C444
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
-
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
-
-// Local to compilation unit
-// Location: 0x60D90F80
+// size = 0xA000, address = 0x800FD960
 static char gMCardCardWorkArea[40960];
 
-// Location: 0x60561380
-long currentIdx;
+// size = 0x4, address = 0x80135660
+s32 currentIdx;
 
-// Local to compilation unit
-// Location: 0x64561380
-static int yes$771;
+// size = 0x4, address = 0x80135664
+static s32 yes$771;
 
-// size: 0x4
-enum __anon_0x1A5F0
-{
-	MC_M_NONE = 0,
-	MC_M_LD01 = 1,
-	MC_M_LD02 = 2,
-	MC_M_LD03 = 3,
-	MC_M_LD04 = 4,
-	MC_M_LD05 = 5,
-	MC_M_LD05_2 = 6,
-	MC_M_LD06 = 7,
-	MC_M_LD06_2 = 8,
-	MC_M_LD06_3 = 9,
-	MC_M_LD06_4 = 10,
-	MC_M_LD07 = 11,
-	MC_M_SV01 = 12,
-	MC_M_SV01_2 = 13,
-	MC_M_SV02 = 14,
-	MC_M_SV03 = 15,
-	MC_M_SV04 = 16,
-	MC_M_SV05 = 17,
-	MC_M_SV05_2 = 18,
-	MC_M_SV06 = 19,
-	MC_M_SV06_2 = 20,
-	MC_M_SV06_3 = 21,
-	MC_M_SV06_4 = 22,
-	MC_M_SV06_5 = 23,
-	MC_M_SV07 = 24,
-	MC_M_SV08_L = 25,
-	MC_M_SV08_L_2 = 26,
-	MC_M_SV08 = 27,
-	MC_M_SV08_2 = 28,
-	MC_M_SV10 = 29,
-	MC_M_SV11 = 30,
-	MC_M_SV12 = 31,
-	MC_M_SV_SHARE = 32,
-	MC_M_IN01_L = 33,
-	MC_M_IN01_S = 34,
-	MC_M_IN02 = 35,
-	MC_M_IN03 = 36,
-	MC_M_IN04_L = 37,
-	MC_M_IN04_S = 38,
-	MC_M_IN05 = 39,
-	MC_M_GF01_L = 40,
-	MC_M_GF01_L_2 = 41,
-	MC_M_GF01_S = 42,
-	MC_M_GF01_S_2 = 43,
-	MC_M_GF02 = 44,
-	MC_M_GF03 = 45,
-	MC_M_GF04_L = 46,
-	MC_M_GF04_S = 47,
-	MC_M_GF05 = 48,
-	MC_M_GF06 = 49
+enum __anon_0x1A5F0 {
+    MC_M_NONE = 0,
+    MC_M_LD01 = 1,
+    MC_M_LD02 = 2,
+    MC_M_LD03 = 3,
+    MC_M_LD04 = 4,
+    MC_M_LD05 = 5,
+    MC_M_LD05_2 = 6,
+    MC_M_LD06 = 7,
+    MC_M_LD06_2 = 8,
+    MC_M_LD06_3 = 9,
+    MC_M_LD06_4 = 10,
+    MC_M_LD07 = 11,
+    MC_M_SV01 = 12,
+    MC_M_SV01_2 = 13,
+    MC_M_SV02 = 14,
+    MC_M_SV03 = 15,
+    MC_M_SV04 = 16,
+    MC_M_SV05 = 17,
+    MC_M_SV05_2 = 18,
+    MC_M_SV06 = 19,
+    MC_M_SV06_2 = 20,
+    MC_M_SV06_3 = 21,
+    MC_M_SV06_4 = 22,
+    MC_M_SV06_5 = 23,
+    MC_M_SV07 = 24,
+    MC_M_SV08_L = 25,
+    MC_M_SV08_L_2 = 26,
+    MC_M_SV08 = 27,
+    MC_M_SV08_2 = 28,
+    MC_M_SV10 = 29,
+    MC_M_SV11 = 30,
+    MC_M_SV12 = 31,
+    MC_M_SV_SHARE = 32,
+    MC_M_IN01_L = 33,
+    MC_M_IN01_S = 34,
+    MC_M_IN02 = 35,
+    MC_M_IN03 = 36,
+    MC_M_IN04_L = 37,
+    MC_M_IN04_S = 38,
+    MC_M_IN05 = 39,
+    MC_M_GF01_L = 40,
+    MC_M_GF01_L_2 = 41,
+    MC_M_GF01_S = 42,
+    MC_M_GF01_S_2 = 43,
+    MC_M_GF02 = 44,
+    MC_M_GF03 = 45,
+    MC_M_GF04_L = 46,
+    MC_M_GF04_S = 47,
+    MC_M_GF05 = 48,
+    MC_M_GF06 = 49,
 };
 
-// Local to compilation unit
-// Location: 0x68561380
-static __anon_0x1A5F0 prevMenuEntry$772;
+// size = 0x4, address = 0x80135668
+static enum __anon_0x1A5F0 prevMenuEntry$772;
 
-// Local to compilation unit
-// Location: 0x6C561380
-static __anon_0x1A5F0 nextMenuEntry$773;
+// size = 0x4, address = 0x8013566C
+static enum __anon_0x1A5F0 nextMenuEntry$773;
 
-// Local to compilation unit
-// Location: 0x70561380
-static int toggle2$1029;
+// size = 0x4, address = 0x80135670
+static s32 toggle2$1029;
 
-// Local to compilation unit
-// Location: 0x80134DB8
-static int toggle$1034;
+// size = 0x4, address = 0x80134DB8
+static s32 toggle$1034;
 
-// Local to compilation unit
-// Location: 0x74561380
-static int checkFailCount$1490;
+// size = 0x4, address = 0x80135674
+static s32 checkFailCount$1490;
 
-// size: 0x28
-struct OSCalendarTime
-{
-	int sec; // 0x0
-	int min; // 0x4
-	int hour; // 0x8
-	int mday; // 0xC
-	int mon; // 0x10
-	int year; // 0x14
-	int wday; // 0x18
-	int yday; // 0x1C
-	int msec; // 0x20
-	int usec; // 0x24
+struct OSCalendarTime {
+    /* 0x00 */ s32 sec;
+    /* 0x04 */ s32 min;
+    /* 0x08 */ s32 hour;
+    /* 0x0C */ s32 mday;
+    /* 0x10 */ s32 mon;
+    /* 0x14 */ s32 year;
+    /* 0x18 */ s32 wday;
+    /* 0x1C */ s32 yday;
+    /* 0x20 */ s32 msec;
+    /* 0x24 */ s32 usec;
+}; // size = 0x28
+
+// size = 0x28, address = 0x80107960
+struct OSCalendarTime gDate;
+
+// size = 0x4, address = 0x80135678
+s32 bWrite2Card;
+
+// size = 0x28, address = 0x80107988
+s32 bNoWriteInCurrentFrame[10];
+
+struct __anon_0x1AC1A {
+    /* 0x00 */ s32 configuration;
+    /* 0x04 */ s32 size;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ char* buffer;
+    /* 0x10 */ s32* writtenBlocks;
+    /* 0x14 */ s32 writtenConfig;
+}; // size = 0x18
+
+struct CARDFileInfo {
+    /* 0x00 */ s32 chan;
+    /* 0x04 */ s32 fileNo;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ s32 length;
+    /* 0x10 */ u16 iBlock;
+    /* 0x12 */ u16 __padding;
+}; // size = 0x14
+
+struct __anon_0x1AEB5 {
+    /* 0x000 */ s32 currentGame;
+    /* 0x004 */ s32 fileSize;
+    /* 0x008 */ char name[33];
+    /* 0x02C */ s32 numberOfGames;
+    /* 0x030 */ struct __anon_0x1AC1A game;
+    /* 0x048 */ s32 changedDate;
+    /* 0x04C */ s32 changedChecksum;
+    /* 0x050 */ s32 gameSize[16];
+    /* 0x090 */ s32 gameOffset[16];
+    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x110 */ char gameName[16][33];
+    /* 0x320 */ struct OSCalendarTime time;
+    /* 0x348 */ struct CARDFileInfo fileInfo;
+}; // size = 0x35C
+
+enum __anon_0x1B0CB {
+    MC_E_NONE = 0,
+    MC_E_BUSY = 1,
+    MC_E_WRONGDEVICE = 2,
+    MC_E_NOCARD = 3,
+    MC_E_NOFILE = 4,
+    MC_E_IOERROR = 5,
+    MC_E_BROKEN = 6,
+    MC_E_EXIST = 7,
+    MC_E_NOENT = 8,
+    MC_E_INSSPACE = 9,
+    MC_E_NOPERM = 10,
+    MC_E_LIMIT = 11,
+    MC_E_NAMETOOLONG = 12,
+    MC_E_ENCODING = 13,
+    MC_E_CANCELED = 14,
+    MC_E_FATAL = 15,
+    MC_E_SECTOR_SIZE_INVALID = 16,
+    MC_E_GAME_NOT_FOUND = 17,
+    MC_E_CHECKSUM = 18,
+    MC_E_NO_FREE_SPACE = 19,
+    MC_E_NO_FREE_FILES = 20,
+    MC_E_FILE_EXISTS = 21,
+    MC_E_GAME_EXISTS = 22,
+    MC_E_TIME_WRONG = 23,
+    MC_E_WRITE_CORRUPTED = 24,
+    MC_E_UNKNOWN = 25,
 };
 
-// Location: 0x60791080
-OSCalendarTime gDate;
+struct _MCARD {
+    /* 0x000 */ struct __anon_0x1AEB5 file;
+    /* 0x35C */ enum __anon_0x1B0CB error;
+    /* 0x360 */ s32 slot;
+    /* 0x364 */ s32 (*pPollFunction)();
+    /* 0x368 */ s32 pollPrevBytes;
+    /* 0x36C */ s32 pollSize;
+    /* 0x370 */ char pollMessage[256];
+    /* 0x470 */ s32 saveToggle;
+    /* 0x474 */ char* writeBuffer;
+    /* 0x478 */ char* readBuffer;
+    /* 0x47C */ s32 writeToggle;
+    /* 0x480 */ s32 soundToggle;
+    /* 0x484 */ s32 writeStatus;
+    /* 0x488 */ s32 writeIndex;
+    /* 0x48C */ s32 accessType;
+    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x494 */ char saveFileName[256];
+    /* 0x594 */ char saveComment[256];
+    /* 0x694 */ char* saveIcon;
+    /* 0x698 */ char* saveBanner;
+    /* 0x69C */ char saveGameName[256];
+    /* 0x79C */ s32 saveFileSize;
+    /* 0x7A0 */ s32 saveGameSize;
+    /* 0x7A4 */ s32 bufferCreated;
+    /* 0x7A8 */ s32 cardSize;
+    /* 0x7AC */ s32 wait;
+    /* 0x7B0 */ s32 isBroken;
+    /* 0x7B4 */ s32 saveConfiguration;
+}; // size = 0x7B8
 
-// Location: 0x78561380
-long bWrite2Card;
+// size = 0x7B8, address = 0x801079B0
+struct _MCARD mCard;
 
-// Location: 0x80107988
-long bNoWriteInCurrentFrame[10];
-
-// size: 0x18
-struct __anon_0x1AC1A
-{
-	int configuration; // 0x0
-	int size; // 0x4
-	int offset; // 0x8
-	char *buffer; // 0xC
-	int *writtenBlocks; // 0x10
-	int writtenConfig; // 0x14
+enum __anon_0x1B813 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// size: 0x14
-struct CARDFileInfo
-{
-	long chan; // 0x0
-	long fileNo; // 0x4
-	long offset; // 0x8
-	long length; // 0xC
-	unsigned short iBlock; // 0x10
-	unsigned short __padding; // 0x12
+struct __anon_0x1B87B {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x1B92C {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x35C
-struct __anon_0x1AEB5
-{
-	int currentGame; // 0x0
-	int fileSize; // 0x4
-	char name[33]; // 0x8
-	int numberOfGames; // 0x2C
-	__anon_0x1AC1A game; // 0x30
-	int changedDate; // 0x48
-	int changedChecksum; // 0x4C
-	int gameSize[16]; // 0x50
-	int gameOffset[16]; // 0x90
-	int gameConfigIndex[16]; // 0xD0
-	char gameName[16][33]; // 0x110
-	OSCalendarTime time; // 0x320
-	CARDFileInfo fileInfo; // 0x348
+enum __anon_0x1BA5D {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum __anon_0x1B0CB
-{
-	MC_E_NONE = 0,
-	MC_E_BUSY = 1,
-	MC_E_WRONGDEVICE = 2,
-	MC_E_NOCARD = 3,
-	MC_E_NOFILE = 4,
-	MC_E_IOERROR = 5,
-	MC_E_BROKEN = 6,
-	MC_E_EXIST = 7,
-	MC_E_NOENT = 8,
-	MC_E_INSSPACE = 9,
-	MC_E_NOPERM = 10,
-	MC_E_LIMIT = 11,
-	MC_E_NAMETOOLONG = 12,
-	MC_E_ENCODING = 13,
-	MC_E_CANCELED = 14,
-	MC_E_FATAL = 15,
-	MC_E_SECTOR_SIZE_INVALID = 16,
-	MC_E_GAME_NOT_FOUND = 17,
-	MC_E_CHECKSUM = 18,
-	MC_E_NO_FREE_SPACE = 19,
-	MC_E_NO_FREE_FILES = 20,
-	MC_E_FILE_EXISTS = 21,
-	MC_E_GAME_EXISTS = 22,
-	MC_E_TIME_WRONG = 23,
-	MC_E_WRITE_CORRUPTED = 24,
-	MC_E_UNKNOWN = 25
+struct __anon_0x1BB9D {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x1B813 eMode;
+    /* 0x10 */ struct __anon_0x1B87B romCopy;
+    /* 0x20 */ enum __anon_0x1B92C eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x1BA5D storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x1BB9D* gpSystem;
+
+enum __anon_0x1BD8E {
+    MC_C_NONE = 0,
+    MC_C_CONTINUE = 1,
+    MC_C_IPL = 2,
+    MC_C_GO_TO_GAME = 3,
+    MC_C_CREATE_GAME = 4,
+    MC_C_DELETE_GAME = 5,
+    MC_C_FORMAT_CARD = 6,
 };
 
-// size: 0x7B8
-struct _MCARD
-{
-	__anon_0x1AEB5 file; // 0x0
-	__anon_0x1B0CB error; // 0x35C
-	int slot; // 0x360
-	int (*pPollFunction)(); // 0x364
-	int pollPrevBytes; // 0x368
-	int pollSize; // 0x36C
-	char pollMessage[256]; // 0x370
-	int saveToggle; // 0x470
-	char *writeBuffer; // 0x474
-	char *readBuffer; // 0x478
-	int writeToggle; // 0x47C
-	int soundToggle; // 0x480
-	int writeStatus; // 0x484
-	int writeIndex; // 0x488
-	int accessType; // 0x48C
-	int gameIsLoaded; // 0x490
-	char saveFileName[256]; // 0x494
-	char saveComment[256]; // 0x594
-	char *saveIcon; // 0x694
-	char *saveBanner; // 0x698
-	char saveGameName[256]; // 0x69C
-	int saveFileSize; // 0x79C
-	int saveGameSize; // 0x7A0
-	int bufferCreated; // 0x7A4
-	int cardSize; // 0x7A8
-	int wait; // 0x7AC
-	int isBroken; // 0x7B0
-	int saveConfiguration; // 0x7B4
+// Range: 0x80013440 -> 0x800136F4
+s32 mcardUpdate() {
+    // Local variables
+    s32 j; // r5
+    s32 i; // r5
+    s32 toggle; // r25
+    enum __anon_0x1BD8E command; // r1+0x8
+    s32 prevIndex; // r24
+    s32 index; // r23
+    s32 counter; // r22
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> s32 bWrite2Card;
+    // -> struct __anon_0x1BB9D* gpSystem;
+}
+
+// Range: 0x800136F4 -> 0x800145FC
+s32 mcardStore(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 i; // r30
+    s32 checksum; // r1+0x4DC
+    s32 bufferOffset; // r4
+    enum __anon_0x1BD8E command; // r1+0x4C8
+
+    // References
+    // -> static s32 checkFailCount$1490;
+    // -> struct _MCARD mCard;
+    // -> struct OSCalendarTime gDate;
+}
+
+// size = 0x4, address = 0x801355D4
+s32 gButtonDownToggle;
+
+// Range: 0x800145FC -> 0x8001514C
+s32 mcardOpenDuringGame(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    s32 i; // r28
+    enum __anon_0x1BD8E command; // r1+0x18
+    s32 loadToggle; // r27
+
+    // References
+    // -> s32 gButtonDownToggle;
+}
+
+// Range: 0x8001514C -> 0x80016950
+s32 mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
+              s32* defaultConfiguration, s32 fileSize, s32 gameSize) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* fileName; // r28
+    // char* comment; // r25
+    // char* icon; // r23
+    // char* banner; // r22
+    // char* gameName; // r29
+    // s32* defaultConfiguration; // r21
+    // s32 fileSize; // r26
+    // s32 gameSize; // r30
+
+    // Local variables
+    s32 i; // r19
+    enum __anon_0x1BD8E command; // r1+0x34
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+    // -> s32 gButtonDownToggle;
+}
+
+// Erased
+static s32 mcardCheckSpace(struct _MCARD* pMCard, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 size; // r31
+
+    // Local variables
+    s32 freeBytes; // r1+0x18
+    s32 freeFiles; // r1+0x14
+}
+
+// Erased
+static s32 mcardGetError(struct _MCARD* pMCard, enum __anon_0x1B0CB* pMCardError) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // enum __anon_0x1B0CB* pMCardError; // r1+0x4
+}
+
+// Range: 0x80016950 -> 0x80016CB0
+s32 mcardWrite(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 address; // r29
+    // s32 size; // r30
+    // char* data; // r31
+
+    // Local variables
+    s32 i; // r1+0x8
+    char testByte; // r25
+
+    // References
+    // -> static s32 toggle2$1029;
+    // -> static s32 toggle$1034;
+    // -> struct __anon_0x1BB9D* gpSystem;
+    // -> s32 currentIdx;
+    // -> s32 bNoWriteInCurrentFrame[10];
+    // -> s32 bWrite2Card;
+}
+
+// Erased
+static s32 corruptionCheck(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r23
+
+    // Local variables
+    char* buffer; // r1+0x4AC
+    s32 checksum1; // r1+0x4A8
+    s32 checksum2; // r26
+    s32 i; // r25
+    s32 toggle; // r24
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80016CB0 -> 0x80016D90
+s32 mcardOpenDuringGameError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // enum __anon_0x1BD8E* pCommand; // r4
+}
+
+// Range: 0x80016D90 -> 0x80016E70
+s32 mcardOpenError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // enum __anon_0x1BD8E* pCommand; // r4
+}
+
+// Range: 0x80016E70 -> 0x80017814
+s32 mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // enum __anon_0x1A5F0 menuEntry; // r4
+    // enum __anon_0x1BD8E* pCommand; // r30
+
+    // References
+    // -> static enum __anon_0x1A5F0 nextMenuEntry$773;
+    // -> static s32 yes$771;
+    // -> static enum __anon_0x1A5F0 prevMenuEntry$772;
+}
+
+// Range: 0x80017814 -> 0x80017844
+s32 mcardRead(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // s32 address; // r4
+    // s32 size; // r5
+    // char* data; // r6
+}
+
+// Range: 0x80017844 -> 0x800178EC
+s32 mcardGameRelease(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Erased
+static s32 mcardFileRelease(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x800178EC -> 0x80017A94
+s32 mcardGameErase(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 index; // r30
+}
+
+// Range: 0x80017A94 -> 0x80017C24
+s32 mcardFileErase(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x80017C24 -> 0x80017D60
+s32 mcardCardErase(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 slot; // r30
+}
+
+// Erased
+static s32 mcardGameCreateDuringGame(struct _MCARD* pMCard, char* name, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r25
+    // char* name; // r29
+    // s32 size; // r24
+
+    // Local variables
+    s32 i; // r26
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80017D60 -> 0x800185F8
+s32 mcardGameCreate(struct _MCARD* pMCard, char* name, s32 defaultConfiguration, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r25
+    // char* name; // r30
+    // s32 defaultConfiguration; // r29
+    // s32 size; // r27
+
+    // Local variables
+    s32 i; // r26
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+struct CARDStat {
+    /* 0x00 */ char fileName[32];
+    /* 0x20 */ u32 length;
+    /* 0x24 */ u32 time;
+    /* 0x28 */ u8 gameName[4];
+    /* 0x2C */ u8 company[2];
+    /* 0x2E */ u8 bannerFormat;
+    /* 0x2F */ u8 __padding;
+    /* 0x30 */ u32 iconAddr;
+    /* 0x34 */ u16 iconFormat;
+    /* 0x36 */ u16 iconSpeed;
+    /* 0x38 */ u32 commentAddr;
+    /* 0x3C */ u32 offsetBanner;
+    /* 0x40 */ u32 offsetBannerTlut;
+    /* 0x44 */ u32 offsetIcon[8];
+    /* 0x64 */ u32 offsetIconTlut;
+    /* 0x68 */ u32 offsetData;
+}; // size = 0x6C
+
+// Range: 0x800185F8 -> 0x80018C50
+s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* name; // r21
+    // char* comment; // r25
+    // char* icon; // r27
+    // char* banner; // r26
+    // s32 size; // r1+0x1C
+
+    // Local variables
+    s32 freeBytes; // r1+0x104
+    s32 freeFiles; // r1+0x100
+    s32 totalSize; // r30
+    s32 i; // r21
+    char* buffer; // r1+0xFC
+    struct _GXTexObj texObj; // r1+0xDC
+    void* dataP; // r4
+    struct CARDStat cardStatus; // r1+0x70
+    s32 fileNo; // r21
+    struct OSCalendarTime date; // r1+0x48
+    char dateString[32]; // r1+0x28
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80018C50 -> 0x80019058
+s32 mcardGameSet(struct _MCARD* pMCard, char* name) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* name; // r28
+
+    // Local variables
+    s32 i; // r29
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+}
+
+// Erased
+static s32 mcardGameSetNoSave(struct _MCARD* pMCard, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 size; // r31
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+}
+
+// Range: 0x80019058 -> 0x8001947C
+s32 mcardFileSet(struct _MCARD* pMCard, char* name) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* name; // r4
+
+    // Local variables
+    s32 i; // r7
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001947C -> 0x800194D8
+s32 mcardInit(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Range: 0x800194D8 -> 0x80019670
+s32 mcardReInit(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x80019670 -> 0x800196D8
+s32 mcardWriteGameDataReset(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteGameDataWait(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r24
+
+    // Local variables
+    s32 checksum; // r1+0x258
+    s32 i; // r25
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteGameData(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // s32 offset; // r4
+}
+
+// Range: 0x800196D8 -> 0x80019A70
+s32 mcardReadGameData(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r23
+
+    // Local variables
+    s32 checksum1; // r1+0x260
+    s32 checksum2; // r26
+    s32 i; // r25
+    s32 toggle; // r24
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardReplaceBlock(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r27
+    // s32 index; // r28
+
+    // Local variables
+    s32 checksum1; // r1+0x4A4
+    s32 checksum2; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019A70 -> 0x80019C74
+static s32 mcardWriteTimeAsynch(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct OSCalendarTime gDate;
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    char dateString[32]; // r1+0x4A4
+    s32 checksum; // r1+0x4A0
+
+    // References
+    // -> struct OSCalendarTime gDate;
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019C74 -> 0x80019E38
+static s32 mcardWriteConfigAsynch(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteConfigPrepareWriteBuffer(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 checksum; // r1+0x4A0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019E38 -> 0x80019FDC
+static s32 mcardReadBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 offset; // r27
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019FDC -> 0x8001A1C0
+static s32 mcardWriteBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // s32 offset; // r30
+
+    // Local variables
+    struct OSCalendarTime date; // r1+0x258
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // char* cardHeader; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0x4A0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* cardHeader; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x258
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A1C0 -> 0x8001A3E4
+static s32 mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A3E4 -> 0x8001A53C
+static s32 mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A53C -> 0x8001A8F8
+static s32 mcardWriteFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0x49C
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A8F8 -> 0x8001AB1C
+static s32 mcardReadFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x254
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001AB1C -> 0x8001ACC8
+static s32 mcardWriteAnywherePartial(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer, s32 partialOffset,
+                                     s32 totalSize) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 offset; // r25
+    // s32 size; // r26
+    // char* buffer; // r27
+    // s32 partialOffset; // r28
+    // s32 totalSize; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001ACC8 -> 0x8001AE64
+static s32 mcardWriteAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 offset; // r27
+    // s32 size; // r28
+    // char* buffer; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001AE64 -> 0x8001AFD4
+static s32 mcardReadAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r27
+    // s32 offset; // r28
+    // s32 size; // r29
+    // char* buffer; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardTimeCheck(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    struct OSCalendarTime time; // r1+0x22C
+}
+
+// Erased
+static s32 mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // struct OSCalendarTime* time; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 offset; // r29
+    // s32 size; // r30
+    // char* buffer; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardReadAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // s32 offset; // r3
+    // s32 size; // r30
+    // char* buffer; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardFinishFile(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Erased
+static s32 mcardReadyFile(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Erased
+static s32 mcardFinishCard(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+}
+
+// Range: 0x8001AFD4 -> 0x8001B168
+static s32 mcardReadyCard(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    s32 i; // r31
+    s32 sectorSize; // r1+0xC
+
+    // References
+    // -> static char gMCardCardWorkArea[40960];
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B168 -> 0x8001B254
+static s32 mcardPoll(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardCopyName(char* name1, char* name2) {
+    // Parameters
+    // char* name1; // r4
+    // char* name2; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardCompareName(char* name1, char* name2) {
+    // Parameters
+    // char* name1; // r4
+    // char* name2; // r5
+}
+
+// Range: 0x8001B254 -> 0x8001B480
+static s32 mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char* buffer; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B480 -> 0x8001B794
+static s32 mcardCheckChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // char* buffer; // r27
+
+    // Local variables
+    s32 checksum; // r31
+    char buffer2[8192]; // r1+0x18
+    s32 toggle; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B794 -> 0x8001BC14
+static s32 mcardReplaceFileBlock(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 index; // r29
+
+    // Local variables
+    s32 checksum1; // r1+0x2238
+    s32 checksum2; // r30
+    char buffer[8192]; // r1+0x238
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // struct OSCalendarTime* time; // r30
+
+    // Local variables
+    char buffer[544]; // r1+0x10
+}
+
+// Range: 0x8001BC14 -> 0x8001BF70
+static s32 mcardSaveChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* buffer; // r31
+
+    // Local variables
+    char buffer2[8192]; // r1+0x1C
+    s32 checksum; // r1+0x18
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001BF70 -> 0x8001C0D8
+static s32 mcardCalculateChecksumFileBlock2(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r8
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001C0D8 -> 0x8001C240
+static s32 mcardCalculateChecksumFileBlock1(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r8
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001C240 -> 0x8001C2A0
+static s32 mcardCalculateChecksum(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r1+0x0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001C2A0 -> 0x8001C444
+static s32 mcardGCErrorHandler(struct _MCARD* pMCard, s32 gcError) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32 gcError; // r1+0x4
+}
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// Location: 0x801079B0
-_MCARD mCard;
-
-// size: 0x4
-enum __anon_0x1B813
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
+enum _GXTexFilter {
+    GX_NEAR = 0,
+    GX_LINEAR = 1,
+    GX_NEAR_MIP_NEAR = 2,
+    GX_LIN_MIP_NEAR = 3,
+    GX_NEAR_MIP_LIN = 4,
+    GX_LIN_MIP_LIN = 5,
 };
 
-// size: 0x10
-struct __anon_0x1B87B
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+struct __anon_0x1F23C {
+    /* 0x00 */ u16 height;
+    /* 0x02 */ u16 width;
+    /* 0x04 */ u32 format;
+    /* 0x08 */ char* data;
+    /* 0x0C */ enum _GXTexWrapMode wrapS;
+    /* 0x10 */ enum _GXTexWrapMode wrapT;
+    /* 0x14 */ enum _GXTexFilter minFilter;
+    /* 0x18 */ enum _GXTexFilter magFilter;
+    /* 0x1C */ float LODBias;
+    /* 0x20 */ u8 edgeLODEnable;
+    /* 0x21 */ u8 minLOD;
+    /* 0x22 */ u8 maxLOD;
+    /* 0x23 */ u8 unpacked;
+}; // size = 0x24
+
+enum _GXTlutFmt {
+    GX_TL_IA8 = 0,
+    GX_TL_RGB565 = 1,
+    GX_TL_RGB5A3 = 2,
+    GX_MAX_TLUTFMT = 3,
 };
 
-// size: 0x4
-enum __anon_0x1B92C
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
+struct __anon_0x1F497 {
+    /* 0x0 */ u16 numEntries;
+    /* 0x2 */ u8 unpacked;
+    /* 0x3 */ u8 pad8;
+    /* 0x4 */ enum _GXTlutFmt format;
+    /* 0x8 */ char* data;
+}; // size = 0xC
 
-// size: 0x4
-enum __anon_0x1BA5D
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
+struct __anon_0x1F563 {
+    /* 0x0 */ struct __anon_0x1F23C* textureHeader;
+    /* 0x4 */ struct __anon_0x1F497* CLUTHeader;
+}; // size = 0x8
 
-// size: 0x88
-struct __anon_0x1BB9D
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x1B813 eMode; // 0xC
-	__anon_0x1B87B romCopy; // 0x10
-	__anon_0x1B92C eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x1BA5D storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
+struct __anon_0x1F5D4 {
+    /* 0x0 */ u32 versionNumber;
+    /* 0x4 */ u32 numDescriptors;
+    /* 0x8 */ struct __anon_0x1F563* descriptorArray;
+}; // size = 0xC
 
-// Location: 0x561380
-__anon_0x1BB9D *gpSystem;
+// Erased
+static void mcardUnpackTexPalette(struct __anon_0x1F5D4* pal) {
+    // Parameters
+    // struct __anon_0x1F5D4* pal; // r1+0x0
 
-// size: 0x4
-enum __anon_0x1BD8E
-{
-	MC_C_NONE = 0,
-	MC_C_CONTINUE = 1,
-	MC_C_IPL = 2,
-	MC_C_GO_TO_GAME = 3,
-	MC_C_CREATE_GAME = 4,
-	MC_C_DELETE_GAME = 5,
-	MC_C_FORMAT_CARD = 6
-};
-
-int mcardUpdate()
-{
-	int j;
-	int i;
-	int toggle;
-	__anon_0x1BD8E command;
-	int prevIndex;
-	int index;
-	int counter;
-	// References: mCard (0x801079B0)
-	// References: bWrite2Card (0x78561380)
-	// References: gpSystem (0x561380)
+    // Local variables
+    u16 i; // r4
 }
-
-int mcardStore(_MCARD *pMCard)
-{
-	int i;
-	int checksum;
-	int bufferOffset;
-	__anon_0x1BD8E command;
-	// References: checkFailCount$1490 (0x74561380)
-	// References: mCard (0x801079B0)
-	// References: gDate (0x60791080)
-}
-
-// Location: 0x801355D4
-int gButtonDownToggle;
-
-int mcardOpenDuringGame(_MCARD *pMCard)
-{
-	int i;
-	__anon_0x1BD8E command;
-	int loadToggle;
-	// References: gButtonDownToggle (0x801355D4)
-}
-
-int mcardOpen(_MCARD *pMCard, char *fileName, char *comment, char *icon, char *banner, char *gameName, int *defaultConfiguration, int fileSize, int gameSize)
-{
-	int i;
-	__anon_0x1BD8E command;
-	// References: gpSystem (0x561380)
-	// References: gButtonDownToggle (0x801355D4)
-}
-
-int mcardCheckSpace(_MCARD *pMCard, int size)
-{
-	int freeBytes;
-	int freeFiles;
-}
-
-int mcardGetError(_MCARD *pMCard, __anon_0x1B0CB *pMCardError);
-
-int mcardWrite(_MCARD *pMCard, int address, int size, char *data)
-{
-	int i;
-	char testByte;
-	// References: toggle2$1029 (0x70561380)
-	// References: toggle$1034 (0x80134DB8)
-	// References: gpSystem (0x561380)
-	// References: currentIdx (0x60561380)
-	// References: bNoWriteInCurrentFrame (0x80107988)
-	// References: bWrite2Card (0x78561380)
-}
-
-int corruptionCheck(_MCARD *pMCard)
-{
-	char *buffer;
-	int checksum1;
-	int checksum2;
-	int i;
-	int toggle;
-	// References: mCard (0x801079B0)
-}
-
-int mcardOpenDuringGameError(_MCARD *pMCard, __anon_0x1BD8E *pCommand);
-
-int mcardOpenError(_MCARD *pMCard, __anon_0x1BD8E *pCommand);
-
-int mcardMenu(_MCARD *pMCard, __anon_0x1A5F0 menuEntry, __anon_0x1BD8E *pCommand)
-{
-	// References: nextMenuEntry$773 (0x6C561380)
-	// References: yes$771 (0x64561380)
-	// References: prevMenuEntry$772 (0x68561380)
-}
-
-int mcardRead(_MCARD *pMCard, int address, int size, char *data);
-
-int mcardGameRelease(_MCARD *pMCard);
-
-int mcardFileRelease(_MCARD *pMCard);
-
-int mcardGameErase(_MCARD *pMCard, int index);
-
-int mcardFileErase(_MCARD *pMCard);
-
-int mcardCardErase(_MCARD *pMCard)
-{
-	int slot;
-}
-
-int mcardGameCreateDuringGame(_MCARD *pMCard, char *name, int size)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-int mcardGameCreate(_MCARD *pMCard, char *name, int defaultConfiguration, int size)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x6C
-struct CARDStat
-{
-	char fileName[32]; // 0x0
-	unsigned long length; // 0x20
-	unsigned long time; // 0x24
-	unsigned char gameName[4]; // 0x28
-	unsigned char company[2]; // 0x2C
-	unsigned char bannerFormat; // 0x2E
-	unsigned char __padding; // 0x2F
-	unsigned long iconAddr; // 0x30
-	unsigned short iconFormat; // 0x34
-	unsigned short iconSpeed; // 0x36
-	unsigned long commentAddr; // 0x38
-	unsigned long offsetBanner; // 0x3C
-	unsigned long offsetBannerTlut; // 0x40
-	unsigned long offsetIcon[8]; // 0x44
-	unsigned long offsetIconTlut; // 0x64
-	unsigned long offsetData; // 0x68
-};
-
-int mcardFileCreate(_MCARD *pMCard, char *name, char *comment, char *icon, char *banner, int size)
-{
-	int freeBytes;
-	int freeFiles;
-	int totalSize;
-	int i;
-	char *buffer;
-	_GXTexObj texObj;
-	void *dataP;
-	CARDStat cardStatus;
-	int fileNo;
-	OSCalendarTime date;
-	char dateString[32];
-	// References: mCard (0x801079B0)
-}
-
-int mcardGameSet(_MCARD *pMCard, char *name)
-{
-	int i;
-	// References: gpSystem (0x561380)
-}
-
-int mcardGameSetNoSave(_MCARD *pMCard, int size)
-{
-	// References: gpSystem (0x561380)
-}
-
-int mcardFileSet(_MCARD *pMCard, char *name)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-int mcardInit(_MCARD *pMCard);
-
-int mcardReInit(_MCARD *pMCard);
-
-int mcardWriteGameDataReset(_MCARD *pMCard)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteGameDataWait(_MCARD *pMCard)
-{
-	int checksum;
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteGameData(_MCARD *pMCard, int offset);
-
-int mcardReadGameData(_MCARD *pMCard)
-{
-	int checksum1;
-	int checksum2;
-	int i;
-	int toggle;
-	// References: mCard (0x801079B0)
-}
-
-int mcardReplaceBlock(_MCARD *pMCard, int index)
-{
-	int checksum1;
-	int checksum2;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteTimeAsynch(_MCARD *pMCard)
-{
-	// References: gDate (0x60791080)
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteTimePrepareWriteBuffer(_MCARD *pMCard)
-{
-	char dateString[32];
-	int checksum;
-	// References: gDate (0x60791080)
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteConfigAsynch(_MCARD *pMCard)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteConfigPrepareWriteBuffer(_MCARD *pMCard)
-{
-	int checksum;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardReadBufferAsynch(_MCARD *pMCard, int offset)
-{
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteBufferAsynch(_MCARD *pMCard, int offset)
-{
-	OSCalendarTime date;
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteCardHeader(_MCARD *pMCard, char *cardHeader)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-int mcardReadCardHeader(_MCARD *pMCard, char *cardHeader)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteFileHeaderInitial(_MCARD *pMCard)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardReadFileHeaderInitial(_MCARD *pMCard)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteFileHeader(_MCARD *pMCard)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardReadFileHeader(_MCARD *pMCard)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteAnywherePartial(_MCARD *pMCard, int offset, int size, char *buffer, int partialOffset, int totalSize)
-{
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardWriteAnywhere(_MCARD *pMCard, int offset, int size, char *buffer)
-{
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardReadAnywhere(_MCARD *pMCard, int offset, int size, char *buffer)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardTimeCheck(_MCARD *pMCard)
-{
-	OSCalendarTime time;
-}
-
-int mcardSetFileTime(_MCARD *pMCard, OSCalendarTime *time)
-{
-	char buffer[24608];
-	// References: mCard (0x801079B0)
-}
-
-int mcardWriteAnywhereNoTime(_MCARD *pMCard, int offset, int size, char *buffer)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardReadAnywhereNoTime(_MCARD *pMCard, int offset, int size, char *buffer)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardFinishFile(_MCARD *pMCard);
-
-int mcardReadyFile(_MCARD *pMCard);
-
-int mcardFinishCard(_MCARD *pMCard);
-
-// Local to compilation unit
-static int mcardReadyCard(_MCARD *pMCard)
-{
-	int i;
-	int sectorSize;
-	// References: gMCardCardWorkArea (0x60D90F80)
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardPoll(_MCARD *pMCard)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardCopyName(char *name1, char *name2)
-{
-	// References: mCard (0x801079B0)
-}
-
-int mcardCompareName(char *name1, char *name2);
-
-// Local to compilation unit
-static int mcardVerifyChecksumFileHeader(_MCARD *pMCard)
-{
-	char *buffer;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardCheckChecksumFileHeader(_MCARD *pMCard, char *buffer)
-{
-	int checksum;
-	char buffer2[8192];
-	int toggle;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardReplaceFileBlock(_MCARD *pMCard, int index)
-{
-	int checksum1;
-	int checksum2;
-	char buffer[8192];
-	// References: mCard (0x801079B0)
-}
-
-int mcardGetFileTime(_MCARD *pMCard, OSCalendarTime *time)
-{
-	char buffer[544];
-}
-
-// Local to compilation unit
-static int mcardSaveChecksumFileHeader(_MCARD *pMCard, char *buffer)
-{
-	char buffer2[8192];
-	int checksum;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardCalculateChecksumFileBlock2(_MCARD *pMCard, int *checksum)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardCalculateChecksumFileBlock1(_MCARD *pMCard, int *checksum)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardCalculateChecksum(_MCARD *pMCard, int *checksum)
-{
-	int i;
-	// References: mCard (0x801079B0)
-}
-
-// Local to compilation unit
-static int mcardGCErrorHandler(_MCARD *pMCard, int gcError);
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x4
-enum _GXTexFilter
-{
-	GX_NEAR = 0,
-	GX_LINEAR = 1,
-	GX_NEAR_MIP_NEAR = 2,
-	GX_LIN_MIP_NEAR = 3,
-	GX_NEAR_MIP_LIN = 4,
-	GX_LIN_MIP_LIN = 5
-};
-
-// size: 0x24
-struct __anon_0x1F23C
-{
-	unsigned short height; // 0x0
-	unsigned short width; // 0x2
-	unsigned long format; // 0x4
-	char *data; // 0x8
-	_GXTexWrapMode wrapS; // 0xC
-	_GXTexWrapMode wrapT; // 0x10
-	_GXTexFilter minFilter; // 0x14
-	_GXTexFilter magFilter; // 0x18
-	float LODBias; // 0x1C
-	unsigned char edgeLODEnable; // 0x20
-	unsigned char minLOD; // 0x21
-	unsigned char maxLOD; // 0x22
-	unsigned char unpacked; // 0x23
-};
-
-// size: 0x4
-enum _GXTlutFmt
-{
-	GX_TL_IA8 = 0,
-	GX_TL_RGB565 = 1,
-	GX_TL_RGB5A3 = 2,
-	GX_MAX_TLUTFMT = 3
-};
-
-// size: 0xC
-struct __anon_0x1F497
-{
-	unsigned short numEntries; // 0x0
-	unsigned char unpacked; // 0x2
-	unsigned char pad8; // 0x3
-	_GXTlutFmt format; // 0x4
-	char *data; // 0x8
-};
-
-// size: 0x8
-struct __anon_0x1F563
-{
-	__anon_0x1F23C *textureHeader; // 0x0
-	__anon_0x1F497 *CLUTHeader; // 0x4
-};
-
-// size: 0xC
-struct __anon_0x1F5D4
-{
-	unsigned long versionNumber; // 0x0
-	unsigned long numDescriptors; // 0x4
-	__anon_0x1F563 *descriptorArray; // 0x8
-};
-
-void mcardUnpackTexPalette(__anon_0x1F5D4 *pal)
-{
-	unsigned short i;
-}
-

--- a/debug/Fire/mcardGCN.c
+++ b/debug/Fire/mcardGCN.c
@@ -16,7 +16,7 @@ s32 currentIdx;
 // size = 0x4, address = 0x80135664
 static s32 yes$771;
 
-enum __anon_0x1A5F0 {
+typedef enum __anon_0x1A5F0 {
     MC_M_NONE = 0,
     MC_M_LD01 = 1,
     MC_M_LD02 = 2,
@@ -67,7 +67,7 @@ enum __anon_0x1A5F0 {
     MC_M_GF04_S = 47,
     MC_M_GF05 = 48,
     MC_M_GF06 = 49,
-};
+} __anon_0x1A5F0;
 
 // size = 0x4, address = 0x80135668
 static enum __anon_0x1A5F0 prevMenuEntry$772;
@@ -84,7 +84,7 @@ static s32 toggle$1034;
 // size = 0x4, address = 0x80135674
 static s32 checkFailCount$1490;
 
-struct OSCalendarTime {
+typedef struct OSCalendarTime {
     /* 0x00 */ s32 sec;
     /* 0x04 */ s32 min;
     /* 0x08 */ s32 hour;
@@ -95,7 +95,7 @@ struct OSCalendarTime {
     /* 0x1C */ s32 yday;
     /* 0x20 */ s32 msec;
     /* 0x24 */ s32 usec;
-}; // size = 0x28
+} __anon_0x1A9EE; // size = 0x28
 
 // size = 0x28, address = 0x80107960
 struct OSCalendarTime gDate;
@@ -106,25 +106,25 @@ s32 bWrite2Card;
 // size = 0x28, address = 0x80107988
 s32 bNoWriteInCurrentFrame[10];
 
-struct __anon_0x1AC1A {
+typedef struct __anon_0x1AC1A {
     /* 0x00 */ s32 configuration;
     /* 0x04 */ s32 size;
     /* 0x08 */ s32 offset;
     /* 0x0C */ char* buffer;
     /* 0x10 */ s32* writtenBlocks;
     /* 0x14 */ s32 writtenConfig;
-}; // size = 0x18
+} __anon_0x1AC1A; // size = 0x18
 
-struct CARDFileInfo {
+typedef struct CARDFileInfo {
     /* 0x00 */ s32 chan;
     /* 0x04 */ s32 fileNo;
     /* 0x08 */ s32 offset;
     /* 0x0C */ s32 length;
     /* 0x10 */ u16 iBlock;
     /* 0x12 */ u16 __padding;
-}; // size = 0x14
+} __anon_0x1ADBD; // size = 0x14
 
-struct __anon_0x1AEB5 {
+typedef struct __anon_0x1AEB5 {
     /* 0x000 */ s32 currentGame;
     /* 0x004 */ s32 fileSize;
     /* 0x008 */ char name[33];
@@ -138,9 +138,9 @@ struct __anon_0x1AEB5 {
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
-}; // size = 0x35C
+} __anon_0x1AEB5; // size = 0x35C
 
-enum __anon_0x1B0CB {
+typedef enum __anon_0x1B0CB {
     MC_E_NONE = 0,
     MC_E_BUSY = 1,
     MC_E_WRONGDEVICE = 2,
@@ -167,9 +167,9 @@ enum __anon_0x1B0CB {
     MC_E_TIME_WRONG = 23,
     MC_E_WRITE_CORRUPTED = 24,
     MC_E_UNKNOWN = 25,
-};
+} __anon_0x1B0CB;
 
-struct _MCARD {
+typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x1AEB5 file;
     /* 0x35C */ enum __anon_0x1B0CB error;
     /* 0x360 */ s32 slot;
@@ -198,25 +198,25 @@ struct _MCARD {
     /* 0x7AC */ s32 wait;
     /* 0x7B0 */ s32 isBroken;
     /* 0x7B4 */ s32 saveConfiguration;
-}; // size = 0x7B8
+} __anon_0x1B36F; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
 struct _MCARD mCard;
 
-enum __anon_0x1B813 {
+typedef enum __anon_0x1B813 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x1B813;
 
-struct __anon_0x1B87B {
+typedef struct __anon_0x1B87B {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x1B87B; // size = 0x10
 
-enum __anon_0x1B92C {
+typedef enum __anon_0x1B92C {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -231,9 +231,9 @@ enum __anon_0x1B92C {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x1B92C;
 
-enum __anon_0x1BA5D {
+typedef enum __anon_0x1BA5D {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -252,9 +252,9 @@ enum __anon_0x1BA5D {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x1BA5D;
 
-struct __anon_0x1BB9D {
+typedef struct __anon_0x1BB9D {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -266,12 +266,12 @@ struct __anon_0x1BB9D {
     /* 0x70 */ enum __anon_0x1BA5D storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x1BB9D; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x1BB9D* gpSystem;
 
-enum __anon_0x1BD8E {
+typedef enum __anon_0x1BD8E {
     MC_C_NONE = 0,
     MC_C_CONTINUE = 1,
     MC_C_IPL = 2,
@@ -279,7 +279,7 @@ enum __anon_0x1BD8E {
     MC_C_CREATE_GAME = 4,
     MC_C_DELETE_GAME = 5,
     MC_C_FORMAT_CARD = 6,
-};
+} __anon_0x1BD8E;
 
 // Range: 0x80013440 -> 0x800136F4
 s32 mcardUpdate() {
@@ -509,11 +509,11 @@ s32 mcardGameCreate(struct _MCARD* pMCard, char* name, s32 defaultConfiguration,
     // -> struct _MCARD mCard;
 }
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x1CD33; // size = 0x20
 
-struct CARDStat {
+typedef struct CARDStat {
     /* 0x00 */ char fileName[32];
     /* 0x20 */ u32 length;
     /* 0x24 */ u32 time;
@@ -530,7 +530,7 @@ struct CARDStat {
     /* 0x44 */ u32 offsetIcon[8];
     /* 0x64 */ u32 offsetIconTlut;
     /* 0x68 */ u32 offsetData;
-}; // size = 0x6C
+} __anon_0x1CDF9; // size = 0x6C
 
 // Range: 0x800185F8 -> 0x80018C50
 s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, s32 size) {
@@ -1062,23 +1062,23 @@ static s32 mcardGCErrorHandler(struct _MCARD* pMCard, s32 gcError) {
     // s32 gcError; // r1+0x4
 }
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x1F142;
 
-enum _GXTexFilter {
+typedef enum _GXTexFilter {
     GX_NEAR = 0,
     GX_LINEAR = 1,
     GX_NEAR_MIP_NEAR = 2,
     GX_LIN_MIP_NEAR = 3,
     GX_NEAR_MIP_LIN = 4,
     GX_LIN_MIP_LIN = 5,
-};
+} __anon_0x1F1AB;
 
-struct __anon_0x1F23C {
+typedef struct __anon_0x1F23C {
     /* 0x00 */ u16 height;
     /* 0x02 */ u16 width;
     /* 0x04 */ u32 format;
@@ -1092,33 +1092,33 @@ struct __anon_0x1F23C {
     /* 0x21 */ u8 minLOD;
     /* 0x22 */ u8 maxLOD;
     /* 0x23 */ u8 unpacked;
-}; // size = 0x24
+} __anon_0x1F23C; // size = 0x24
 
-enum _GXTlutFmt {
+typedef enum _GXTlutFmt {
     GX_TL_IA8 = 0,
     GX_TL_RGB565 = 1,
     GX_TL_RGB5A3 = 2,
     GX_MAX_TLUTFMT = 3,
-};
+} __anon_0x1F42F;
 
-struct __anon_0x1F497 {
+typedef struct __anon_0x1F497 {
     /* 0x0 */ u16 numEntries;
     /* 0x2 */ u8 unpacked;
     /* 0x3 */ u8 pad8;
     /* 0x4 */ enum _GXTlutFmt format;
     /* 0x8 */ char* data;
-}; // size = 0xC
+} __anon_0x1F497; // size = 0xC
 
-struct __anon_0x1F563 {
+typedef struct __anon_0x1F563 {
     /* 0x0 */ struct __anon_0x1F23C* textureHeader;
     /* 0x4 */ struct __anon_0x1F497* CLUTHeader;
-}; // size = 0x8
+} __anon_0x1F563; // size = 0x8
 
-struct __anon_0x1F5D4 {
+typedef struct __anon_0x1F5D4 {
     /* 0x0 */ u32 versionNumber;
     /* 0x4 */ u32 numDescriptors;
     /* 0x8 */ struct __anon_0x1F563* descriptorArray;
-}; // size = 0xC
+} __anon_0x1F5D4; // size = 0xC
 
 // Erased
 static void mcardUnpackTexPalette(struct __anon_0x1F5D4* pal) {

--- a/debug/Fire/mips.c
+++ b/debug/Fire/mips.c
@@ -7,22 +7,22 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x7322B; // size = 0x10
 
 // size = 0x10, address = 0x800EE6D0
 struct _XL_OBJECTTYPE gClassMips;
 
-struct __anon_0x7331D {
+typedef struct __anon_0x7331D {
     /* 0x0 */ s32 nMask;
     /* 0x4 */ s32 nMode;
     /* 0x8 */ void* pHost;
     /* 0xC */ s32 nInterrupt;
-}; // size = 0x10
+} __anon_0x7331D; // size = 0x10
 
 // Range: 0x8008D248 -> 0x8008D358
 s32 mipsEvent(struct __anon_0x7331D* pMips, s32 nEvent, void* pArgument) {
@@ -69,7 +69,7 @@ s32 mipsPut16() {}
 // Range: 0x8008D5F0 -> 0x8008D5F8
 s32 mipsPut8() {}
 
-enum __anon_0x736C0 {
+typedef enum __anon_0x736C0 {
     MIT_NONE = -1,
     MIT_SP = 0,
     MIT_SI = 1,
@@ -77,7 +77,7 @@ enum __anon_0x736C0 {
     MIT_VI = 3,
     MIT_PI = 4,
     MIT_DP = 5,
-};
+} __anon_0x736C0;
 
 // Range: 0x8008D5F8 -> 0x8008D69C
 s32 mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {

--- a/debug/Fire/mips.c
+++ b/debug/Fire/mips.c
@@ -1,76 +1,100 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\mips.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008D248 -> 0x8008D788
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE6D0
+struct _XL_OBJECTTYPE gClassMips;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x7331D {
+    /* 0x0 */ s32 nMask;
+    /* 0x4 */ s32 nMode;
+    /* 0x8 */ void* pHost;
+    /* 0xC */ s32 nInterrupt;
+}; // size = 0x10
 
-// Location: 0x800EE6D0
-_XL_OBJECTTYPE gClassMips;
-
-// size: 0x10
-struct __anon_0x7331D
-{
-	int nMask; // 0x0
-	int nMode; // 0x4
-	void *pHost; // 0x8
-	int nInterrupt; // 0xC
-};
-
-int mipsEvent(__anon_0x7331D *pMips, int nEvent, void *pArgument);
-
-int mipsGet64();
-
-int mipsGet32(__anon_0x7331D *pMips, unsigned int nAddress, int *pData);
-
-int mipsGet16();
-
-int mipsGet8();
-
-int mipsPut64();
-
-int mipsPut32(__anon_0x7331D *pMips, unsigned int nAddress, int *pData)
-{
-	int nData;
+// Range: 0x8008D248 -> 0x8008D358
+s32 mipsEvent(struct __anon_0x7331D* pMips, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int mipsPut16();
+// Range: 0x8008D358 -> 0x8008D360
+s32 mipsGet64() {}
 
-int mipsPut8();
+// Range: 0x8008D360 -> 0x8008D3C8
+s32 mipsGet32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
 
-// size: 0x4
-enum __anon_0x736C0
-{
-	MIT_NONE = 4294967295,
-	MIT_SP = 0,
-	MIT_SI = 1,
-	MIT_AI = 2,
-	MIT_VI = 3,
-	MIT_PI = 4,
-	MIT_DP = 5
+// Range: 0x8008D3C8 -> 0x8008D3D0
+s32 mipsGet16() {}
+
+// Range: 0x8008D3D0 -> 0x8008D3D8
+s32 mipsGet8() {}
+
+// Range: 0x8008D3D8 -> 0x8008D3E0
+s32 mipsPut64() {}
+
+// Range: 0x8008D3E0 -> 0x8008D5E8
+s32 mipsPut32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 nData; // r31
+}
+
+// Range: 0x8008D5E8 -> 0x8008D5F0
+s32 mipsPut16() {}
+
+// Range: 0x8008D5F0 -> 0x8008D5F8
+s32 mipsPut8() {}
+
+enum __anon_0x736C0 {
+    MIT_NONE = -1,
+    MIT_SP = 0,
+    MIT_SI = 1,
+    MIT_AI = 2,
+    MIT_VI = 3,
+    MIT_PI = 4,
+    MIT_DP = 5,
 };
 
-int mipsResetInterrupt(__anon_0x7331D *pMips, __anon_0x736C0 eType)
-{
-	int nInterrupt;
+// Range: 0x8008D5F8 -> 0x8008D69C
+s32 mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r1+0x0
+    // enum __anon_0x736C0 eType; // r1+0x4
+
+    // Local variables
+    s32 nInterrupt; // r5
 }
 
-int mipsSetInterrupt(__anon_0x7331D *pMips, __anon_0x736C0 eType)
-{
-	int nInterrupt;
-}
+// Range: 0x8008D69C -> 0x8008D788
+s32 mipsSetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r1+0x0
+    // enum __anon_0x736C0 eType; // r1+0x4
 
+    // Local variables
+    s32 nInterrupt; // r5
+}

--- a/debug/Fire/movie.c
+++ b/debug/Fire/movie.c
@@ -1,84 +1,80 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\movie.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8000F7CC -> 0x8000F890
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// size = 0x4, address = 0x80135610
+u8* gBufferP;
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x4, address = 0x80135420
+s32 __OSCurrHeap;
 
-// Location: 0x10561380
-unsigned char *gBufferP;
-
-// Location: 0x20541380
-int __OSCurrHeap;
-
-void MovieDestroy()
-{
-	// References: gBufferP (0x10561380)
-	// References: __OSCurrHeap (0x20541380)
+// Erased
+static void MovieDestroy() {
+    // References
+    // -> u8* gBufferP;
+    // -> s32 __OSCurrHeap;
 }
 
-// size: 0x4
-enum __anon_0xEF02
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
+enum __anon_0xEF02 {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
 };
 
-// size: 0x4
-enum __anon_0xF04A
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
+enum __anon_0xF04A {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
 };
 
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0xEF02 viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0xF04A xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0xEF02 viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0xF04A xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
 
-// Location: 0x8013559C
-_GXRenderModeObj *rmode;
+// size = 0x4, address = 0x8013559C
+struct _GXRenderModeObj* rmode;
 
-void MovieDraw()
-{
-	// References: rmode (0x8013559C)
+// Range: 0x8000F7CC -> 0x8000F804
+void MovieDraw() {
+    // References
+    // -> struct _GXRenderModeObj* rmode;
 }
 
-void MovieUpdate();
+// Erased
+static void MovieUpdate() {}
 
-void MovieInit()
-{
-	char *szText;
-	unsigned long size;
-	// References: gBufferP (0x10561380)
-	// References: __OSCurrHeap (0x20541380)
+// Range: 0x8000F804 -> 0x8000F890
+void MovieInit() {
+    // Local variables
+    char* szText; // r1+0x8
+    u32 size; // r4
+
+    // References
+    // -> u8* gBufferP;
+    // -> s32 __OSCurrHeap;
 }
-

--- a/debug/Fire/movie.c
+++ b/debug/Fire/movie.c
@@ -20,7 +20,7 @@ static void MovieDestroy() {
     // -> s32 __OSCurrHeap;
 }
 
-enum __anon_0xEF02 {
+typedef enum __anon_0xEF02 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -33,14 +33,14 @@ enum __anon_0xEF02 {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0xEF02;
 
-enum __anon_0xF04A {
+typedef enum __anon_0xF04A {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0xF04A;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0xEF02 viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -54,7 +54,7 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0xF0F9; // size = 0x3C
 
 // size = 0x4, address = 0x8013559C
 struct _GXRenderModeObj* rmode;

--- a/debug/Fire/peripheral.c
+++ b/debug/Fire/peripheral.c
@@ -1,150 +1,158 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\peripheral.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8009779C -> 0x80097D9C
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EFFBC
+struct _XL_OBJECTTYPE gClassPeripheral;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x83D15 {
+    /* 0x00 */ void* pHost;
+    /* 0x04 */ s32 nStatus;
+    /* 0x08 */ s32 nSizeGet;
+    /* 0x0C */ s32 nSizePut;
+    /* 0x10 */ s32 nLatency1;
+    /* 0x14 */ s32 nLatency2;
+    /* 0x18 */ s32 nRelease1;
+    /* 0x1C */ s32 nRelease2;
+    /* 0x20 */ s32 nSizePage1;
+    /* 0x24 */ s32 nSizePage2;
+    /* 0x28 */ s32 nAddressRAM;
+    /* 0x2C */ s32 nAddressROM;
+    /* 0x30 */ s32 nWidthPulse1;
+    /* 0x34 */ s32 nWidthPulse2;
+}; // size = 0x38
 
-// Location: 0x800EFFBC
-_XL_OBJECTTYPE gClassPeripheral;
-
-// size: 0x38
-struct __anon_0x83D15
-{
-	void *pHost; // 0x0
-	int nStatus; // 0x4
-	int nSizeGet; // 0x8
-	int nSizePut; // 0xC
-	int nLatency1; // 0x10
-	int nLatency2; // 0x14
-	int nRelease1; // 0x18
-	int nRelease2; // 0x1C
-	int nSizePage1; // 0x20
-	int nSizePage2; // 0x24
-	int nAddressRAM; // 0x28
-	int nAddressROM; // 0x2C
-	int nWidthPulse1; // 0x30
-	int nWidthPulse2; // 0x34
-};
-
-int peripheralEvent(__anon_0x83D15 *pPeripheral, int nEvent, void *pArgument);
-
-int peripheralGet64();
-
-int peripheralGet32(__anon_0x83D15 *pPeripheral, unsigned int nAddress, int *pData);
-
-int peripheralGet16();
-
-int peripheralGet8();
-
-int peripheralPut64();
-
-// size: 0x4
-enum __anon_0x8415D
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
-
-int peripheralPut32(__anon_0x83D15 *pPeripheral, unsigned int nAddress, int *pData)
-{
-	int bFlag;
-	__anon_0x8415D storageDevice;
+// Range: 0x8009779C -> 0x800978A4
+s32 peripheralEvent(struct __anon_0x83D15* pPeripheral, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int peripheralPut16();
+// Range: 0x800978A4 -> 0x800978AC
+s32 peripheralGet64() {}
 
-int peripheralPut8();
-
-// size: 0x4
-enum __anon_0x843DE
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
-
-// size: 0x10
-struct __anon_0x84447
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
-};
-
-// size: 0x4
-enum __anon_0x844F8
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
-
-// size: 0x88
-struct __anon_0x8464B
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x843DE eMode; // 0xC
-	__anon_0x84447 romCopy; // 0x10
-	__anon_0x844F8 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x8415D storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
-
-// Location: 0x561380
-__anon_0x8464B *gpSystem;
-
-// Local to compilation unit
-static int peripheralDMA_Complete()
-{
-	__anon_0x83D15 *pPeripheral;
-	// References: gpSystem (0x561380)
+// Range: 0x800978AC -> 0x800979AC
+s32 peripheralGet32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
 }
 
+// Range: 0x800979AC -> 0x800979B4
+s32 peripheralGet16() {}
+
+// Range: 0x800979B4 -> 0x800979BC
+s32 peripheralGet8() {}
+
+// Range: 0x800979BC -> 0x800979C4
+s32 peripheralPut64() {}
+
+enum __anon_0x8415D {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
+};
+
+// Range: 0x800979C4 -> 0x80097D48
+s32 peripheralPut32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 bFlag; // r31
+    enum __anon_0x8415D storageDevice; // r1+0x14
+}
+
+// Range: 0x80097D48 -> 0x80097D50
+s32 peripheralPut16() {}
+
+// Range: 0x80097D50 -> 0x80097D58
+s32 peripheralPut8() {}
+
+enum __anon_0x843DE {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
+
+struct __anon_0x84447 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x844F8 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
+};
+
+struct __anon_0x8464B {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x843DE eMode;
+    /* 0x10 */ struct __anon_0x84447 romCopy;
+    /* 0x20 */ enum __anon_0x844F8 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x8415D storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x8464B* gpSystem;
+
+// Range: 0x80097D58 -> 0x80097D9C
+static s32 peripheralDMA_Complete() {
+    // Local variables
+    struct __anon_0x83D15* pPeripheral; // r3
+
+    // References
+    // -> struct __anon_0x8464B* gpSystem;
+}

--- a/debug/Fire/peripheral.c
+++ b/debug/Fire/peripheral.c
@@ -7,17 +7,17 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x83C1D; // size = 0x10
 
 // size = 0x10, address = 0x800EFFBC
 struct _XL_OBJECTTYPE gClassPeripheral;
 
-struct __anon_0x83D15 {
+typedef struct __anon_0x83D15 {
     /* 0x00 */ void* pHost;
     /* 0x04 */ s32 nStatus;
     /* 0x08 */ s32 nSizeGet;
@@ -32,7 +32,7 @@ struct __anon_0x83D15 {
     /* 0x2C */ s32 nAddressROM;
     /* 0x30 */ s32 nWidthPulse1;
     /* 0x34 */ s32 nWidthPulse2;
-}; // size = 0x38
+} __anon_0x83D15; // size = 0x38
 
 // Range: 0x8009779C -> 0x800978A4
 s32 peripheralEvent(struct __anon_0x83D15* pPeripheral, s32 nEvent, void* pArgument) {
@@ -62,7 +62,7 @@ s32 peripheralGet8() {}
 // Range: 0x800979BC -> 0x800979C4
 s32 peripheralPut64() {}
 
-enum __anon_0x8415D {
+typedef enum __anon_0x8415D {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -81,7 +81,7 @@ enum __anon_0x8415D {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x8415D;
 
 // Range: 0x800979C4 -> 0x80097D48
 s32 peripheralPut32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
@@ -101,20 +101,20 @@ s32 peripheralPut16() {}
 // Range: 0x80097D50 -> 0x80097D58
 s32 peripheralPut8() {}
 
-enum __anon_0x843DE {
+typedef enum __anon_0x843DE {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x843DE;
 
-struct __anon_0x84447 {
+typedef struct __anon_0x84447 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x84447; // size = 0x10
 
-enum __anon_0x844F8 {
+typedef enum __anon_0x844F8 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -129,9 +129,9 @@ enum __anon_0x844F8 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x844F8;
 
-struct __anon_0x8464B {
+typedef struct __anon_0x8464B {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -143,7 +143,7 @@ struct __anon_0x8464B {
     /* 0x70 */ enum __anon_0x8415D storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x8464B; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x8464B* gpSystem;

--- a/debug/Fire/pif.c
+++ b/debug/Fire/pif.c
@@ -7,24 +7,24 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x4A7FA; // size = 0x10
 
 // size = 0x10, address = 0x800ED6B8
 struct _XL_OBJECTTYPE gClassPIF;
 
-struct __anon_0x4A974 {
+typedef struct __anon_0x4A974 {
     /* 0x00 */ void* pROM;
     /* 0x04 */ void* pRAM;
     /* 0x08 */ void* pHost;
     /* 0x0C */ u16 controllerType[5];
     /* 0x16 */ char controllerStatus[5];
     /* 0x1C */ enum __anon_0x4B3FE eControllerType[5];
-}; // size = 0x30
+} __anon_0x4A974; // size = 0x30
 
 // Range: 0x8006BE68 -> 0x8006C090
 s32 pifEvent(struct __anon_0x4A974* pPIF, s32 nEvent, void* pArgument) {
@@ -148,7 +148,7 @@ static s32 pifPut8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
     // char* pData; // r1+0x8
 }
 
-enum __anon_0x4B3FE {
+typedef enum __anon_0x4B3FE {
     CT_NONE = 0,
     CT_CONTROLLER = 1,
     CT_CONTROLLER_W_PAK = 2,
@@ -158,7 +158,7 @@ enum __anon_0x4B3FE {
     CT_4K = 6,
     CT_16K = 7,
     CT_COUNT = 8,
-};
+} __anon_0x4B3FE;
 
 // Erased
 static s32 pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {

--- a/debug/Fire/pif.c
+++ b/debug/Fire/pif.c
@@ -1,146 +1,272 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\pif.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8006BE68 -> 0x8006CD98
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800ED6B8
+struct _XL_OBJECTTYPE gClassPIF;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+struct __anon_0x4A974 {
+    /* 0x00 */ void* pROM;
+    /* 0x04 */ void* pRAM;
+    /* 0x08 */ void* pHost;
+    /* 0x0C */ u16 controllerType[5];
+    /* 0x16 */ char controllerStatus[5];
+    /* 0x1C */ enum __anon_0x4B3FE eControllerType[5];
+}; // size = 0x30
+
+// Range: 0x8006BE68 -> 0x8006C090
+s32 pifEvent(struct __anon_0x4A974* pPIF, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+
+    // Local variables
+    s32 i; // r31
+}
+
+// Range: 0x8006C090 -> 0x8006C0FC
+s32 pifGetData(struct __anon_0x4A974* pPIF, u8* acData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+    // u8* acData; // r31
+}
+
+// Range: 0x8006C0FC -> 0x8006C15C
+s32 pifSetData(struct __anon_0x4A974* pPIF, u8* acData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r31
+    // u8* acData; // r4
+}
+
+// Range: 0x8006C15C -> 0x8006C2F8
+s32 pifProcessOutputData(struct __anon_0x4A974* pPIF) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r29
+
+    // Local variables
+    u8* prx; // r6
+    u8* ptx; // r5
+    s32 iData; // r31
+    s32 channel; // r30
+}
+
+// Range: 0x8006C2F8 -> 0x8006C488
+s32 pifProcessInputData(struct __anon_0x4A974* pPIF) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+
+    // Local variables
+    u8* prx; // r6
+    u8* ptx; // r5
+    s32 iData; // r29
+    s32 channel; // r31
+}
+
+// Range: 0x8006C488 -> 0x8006C72C
+s32 pifExecuteCommand(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+    // u8* buffer; // r31
+    // u8* prx; // r1+0x14
+    // s32 channel; // r7
+}
+
+// Range: 0x8006C72C -> 0x8006C780
+static s32 pifGet64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006C780 -> 0x8006C7BC
+static s32 pifGet32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006C7BC -> 0x8006C7F8
+static s32 pifGet16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006C7F8 -> 0x8006C82C
+static s32 pifGet8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8006C82C -> 0x8006C860
+static s32 pifPut64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006C860 -> 0x8006C888
+static s32 pifPut32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006C888 -> 0x8006C8B0
+static s32 pifPut16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006C8B0 -> 0x8006C8D4
+static s32 pifPut8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+enum __anon_0x4B3FE {
+    CT_NONE = 0,
+    CT_CONTROLLER = 1,
+    CT_CONTROLLER_W_PAK = 2,
+    CT_CONTROLLER_W_RPAK = 3,
+    CT_MOUSE = 4,
+    CT_VOICE = 5,
+    CT_4K = 6,
+    CT_16K = 7,
+    CT_COUNT = 8,
 };
 
-// Location: 0x800ED6B8
-_XL_OBJECTTYPE gClassPIF;
+// Erased
+static s32 pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x8
+    // u8* buffer; // r4
+    // u8* prx; // r1+0x14
+    // s32 channel; // r7
 
-// Location: 0x0
-int counter$295;
-
-// size: 0x30
-struct __anon_0x4A974
-{
-	void *pROM; // 0x0
-	void *pRAM; // 0x4
-	void *pHost; // 0x8
-	unsigned short controllerType[5]; // 0xC
-	char controllerStatus[5]; // 0x16
-	__anon_0x4B3FE eControllerType[5]; // 0x1C
-};
-
-int pifEvent(__anon_0x4A974 *pPIF, int nEvent, void *pArgument)
-{
-	int i;
+    // Local variables
+    enum __anon_0x4B3FE type; // r1+0x8
 }
 
-int pifGetData(__anon_0x4A974 *pPIF, unsigned char *acData);
-
-int pifSetData(__anon_0x4A974 *pPIF, unsigned char *acData);
-
-int pifProcessOutputData(__anon_0x4A974 *pPIF)
-{
-	unsigned char *prx;
-	unsigned char *ptx;
-	int iData;
-	int channel;
+// Erased
+static s32 pifQueryController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u8* buffer; // r1+0x4
+    // u8* prx; // r1+0xC
+    // s32 channel; // r1+0x10
 }
 
-int pifProcessInputData(__anon_0x4A974 *pPIF)
-{
-	unsigned char *prx;
-	unsigned char *ptx;
-	int iData;
-	int channel;
+// Range: 0x8006C8D4 -> 0x8006C918
+s32 pifGetEEPROMSize(struct __anon_0x4A974* pPIF, u32* size) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32* size; // r1+0x4
 }
 
-int pifExecuteCommand(__anon_0x4A974 *pPIF, unsigned char *buffer, unsigned char *prx, int channel);
+// Erased
+static s32 pifGetControllerType(struct __anon_0x4A974* pPIF, s32 channel, u16* type, char* status) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // s32 channel; // r1+0x4
+    // u16* type; // r1+0x8
+    // char* status; // r1+0xC
 
-// Local to compilation unit
-static int pifGet64(__anon_0x4A974 *pPIF, unsigned int nAddress, signed long long *pData);
-
-// Local to compilation unit
-static int pifGet32(__anon_0x4A974 *pPIF, unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int pifGet16(__anon_0x4A974 *pPIF, unsigned int nAddress, signed short *pData);
-
-// Local to compilation unit
-static int pifGet8(__anon_0x4A974 *pPIF, unsigned int nAddress, char *pData);
-
-// Local to compilation unit
-static int pifPut64(__anon_0x4A974 *pPIF, unsigned int nAddress, signed long long *pData);
-
-// Local to compilation unit
-static int pifPut32(__anon_0x4A974 *pPIF, unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int pifPut16(__anon_0x4A974 *pPIF, unsigned int nAddress, signed short *pData);
-
-// Local to compilation unit
-static int pifPut8(__anon_0x4A974 *pPIF, unsigned int nAddress, char *pData);
-
-// size: 0x4
-enum __anon_0x4B3FE
-{
-	CT_NONE = 0,
-	CT_CONTROLLER = 1,
-	CT_CONTROLLER_W_PAK = 2,
-	CT_CONTROLLER_W_RPAK = 3,
-	CT_MOUSE = 4,
-	CT_VOICE = 5,
-	CT_4K = 6,
-	CT_16K = 7,
-	CT_COUNT = 8
-};
-
-int pifReadController(__anon_0x4A974 *pPIF, unsigned char *buffer, unsigned char *prx, int channel)
-{
-	__anon_0x4B3FE type;
+    // Local variables
+    enum __anon_0x4B3FE eType; // r1+0x0
 }
 
-int pifQueryController(__anon_0x4A974 *pPIF, unsigned char *buffer, unsigned char *prx, int channel);
-
-int pifGetEEPROMSize(__anon_0x4A974 *pPIF, unsigned int *size);
-
-int pifGetControllerType(__anon_0x4A974 *pPIF, int channel, unsigned short *type, char *status)
-{
-	__anon_0x4B3FE eType;
+// Erased
+static s32 pifGetControllerInput(s32 channel, u32* controllerInput) {
+    // Parameters
+    // s32 channel; // r4
+    // u32* controllerInput; // r5
 }
 
-int pifGetControllerInput(int channel, unsigned int *controllerInput);
-
-int pifSetEEPROMType(__anon_0x4A974 *pPIF, __anon_0x4B3FE type);
-
-int pifGetEControllerType(__anon_0x4A974 *pPIF, int channel, __anon_0x4B3FE *type);
-
-int pifSetControllerType(__anon_0x4A974 *pPIF, int channel, __anon_0x4B3FE type);
-
-// Local to compilation unit
-static unsigned char pifContDataCrc(unsigned char *data)
-{
-	unsigned int temp;
-	unsigned int i;
-	unsigned int j;
+// Range: 0x8006C918 -> 0x8006C97C
+s32 pifSetEEPROMType(struct __anon_0x4A974* pPIF, enum __anon_0x4B3FE type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // enum __anon_0x4B3FE type; // r1+0x4
 }
 
-int pifWriteRumble(int channel, unsigned short address, unsigned char *data);
-
-int pifReadRumble(unsigned short address, unsigned char *data)
-{
-	int i;
+// Range: 0x8006C97C -> 0x8006C994
+s32 pifGetEControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE* type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // s32 channel; // r1+0x4
+    // enum __anon_0x4B3FE* type; // r1+0x8
 }
 
-int pifIdCheckSum(unsigned short *ptr, unsigned short *csum, unsigned short *icsum)
-{
-	unsigned short data;
-	unsigned int j;
+// Range: 0x8006C994 -> 0x8006CAA4
+s32 pifSetControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r29
+    // s32 channel; // r30
+    // enum __anon_0x4B3FE type; // r31
 }
 
+// Range: 0x8006CAA4 -> 0x8006CC1C
+static u8 pifContDataCrc(u8* data) {
+    // Parameters
+    // u8* data; // r4
+
+    // Local variables
+    u32 temp; // r3
+    u32 i; // r5
+    u32 j; // r6
+}
+
+// Range: 0x8006CC1C -> 0x8006CC74
+s32 pifWriteRumble(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r4
+    // u16 address; // r1+0x10
+    // u8* data; // r1+0x14
+}
+
+// Range: 0x8006CC74 -> 0x8006CD98
+s32 pifReadRumble(u16 address, u8* data) {
+    // Parameters
+    // u16 address; // r1+0x8
+    // u8* data; // r1+0xC
+
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Erased
+static s32 pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
+    // Parameters
+    // u16* ptr; // r4
+    // u16* csum; // r1+0x8
+    // u16* icsum; // r1+0xC
+
+    // Local variables
+    u16 data; // r7
+    u32 j; // r1+0x0
+}

--- a/debug/Fire/ram.c
+++ b/debug/Fire/ram.c
@@ -7,21 +7,21 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x4BEF6; // size = 0x10
 
 // size = 0x10, address = 0x800ED6C8
 struct _XL_OBJECTTYPE gClassRAM;
 
-struct __anon_0x4BFE7 {
+typedef struct __anon_0x4BFE7 {
     /* 0x0 */ void* pHost;
     /* 0x4 */ void* pBuffer;
     /* 0x8 */ u32 nSize;
-}; // size = 0xC
+} __anon_0x4BFE7; // size = 0xC
 
 // Range: 0x8006CD98 -> 0x8006CFD0
 s32 ramEvent(struct __anon_0x4BFE7* pRAM, s32 nEvent, void* pArgument) {

--- a/debug/Fire/ram.c
+++ b/debug/Fire/ram.c
@@ -1,114 +1,185 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\ram.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8006CD98 -> 0x8006D3AC
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800ED6C8
+struct _XL_OBJECTTYPE gClassRAM;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x4BFE7 {
+    /* 0x0 */ void* pHost;
+    /* 0x4 */ void* pBuffer;
+    /* 0x8 */ u32 nSize;
+}; // size = 0xC
 
-// Location: 0x800ED6C8
-_XL_OBJECTTYPE gClassRAM;
+// Range: 0x8006CD98 -> 0x8006CFD0
+s32 ramEvent(struct __anon_0x4BFE7* pRAM, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}
 
-// size: 0xC
-struct __anon_0x4BFE7
-{
-	void *pHost; // 0x0
-	void *pBuffer; // 0x4
-	unsigned int nSize; // 0x8
-};
+// Range: 0x8006CFD0 -> 0x8006CFE8
+s32 ramGetSize(struct __anon_0x4BFE7* pRAM, u32* pnSize) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32* pnSize; // r1+0x4
+}
 
-int ramEvent(__anon_0x4BFE7 *pRAM, int nEvent, void *pArgument);
+// Range: 0x8006CFE8 -> 0x8006D058
+s32 ramSetSize(struct __anon_0x4BFE7* pRAM, u32 nSize) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r30
+    // u32 nSize; // r31
+}
 
-int ramGetSize(__anon_0x4BFE7 *pRAM, unsigned int *pnSize);
+// Range: 0x8006D058 -> 0x8006D0A0
+s32 ramWipe(struct __anon_0x4BFE7* pRAM) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r3
+}
 
-int ramSetSize(__anon_0x4BFE7 *pRAM, unsigned int nSize);
+// Range: 0x8006D0A0 -> 0x8006D0F8
+s32 ramGetBuffer(struct __anon_0x4BFE7* pRAM, void* ppRAM, u32 nOffset, u32* pnSize) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // void* ppRAM; // r1+0x4
+    // u32 nOffset; // r5
+    // u32* pnSize; // r1+0xC
+}
 
-int ramWipe(__anon_0x4BFE7 *pRAM);
+// Range: 0x8006D0F8 -> 0x8006D13C
+static s32 ramGet64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s64* pData; // r1+0x8
+}
 
-int ramGetBuffer(__anon_0x4BFE7 *pRAM, void *ppRAM, unsigned int nOffset, unsigned int *pnSize);
+// Range: 0x8006D13C -> 0x8006D170
+static s32 ramGet32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s32* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramGet64(__anon_0x4BFE7 *pRAM, unsigned int nAddress, signed long long *pData);
+// Range: 0x8006D170 -> 0x8006D1A4
+static s32 ramGet16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s16* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramGet32(__anon_0x4BFE7 *pRAM, unsigned int nAddress, int *pData);
+// Range: 0x8006D1A4 -> 0x8006D1D4
+static s32 ramGet8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // char* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramGet16(__anon_0x4BFE7 *pRAM, unsigned int nAddress, signed short *pData);
+// Range: 0x8006D1D4 -> 0x8006D208
+static s32 ramPut64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s64* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramGet8(__anon_0x4BFE7 *pRAM, unsigned int nAddress, char *pData);
+// Range: 0x8006D208 -> 0x8006D230
+static s32 ramPut32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r6
+    // s32* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramPut64(__anon_0x4BFE7 *pRAM, unsigned int nAddress, signed long long *pData);
+// Range: 0x8006D230 -> 0x8006D258
+static s32 ramPut16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r6
+    // s16* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramPut32(__anon_0x4BFE7 *pRAM, unsigned int nAddress, int *pData);
+// Range: 0x8006D258 -> 0x8006D27C
+static s32 ramPut8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r6
+    // char* pData; // r1+0x8
+}
 
-// Local to compilation unit
-static int ramPut16(__anon_0x4BFE7 *pRAM, unsigned int nAddress, signed short *pData);
+// Range: 0x8006D27C -> 0x8006D284
+static s32 ramGetRI64() {}
 
-// Local to compilation unit
-static int ramPut8(__anon_0x4BFE7 *pRAM, unsigned int nAddress, char *pData);
+// Range: 0x8006D284 -> 0x8006D2B8
+static s32 ramGetRI32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
-// Local to compilation unit
-static int ramGetRI64();
+// Range: 0x8006D2B8 -> 0x8006D2C0
+static s32 ramGetRI16() {}
 
-// Local to compilation unit
-static int ramGetRI32(unsigned int nAddress);
+// Range: 0x8006D2C0 -> 0x8006D2C8
+static s32 ramGetRI8() {}
 
-// Local to compilation unit
-static int ramGetRI16();
+// Range: 0x8006D2C8 -> 0x8006D2D0
+static s32 ramPutRI64() {}
 
-// Local to compilation unit
-static int ramGetRI8();
+// Range: 0x8006D2D0 -> 0x8006D304
+static s32 ramPutRI32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
-// Local to compilation unit
-static int ramPutRI64();
+// Range: 0x8006D304 -> 0x8006D30C
+static s32 ramPutRI16() {}
 
-// Local to compilation unit
-static int ramPutRI32(unsigned int nAddress);
+// Range: 0x8006D30C -> 0x8006D314
+static s32 ramPutRI8() {}
 
-// Local to compilation unit
-static int ramPutRI16();
+// Range: 0x8006D314 -> 0x8006D31C
+static s32 ramGetControl64() {}
 
-// Local to compilation unit
-static int ramPutRI8();
+// Range: 0x8006D31C -> 0x8006D350
+static s32 ramGetControl32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
-// Local to compilation unit
-static int ramGetControl64();
+// Range: 0x8006D350 -> 0x8006D358
+static s32 ramGetControl16() {}
 
-// Local to compilation unit
-static int ramGetControl32(unsigned int nAddress);
+// Range: 0x8006D358 -> 0x8006D360
+static s32 ramGetControl8() {}
 
-// Local to compilation unit
-static int ramGetControl16();
+// Range: 0x8006D360 -> 0x8006D368
+static s32 ramPutControl64() {}
 
-// Local to compilation unit
-static int ramGetControl8();
+// Range: 0x8006D368 -> 0x8006D39C
+static s32 ramPutControl32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
-// Local to compilation unit
-static int ramPutControl64();
+// Range: 0x8006D39C -> 0x8006D3A4
+static s32 ramPutControl16() {}
 
-// Local to compilation unit
-static int ramPutControl32(unsigned int nAddress);
-
-// Local to compilation unit
-static int ramPutControl16();
-
-// Local to compilation unit
-static int ramPutControl8();
-
+// Range: 0x8006D3A4 -> 0x8006D3AC
+static s32 ramPutControl8() {}

--- a/debug/Fire/rdb.c
+++ b/debug/Fire/rdb.c
@@ -7,23 +7,23 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x568FE; // size = 0x10
 
 // size = 0x10, address = 0x800EE1B0
 struct _XL_OBJECTTYPE gClassRdb;
 
-struct __anon_0x56A0F {
+typedef struct __anon_0x56A0F {
     /* 0x000 */ s32 nHackCount;
     /* 0x004 */ char szString[256];
     /* 0x104 */ s32 nIndexString;
     /* 0x108 */ s32 nAddress;
     /* 0x10C */ void* pHost;
-}; // size = 0x110
+} __anon_0x56A0F; // size = 0x110
 
 // Range: 0x800715D0 -> 0x800716D8
 s32 rdbEvent(struct __anon_0x56A0F* pRDB, s32 nEvent, void* pArgument) {

--- a/debug/Fire/rdb.c
+++ b/debug/Fire/rdb.c
@@ -1,64 +1,70 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\rdb.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x800715D0 -> 0x80071BB8
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE1B0
+struct _XL_OBJECTTYPE gClassRdb;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x56A0F {
+    /* 0x000 */ s32 nHackCount;
+    /* 0x004 */ char szString[256];
+    /* 0x104 */ s32 nIndexString;
+    /* 0x108 */ s32 nAddress;
+    /* 0x10C */ void* pHost;
+}; // size = 0x110
 
-// Location: 0x800EE1B0
-_XL_OBJECTTYPE gClassRdb;
-
-// size: 0x110
-struct __anon_0x56A0F
-{
-	int nHackCount; // 0x0
-	char szString[256]; // 0x4
-	int nIndexString; // 0x104
-	int nAddress; // 0x108
-	void *pHost; // 0x10C
-};
-
-int rdbEvent(__anon_0x56A0F *pRDB, int nEvent, void *pArgument);
-
-// Local to compilation unit
-static int rdbGet64();
-
-// Local to compilation unit
-static int rdbGet32(unsigned int nAddress);
-
-// Local to compilation unit
-static int rdbGet16();
-
-// Local to compilation unit
-static int rdbGet8();
-
-// Local to compilation unit
-static int rdbPut64();
-
-// Local to compilation unit
-static int rdbPut32(__anon_0x56A0F *pRDB, unsigned int nAddress, int *pData)
-{
-	int nLength;
-	int iCounter;
+// Range: 0x800715D0 -> 0x800716D8
+s32 rdbEvent(struct __anon_0x56A0F* pRDB, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x56A0F* pRDB; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-// Local to compilation unit
-static int rdbPut16();
+// Range: 0x800716D8 -> 0x800716E0
+static s32 rdbGet64() {}
 
-// Local to compilation unit
-static int rdbPut8();
+// Range: 0x800716E0 -> 0x80071714
+static s32 rdbGet32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
 
+// Range: 0x80071714 -> 0x8007171C
+static s32 rdbGet16() {}
+
+// Range: 0x8007171C -> 0x80071724
+static s32 rdbGet8() {}
+
+// Range: 0x80071724 -> 0x8007172C
+static s32 rdbPut64() {}
+
+// Range: 0x8007172C -> 0x80071BA8
+static s32 rdbPut32(struct __anon_0x56A0F* pRDB, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x56A0F* pRDB; // r3
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 nLength; // r7
+    s32 iCounter; // r5
+}
+
+// Range: 0x80071BA8 -> 0x80071BB0
+static s32 rdbPut16() {}
+
+// Range: 0x80071BB0 -> 0x80071BB8
+static s32 rdbPut8() {}

--- a/debug/Fire/rdp.c
+++ b/debug/Fire/rdp.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x52A92; // size = 0x10
 
 // size = 0x10, address = 0x800EDF40
 struct _XL_OBJECTTYPE gClassRDP;
@@ -35,7 +35,7 @@ static s32 nZBufferCount$126;
 // size = 0xC, address = 0x800EDF50
 static u32 sCommandCodes$168[3];
 
-struct __anon_0x52CD0 {
+typedef struct __anon_0x52CD0 {
     /* 0x00 */ s32 nBIST;
     /* 0x04 */ s32 nStatus;
     /* 0x08 */ void* pHost;
@@ -48,7 +48,7 @@ struct __anon_0x52CD0 {
     /* 0x24 */ s32 nClockCmd;
     /* 0x28 */ s32 nClockPipe;
     /* 0x2C */ s32 nClockTMEM;
-}; // size = 0x30
+} __anon_0x52CD0; // size = 0x30
 
 // Range: 0x8006FEC0 -> 0x80070064
 s32 rdpEvent(struct __anon_0x52CD0* pRDP, s32 nEvent, void* pArgument) {
@@ -129,20 +129,20 @@ static s32 rdpPut16() {}
 // Range: 0x80070338 -> 0x80070340
 static s32 rdpPut8() {}
 
-enum __anon_0x533F6 {
+typedef enum __anon_0x533F6 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x533F6;
 
-struct __anon_0x53458 {
+typedef struct __anon_0x53458 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x53458; // size = 0x10
 
-enum __anon_0x53509 {
+typedef enum __anon_0x53509 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -157,9 +157,9 @@ enum __anon_0x53509 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x53509;
 
-enum __anon_0x53635 {
+typedef enum __anon_0x53635 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -178,9 +178,9 @@ enum __anon_0x53635 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x53635;
 
-struct __anon_0x53770 {
+typedef struct __anon_0x53770 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -192,12 +192,12 @@ struct __anon_0x53770 {
     /* 0x70 */ enum __anon_0x53635 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x53770; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x53770* gpSystem;
 
-enum __anon_0x53961 {
+typedef enum __anon_0x53961 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -210,14 +210,14 @@ enum __anon_0x53961 {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0x53961;
 
-enum __anon_0x53AA8 {
+typedef enum __anon_0x53AA8 {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0x53AA8;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0x53961 viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -231,33 +231,33 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0x53B56; // size = 0x3C
 
 // size = 0x4, address = 0x8013559C
 struct _GXRenderModeObj* rmode;
 
-struct __anon_0x53DD5 {
+typedef struct __anon_0x53DD5 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x53DD5; // size = 0x10
 
-struct __anon_0x53E6F {
+typedef struct __anon_0x53E6F {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x53E6F; // size = 0x14
 
-struct __anon_0x53FB0 {
+typedef struct __anon_0x53FB0 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x53FB0; // size = 0xC
 
-struct __anon_0x54020 {
+typedef struct __anon_0x54020 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x53FB0 rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -272,36 +272,36 @@ struct __anon_0x54020 {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x54020; // size = 0x3C
 
-struct __anon_0x54250 {
+typedef struct __anon_0x54250 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x53FB0 rS;
     /* 0x10 */ struct __anon_0x53FB0 rT;
     /* 0x1C */ struct __anon_0x53FB0 rSRaw;
     /* 0x28 */ struct __anon_0x53FB0 rTRaw;
-}; // size = 0x34
+} __anon_0x54250; // size = 0x34
 
-struct __anon_0x54339 {
+typedef struct __anon_0x54339 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x53FB0 vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x54339; // size = 0x1C
 
-union __anon_0x54498 {
+typedef union __anon_0x54498 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x54498;
 
-struct __anon_0x54535 {
+typedef struct __anon_0x54535 {
     /* 0x0 */ union __anon_0x54498 data;
-}; // size = 0x1000
+} __anon_0x54535; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -328,24 +328,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x545CE;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x54790; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x547F7; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x5483D;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -365,9 +365,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x548A6; // size = 0x6C
 
-struct __anon_0x54C03 {
+typedef struct __anon_0x54C03 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -384,15 +384,15 @@ struct __anon_0x54C03 {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x54C03; // size = 0x2C
 
-enum __anon_0x54EE5 {
+typedef enum __anon_0x54EE5 {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x54EE5;
 
-struct __anon_0x54F66 {
+typedef struct __anon_0x54F66 {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -402,16 +402,16 @@ struct __anon_0x54F66 {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x54EE5 eProjection;
-}; // size = 0x24
+} __anon_0x54F66; // size = 0x24
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x550FB; // size = 0x4
 
-struct __anon_0x551B6 {
+typedef struct __anon_0x551B6 {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -502,9 +502,9 @@ struct __anon_0x551B6 {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x551B6; // size = 0x3D150
 
-struct __anon_0x56000 {
+typedef struct __anon_0x56000 {
     /* 0x00 */ s32 bFlip;
     /* 0x04 */ s32 iTile;
     /* 0x08 */ s32 nX0;
@@ -515,7 +515,7 @@ struct __anon_0x56000 {
     /* 0x1C */ float rT;
     /* 0x20 */ float rDeltaS;
     /* 0x24 */ float rDeltaT;
-}; // size = 0x28
+} __anon_0x56000; // size = 0x28
 
 // Range: 0x80070340 -> 0x800715D0
 s32 rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {

--- a/debug/Fire/rdp.c
+++ b/debug/Fire/rdp.c
@@ -1,613 +1,575 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\rdp.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8006FEC0 -> 0x800715D0
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EDF40
+struct _XL_OBJECTTYPE gClassRDP;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+// size = 0x4, address = 0x80135770
+static s32 nCount$122;
 
-// Location: 0x40DF0E80
-_XL_OBJECTTYPE gClassRDP;
+// size = 0x4, address = 0x80135774
+static s32 nBlurCount$123;
 
-// Local to compilation unit
-// Location: 0x70571380
-static int nCount$122;
+// size = 0x4, address = 0x80135778
+static s32 nNoteCount$124;
 
-// Local to compilation unit
-// Location: 0x74571380
-static int nBlurCount$123;
+// size = 0x4, address = 0x8013577C
+static s32 nZCount$125;
 
-// Local to compilation unit
-// Location: 0x78571380
-static int nNoteCount$124;
+// size = 0x4, address = 0x80135780
+static s32 nZBufferCount$126;
 
-// Local to compilation unit
-// Location: 0x7C571380
-static int nZCount$125;
+// size = 0xC, address = 0x800EDF50
+static u32 sCommandCodes$168[3];
 
-// Local to compilation unit
-// Location: 0x80135780
-static int nZBufferCount$126;
+struct __anon_0x52CD0 {
+    /* 0x00 */ s32 nBIST;
+    /* 0x04 */ s32 nStatus;
+    /* 0x08 */ void* pHost;
+    /* 0x0C */ s32 nModeTest;
+    /* 0x10 */ s32 nDataTest;
+    /* 0x14 */ s32 nAddressTest;
+    /* 0x18 */ s32 nAddress0;
+    /* 0x1C */ s32 nAddress1;
+    /* 0x20 */ s32 nClock;
+    /* 0x24 */ s32 nClockCmd;
+    /* 0x28 */ s32 nClockPipe;
+    /* 0x2C */ s32 nClockTMEM;
+}; // size = 0x30
 
-// Location: 0x0
-int nLensBufferCount$127;
-
-// Local to compilation unit
-// Location: 0x50DF0E80
-static unsigned int sCommandCodes$168[3];
-
-// size: 0x30
-struct __anon_0x52CD0
-{
-	int nBIST; // 0x0
-	int nStatus; // 0x4
-	void *pHost; // 0x8
-	int nModeTest; // 0xC
-	int nDataTest; // 0x10
-	int nAddressTest; // 0x14
-	int nAddress0; // 0x18
-	int nAddress1; // 0x1C
-	int nClock; // 0x20
-	int nClockCmd; // 0x24
-	int nClockPipe; // 0x28
-	int nClockTMEM; // 0x2C
-};
-
-int rdpEvent(__anon_0x52CD0 *pRDP, int nEvent, void *pArgument);
-
-// Local to compilation unit
-static int rdpGetSpan64();
-
-// Local to compilation unit
-static int rdpGetSpan32(__anon_0x52CD0 *pRDP, unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int rdpGetSpan16();
-
-// Local to compilation unit
-static int rdpGetSpan8();
-
-// Local to compilation unit
-static int rdpPutSpan64();
-
-// Local to compilation unit
-static int rdpPutSpan32(__anon_0x52CD0 *pRDP, unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int rdpPutSpan16();
-
-// Local to compilation unit
-static int rdpPutSpan8();
-
-// Local to compilation unit
-static int rdpGet64();
-
-// Local to compilation unit
-static int rdpGet32(__anon_0x52CD0 *pRDP, unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int rdpGet16();
-
-// Local to compilation unit
-static int rdpGet8();
-
-// Local to compilation unit
-static int rdpPut64();
-
-// Local to compilation unit
-static int rdpPut32(__anon_0x52CD0 *pRDP, unsigned int nAddress, int *pData)
-{
-	int nData;
+// Range: 0x8006FEC0 -> 0x80070064
+s32 rdpEvent(struct __anon_0x52CD0* pRDP, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-// Local to compilation unit
-static int rdpPut16();
+// Range: 0x80070064 -> 0x8007006C
+static s32 rdpGetSpan64() {}
 
-// Local to compilation unit
-static int rdpPut8();
-
-// size: 0x4
-enum __anon_0x533F6
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
-
-// size: 0x10
-struct __anon_0x53458
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
-};
-
-// size: 0x4
-enum __anon_0x53509
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
-
-// size: 0x4
-enum __anon_0x53635
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
-
-// size: 0x88
-struct __anon_0x53770
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x533F6 eMode; // 0xC
-	__anon_0x53458 romCopy; // 0x10
-	__anon_0x53509 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x53635 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
-
-// Location: 0x561380
-__anon_0x53770 *gpSystem;
-
-// size: 0x4
-enum __anon_0x53961
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
-};
-
-// size: 0x4
-enum __anon_0x53AA8
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
-};
-
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0x53961 viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0x53AA8 xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
-
-// Location: 0x8013559C
-_GXRenderModeObj *rmode;
-
-// size: 0x10
-struct __anon_0x53DD5
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x53E6F
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
-};
-
-// size: 0xC
-struct __anon_0x53FB0
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-// size: 0x3C
-struct __anon_0x54020
-{
-	int bTransformed; // 0x0
-	__anon_0x53FB0 rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
-
-// size: 0x34
-struct __anon_0x54250
-{
-	int bTransformed; // 0x0
-	__anon_0x53FB0 rS; // 0x4
-	__anon_0x53FB0 rT; // 0x10
-	__anon_0x53FB0 rSRaw; // 0x1C
-	__anon_0x53FB0 rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x54339
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x53FB0 vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x54498
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x54535
-{
-	__anon_0x54498 data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x54C03
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x54EE5
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x54F66
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x54EE5 eProjection; // 0x20
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x3D150
-struct __anon_0x551B6
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x53DD5 viewport; // 0xB8
-	__anon_0x53E6F aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x54020 aLight[8]; // 0x140
-	__anon_0x54250 lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x54339 aVertex[80]; // 0x358
-	__anon_0x54535 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x54C03 aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x54EE5 eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x54F66 aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-// size: 0x28
-struct __anon_0x56000
-{
-	int bFlip; // 0x0
-	int iTile; // 0x4
-	int nX0; // 0x8
-	int nY0; // 0xC
-	int nX1; // 0x10
-	int nY1; // 0x14
-	float rS; // 0x18
-	float rT; // 0x1C
-	float rDeltaS; // 0x20
-	float rDeltaT; // 0x24
-};
-
-int rdpParseGBI(__anon_0x52CD0 *pRDP, unsigned long long **ppnGBI)
-{
-	unsigned int nA;
-	unsigned int nB;
-	unsigned int nC;
-	unsigned int nD;
-	unsigned long long *pnGBI;
-	unsigned int nCommandLo;
-	unsigned int nCommandHi;
-	__anon_0x551B6 *pFrame;
-	int nFound;
-	int i;
-	unsigned int nAddress;
-	int nSetLens;
-	__anon_0x53E6F *pBuffer;
-	int i;
-	unsigned int *pGBI;
-	int nAddress;
-	__anon_0x53E6F *pBuffer;
-	int nAddress;
-	__anon_0x53E6F *pBuffer;
-	unsigned int nColor;
-	__anon_0x56000 primitive;
-	int iTile;
-	__anon_0x54C03 *pTile;
-	int iTile;
-	int iTile;
-	__anon_0x54C03 *pTile;
-	int iTile;
-	int nCount;
-	float rDepth;
-	float rDelta;
-	__anon_0x56000 rectangle;
-	__anon_0x56000 primitive;
-	float rX0;
-	float rY0;
-	float rX1;
-	float rY1;
-	unsigned int *pGBI;
-	unsigned int *pGBI;
-	// References: gpSystem (0x561380)
-	// References: rmode (0x8013559C)
-	// References: nCount$122 (0x70571380)
-	// References: nBlurCount$123 (0x74571380)
-	// References: nNoteCount$124 (0x78571380)
-	// References: nZCount$125 (0x7C571380)
-	// References: sCommandCodes$168 (0x50DF0E80)
-	// References: nZBufferCount$126 (0x80135780)
+// Range: 0x8007006C -> 0x800700DC
+static s32 rdpGetSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
 }
 
+// Range: 0x800700DC -> 0x800700E4
+static s32 rdpGetSpan16() {}
+
+// Range: 0x800700E4 -> 0x800700EC
+static s32 rdpGetSpan8() {}
+
+// Range: 0x800700EC -> 0x800700F4
+static s32 rdpPutSpan64() {}
+
+// Range: 0x800700F4 -> 0x80070158
+static s32 rdpPutSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x80070158 -> 0x80070160
+static s32 rdpPutSpan16() {}
+
+// Range: 0x80070160 -> 0x80070168
+static s32 rdpPutSpan8() {}
+
+// Range: 0x80070168 -> 0x80070170
+static s32 rdpGet64() {}
+
+// Range: 0x80070170 -> 0x80070214
+static s32 rdpGet32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x80070214 -> 0x8007021C
+static s32 rdpGet16() {}
+
+// Range: 0x8007021C -> 0x80070224
+static s32 rdpGet8() {}
+
+// Range: 0x80070224 -> 0x8007022C
+static s32 rdpPut64() {}
+
+// Range: 0x8007022C -> 0x80070330
+static s32 rdpPut32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r3
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 nData; // r4
+}
+
+// Range: 0x80070330 -> 0x80070338
+static s32 rdpPut16() {}
+
+// Range: 0x80070338 -> 0x80070340
+static s32 rdpPut8() {}
+
+enum __anon_0x533F6 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
+
+struct __anon_0x53458 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x53509 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
+};
+
+enum __anon_0x53635 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
+};
+
+struct __anon_0x53770 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x533F6 eMode;
+    /* 0x10 */ struct __anon_0x53458 romCopy;
+    /* 0x20 */ enum __anon_0x53509 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x53635 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x53770* gpSystem;
+
+enum __anon_0x53961 {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
+};
+
+enum __anon_0x53AA8 {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
+};
+
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0x53961 viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0x53AA8 xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
+
+// size = 0x4, address = 0x8013559C
+struct _GXRenderModeObj* rmode;
+
+struct __anon_0x53DD5 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x53E6F {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x53FB0 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x54020 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x53FB0 rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x54250 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x53FB0 rS;
+    /* 0x10 */ struct __anon_0x53FB0 rT;
+    /* 0x1C */ struct __anon_0x53FB0 rSRaw;
+    /* 0x28 */ struct __anon_0x53FB0 rTRaw;
+}; // size = 0x34
+
+struct __anon_0x54339 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x53FB0 vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x54498 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
+};
+
+struct __anon_0x54535 {
+    /* 0x0 */ union __anon_0x54498 data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
+};
+
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
+};
+
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x54C03 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x54EE5 {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
+};
+
+struct __anon_0x54F66 {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x54EE5 eProjection;
+}; // size = 0x24
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+struct __anon_0x551B6 {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x53DD5 viewport;
+    /* 0x000C8 */ struct __anon_0x53E6F aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x54020 aLight[8];
+    /* 0x00320 */ struct __anon_0x54250 lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x54339 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x54535 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x54C03 aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x54EE5 eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x54F66 aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+struct __anon_0x56000 {
+    /* 0x00 */ s32 bFlip;
+    /* 0x04 */ s32 iTile;
+    /* 0x08 */ s32 nX0;
+    /* 0x0C */ s32 nY0;
+    /* 0x10 */ s32 nX1;
+    /* 0x14 */ s32 nY1;
+    /* 0x18 */ float rS;
+    /* 0x1C */ float rT;
+    /* 0x20 */ float rDeltaS;
+    /* 0x24 */ float rDeltaT;
+}; // size = 0x28
+
+// Range: 0x80070340 -> 0x800715D0
+s32 rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r25
+    // u64** ppnGBI; // r26
+
+    // Local variables
+    u32 nA; // r4
+    u32 nB; // r3
+    u32 nC; // r5
+    u32 nD; // r6
+    u64* pnGBI; // r1+0x9C
+    u32 nCommandLo; // r1+0x98
+    u32 nCommandHi; // r1+0x94
+    struct __anon_0x551B6* pFrame; // r30
+    s32 nFound; // r31
+    s32 i; // r5
+    u32 nAddress; // r29
+    s32 nSetLens; // r28
+    struct __anon_0x53E6F* pBuffer; // r27
+    s32 i; // r7
+    u32* pGBI; // r1+0x8
+    s32 nAddress; // r5
+    struct __anon_0x53E6F* pBuffer; // r8
+    s32 nAddress; // r5
+    struct __anon_0x53E6F* pBuffer; // r27
+    u32 nColor; // r5
+    struct __anon_0x56000 primitive; // r1+0x6C
+    s32 iTile; // r1+0x8
+    struct __anon_0x54C03* pTile; // r5
+    s32 iTile; // r6
+    s32 iTile; // r5
+    struct __anon_0x54C03* pTile; // r5
+    s32 iTile; // r5
+    s32 nCount; // r4
+    float rDepth; // f1
+    float rDelta; // f2
+    struct __anon_0x56000 rectangle; // r1+0x40
+    struct __anon_0x56000 primitive; // r1+0x14
+    float rX0; // f31
+    float rY0; // f30
+    float rX1; // f29
+    float rY1; // f28
+    u32* pGBI; // r1+0x8
+    u32* pGBI; // r4
+
+    // References
+    // -> struct __anon_0x53770* gpSystem;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> static s32 nCount$122;
+    // -> static s32 nBlurCount$123;
+    // -> static s32 nNoteCount$124;
+    // -> static s32 nZCount$125;
+    // -> static u32 sCommandCodes$168[3];
+    // -> static s32 nZBufferCount$126;
+}

--- a/debug/Fire/rom.c
+++ b/debug/Fire/rom.c
@@ -1,809 +1,936 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\rom.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8006D3AC -> 0x8006FEC0
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800ED8E8
+struct _XL_OBJECTTYPE gClassROM;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+// size = 0x318, address = 0x800ED8F8
+static u32 ganOffsetBlock_ZLJ[198];
+
+// size = 0x318, address = 0x800EDC10
+static u32 ganOffsetBlock_URAZLJ[198];
+
+// size = 0x4, address = 0x80135760
+static s32 gbProgress;
+
+// size = 0x4, address = 0x80135764
+static void* gpImageBack;
+
+// size = 0x4, address = 0x80135768
+static s32 iImage$294;
+
+enum __anon_0x4CF87 {
+    RLM_NONE = -1,
+    RLM_PART = 0,
+    RLM_FULL = 1,
+    RLM_COUNT_ = 2,
 };
 
-// Location: 0x800ED8E8
-_XL_OBJECTTYPE gClassROM;
+struct __anon_0x4CFE6 {
+    /* 0x0 */ s32 iCache;
+    /* 0x4 */ u32 nSize;
+    /* 0x8 */ u32 nTickUsed;
+    /* 0xC */ char keep;
+}; // size = 0x10
 
-// Local to compilation unit
-// Location: 0x800ED8F8
-static unsigned int ganOffsetBlock_ZLJ[198];
+struct __anon_0x4D0FA {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 (*pCallback)();
+    /* 0x08 */ u8* pTarget;
+    /* 0x0C */ u32 nSize;
+    /* 0x10 */ u32 nOffset;
+}; // size = 0x14
 
-// Local to compilation unit
-// Location: 0x10DC0E80
-static unsigned int ganOffsetBlock_URAZLJ[198];
+struct __anon_0x4D1DA {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 bDone;
+    /* 0x08 */ s32 nResult;
+    /* 0x0C */ u8* anData;
+    /* 0x10 */ s32 (*pCallback)();
+    /* 0x14 */ s32 iCache;
+    /* 0x18 */ s32 iBlock;
+    /* 0x1C */ s32 nOffset;
+    /* 0x20 */ u32 nOffset0;
+    /* 0x24 */ u32 nOffset1;
+    /* 0x28 */ u32 nSize;
+    /* 0x2C */ u32 nSizeRead;
+}; // size = 0x30
 
-// Location: 0x0
-int iImage$261;
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
 
-// Local to compilation unit
-// Location: 0x60571380
-static int gbProgress;
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
-// Local to compilation unit
-// Location: 0x64571380
-static void *gpImageBack;
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
 
-// Local to compilation unit
-// Location: 0x68571380
-static int iImage$294;
+struct __anon_0x4D873 {
+    /* 0x00000 */ void* pHost;
+    /* 0x00004 */ void* pBuffer;
+    /* 0x00008 */ s32 bFlip;
+    /* 0x0000C */ s32 bLoad;
+    /* 0x00010 */ char acNameFile[513];
+    /* 0x00214 */ u32 nSize;
+    /* 0x00218 */ enum __anon_0x4CF87 eModeLoad;
+    /* 0x0021C */ struct __anon_0x4CFE6 aBlock[4096];
+    /* 0x1021C */ u32 nTick;
+    /* 0x10220 */ u8* pCacheRAM;
+    /* 0x10224 */ u8 anBlockCachedRAM[1024];
+    /* 0x10624 */ u8 anBlockCachedARAM[2046];
+    /* 0x10E24 */ struct __anon_0x4D0FA copy;
+    /* 0x10E38 */ struct __anon_0x4D1DA load;
+    /* 0x10E68 */ s32 nCountBlockRAM;
+    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E70 */ u8 acHeader[64];
+    /* 0x10EB0 */ u32* anOffsetBlock;
+    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB8 */ struct DVDFileInfo fileInfo;
+    /* 0x10EF4 */ s32 offsetToRom;
+}; // size = 0x10EF8
 
-// size: 0x4
-enum __anon_0x4CF87
-{
-	RLM_NONE = 4294967295,
-	RLM_PART = 0,
-	RLM_FULL = 1,
-	RLM_COUNT_ = 2
-};
-
-// size: 0x10
-struct __anon_0x4CFE6
-{
-	int iCache; // 0x0
-	unsigned int nSize; // 0x4
-	unsigned int nTickUsed; // 0x8
-	char keep; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x4D0FA
-{
-	int bWait; // 0x0
-	int (*pCallback)(); // 0x4
-	unsigned char *pTarget; // 0x8
-	unsigned int nSize; // 0xC
-	unsigned int nOffset; // 0x10
-};
-
-// size: 0x30
-struct __anon_0x4D1DA
-{
-	int bWait; // 0x0
-	int bDone; // 0x4
-	int nResult; // 0x8
-	unsigned char *anData; // 0xC
-	int (*pCallback)(); // 0x10
-	int iCache; // 0x14
-	int iBlock; // 0x18
-	int nOffset; // 0x1C
-	unsigned int nOffset0; // 0x20
-	unsigned int nOffset1; // 0x24
-	unsigned int nSize; // 0x28
-	unsigned int nSizeRead; // 0x2C
-};
-
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
-
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// size: 0x10EF8
-struct __anon_0x4D873
-{
-	void *pHost; // 0x0
-	void *pBuffer; // 0x4
-	int bFlip; // 0x8
-	int bLoad; // 0xC
-	char acNameFile[513]; // 0x10
-	unsigned int nSize; // 0x214
-	__anon_0x4CF87 eModeLoad; // 0x218
-	__anon_0x4CFE6 aBlock[4096]; // 0x21C
-	unsigned int nTick; // 0x1021C
-	unsigned char *pCacheRAM; // 0x10220
-	unsigned char anBlockCachedRAM[1024]; // 0x10224
-	unsigned char anBlockCachedARAM[2046]; // 0x10624
-	__anon_0x4D0FA copy; // 0x10E24
-	__anon_0x4D1DA load; // 0x10E38
-	int nCountBlockRAM; // 0x10E68
-	int nSizeCacheRAM; // 0x10E6C
-	unsigned char acHeader[64]; // 0x10E70
-	unsigned int *anOffsetBlock; // 0x10EB0
-	int nCountOffsetBlocks; // 0x10EB4
-	DVDFileInfo fileInfo; // 0x10EB8
-	int offsetToRom; // 0x10EF4
-};
-
-int romEvent(__anon_0x4D873 *pROM, int nEvent, void *pArgument);
-
-int romGetImage(__anon_0x4D873 *pROM, char *acNameFile)
-{
-	int iName;
+// Range: 0x8006D3AC -> 0x8006D5D8
+s32 romEvent(struct __anon_0x4D873* pROM, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-// size: 0x4
-enum __anon_0x4DD08
-{
-	XLFT_NONE = 4294967295,
-	XLFT_TEXT = 0,
-	XLFT_BINARY = 1
+// Range: 0x8006D5D8 -> 0x8006D620
+s32 romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // char* acNameFile; // r1+0x4
+
+    // Local variables
+    s32 iName; // r6
+}
+
+enum __anon_0x4DD08 {
+    XLFT_NONE = -1,
+    XLFT_TEXT = 0,
+    XLFT_BINARY = 1,
 };
 
-// size: 0x58
-struct tXL_FILE
-{
-	int iBuffer; // 0x0
-	void *pData; // 0x4
-	void *pBuffer; // 0x8
-	int nAttributes; // 0xC
-	int nSize; // 0x10
-	int nOffset; // 0x14
-	__anon_0x4DD08 eType; // 0x18
-	DVDFileInfo info; // 0x1C
+struct tXL_FILE {
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ enum __anon_0x4DD08 eType;
+    /* 0x1C */ struct DVDFileInfo info;
+}; // size = 0x58
+
+// Range: 0x8006D620 -> 0x8006D794
+s32 romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r28
+    // char* szNameFile; // r29
+
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x14
+    s32 iName; // r5
+    s32 nSize; // r1+0x10
+}
+
+// Erased
+static s32 romGetCacheSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* pnSize; // r1+0x4
+}
+
+// Range: 0x8006D794 -> 0x8006D830
+s32 romSetCacheSize(struct __anon_0x4D873* pROM, s32 nSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 nSize; // r4
+}
+
+// Erased
+static s32 romCopyBusy(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+}
+
+// Range: 0x8006D830 -> 0x8006D990
+s32 romUpdate(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+
+    // Local variables
+    s32 nStatus; // r30
+}
+
+// Range: 0x8006D990 -> 0x8006DBF8
+s32 romCopyImmediate(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffsetROM, u32 nSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r26
+    // void* pTarget; // r27
+    // s32 nOffsetROM; // r28
+    // u32 nSize; // r29
+
+    // Local variables
+    void* pSource; // r4
+    struct __anon_0x4CFE6* pBlock; // r3
+    s32 nOffsetARAM; // r23
+    s32 nSizeCopy; // r31
+    s32 nOffsetBlock; // r1+0x8
+    s32 nSizeCopyARAM; // r22
+    s32 nSizeDMA; // r21
+    s32 nOffset; // r20
+    s32 nOffsetTarget; // r19
+    u8* pBuffer; // r30
+    u8 anBuffer[608]; // r1+0x18
+}
+
+// Range: 0x8006DBF8 -> 0x8006DE90
+s32 romCopy(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffset, u32 nSize, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r27
+    // void* pTarget; // r28
+    // s32 nOffset; // r29
+    // u32 nSize; // r30
+    // s32 (* pCallback)(); // r31
+
+    // Local variables
+    void* pSource; // r4
+    struct tXL_FILE* pFile; // r1+0x1C
+}
+
+// Erased
+static s32 romGetSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* pnSize; // r1+0x4
+}
+
+// Range: 0x8006DE90 -> 0x8006DEA4
+static s32 romGetDebug64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006DEA4 -> 0x8006DEB4
+static s32 romGetDebug32(s32* pData) {
+    // Parameters
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006DEB4 -> 0x8006DEC4
+static s32 romGetDebug16(s16* pData) {
+    // Parameters
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006DEC4 -> 0x8006DED4
+static s32 romGetDebug8(char* pData) {
+    // Parameters
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8006DED4 -> 0x8006DEDC
+static s32 romPutDebug64() {}
+
+// Range: 0x8006DEDC -> 0x8006DEE4
+static s32 romPutDebug32() {}
+
+// Range: 0x8006DEE4 -> 0x8006DEEC
+static s32 romPutDebug16() {}
+
+// Range: 0x8006DEEC -> 0x8006DEF4
+static s32 romPutDebug8() {}
+
+// Range: 0x8006DEF4 -> 0x8006DF70
+static s32 romGet64(struct __anon_0x4D873* pROM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s64* pData; // r31
+
+    // Local variables
+    u64 nData; // r1+0x18
+}
+
+// Range: 0x8006DF70 -> 0x8006DFE0
+static s32 romGet32(struct __anon_0x4D873* pROM, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s32* pData; // r31
+
+    // Local variables
+    u32 nData; // r1+0x14
+}
+
+// Range: 0x8006DFE0 -> 0x8006E050
+static s32 romGet16(struct __anon_0x4D873* pROM, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s16* pData; // r31
+
+    // Local variables
+    u16 nData; // r1+0x14
+}
+
+// Range: 0x8006E050 -> 0x8006E0C0
+static s32 romGet8(struct __anon_0x4D873* pROM, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // char* pData; // r31
+
+    // Local variables
+    u8 nData; // r1+0x14
+}
+
+// Range: 0x8006E0C0 -> 0x8006E0C8
+static s32 romPut64() {}
+
+// Range: 0x8006E0C8 -> 0x8006E0D0
+static s32 romPut32() {}
+
+// Range: 0x8006E0D0 -> 0x8006E0D8
+static s32 romPut16() {}
+
+// Range: 0x8006E0D8 -> 0x8006E0E0
+static s32 romPut8() {}
+
+// Range: 0x8006E0E0 -> 0x8006E1A4
+s32 romTestCode(struct __anon_0x4D873* pROM, char* acCode) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x8
+    // char* acCode; // r1+0xC
+
+    // Local variables
+    s32 iCode; // r1+0x8
+    char acCodeCurrent[5]; // r1+0x1C
+}
+
+// Erased
+static s32 romGetMask(struct __anon_0x4D873* pROM, s32* pnMask) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* pnMask; // r1+0x4
+}
+
+// Erased
+static s32 romGetName(struct __anon_0x4D873* pROM, char* acName) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // char* acName; // r1+0x4
+
+    // Local variables
+    s32 iName; // r10
+}
+
+// Range: 0x8006E1A4 -> 0x8006E1D8
+s32 romGetCode(struct __anon_0x4D873* pROM, char* acCode) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // char* acCode; // r1+0x4
+}
+
+// Range: 0x8006E1D8 -> 0x8006E3D4
+s32 romGetPC(struct __anon_0x4D873* pROM, u64* pnPC) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u64* pnPC; // r31
+
+    // Local variables
+    s32 nOffset; // r5
+    u32 nData; // r5
+    u32 iData; // r1+0x8
+    u32 anData[1024]; // r1+0x18
+}
+
+// Erased
+static s32 romLoad(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+}
+
+// Range: 0x8006E3D4 -> 0x8006E83C
+static s32 romLoadFullOrPart(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x1C
+    s32 iBlock; // r1+0x8
+    s32 nLoad; // r27
+    s32 nStep; // r28
+    s32 iData; // r7
+    u32 nData; // r1+0x8
+}
+
+// Erased
+static s32 romCacheAllBlocks(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r27
+
+    // Local variables
+    s32 iCache; // r1+0xC
+    u32 iBlock; // r28
+    u32 iBlockLast; // r1+0x8
+}
+
+struct __anon_0x4F17B {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x4F17B* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x4F530 {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-int romSetImage(__anon_0x4D873 *pROM, char *szNameFile)
-{
-	tXL_FILE *pFile;
-	int iName;
-	int nSize;
-}
-
-int romGetCacheSize(__anon_0x4D873 *pROM, int *pnSize);
-
-int romSetCacheSize(__anon_0x4D873 *pROM, int nSize);
-
-int romCopyBusy(__anon_0x4D873 *pROM);
-
-int romUpdate(__anon_0x4D873 *pROM)
-{
-	int nStatus;
-}
-
-int romCopyImmediate(__anon_0x4D873 *pROM, void *pTarget, int nOffsetROM, unsigned int nSize)
-{
-	void *pSource;
-	__anon_0x4CFE6 *pBlock;
-	int nOffsetARAM;
-	int nSizeCopy;
-	int nOffsetBlock;
-	int nSizeCopyARAM;
-	int nSizeDMA;
-	int nOffset;
-	int nOffsetTarget;
-	unsigned char *pBuffer;
-	unsigned char anBuffer[608];
-}
-
-int romCopy(__anon_0x4D873 *pROM, void *pTarget, int nOffset, unsigned int nSize, int (*pCallback)())
-{
-	void *pSource;
-	tXL_FILE *pFile;
-}
-
-int romGetSize(__anon_0x4D873 *pROM, int *pnSize);
-
-// Local to compilation unit
-static int romGetDebug64(signed long long *pData);
-
-// Local to compilation unit
-static int romGetDebug32(int *pData);
-
-// Local to compilation unit
-static int romGetDebug16(signed short *pData);
-
-// Local to compilation unit
-static int romGetDebug8(char *pData);
-
-// Local to compilation unit
-static int romPutDebug64();
-
-// Local to compilation unit
-static int romPutDebug32();
-
-// Local to compilation unit
-static int romPutDebug16();
-
-// Local to compilation unit
-static int romPutDebug8();
-
-// Local to compilation unit
-static int romGet64(__anon_0x4D873 *pROM, unsigned int nAddress, signed long long *pData)
-{
-	unsigned long long nData;
-}
-
-// Local to compilation unit
-static int romGet32(__anon_0x4D873 *pROM, unsigned int nAddress, int *pData)
-{
-	unsigned int nData;
-}
-
-// Local to compilation unit
-static int romGet16(__anon_0x4D873 *pROM, unsigned int nAddress, signed short *pData)
-{
-	unsigned short nData;
-}
-
-// Local to compilation unit
-static int romGet8(__anon_0x4D873 *pROM, unsigned int nAddress, char *pData)
-{
-	unsigned char nData;
-}
-
-// Local to compilation unit
-static int romPut64();
-
-// Local to compilation unit
-static int romPut32();
-
-// Local to compilation unit
-static int romPut16();
-
-// Local to compilation unit
-static int romPut8();
-
-int romTestCode(__anon_0x4D873 *pROM, char *acCode)
-{
-	int iCode;
-	char acCodeCurrent[5];
-}
-
-int romGetMask(__anon_0x4D873 *pROM, int *pnMask);
-
-int romGetName(__anon_0x4D873 *pROM, char *acName)
-{
-	int iName;
-}
-
-int romGetCode(__anon_0x4D873 *pROM, char *acCode);
-
-int romGetPC(__anon_0x4D873 *pROM, unsigned long long *pnPC)
-{
-	int nOffset;
-	unsigned int nData;
-	unsigned int iData;
-	unsigned int anData[1024];
-}
-
-int romLoad(__anon_0x4D873 *pROM);
-
-// Local to compilation unit
-static int romLoadFullOrPart(__anon_0x4D873 *pROM)
-{
-	tXL_FILE *pFile;
-	int iBlock;
-	int nLoad;
-	int nStep;
-	int iData;
-	unsigned int nData;
-}
-
-int romCacheAllBlocks(__anon_0x4D873 *pROM)
-{
-	int iCache;
-	unsigned int iBlock;
-	unsigned int iBlockLast;
-}
-
-// size: 0x8
-struct __anon_0x4F17B
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
+union __anon_0x4F944 {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
-};
+struct __anon_0x4FE52 {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
 
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x4F17B *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
-};
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
 
-// size: 0x8
-union __anon_0x4F530
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
 
-// size: 0x8
-union __anon_0x4F944
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
+struct __anon_0x50416 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
 
-// size: 0x34
-struct __anon_0x4FE52
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
-};
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
 
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
-};
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
 
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
-};
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
 
-// size: 0xC
-struct __anon_0x50416
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
-};
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x4F530 aGPR[32];
+    /* 0x00140 */ union __anon_0x4F944 aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x4FE52* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x50416 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
 
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
+// Range: 0x8006E83C -> 0x8006EAC0
+static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r29
 
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
-
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
-
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x4F530 aGPR[32]; // 0x40
-	__anon_0x4F944 aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x4FE52 *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x50416 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
-
-// Local to compilation unit
-static int romCopyUpdate(__anon_0x4D873 *pROM)
-{
-	__anon_0x4CFE6 *pBlock;
-	int iCache;
-	int nTickLast;
-	unsigned char *anData;
-	unsigned int iBlock;
-	unsigned int nSize;
-	unsigned int nOffsetBlock;
-	_CPU *pCPU;
+    // Local variables
+    struct __anon_0x4CFE6* pBlock; // r28
+    s32 iCache; // r1+0xC
+    s32 nTickLast; // r27
+    u8* anData; // r1+0x8
+    u32 iBlock; // r26
+    u32 nSize; // r26
+    u32 nOffsetBlock; // r1+0x8
+    struct _CPU* pCPU; // r30
 }
 
-// size: 0x4
-enum __anon_0x51281
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
+enum __anon_0x51281 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// size: 0x10
-struct __anon_0x512E3
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+struct __anon_0x512E3 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x51394 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x4
-enum __anon_0x51394
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
+enum __anon_0x514C0 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum __anon_0x514C0
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
+struct __anon_0x515FB {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x51281 eMode;
+    /* 0x10 */ struct __anon_0x512E3 romCopy;
+    /* 0x20 */ enum __anon_0x51394 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x514C0 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x515FB* gpSystem;
+
+// Range: 0x8006EAC0 -> 0x8006EADC
+static s32 __romCopyUpdate_Complete() {
+    // References
+    // -> struct __anon_0x515FB* gpSystem;
+}
+
+// Range: 0x8006EADC -> 0x8006EC3C
+static s32 romLoadUpdate(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r29
+
+    // Local variables
+    s32 iCache; // r1+0xC
+    struct __anon_0x4CFE6* pBlock; // r4
+    u32 iBlock0; // r31
+    u32 iBlock1; // r25
+    struct _CPU* pCPU; // r30
+}
+
+// Erased
+static s32 romLoadInProgress(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+}
+
+// Range: 0x8006EC3C -> 0x8006EC58
+static s32 __romLoadUpdate_Complete() {
+    // References
+    // -> struct __anon_0x515FB* gpSystem;
+}
+
+// size = 0x4, address = 0x801355D8
+s32 gDVDResetToggle;
+
+// size = 0x4, address = 0x801356D8
+u32 gnFlagZelda;
+
+// size = 0x4, address = 0x801355FC
+s32 gbDisplayedError;
+
+// Range: 0x8006EC58 -> 0x8006F208
+static s32 romCacheGame(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+
+    // Local variables
+    s32 blockCount; // r1+0x68
+    s32 nSize; // r30
+    char* szName; // r5
+    struct tXL_FILE* pFile; // r1+0x5C
+
+    // References
+    // -> s32 gDVDResetToggle;
+    // -> u32 gnFlagZelda;
+    // -> s32 gbDisplayedError;
+    // -> static s32 gbProgress;
+    // -> static void* gpImageBack;
+    // -> static u32 ganOffsetBlock_URAZLJ[198];
+    // -> static u32 ganOffsetBlock_ZLJ[198];
+}
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+// Range: 0x8006F208 -> 0x8006F488
+static s32 romCacheGame_ZELDA(float rProgress) {
+    // Parameters
+    // float rProgress; // f31
+
+    // Local variables
+    s32 nSize; // r31
+    float matrix44[4][4]; // r1+0x2C
+    struct _GXTexObj textureObject; // r1+0xC
+
+    // References
+    // -> static s32 gbProgress;
+    // -> static s32 iImage$294;
+    // -> struct __anon_0x515FB* gpSystem;
+    // -> static void* gpImageBack;
+    // -> s32 gbDisplayedError;
+}
+
+// Range: 0x8006F488 -> 0x8006F5D4
+static s32 romLoadRange(struct __anon_0x4D873* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
+                        s32 (*pfProgress)(float)) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r26
+    // s32 begin; // r1+0xC
+    // s32 end; // r1+0x10
+    // s32* blockCount; // r27
+    // s32 whichBlock; // r1+0x18
+    // s32 (* pfProgress)(float); // r28
+
+    // Local variables
+    s32 iCache; // r1+0x20
+    u32 iBlock; // r30
+    u32 iBlockLast; // r29
+}
+
+// Erased
+static s32 romKeepCheck() {}
+
+// Range: 0x8006F5D4 -> 0x8006F6D0
+static s32 romLoadBlock(struct __anon_0x4D873* pROM, s32 iBlock, s32 iCache, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+    // s32 iBlock; // r1+0xC
+    // s32 iCache; // r1+0x10
+    // s32 (* pCallback)(); // r1+0x14
+
+    // Local variables
+    u8* anData; // r8
+    s32 nSizeRead; // r10
+    u32 nSize; // r10
+    u32 nOffset; // r1+0x8
+}
+
+// Range: 0x8006F6D0 -> 0x8006F6EC
+static void __romLoadBlock_CompleteGCN(s32 nResult) {
+    // Parameters
+    // s32 nResult; // r1+0x0
+
+    // Local variables
+    struct __anon_0x4D873* pROM; // r4
+
+    // References
+    // -> struct __anon_0x515FB* gpSystem;
+}
+
+// Range: 0x8006F6EC -> 0x8006F7E0
+static s32 __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x8
+
+    // Local variables
+    u32 iData; // r9
+    u32 nData; // r1+0x8
+}
+
+enum __anon_0x5219D {
+    RCT_NONE = -1,
+    RCT_RAM = 0,
+    RCT_ARAM = 1,
 };
 
-// size: 0x88
-struct __anon_0x515FB
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x51281 eMode; // 0xC
-	__anon_0x512E3 romCopy; // 0x10
-	__anon_0x51394 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x514C0 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
+// Range: 0x8006F7E0 -> 0x8006FA38
+static s32 romSetBlockCache(struct __anon_0x4D873* pROM, s32 iBlock, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 iBlock; // r1+0xC
+    // enum __anon_0x5219D eType; // r1+0x10
 
-// Location: 0x561380
-__anon_0x515FB *gpSystem;
-
-// Local to compilation unit
-static int __romCopyUpdate_Complete()
-{
-	// References: gpSystem (0x561380)
+    // Local variables
+    struct __anon_0x4CFE6* pBlock; // r31
+    s32 iCacheRAM; // r1+0x18
+    s32 iCacheARAM; // r1+0x14
+    s32 nOffsetRAM; // r28
+    s32 nOffsetARAM; // r29
 }
 
-// Local to compilation unit
-static int romLoadUpdate(__anon_0x4D873 *pROM)
-{
-	int iCache;
-	__anon_0x4CFE6 *pBlock;
-	unsigned int iBlock0;
-	unsigned int iBlock1;
-	_CPU *pCPU;
+// Range: 0x8006FA38 -> 0x8006FC4C
+static s32 romMakeFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32* piCache; // r31
+    // enum __anon_0x5219D eType; // r1+0x10
+
+    // Local variables
+    s32 iCache; // r1+0x20
+    s32 iBlockOldest; // r1+0x1C
 }
 
-int romLoadInProgress(__anon_0x4D873 *pROM);
+// Range: 0x8006FC4C -> 0x8006FDFC
+static s32 romFindOldestBlock(struct __anon_0x4D873* pROM, s32* piBlock, enum __anon_0x5219D eTypeCache,
+                              s32 whichBlock) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // s32* piBlock; // r1+0x4
+    // enum __anon_0x5219D eTypeCache; // r1+0x8
+    // s32 whichBlock; // r1+0xC
 
-// Local to compilation unit
-static int __romLoadUpdate_Complete()
-{
-	// References: gpSystem (0x561380)
+    // Local variables
+    struct __anon_0x4CFE6* pBlock; // r7
+    s32 iBlock; // r8
+    s32 iBlockOldest; // r9
+    u32 nTick; // r10
+    u32 nTickDelta; // r11
+    u32 nTickDeltaOldest; // r12
 }
 
-// Location: 0x801355D8
-int gDVDResetToggle;
+// Range: 0x8006FDFC -> 0x8006FEC0
+static s32 romFindFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* piCache; // r1+0x4
+    // enum __anon_0x5219D eType; // r1+0x8
 
-// Location: 0x801356D8
-unsigned int gnFlagZelda;
-
-// Location: 0x801355FC
-int gbDisplayedError;
-
-// Local to compilation unit
-static int romCacheGame(__anon_0x4D873 *pROM)
-{
-	int blockCount;
-	int nSize;
-	char *szName;
-	tXL_FILE *pFile;
-	// References: gDVDResetToggle (0x801355D8)
-	// References: gnFlagZelda (0x801356D8)
-	// References: gbDisplayedError (0x801355FC)
-	// References: gbProgress (0x60571380)
-	// References: gpImageBack (0x64571380)
-	// References: ganOffsetBlock_URAZLJ (0x10DC0E80)
-	// References: ganOffsetBlock_ZLJ (0x800ED8F8)
+    // Local variables
+    s32 iBlock; // r7
 }
 
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
+// Erased
+static s32 romFreeBlock(struct __anon_0x4D873* pROM, s32 iBlock) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32 iBlock; // r1+0x4
 
-// Local to compilation unit
-static int romCacheGame_ZELDA(float rProgress)
-{
-	int nSize;
-	float matrix44[4][4];
-	_GXTexObj textureObject;
-	// References: gbProgress (0x60571380)
-	// References: iImage$294 (0x68571380)
-	// References: gpSystem (0x561380)
-	// References: gpImageBack (0x64571380)
-	// References: gbDisplayedError (0x801355FC)
+    // Local variables
+    s32 iCache; // r4
+    struct __anon_0x4CFE6* pBlock; // r1+0x0
 }
 
-// Local to compilation unit
-static int romLoadRange(__anon_0x4D873 *pROM, int begin, int end, int *blockCount, int whichBlock, int (*pfProgress)(float /* unknown0 */))
-{
-	int iCache;
-	unsigned int iBlock;
-	unsigned int iBlockLast;
+// Erased
+static s32 romMatchRange(struct __anon_0x4D873* pROM, u32 nOffset, s32* pnOffset0, s32* pnOffset1) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // u32 nOffset; // r1+0x4
+    // s32* pnOffset0; // r1+0x8
+    // s32* pnOffset1; // r1+0xC
+
+    // Local variables
+    s32 iBlock; // r10
 }
 
-int romKeepCheck();
-
-// Local to compilation unit
-static int romLoadBlock(__anon_0x4D873 *pROM, int iBlock, int iCache, int (*pCallback)())
-{
-	unsigned char *anData;
-	int nSizeRead;
-	unsigned int nSize;
-	unsigned int nOffset;
-}
-
-// Local to compilation unit
-static void __romLoadBlock_CompleteGCN(long nResult)
-{
-	__anon_0x4D873 *pROM;
-	// References: gpSystem (0x561380)
-}
-
-// Local to compilation unit
-static int __romLoadBlock_Complete(__anon_0x4D873 *pROM)
-{
-	unsigned int iData;
-	unsigned int nData;
-}
-
-// size: 0x4
-enum __anon_0x5219D
-{
-	RCT_NONE = 4294967295,
-	RCT_RAM = 0,
-	RCT_ARAM = 1
-};
-
-// Local to compilation unit
-static int romSetBlockCache(__anon_0x4D873 *pROM, int iBlock, __anon_0x5219D eType)
-{
-	__anon_0x4CFE6 *pBlock;
-	int iCacheRAM;
-	int iCacheARAM;
-	int nOffsetRAM;
-	int nOffsetARAM;
-}
-
-// Local to compilation unit
-static int romMakeFreeCache(__anon_0x4D873 *pROM, int *piCache, __anon_0x5219D eType)
-{
-	int iCache;
-	int iBlockOldest;
-}
-
-// Local to compilation unit
-static int romFindOldestBlock(__anon_0x4D873 *pROM, int *piBlock, __anon_0x5219D eTypeCache, int whichBlock)
-{
-	__anon_0x4CFE6 *pBlock;
-	int iBlock;
-	int iBlockOldest;
-	unsigned int nTick;
-	unsigned int nTickDelta;
-	unsigned int nTickDeltaOldest;
-}
-
-// Local to compilation unit
-static int romFindFreeCache(__anon_0x4D873 *pROM, int *piCache, __anon_0x5219D eType)
-{
-	int iBlock;
-}
-
-int romFreeBlock(__anon_0x4D873 *pROM, int iBlock)
-{
-	int iCache;
-	__anon_0x4CFE6 *pBlock;
-}
-
-int romMatchRange(__anon_0x4D873 *pROM, unsigned int nOffset, int *pnOffset0, int *pnOffset1)
-{
-	int iBlock;
-}
-
-int romTestARAM();
-
+// Erased
+static s32 romTestARAM() {}

--- a/debug/Fire/rom.c
+++ b/debug/Fire/rom.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x4CD3A; // size = 0x10
 
 // size = 0x10, address = 0x800ED8E8
 struct _XL_OBJECTTYPE gClassROM;
@@ -32,29 +32,29 @@ static void* gpImageBack;
 // size = 0x4, address = 0x80135768
 static s32 iImage$294;
 
-enum __anon_0x4CF87 {
+typedef enum __anon_0x4CF87 {
     RLM_NONE = -1,
     RLM_PART = 0,
     RLM_FULL = 1,
     RLM_COUNT_ = 2,
-};
+} __anon_0x4CF87;
 
-struct __anon_0x4CFE6 {
+typedef struct __anon_0x4CFE6 {
     /* 0x0 */ s32 iCache;
     /* 0x4 */ u32 nSize;
     /* 0x8 */ u32 nTickUsed;
     /* 0xC */ char keep;
-}; // size = 0x10
+} __anon_0x4CFE6; // size = 0x10
 
-struct __anon_0x4D0FA {
+typedef struct __anon_0x4D0FA {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 (*pCallback)();
     /* 0x08 */ u8* pTarget;
     /* 0x0C */ u32 nSize;
     /* 0x10 */ u32 nOffset;
-}; // size = 0x14
+} __anon_0x4D0FA; // size = 0x14
 
-struct __anon_0x4D1DA {
+typedef struct __anon_0x4D1DA {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 bDone;
     /* 0x08 */ s32 nResult;
@@ -67,9 +67,9 @@ struct __anon_0x4D1DA {
     /* 0x24 */ u32 nOffset1;
     /* 0x28 */ u32 nSize;
     /* 0x2C */ u32 nSizeRead;
-}; // size = 0x30
+} __anon_0x4D1DA; // size = 0x30
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -77,9 +77,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x4D425; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -92,16 +92,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x4D595; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x4D7BB; // size = 0x3C
 
-struct __anon_0x4D873 {
+typedef struct __anon_0x4D873 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
     /* 0x00008 */ s32 bFlip;
@@ -123,7 +123,7 @@ struct __anon_0x4D873 {
     /* 0x10EB4 */ s32 nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
     /* 0x10EF4 */ s32 offsetToRom;
-}; // size = 0x10EF8
+} __anon_0x4D873; // size = 0x10EF8
 
 // Range: 0x8006D3AC -> 0x8006D5D8
 s32 romEvent(struct __anon_0x4D873* pROM, s32 nEvent, void* pArgument) {
@@ -143,13 +143,13 @@ s32 romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
     s32 iName; // r6
 }
 
-enum __anon_0x4DD08 {
+typedef enum __anon_0x4DD08 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
-};
+} __anon_0x4DD08;
 
-struct tXL_FILE {
+typedef struct tXL_FILE {
     /* 0x00 */ s32 iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
@@ -158,7 +158,7 @@ struct tXL_FILE {
     /* 0x14 */ s32 nOffset;
     /* 0x18 */ enum __anon_0x4DD08 eType;
     /* 0x1C */ struct DVDFileInfo info;
-}; // size = 0x58
+} __anon_0x4DD5C; // size = 0x58
 
 // Range: 0x8006D620 -> 0x8006D794
 s32 romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
@@ -415,17 +415,17 @@ static s32 romCacheAllBlocks(struct __anon_0x4D873* pROM) {
     u32 iBlockLast; // r1+0x8
 }
 
-struct __anon_0x4F17B {
+typedef struct __anon_0x4F17B {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x4F17B; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x4F1E1; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -444,9 +444,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x4F254; // size = 0x48
 
-union __anon_0x4F530 {
+typedef union __anon_0x4F530 {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -477,9 +477,9 @@ union __anon_0x4F530 {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x4F530;
 
-union __anon_0x4F944 {
+typedef union __anon_0x4F944 {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -489,9 +489,9 @@ union __anon_0x4F944 {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x4F944;
 
-struct __anon_0x4FE52 {
+typedef struct __anon_0x4FE52 {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -505,9 +505,9 @@ struct __anon_0x4FE52 {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x4FE52; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -522,21 +522,21 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x50120; // size = 0x84
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x50361; // size = 0xC
 
-struct __anon_0x50416 {
+typedef struct __anon_0x50416 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x50416; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -552,9 +552,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x50541; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -562,9 +562,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x50798; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -575,9 +575,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x508B3; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -621,7 +621,7 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x50A60; // size = 0x12090
 
 // Range: 0x8006E83C -> 0x8006EAC0
 static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
@@ -639,20 +639,20 @@ static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
     struct _CPU* pCPU; // r30
 }
 
-enum __anon_0x51281 {
+typedef enum __anon_0x51281 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x51281;
 
-struct __anon_0x512E3 {
+typedef struct __anon_0x512E3 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x512E3; // size = 0x10
 
-enum __anon_0x51394 {
+typedef enum __anon_0x51394 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -667,9 +667,9 @@ enum __anon_0x51394 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x51394;
 
-enum __anon_0x514C0 {
+typedef enum __anon_0x514C0 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -688,9 +688,9 @@ enum __anon_0x514C0 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x514C0;
 
-struct __anon_0x515FB {
+typedef struct __anon_0x515FB {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -702,7 +702,7 @@ struct __anon_0x515FB {
     /* 0x70 */ enum __anon_0x514C0 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x515FB; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x515FB* gpSystem;
@@ -768,9 +768,9 @@ static s32 romCacheGame(struct __anon_0x4D873* pROM) {
     // -> static u32 ganOffsetBlock_ZLJ[198];
 }
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x51BD0; // size = 0x20
 
 // Range: 0x8006F208 -> 0x8006F488
 static s32 romCacheGame_ZELDA(float rProgress) {
@@ -847,11 +847,11 @@ static s32 __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
     u32 nData; // r1+0x8
 }
 
-enum __anon_0x5219D {
+typedef enum __anon_0x5219D {
     RCT_NONE = -1,
     RCT_RAM = 0,
     RCT_ARAM = 1,
-};
+} __anon_0x5219D;
 
 // Range: 0x8006F7E0 -> 0x8006FA38
 static s32 romSetBlockCache(struct __anon_0x4D873* pROM, s32 iBlock, enum __anon_0x5219D eType) {

--- a/debug/Fire/rsp.c
+++ b/debug/Fire/rsp.c
@@ -1,1396 +1,1340 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\rsp.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80071BB8 -> 0x80074454
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE220
+struct _XL_OBJECTTYPE gClassRSP;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+// size = 0x20, address = 0x800EE230
+s32 cmask_tab[8];
+
+// size = 0x20, address = 0x800EE250
+s32 emask_tab[8];
+
+// size = 0x4, address = 0x801352C4
+static s32 nFirstTime$2148;
+
+// size = 0x4, address = 0x80135788
+static s32 counter$2409;
+
+// size = 0x4, address = 0x801352C8
+static s32 nFirstTime$2648;
+
+// size = 0x4, address = 0x801352CC
+static s32 nFirstTime$2757;
+
+// size = 0x4, address = 0x801352D0
+static s32 nFirstTime$2796;
+
+// size = 0x2, address = 0x8013578C
+static u16 scissorX0;
+
+// size = 0x2, address = 0x8013578E
+static u16 scissorY0;
+
+// size = 0x2, address = 0x801352D4
+static u16 scissorX1;
+
+// size = 0x2, address = 0x801352D6
+static u16 scissorY1;
+
+// size = 0x1, address = 0x80135790
+static u8 flagBilerp;
+
+// size = 0x4, address = 0x80135794
+static u32 rdpSetTimg_w0;
+
+// size = 0x4, address = 0x80135798
+static u32 rdpSetTile_w0;
+
+// size = 0x2, address = 0x8013579C
+static u16 tmemSliceWmax;
+
+// size = 0x2, address = 0x8013579E
+static u16 imageSrcWsize;
+
+// size = 0x2, address = 0x801357A0
+static u16 flagSplit;
+
+// size = 0x2, address = 0x801357A2
+static u16 imagePtrX0;
+
+// size = 0x4, address = 0x801357A4
+static u32 imageTop;
+
+// size = 0x2, address = 0x801357A8
+static s16 tmemSrcLines;
+
+// size = 0xA, address = 0x800EE270
+static s16 TMEMSIZE$3463[5];
+
+// size = 0x8, address = 0x801352D8
+static s16 TMEMMASK$3464[4];
+
+// size = 0x8, address = 0x801352E0
+static s16 TMEMSHIFT$3465[4];
+
+struct __anon_0x575BD {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ s32 nFlag;
+    /* 0x08 */ s32 nOffsetBoot;
+    /* 0x0C */ s32 nLengthBoot;
+    /* 0x10 */ s32 nOffsetCode;
+    /* 0x14 */ s32 nLengthCode;
+    /* 0x18 */ s32 nOffsetData;
+    /* 0x1C */ s32 nLengthData;
+    /* 0x20 */ s32 nOffsetStack;
+    /* 0x24 */ s32 nLengthStack;
+    /* 0x28 */ s32 nOffsetBuffer;
+    /* 0x2C */ s32 nLengthBuffer;
+    /* 0x30 */ s32 nOffsetMBI;
+    /* 0x34 */ s32 nLengthMBI;
+    /* 0x38 */ s32 nOffsetYield;
+    /* 0x3C */ s32 nLengthYield;
+}; // size = 0x40
+
+struct __anon_0x57890 {
+    /* 0x00 */ s32 iDL;
+    /* 0x04 */ s32 bValid;
+    /* 0x08 */ struct __anon_0x575BD task;
+    /* 0x48 */ s32 nCountVertex;
+    /* 0x4C */ enum __anon_0x60B3F eTypeUCode;
+    /* 0x50 */ u32 n2TriMult;
+    /* 0x54 */ u32 nVersionUCode;
+    /* 0x58 */ s32 anBaseSegment[16];
+    /* 0x98 */ u64* apDL[16];
+}; // size = 0xD8
+
+struct __anon_0x57AB1 {
+    /* 0x00 */ float aRotations[2][2];
+    /* 0x10 */ float fX;
+    /* 0x14 */ float fY;
+    /* 0x18 */ float fBaseScaleX;
+    /* 0x1C */ float fBaseScaleY;
+}; // size = 0x20
+
+struct __anon_0x57BBE {
+    /* 0x0 */ float rS;
+    /* 0x4 */ float rT;
+    /* 0x8 */ s16 nX;
+    /* 0xA */ s16 nY;
+    /* 0xC */ s16 nZ;
+    /* 0xE */ u8 anData[4];
+}; // size = 0x14
+
+struct __anon_0x57CD6 {
+    /* 0x0 */ char anNormal[3];
+}; // size = 0x3
+
+struct __anon_0x57D55 {
+    /* 0x0 */ u8 anMaterial[4];
+}; // size = 0x4
+
+struct __anon_0x57DF8 {
+    /* 0x0 */ float aMatrix[4][4];
+}; // size = 0x40
+
+struct __anon_0x57E56 {
+    /* 0x0 */ u8 nRed;
+    /* 0x1 */ u8 nGreen;
+    /* 0x2 */ u8 nBlue;
+    /* 0x3 */ char rVectorX;
+    /* 0x4 */ char rVectorY;
+    /* 0x5 */ char rVectorZ;
+}; // size = 0x6
+
+struct __anon_0x58107 {
+    /* 0x0 */ s16 anSlice[8];
+}; // size = 0x10
+
+enum __anon_0x581E7 {
+    RUT_NOCODE = -1,
+    RUT_ABI1 = 0,
+    RUT_ABI2 = 1,
+    RUT_ABI3 = 2,
+    RUT_ABI4 = 3,
+    RUT_UNKNOWN = 4,
 };
 
-// Location: 0x20E20E80
-_XL_OBJECTTYPE gClassRSP;
-
-// Location: 0x0
-unsigned short rsp_VCO;
-
-// Location: 0x0
-unsigned short rsp_VCC;
-
-// Location: 0x0
-unsigned char rsp_VCE;
-
-// Location: 0x0
-unsigned char vco_carry[8];
-
-// Location: 0x0
-unsigned char vco_equal[8];
-
-// Location: 0x30E20E80
-int cmask_tab[8];
-
-// Location: 0x50E20E80
-int emask_tab[8];
-
-// Location: 0x0
-int bSoundDebugOutput;
-
-// Local to compilation unit
-// Location: 0x801352C4
-static int nFirstTime$2148;
-
-// Location: 0x0
-unsigned int nTimesCalled$2403;
-
-// Local to compilation unit
-// Location: 0x80135788
-static int counter$2409;
-
-// Local to compilation unit
-// Location: 0x801352C8
-static int nFirstTime$2648;
-
-// Local to compilation unit
-// Location: 0x801352CC
-static int nFirstTime$2757;
-
-// Local to compilation unit
-// Location: 0x801352D0
-static int nFirstTime$2796;
-
-// Local to compilation unit
-// Location: 0x8013578C
-static unsigned short scissorX0;
-
-// Local to compilation unit
-// Location: 0x8013578E
-static unsigned short scissorY0;
-
-// Local to compilation unit
-// Location: 0x801352D4
-static unsigned short scissorX1;
-
-// Local to compilation unit
-// Location: 0x801352D6
-static unsigned short scissorY1;
-
-// Local to compilation unit
-// Location: 0x80135790
-static unsigned char flagBilerp;
-
-// Local to compilation unit
-// Location: 0x80135794
-static unsigned int rdpSetTimg_w0;
-
-// Local to compilation unit
-// Location: 0x80135798
-static unsigned int rdpSetTile_w0;
-
-// Local to compilation unit
-// Location: 0x8013579C
-static unsigned short tmemSliceWmax;
-
-// Local to compilation unit
-// Location: 0x8013579E
-static unsigned short imageSrcWsize;
-
-// Local to compilation unit
-// Location: 0x801357A0
-static unsigned short flagSplit;
-
-// Local to compilation unit
-// Location: 0x801357A2
-static unsigned short imagePtrX0;
-
-// Local to compilation unit
-// Location: 0x801357A4
-static unsigned int imageTop;
-
-// Local to compilation unit
-// Location: 0x801357A8
-static signed short tmemSrcLines;
-
-// Local to compilation unit
-// Location: 0x70E20E80
-static signed short TMEMSIZE$3463[5];
-
-// Local to compilation unit
-// Location: 0x801352D8
-static signed short TMEMMASK$3464[4];
-
-// Local to compilation unit
-// Location: 0x801352E0
-static signed short TMEMSHIFT$3465[4];
-
-// size: 0x40
-struct __anon_0x575BD
-{
-	int nType; // 0x0
-	int nFlag; // 0x4
-	int nOffsetBoot; // 0x8
-	int nLengthBoot; // 0xC
-	int nOffsetCode; // 0x10
-	int nLengthCode; // 0x14
-	int nOffsetData; // 0x18
-	int nLengthData; // 0x1C
-	int nOffsetStack; // 0x20
-	int nLengthStack; // 0x24
-	int nOffsetBuffer; // 0x28
-	int nLengthBuffer; // 0x2C
-	int nOffsetMBI; // 0x30
-	int nLengthMBI; // 0x34
-	int nOffsetYield; // 0x38
-	int nLengthYield; // 0x3C
-};
-
-// size: 0xD8
-struct __anon_0x57890
-{
-	int iDL; // 0x0
-	int bValid; // 0x4
-	__anon_0x575BD task; // 0x8
-	int nCountVertex; // 0x48
-	__anon_0x60B3F eTypeUCode; // 0x4C
-	unsigned int n2TriMult; // 0x50
-	unsigned int nVersionUCode; // 0x54
-	int anBaseSegment[16]; // 0x58
-	unsigned long long  *apDL[16]; // 0x98
-};
-
-// size: 0x20
-struct __anon_0x57AB1
-{
-	float aRotations[2][2]; // 0x0
-	float fX; // 0x10
-	float fY; // 0x14
-	float fBaseScaleX; // 0x18
-	float fBaseScaleY; // 0x1C
-};
-
-// size: 0x14
-struct __anon_0x57BBE
-{
-	float rS; // 0x0
-	float rT; // 0x4
-	signed short nX; // 0x8
-	signed short nY; // 0xA
-	signed short nZ; // 0xC
-	unsigned char anData[4]; // 0xE
-};
-
-// size: 0x3
-struct __anon_0x57CD6
-{
-	char anNormal[3]; // 0x0
-};
-
-// size: 0x4
-struct __anon_0x57D55
-{
-	unsigned char anMaterial[4]; // 0x0
-};
-
-// size: 0x40
-struct __anon_0x57DF8
-{
-	float aMatrix[4][4]; // 0x0
-};
-
-// size: 0x6
-struct __anon_0x57E56
-{
-	unsigned char nRed; // 0x0
-	unsigned char nGreen; // 0x1
-	unsigned char nBlue; // 0x2
-	char rVectorX; // 0x3
-	char rVectorY; // 0x4
-	char rVectorZ; // 0x5
-};
-
-// size: 0x10
-struct __anon_0x58107
-{
-	signed short anSlice[8]; // 0x0
-};
-
-// size: 0x4
-enum __anon_0x581E7
-{
-	RUT_NOCODE = 4294967295,
-	RUT_ABI1 = 0,
-	RUT_ABI2 = 1,
-	RUT_ABI3 = 2,
-	RUT_ABI4 = 3,
-	RUT_UNKNOWN = 4
-};
-
-// size: 0x10
-struct tXL_LIST
-{
-	int nItemSize; // 0x0
-	int nItemCount; // 0x4
-	void *pNodeHead; // 0x8
-	void *pNodeNext; // 0xC
-};
-
-// size: 0x8
-struct __anon_0x58360
-{
-	signed short r; // 0x0
-	signed short g; // 0x2
-	signed short b; // 0x4
-	signed short a; // 0x6
-};
-
-// size: 0x6
-struct __anon_0x583EE
-{
-	signed short y; // 0x0
-	signed short u; // 0x2
-	signed short v; // 0x4
-};
-
-// size: 0x39CC
-struct __anon_0x5845E
-{
-	int nMode; // 0x0
-	__anon_0x57890 yield; // 0x4
-	unsigned int nTickLast; // 0xDC
-	int (*pfUpdateWaiting)(); // 0xE0
-	unsigned int n2TriMult; // 0xE4
-	int aStatus[4]; // 0xE8
-	float aMatrixOrtho[4][4]; // 0xF8
-	unsigned int nMode2D; // 0x138
-	__anon_0x57AB1 twoDValues; // 0x13C
-	int nPass; // 0x15C
-	unsigned int nZSortSubDL; // 0x160
-	unsigned int nStatusSubDL; // 0x164
-	unsigned int nNumZSortLights; // 0x168
-	int aLightAddresses[8]; // 0x16C
-	int nAmbientLightAddress; // 0x18C
-	__anon_0x57BBE aZSortVertex[128]; // 0x190
-	__anon_0x57CD6 aZSortNormal[128]; // 0xB90
-	__anon_0x57D55 aZSortMaterial[128]; // 0xD10
-	__anon_0x57DF8 aZSortMatrix[128]; // 0xF10
-	__anon_0x57E56 aZSortLight[8]; // 0x2F10
-	int aZSortInvW[128]; // 0x2F40
-	signed short aZSortWiVal[128]; // 0x3140
-	unsigned int nNumZSortMatrices; // 0x3240
-	unsigned int nNumZSortVertices; // 0x3244
-	unsigned int nTotalZSortVertices; // 0x3248
-	unsigned int nNumZSortNormals; // 0x324C
-	unsigned int nNumZSortMaterials; // 0x3250
-	int anAudioBaseSegment[16]; // 0x3254
-	signed short *anAudioBuffer; // 0x3294
-	signed short anADPCMCoef[5][2][8]; // 0x3298
-	unsigned short nAudioDMOutR[2]; // 0x3338
-	unsigned short nAudioDMauxL[2]; // 0x333C
-	unsigned short nAudioDMauxR[2]; // 0x3340
-	unsigned short nAudioCount[2]; // 0x3344
-	unsigned short nAudioFlags; // 0x3348
-	unsigned short nAudioDMEMIn[2]; // 0x334A
-	unsigned short nAudioDMEMOut[2]; // 0x334E
-	unsigned int nAudioLoopAddress; // 0x3354
-	unsigned int nAudioDryAmt; // 0x3358
-	unsigned int nAudioWetAmt; // 0x335C
-	unsigned int nAudioVolL; // 0x3360
-	unsigned int nAudioVolR; // 0x3364
-	unsigned int nAudioVolTGTL; // 0x3368
-	unsigned int nAudioVolRateLM; // 0x336C
-	unsigned int nAudioVolRateLL; // 0x3370
-	unsigned int nAudioVolTGTR; // 0x3374
-	unsigned int nAudioVolRateRM; // 0x3378
-	unsigned int nAudioVolRateRL; // 0x337C
-	__anon_0x58107 vParams; // 0x3380
-	signed short stepF; // 0x3390
-	signed short stepL; // 0x3392
-	signed short stepR; // 0x3394
-	int anGenReg[32]; // 0x3398
-	__anon_0x58107 aVectorReg[32]; // 0x3418
-	int anCP0Reg[32]; // 0x3618
-	__anon_0x58107 anCP2Reg[32]; // 0x3698
-	signed short anAcc[24]; // 0x3898
-	signed short nVCC; // 0x38C8
-	signed short nVC0; // 0x38CA
-	char nVCE; // 0x38CC
-	__anon_0x581E7 eTypeAudioUCode; // 0x38D0
-	unsigned short nAudioMemOffset; // 0x38D4
-	unsigned short nAudioADPCMOffset; // 0x38D6
-	unsigned short nAudioScratchOffset; // 0x38D8
-	unsigned short nAudioParBase; // 0x38DA
-	int nPC; // 0x38DC
-	int iDL; // 0x38E0
-	int nBIST; // 0x38E4
-	void *pHost; // 0x38E8
-	void *pDMEM; // 0x38EC
-	void *pIMEM; // 0x38F0
-	int nStatus; // 0x38F4
-	int nFullDMA; // 0x38F8
-	int nBusyDMA; // 0x38FC
-	int nSizeGet; // 0x3900
-	int nSizePut; // 0x3904
-	int nSemaphore; // 0x3908
-	int nAddressSP; // 0x390C
-	int nGeometryMode; // 0x3910
-	int nAddressRDRAM; // 0x3914
-	tXL_LIST *pListUCode; // 0x3918
-	int nCountVertex; // 0x391C
-	__anon_0x60B3F eTypeUCode; // 0x3920
-	unsigned int nVersionUCode; // 0x3924
-	int anBaseSegment[16]; // 0x3928
-	unsigned long long  *apDL[16]; // 0x3968
-	int *Coeff; // 0x39A8
-	signed short *QTable; // 0x39AC
-	signed short *QYTable; // 0x39B0
-	signed short *QCbTable; // 0x39B4
-	signed short *QCrTable; // 0x39B8
-	int *Zigzag; // 0x39BC
-	__anon_0x58360 *rgbaBuf; // 0x39C0
-	__anon_0x583EE *yuvBuf; // 0x39C4
-	int *dctBuf; // 0x39C8
-};
-
-int rspEvent(__anon_0x5845E *pRSP, int nEvent, void *pArgument);
-
-// Location: 0x801356BC
-int gNoSwapBuffer;
-
-// size: 0x4
-enum __anon_0x5943B
-{
-	RUM_NONE = 0,
-	RUM_IDLE = 1
-};
-
-// size: 0x10
-struct __anon_0x594BE
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x59558
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
-};
-
-// size: 0xC
-struct __anon_0x59699
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-// size: 0x3C
-struct __anon_0x59709
-{
-	int bTransformed; // 0x0
-	__anon_0x59699 rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
-
-// size: 0x34
-struct __anon_0x59939
-{
-	int bTransformed; // 0x0
-	__anon_0x59699 rS; // 0x4
-	__anon_0x59699 rT; // 0x10
-	__anon_0x59699 rSRaw; // 0x1C
-	__anon_0x59699 rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x59A22
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x59699 vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x59B81
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x59C1E
-{
-	__anon_0x59B81 data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x5A2EC
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x5A5CE
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x5A64F
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x5A5CE eProjection; // 0x20
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x3D150
-struct __anon_0x5A89F
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x594BE viewport; // 0xB8
-	__anon_0x59558 aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x59709 aLight[8]; // 0x140
-	__anon_0x59939 lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x59A22 aVertex[80]; // 0x358
-	__anon_0x59C1E TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x5A2EC aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x5A5CE eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x5A64F aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-int rspUpdate(__anon_0x5845E *pRSP, __anon_0x5943B eMode)
-{
-	__anon_0x575BD *pTask;
-	int bDone;
-	int nCount;
-	__anon_0x5A89F *pFrame;
-	// References: gNoSwapBuffer (0x801356BC)
+struct tXL_LIST {
+    /* 0x0 */ s32 nItemSize;
+    /* 0x4 */ s32 nItemCount;
+    /* 0x8 */ void* pNodeHead;
+    /* 0xC */ void* pNodeNext;
+}; // size = 0x10
+
+struct __anon_0x58360 {
+    /* 0x0 */ s16 r;
+    /* 0x2 */ s16 g;
+    /* 0x4 */ s16 b;
+    /* 0x6 */ s16 a;
+}; // size = 0x8
+
+struct __anon_0x583EE {
+    /* 0x0 */ s16 y;
+    /* 0x2 */ s16 u;
+    /* 0x4 */ s16 v;
+}; // size = 0x6
+
+struct __anon_0x5845E {
+    /* 0x0000 */ s32 nMode;
+    /* 0x0004 */ struct __anon_0x57890 yield;
+    /* 0x00DC */ u32 nTickLast;
+    /* 0x00E0 */ s32 (*pfUpdateWaiting)();
+    /* 0x00E4 */ u32 n2TriMult;
+    /* 0x00E8 */ s32 aStatus[4];
+    /* 0x00F8 */ float aMatrixOrtho[4][4];
+    /* 0x0138 */ u32 nMode2D;
+    /* 0x013C */ struct __anon_0x57AB1 twoDValues;
+    /* 0x015C */ s32 nPass;
+    /* 0x0160 */ u32 nZSortSubDL;
+    /* 0x0164 */ u32 nStatusSubDL;
+    /* 0x0168 */ u32 nNumZSortLights;
+    /* 0x016C */ s32 aLightAddresses[8];
+    /* 0x018C */ s32 nAmbientLightAddress;
+    /* 0x0190 */ struct __anon_0x57BBE aZSortVertex[128];
+    /* 0x0B90 */ struct __anon_0x57CD6 aZSortNormal[128];
+    /* 0x0D10 */ struct __anon_0x57D55 aZSortMaterial[128];
+    /* 0x0F10 */ struct __anon_0x57DF8 aZSortMatrix[128];
+    /* 0x2F10 */ struct __anon_0x57E56 aZSortLight[8];
+    /* 0x2F40 */ s32 aZSortInvW[128];
+    /* 0x3140 */ s16 aZSortWiVal[128];
+    /* 0x3240 */ u32 nNumZSortMatrices;
+    /* 0x3244 */ u32 nNumZSortVertices;
+    /* 0x3248 */ u32 nTotalZSortVertices;
+    /* 0x324C */ u32 nNumZSortNormals;
+    /* 0x3250 */ u32 nNumZSortMaterials;
+    /* 0x3254 */ s32 anAudioBaseSegment[16];
+    /* 0x3294 */ s16* anAudioBuffer;
+    /* 0x3298 */ s16 anADPCMCoef[5][2][8];
+    /* 0x3338 */ u16 nAudioDMOutR[2];
+    /* 0x333C */ u16 nAudioDMauxL[2];
+    /* 0x3340 */ u16 nAudioDMauxR[2];
+    /* 0x3344 */ u16 nAudioCount[2];
+    /* 0x3348 */ u16 nAudioFlags;
+    /* 0x334A */ u16 nAudioDMEMIn[2];
+    /* 0x334E */ u16 nAudioDMEMOut[2];
+    /* 0x3354 */ u32 nAudioLoopAddress;
+    /* 0x3358 */ u32 nAudioDryAmt;
+    /* 0x335C */ u32 nAudioWetAmt;
+    /* 0x3360 */ u32 nAudioVolL;
+    /* 0x3364 */ u32 nAudioVolR;
+    /* 0x3368 */ u32 nAudioVolTGTL;
+    /* 0x336C */ u32 nAudioVolRateLM;
+    /* 0x3370 */ u32 nAudioVolRateLL;
+    /* 0x3374 */ u32 nAudioVolTGTR;
+    /* 0x3378 */ u32 nAudioVolRateRM;
+    /* 0x337C */ u32 nAudioVolRateRL;
+    /* 0x3380 */ struct __anon_0x58107 vParams;
+    /* 0x3390 */ s16 stepF;
+    /* 0x3392 */ s16 stepL;
+    /* 0x3394 */ s16 stepR;
+    /* 0x3398 */ s32 anGenReg[32];
+    /* 0x3418 */ struct __anon_0x58107 aVectorReg[32];
+    /* 0x3618 */ s32 anCP0Reg[32];
+    /* 0x3698 */ struct __anon_0x58107 anCP2Reg[32];
+    /* 0x3898 */ s16 anAcc[24];
+    /* 0x38C8 */ s16 nVCC;
+    /* 0x38CA */ s16 nVC0;
+    /* 0x38CC */ char nVCE;
+    /* 0x38D0 */ enum __anon_0x581E7 eTypeAudioUCode;
+    /* 0x38D4 */ u16 nAudioMemOffset;
+    /* 0x38D6 */ u16 nAudioADPCMOffset;
+    /* 0x38D8 */ u16 nAudioScratchOffset;
+    /* 0x38DA */ u16 nAudioParBase;
+    /* 0x38DC */ s32 nPC;
+    /* 0x38E0 */ s32 iDL;
+    /* 0x38E4 */ s32 nBIST;
+    /* 0x38E8 */ void* pHost;
+    /* 0x38EC */ void* pDMEM;
+    /* 0x38F0 */ void* pIMEM;
+    /* 0x38F4 */ s32 nStatus;
+    /* 0x38F8 */ s32 nFullDMA;
+    /* 0x38FC */ s32 nBusyDMA;
+    /* 0x3900 */ s32 nSizeGet;
+    /* 0x3904 */ s32 nSizePut;
+    /* 0x3908 */ s32 nSemaphore;
+    /* 0x390C */ s32 nAddressSP;
+    /* 0x3910 */ s32 nGeometryMode;
+    /* 0x3914 */ s32 nAddressRDRAM;
+    /* 0x3918 */ struct tXL_LIST* pListUCode;
+    /* 0x391C */ s32 nCountVertex;
+    /* 0x3920 */ enum __anon_0x60B3F eTypeUCode;
+    /* 0x3924 */ u32 nVersionUCode;
+    /* 0x3928 */ s32 anBaseSegment[16];
+    /* 0x3968 */ u64* apDL[16];
+    /* 0x39A8 */ s32* Coeff;
+    /* 0x39AC */ s16* QTable;
+    /* 0x39B0 */ s16* QYTable;
+    /* 0x39B4 */ s16* QCbTable;
+    /* 0x39B8 */ s16* QCrTable;
+    /* 0x39BC */ s32* Zigzag;
+    /* 0x39C0 */ struct __anon_0x58360* rgbaBuf;
+    /* 0x39C4 */ struct __anon_0x583EE* yuvBuf;
+    /* 0x39C8 */ s32* dctBuf;
+}; // size = 0x39CC
+
+// Range: 0x80071BB8 -> 0x80071D8C
+s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int rspFrameComplete(__anon_0x5845E *pRSP);
+// size = 0x4, address = 0x801356BC
+s32 gNoSwapBuffer;
 
-int rspEnableABI(__anon_0x5845E *pRSP, int bFlag);
-
-// size: 0x60
-struct __anon_0x5B8F2
-{
-	int nOffsetCode; // 0x0
-	int nLengthCode; // 0x4
-	int nOffsetData; // 0x8
-	int nLengthData; // 0xC
-	char acUCodeName[64]; // 0x10
-	unsigned long long nUCodeCheckSum; // 0x50
-	int nCountVertex; // 0x58
-	__anon_0x60B3F eType; // 0x5C
+enum __anon_0x5943B {
+    RUM_NONE = 0,
+    RUM_IDLE = 1,
 };
 
-int rspInvalidateCache(__anon_0x5845E *pRSP, int nOffset0, int nOffset1)
-{
-	__anon_0x5B8F2 *pUCode;
-	void *pListNode;
-	int nOffsetUCode0;
-	int nOffsetUCode1;
+struct __anon_0x594BE {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x59558 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x59699 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x59709 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x59699 rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x59939 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x59699 rS;
+    /* 0x10 */ struct __anon_0x59699 rT;
+    /* 0x1C */ struct __anon_0x59699 rSRaw;
+    /* 0x28 */ struct __anon_0x59699 rTRaw;
+}; // size = 0x34
+
+struct __anon_0x59A22 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x59699 vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x59B81 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
+};
+
+struct __anon_0x59C1E {
+    /* 0x0 */ union __anon_0x59B81 data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
+};
+
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
+};
+
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x5A2EC {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x5A5CE {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
+};
+
+struct __anon_0x5A64F {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x5A5CE eProjection;
+}; // size = 0x24
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+struct __anon_0x5A89F {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x594BE viewport;
+    /* 0x000C8 */ struct __anon_0x59558 aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x59709 aLight[8];
+    /* 0x00320 */ struct __anon_0x59939 lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x59A22 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x59C1E TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x5A2EC aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x5A5CE eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x5A64F aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+// Range: 0x80071D8C -> 0x80071F6C
+s32 rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // enum __anon_0x5943B eMode; // r30
+
+    // Local variables
+    struct __anon_0x575BD* pTask; // r4
+    s32 bDone; // r1+0x10
+    s32 nCount; // r31
+    struct __anon_0x5A89F* pFrame; // r28
+
+    // References
+    // -> s32 gNoSwapBuffer;
 }
 
-int rspGet64(__anon_0x5845E *pRSP, unsigned int nAddress, signed long long *pData);
-
-int rspGet32(__anon_0x5845E *pRSP, unsigned int nAddress, int *pData);
-
-int rspGet16(__anon_0x5845E *pRSP, unsigned int nAddress, signed short *pData);
-
-int rspGet8(__anon_0x5845E *pRSP, unsigned int nAddress, char *pData);
-
-int rspPut64(__anon_0x5845E *pRSP, unsigned int nAddress, signed long long *pData);
-
-int rspPut32(__anon_0x5845E *pRSP, unsigned int nAddress, int *pData)
-{
-	__anon_0x575BD *pTask;
-	int nData;
-	int nSize;
-	void *pTarget;
-	void *pSource;
-	int nLength;
+// Range: 0x80071F6C -> 0x80071FC0
+s32 rspFrameComplete(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
 }
 
-int rspPut16(__anon_0x5845E *pRSP, unsigned int nAddress, signed short *pData);
-
-int rspPut8(__anon_0x5845E *pRSP, unsigned int nAddress, char *pData);
-
-int rspSaveUCode();
-
-// size: 0x8
-struct __anon_0x5C1E6
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
-};
-
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
-};
-
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x5C1E6 *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
-};
-
-// size: 0x8
-union __anon_0x5C59B
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x8
-union __anon_0x5C9AF
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x34
-struct __anon_0x5CEBD
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
-};
-
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
-};
-
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
-};
-
-// size: 0xC
-struct __anon_0x5D481
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
-};
-
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
-
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
-
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
-
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x5C59B aGPR[32]; // 0x40
-	__anon_0x5C9AF aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x5CEBD *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x5D481 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
-
-// Local to compilation unit
-static int rspParseGBI(__anon_0x5845E *pRSP, int *pbDone, int nCount)
-{
-	int bDone;
-	int nStatus;
-	unsigned long long *pDL;
-	_CPU *pCPU;
+// Range: 0x80071FC0 -> 0x80071FE0
+s32 rspEnableABI(struct __anon_0x5845E* pRSP, s32 bFlag) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s32 bFlag; // r1+0x4
 }
 
-// Local to compilation unit
-static int rspParseGBI_Setup(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	int iSegment;
+struct __anon_0x5B8F2 {
+    /* 0x00 */ s32 nOffsetCode;
+    /* 0x04 */ s32 nLengthCode;
+    /* 0x08 */ s32 nOffsetData;
+    /* 0x0C */ s32 nLengthData;
+    /* 0x10 */ char acUCodeName[64];
+    /* 0x50 */ u64 nUCodeCheckSum;
+    /* 0x58 */ s32 nCountVertex;
+    /* 0x5C */ enum __anon_0x60B3F eType;
+}; // size = 0x60
+
+// Range: 0x80071FE0 -> 0x800720B8
+s32 rspInvalidateCache(struct __anon_0x5845E* pRSP, s32 nOffset0, s32 nOffset1) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // s32 nOffset0; // r29
+    // s32 nOffset1; // r30
+
+    // Local variables
+    struct __anon_0x5B8F2* pUCode; // r1+0x14
+    void* pListNode; // r31
+    s32 nOffsetUCode0; // r3
+    s32 nOffsetUCode1; // r1+0x8
 }
 
-int rspTaskComplete(__anon_0x5845E *pRSP, int bUsedSP, int bUsedDP);
-
-int rspParseDisplayLists(__anon_0x5845E *pRSP)
-{
-	int bDone;
-	int nStatus;
-	unsigned long long *pDL;
-	unsigned long long nGBI;
+// Range: 0x800720B8 -> 0x80072124
+s32 rspGet64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspLoadYield(__anon_0x5845E *pRSP)
-{
-	int iData;
-	__anon_0x575BD *pTask;
+// Range: 0x80072124 -> 0x80072270
+s32 rspGet32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspSaveYield(__anon_0x5845E *pRSP)
-{
-	int iData;
-	__anon_0x575BD *pTask;
+// Range: 0x80072270 -> 0x800722C4
+s32 rspGet16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
 }
 
-// size: 0x4
-enum __anon_0x5E613
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
-
-// size: 0x10
-struct __anon_0x5E675
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
-};
-
-// size: 0x4
-enum __anon_0x5E726
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
-
-// size: 0x4
-enum __anon_0x5E852
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
-
-// size: 0x88
-struct __anon_0x5E98D
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x5E613 eMode; // 0xC
-	__anon_0x5E675 romCopy; // 0x10
-	__anon_0x5E726 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x5E852 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
-
-// Location: 0x561380
-__anon_0x5E98D *gpSystem;
-
-// size: 0x304
-struct __anon_0x5EBE0
-{
-	int nCount; // 0x0
-	unsigned char anData[768]; // 0x4
-};
-
-// size: 0x10
-struct __anon_0x5EC3E
-{
-	signed short sx; // 0x0
-	signed short sy; // 0x2
-	int invw; // 0x4
-	signed short xi; // 0x8
-	signed short yi; // 0xA
-	unsigned char cc; // 0xC
-	unsigned char fog; // 0xD
-	signed short wi; // 0xE
-};
-
-// size: 0x28
-struct __anon_0x5ED4F
-{
-	unsigned short imageX; // 0x0
-	unsigned short imageW; // 0x2
-	signed short frameX; // 0x4
-	unsigned short frameW; // 0x6
-	unsigned short imageY; // 0x8
-	unsigned short imageH; // 0xA
-	signed short frameY; // 0xC
-	unsigned short frameH; // 0xE
-	unsigned int imagePtr; // 0x10
-	unsigned short imageLoad; // 0x14
-	unsigned char imageFmt; // 0x16
-	unsigned char imageSiz; // 0x17
-	unsigned short imagePal; // 0x18
-	unsigned short imageFlip; // 0x1A
-	unsigned short tmemW; // 0x1C
-	unsigned short tmemH; // 0x1E
-	unsigned short tmemLoadSH; // 0x20
-	unsigned short tmemLoadTH; // 0x22
-	unsigned short tmemSizeW; // 0x24
-	unsigned short tmemSize; // 0x26
-};
-
-// size: 0x28
-struct __anon_0x5F05A
-{
-	unsigned short imageX; // 0x0
-	unsigned short imageW; // 0x2
-	signed short frameX; // 0x4
-	unsigned short frameW; // 0x6
-	unsigned short imageY; // 0x8
-	unsigned short imageH; // 0xA
-	signed short frameY; // 0xC
-	unsigned short frameH; // 0xE
-	unsigned int imagePtr; // 0x10
-	unsigned short imageLoad; // 0x14
-	unsigned char imageFmt; // 0x16
-	unsigned char imageSiz; // 0x17
-	unsigned short imagePal; // 0x18
-	unsigned short imageFlip; // 0x1A
-	unsigned short scaleW; // 0x1C
-	unsigned short scaleH; // 0x1E
-	int imageYorig; // 0x20
-	unsigned char padding[4]; // 0x24
-};
-
-// size: 0x28
-union __anon_0x5F2FB
-{
-	__anon_0x5ED4F b; // 0x0
-	__anon_0x5F05A s; // 0x0
-	signed long long force_structure_alignment; // 0x0
-};
-
-// size: 0x18
-struct __anon_0x5F429
-{
-	signed short objX; // 0x0
-	unsigned short scaleW; // 0x2
-	unsigned short imageW; // 0x4
-	unsigned short paddingX; // 0x6
-	signed short objY; // 0x8
-	unsigned short scaleH; // 0xA
-	unsigned short imageH; // 0xC
-	unsigned short paddingY; // 0xE
-	unsigned short imageStride; // 0x10
-	unsigned short imageAdrs; // 0x12
-	unsigned char imageFmt; // 0x14
-	unsigned char imageSiz; // 0x15
-	unsigned char imagePal; // 0x16
-	unsigned char imageFlags; // 0x17
-};
-
-// size: 0x18
-union __anon_0x5F63B
-{
-	__anon_0x5F429 s; // 0x0
-	signed long long force_structure_alignment; // 0x0
-};
-
-// size: 0xC
-struct __anon_0x5F6E9
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-// size: 0x28
-struct __anon_0x5F759
-{
-	int bFlip; // 0x0
-	int iTile; // 0x4
-	int nX0; // 0x8
-	int nY0; // 0xC
-	int nX1; // 0x10
-	int nY1; // 0x14
-	float rS; // 0x18
-	float rT; // 0x1C
-	float rDeltaS; // 0x20
-	float rDeltaT; // 0x24
-};
-
-// size: 0x18
-struct __anon_0x5F8B9
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short tmem; // 0x8
-	unsigned short tsize; // 0xA
-	unsigned short tline; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-struct __anon_0x5F9D9
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short tmem; // 0x8
-	unsigned short twidth; // 0xA
-	unsigned short theight; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-struct __anon_0x5FAFC
-{
-	unsigned int type; // 0x0
-	unsigned int image; // 0x4
-	unsigned short phead; // 0x8
-	unsigned short pnum; // 0xA
-	unsigned short zero; // 0xC
-	unsigned short sid; // 0xE
-	unsigned int flag; // 0x10
-	unsigned int mask; // 0x14
-};
-
-// size: 0x18
-union __anon_0x5FC1B
-{
-	__anon_0x5F8B9 block; // 0x0
-	__anon_0x5F9D9 tile; // 0x0
-	__anon_0x5FAFC tlut; // 0x0
-	signed long long force_structure_alignment; // 0x0
-};
-
-// size: 0x4
-enum __anon_0x6029B
-{
-	XLFT_NONE = 4294967295,
-	XLFT_TEXT = 0,
-	XLFT_BINARY = 1
-};
-
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
-
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// size: 0x58
-struct tXL_FILE
-{
-	int iBuffer; // 0x0
-	void *pData; // 0x4
-	void *pBuffer; // 0x8
-	int nAttributes; // 0xC
-	int nSize; // 0x10
-	int nOffset; // 0x14
-	__anon_0x6029B eType; // 0x18
-	DVDFileInfo info; // 0x1C
-};
-
-// size: 0x4
-enum __anon_0x60B3F
-{
-	RUT_NONE = 4294967295,
-	RUT_TURBO = 0,
-	RUT_SPRITE2D = 1,
-	RUT_FAST3D = 2,
-	RUT_ZSORT = 3,
-	RUT_LINE3D = 4,
-	RUT_F3DEX1 = 5,
-	RUT_F3DEX2 = 6,
-	RUT_S2DEX1 = 7,
-	RUT_S2DEX2 = 8,
-	RUT_L3DEX1 = 9,
-	RUT_L3DEX2 = 10,
-	RUT_AUDIO1 = 11,
-	RUT_AUDIO2 = 12,
-	RUT_JPEG = 13
-};
-
-// Local to compilation unit
-static int rspFindUCode(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	int nCountVertex;
-	__anon_0x5B8F2 *pUCode;
-	__anon_0x60B3F eType;
-	void *pListNode;
-	int nOffsetCode;
-	int nOffsetData;
-	unsigned long long nFUData;
-	unsigned long long *pFUData;
-	unsigned long long *pFUCode;
-	unsigned long long nCheckSum;
-	unsigned int nLengthData;
-	unsigned int i;
-	unsigned int nLengthCode;
-	char aBigBuffer[4096];
-	char acUCodeName[64];
+// Range: 0x800722C4 -> 0x80072318
+s32 rspGet8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
 }
 
-int rspGetUCodeName(__anon_0x5845E *pRSP)
-{
-	unsigned int nItemCount;
-	void *pListNode;
+// Range: 0x80072318 -> 0x80072384
+s32 rspPut64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
 }
 
-int rspGetNumUCodes(__anon_0x5845E *pRSP, unsigned int *pNumCodes);
+// Range: 0x80072384 -> 0x800729B4
+s32 rspPut32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
 
-int rspSetupUCode(__anon_0x5845E *pRSP)
-{
-	__anon_0x5A89F *pFrame;
+    // Local variables
+    struct __anon_0x575BD* pTask; // r4
+    s32 nData; // r31
+    s32 nSize; // r1+0x24
+    void* pTarget; // r1+0x20
+    void* pSource; // r4
+    s32 nLength; // r5
 }
 
-int rspPopDL(__anon_0x5845E *pRSP);
-
-int rspSetDL(__anon_0x5845E *pRSP, int nOffsetRDRAM, int bPush)
-{
-	int nAddress;
-	unsigned long long *pDL;
+// Range: 0x800729B4 -> 0x80072A08
+s32 rspPut16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspLoadMatrix(__anon_0x5845E *pRSP, int nAddress, float *matrix[4])
-{
-	int *pMtx;
-	int nDataA;
-	int nDataB;
-	float rScale;
-	float rUpper;
-	float rLower;
-	unsigned short nUpper;
-	unsigned short nLower;
+// Range: 0x80072A08 -> 0x80072A5C
+s32 rspPut8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
 }
 
+// Erased
+static s32 rspSaveUCode() {}
+
+struct __anon_0x5C1E6 {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x5C1E6* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x5C59B {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
+};
+
+union __anon_0x5C9AF {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
+};
+
+struct __anon_0x5CEBD {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
+
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
+
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
+
+struct __anon_0x5D481 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
+
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
+
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
+
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
+
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x5C59B aGPR[32];
+    /* 0x00140 */ union __anon_0x5C9AF aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x5CEBD* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x5D481 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
+
+// Range: 0x80072A5C -> 0x80072C10
+static s32 rspParseGBI(struct __anon_0x5845E* pRSP, s32* pbDone, s32 nCount) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+    // s32* pbDone; // r28
+    // s32 nCount; // r29
+
+    // Local variables
+    s32 bDone; // r1+0x14
+    s32 nStatus; // r3
+    u64* pDL; // r26
+    struct _CPU* pCPU; // r30
+}
+
+// Range: 0x80072C10 -> 0x80072D6C
+static s32 rspParseGBI_Setup(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r31
+
+    // Local variables
+    s32 iSegment; // r1+0x8
+}
+
+// Erased
+static s32 rspTaskComplete(struct __anon_0x5845E* pRSP, s32 bUsedSP, s32 bUsedDP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 bUsedSP; // r1+0xC
+    // s32 bUsedDP; // r31
+}
+
+// Erased
+static s32 rspParseDisplayLists(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+
+    // Local variables
+    s32 bDone; // r1+0xC
+    s32 nStatus; // r3
+    s32* pDL; // r1+0x8
+    u64 nGBI; // r30
+}
+
+// Range: 0x80072D6C -> 0x80072EF4
+static s32 rspLoadYield(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+
+    // Local variables
+    s32 iData; // r1+0x8
+    struct __anon_0x575BD* pTask; // r3
+}
+
+// Range: 0x80072EF4 -> 0x8007306C
+static s32 rspSaveYield(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r7
+
+    // Local variables
+    s32 iData; // r1+0x8
+    struct __anon_0x575BD* pTask; // r4
+}
+
+enum __anon_0x5E613 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
+
+struct __anon_0x5E675 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x5E726 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
+};
+
+enum __anon_0x5E852 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
+};
+
+struct __anon_0x5E98D {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x5E613 eMode;
+    /* 0x10 */ struct __anon_0x5E675 romCopy;
+    /* 0x20 */ enum __anon_0x5E726 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x5E852 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x5E98D* gpSystem;
+
+struct __anon_0x5EBE0 {
+    /* 0x0 */ s32 nCount;
+    /* 0x4 */ u8 anData[768];
+}; // size = 0x304
+
+struct __anon_0x5EC3E {
+    /* 0x0 */ s16 sx;
+    /* 0x2 */ s16 sy;
+    /* 0x4 */ s32 invw;
+    /* 0x8 */ s16 xi;
+    /* 0xA */ s16 yi;
+    /* 0xC */ u8 cc;
+    /* 0xD */ u8 fog;
+    /* 0xE */ s16 wi;
+}; // size = 0x10
+
+struct __anon_0x5ED4F {
+    /* 0x00 */ u16 imageX;
+    /* 0x02 */ u16 imageW;
+    /* 0x04 */ s16 frameX;
+    /* 0x06 */ u16 frameW;
+    /* 0x08 */ u16 imageY;
+    /* 0x0A */ u16 imageH;
+    /* 0x0C */ s16 frameY;
+    /* 0x0E */ u16 frameH;
+    /* 0x10 */ u32 imagePtr;
+    /* 0x14 */ u16 imageLoad;
+    /* 0x16 */ u8 imageFmt;
+    /* 0x17 */ u8 imageSiz;
+    /* 0x18 */ u16 imagePal;
+    /* 0x1A */ u16 imageFlip;
+    /* 0x1C */ u16 tmemW;
+    /* 0x1E */ u16 tmemH;
+    /* 0x20 */ u16 tmemLoadSH;
+    /* 0x22 */ u16 tmemLoadTH;
+    /* 0x24 */ u16 tmemSizeW;
+    /* 0x26 */ u16 tmemSize;
+}; // size = 0x28
+
+struct __anon_0x5F05A {
+    /* 0x00 */ u16 imageX;
+    /* 0x02 */ u16 imageW;
+    /* 0x04 */ s16 frameX;
+    /* 0x06 */ u16 frameW;
+    /* 0x08 */ u16 imageY;
+    /* 0x0A */ u16 imageH;
+    /* 0x0C */ s16 frameY;
+    /* 0x0E */ u16 frameH;
+    /* 0x10 */ u32 imagePtr;
+    /* 0x14 */ u16 imageLoad;
+    /* 0x16 */ u8 imageFmt;
+    /* 0x17 */ u8 imageSiz;
+    /* 0x18 */ u16 imagePal;
+    /* 0x1A */ u16 imageFlip;
+    /* 0x1C */ u16 scaleW;
+    /* 0x1E */ u16 scaleH;
+    /* 0x20 */ s32 imageYorig;
+    /* 0x24 */ u8 padding[4];
+}; // size = 0x28
+
+union __anon_0x5F2FB {
+    /* 0x0 */ struct __anon_0x5ED4F b;
+    /* 0x0 */ struct __anon_0x5F05A s;
+    /* 0x0 */ s64 force_structure_alignment;
+};
+
+struct __anon_0x5F429 {
+    /* 0x00 */ s16 objX;
+    /* 0x02 */ u16 scaleW;
+    /* 0x04 */ u16 imageW;
+    /* 0x06 */ u16 paddingX;
+    /* 0x08 */ s16 objY;
+    /* 0x0A */ u16 scaleH;
+    /* 0x0C */ u16 imageH;
+    /* 0x0E */ u16 paddingY;
+    /* 0x10 */ u16 imageStride;
+    /* 0x12 */ u16 imageAdrs;
+    /* 0x14 */ u8 imageFmt;
+    /* 0x15 */ u8 imageSiz;
+    /* 0x16 */ u8 imagePal;
+    /* 0x17 */ u8 imageFlags;
+}; // size = 0x18
+
+union __anon_0x5F63B {
+    /* 0x0 */ struct __anon_0x5F429 s;
+    /* 0x0 */ s64 force_structure_alignment;
+};
+
+struct __anon_0x5F6E9 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x5F759 {
+    /* 0x00 */ s32 bFlip;
+    /* 0x04 */ s32 iTile;
+    /* 0x08 */ s32 nX0;
+    /* 0x0C */ s32 nY0;
+    /* 0x10 */ s32 nX1;
+    /* 0x14 */ s32 nY1;
+    /* 0x18 */ float rS;
+    /* 0x1C */ float rT;
+    /* 0x20 */ float rDeltaS;
+    /* 0x24 */ float rDeltaT;
+}; // size = 0x28
+
+struct __anon_0x5F8B9 {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 tmem;
+    /* 0x0A */ u16 tsize;
+    /* 0x0C */ u16 tline;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+struct __anon_0x5F9D9 {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 tmem;
+    /* 0x0A */ u16 twidth;
+    /* 0x0C */ u16 theight;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+struct __anon_0x5FAFC {
+    /* 0x00 */ u32 type;
+    /* 0x04 */ u32 image;
+    /* 0x08 */ u16 phead;
+    /* 0x0A */ u16 pnum;
+    /* 0x0C */ u16 zero;
+    /* 0x0E */ u16 sid;
+    /* 0x10 */ u32 flag;
+    /* 0x14 */ u32 mask;
+}; // size = 0x18
+
+union __anon_0x5FC1B {
+    /* 0x0 */ struct __anon_0x5F8B9 block;
+    /* 0x0 */ struct __anon_0x5F9D9 tile;
+    /* 0x0 */ struct __anon_0x5FAFC tlut;
+    /* 0x0 */ s64 force_structure_alignment;
+};
+
+enum __anon_0x6029B {
+    XLFT_NONE = -1,
+    XLFT_TEXT = 0,
+    XLFT_BINARY = 1,
+};
+
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+struct tXL_FILE {
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ enum __anon_0x6029B eType;
+    /* 0x1C */ struct DVDFileInfo info;
+}; // size = 0x58
+
+enum __anon_0x60B3F {
+    RUT_NONE = -1,
+    RUT_TURBO = 0,
+    RUT_SPRITE2D = 1,
+    RUT_FAST3D = 2,
+    RUT_ZSORT = 3,
+    RUT_LINE3D = 4,
+    RUT_F3DEX1 = 5,
+    RUT_F3DEX2 = 6,
+    RUT_S2DEX1 = 7,
+    RUT_S2DEX2 = 8,
+    RUT_L3DEX1 = 9,
+    RUT_L3DEX2 = 10,
+    RUT_AUDIO1 = 11,
+    RUT_AUDIO2 = 12,
+    RUT_JPEG = 13,
+};
+
+// Range: 0x8007306C -> 0x800741CC
+static s32 rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r24
+    // struct __anon_0x575BD* pTask; // r1+0xC
+
+    // Local variables
+    s32 nCountVertex; // r16
+    struct __anon_0x5B8F2* pUCode; // r1+0x1080
+    enum __anon_0x60B3F eType; // r17
+    void* pListNode; // r5
+    s32 nOffsetCode; // r1+0x108C
+    s32 nOffsetData; // r14
+    u64 nFUData; // r30
+    u64* pFUData; // r1+0x107C
+    u64* pFUCode; // r1+0x1078
+    u64 nCheckSum; // r27
+    u32 nLengthData; // r1+0x1088
+    u32 i; // r6
+    u32 nLengthCode; // r1+0x1084
+    char aBigBuffer[4096]; // r1+0x5C
+    char acUCodeName[64]; // r1+0x1C
+}
+
+// Erased
+static s32 rspGetUCodeName(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+
+    // Local variables
+    u32 nItemCount; // r1+0x0
+    void* pListNode; // r3
+}
+
+// Erased
+static s32 rspGetNumUCodes(struct __anon_0x5845E* pRSP, u32* pNumCodes) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32* pNumCodes; // r1+0x4
+}
+
+// Erased
+static s32 rspSetupUCode(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    struct __anon_0x5A89F* pFrame; // r3
+}
+
+// Erased
+static s32 rspPopDL(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+}
+
+// Erased
+static s32 rspSetDL(struct __anon_0x5845E* pRSP, s32 nOffsetRDRAM, s32 bPush) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 nOffsetRDRAM; // r1+0xC
+    // s32 bPush; // r31
+
+    // Local variables
+    s32 nAddress; // r5
+    s32* pDL; // r1+0x14
+}
+
+// Range: 0x800741CC -> 0x80074454
+static s32 rspLoadMatrix(struct __anon_0x5845E* pRSP, s32 nAddress, float (*matrix)[4]) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // float (* matrix)[4]; // r31
+
+    // Local variables
+    s32* pMtx; // r1+0x18
+    s32 nDataA; // r6
+    s32 nDataB; // r7
+    float rScale; // f31
+    float rUpper; // r1+0x8
+    float rLower; // r1+0x8
+    u16 nUpper; // r1+0x16
+    u16 nLower; // r1+0x14
+}

--- a/debug/Fire/rsp.c
+++ b/debug/Fire/rsp.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x56F42; // size = 0x10
 
 // size = 0x10, address = 0x800EE220
 struct _XL_OBJECTTYPE gClassRSP;
@@ -86,7 +86,7 @@ static s16 TMEMMASK$3464[4];
 // size = 0x8, address = 0x801352E0
 static s16 TMEMSHIFT$3465[4];
 
-struct __anon_0x575BD {
+typedef struct __anon_0x575BD {
     /* 0x00 */ s32 nType;
     /* 0x04 */ s32 nFlag;
     /* 0x08 */ s32 nOffsetBoot;
@@ -103,9 +103,9 @@ struct __anon_0x575BD {
     /* 0x34 */ s32 nLengthMBI;
     /* 0x38 */ s32 nOffsetYield;
     /* 0x3C */ s32 nLengthYield;
-}; // size = 0x40
+} __anon_0x575BD; // size = 0x40
 
-struct __anon_0x57890 {
+typedef struct __anon_0x57890 {
     /* 0x00 */ s32 iDL;
     /* 0x04 */ s32 bValid;
     /* 0x08 */ struct __anon_0x575BD task;
@@ -115,80 +115,80 @@ struct __anon_0x57890 {
     /* 0x54 */ u32 nVersionUCode;
     /* 0x58 */ s32 anBaseSegment[16];
     /* 0x98 */ u64* apDL[16];
-}; // size = 0xD8
+} __anon_0x57890; // size = 0xD8
 
-struct __anon_0x57AB1 {
+typedef struct __anon_0x57AB1 {
     /* 0x00 */ float aRotations[2][2];
     /* 0x10 */ float fX;
     /* 0x14 */ float fY;
     /* 0x18 */ float fBaseScaleX;
     /* 0x1C */ float fBaseScaleY;
-}; // size = 0x20
+} __anon_0x57AB1; // size = 0x20
 
-struct __anon_0x57BBE {
+typedef struct __anon_0x57BBE {
     /* 0x0 */ float rS;
     /* 0x4 */ float rT;
     /* 0x8 */ s16 nX;
     /* 0xA */ s16 nY;
     /* 0xC */ s16 nZ;
     /* 0xE */ u8 anData[4];
-}; // size = 0x14
+} __anon_0x57BBE; // size = 0x14
 
-struct __anon_0x57CD6 {
+typedef struct __anon_0x57CD6 {
     /* 0x0 */ char anNormal[3];
-}; // size = 0x3
+} __anon_0x57CD6; // size = 0x3
 
-struct __anon_0x57D55 {
+typedef struct __anon_0x57D55 {
     /* 0x0 */ u8 anMaterial[4];
-}; // size = 0x4
+} __anon_0x57D55; // size = 0x4
 
-struct __anon_0x57DF8 {
+typedef struct __anon_0x57DF8 {
     /* 0x0 */ float aMatrix[4][4];
-}; // size = 0x40
+} __anon_0x57DF8; // size = 0x40
 
-struct __anon_0x57E56 {
+typedef struct __anon_0x57E56 {
     /* 0x0 */ u8 nRed;
     /* 0x1 */ u8 nGreen;
     /* 0x2 */ u8 nBlue;
     /* 0x3 */ char rVectorX;
     /* 0x4 */ char rVectorY;
     /* 0x5 */ char rVectorZ;
-}; // size = 0x6
+} __anon_0x57E56; // size = 0x6
 
-struct __anon_0x58107 {
+typedef struct __anon_0x58107 {
     /* 0x0 */ s16 anSlice[8];
-}; // size = 0x10
+} __anon_0x58107; // size = 0x10
 
-enum __anon_0x581E7 {
+typedef enum __anon_0x581E7 {
     RUT_NOCODE = -1,
     RUT_ABI1 = 0,
     RUT_ABI2 = 1,
     RUT_ABI3 = 2,
     RUT_ABI4 = 3,
     RUT_UNKNOWN = 4,
-};
+} __anon_0x581E7;
 
-struct tXL_LIST {
+typedef struct tXL_LIST {
     /* 0x0 */ s32 nItemSize;
     /* 0x4 */ s32 nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
-}; // size = 0x10
+} __anon_0x58263; // size = 0x10
 
-struct __anon_0x58360 {
+typedef struct __anon_0x58360 {
     /* 0x0 */ s16 r;
     /* 0x2 */ s16 g;
     /* 0x4 */ s16 b;
     /* 0x6 */ s16 a;
-}; // size = 0x8
+} __anon_0x58360; // size = 0x8
 
-struct __anon_0x583EE {
+typedef struct __anon_0x583EE {
     /* 0x0 */ s16 y;
     /* 0x2 */ s16 u;
     /* 0x4 */ s16 v;
-}; // size = 0x6
+} __anon_0x583EE; // size = 0x6
 
-struct __anon_0x5845E {
+typedef struct __anon_0x5845E {
     /* 0x0000 */ s32 nMode;
     /* 0x0004 */ struct __anon_0x57890 yield;
     /* 0x00DC */ u32 nTickLast;
@@ -284,7 +284,7 @@ struct __anon_0x5845E {
     /* 0x39C0 */ struct __anon_0x58360* rgbaBuf;
     /* 0x39C4 */ struct __anon_0x583EE* yuvBuf;
     /* 0x39C8 */ s32* dctBuf;
-}; // size = 0x39CC
+} __anon_0x5845E; // size = 0x39CC
 
 // Range: 0x80071BB8 -> 0x80071D8C
 s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
@@ -297,33 +297,33 @@ s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
 // size = 0x4, address = 0x801356BC
 s32 gNoSwapBuffer;
 
-enum __anon_0x5943B {
+typedef enum __anon_0x5943B {
     RUM_NONE = 0,
     RUM_IDLE = 1,
-};
+} __anon_0x5943B;
 
-struct __anon_0x594BE {
+typedef struct __anon_0x594BE {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x594BE; // size = 0x10
 
-struct __anon_0x59558 {
+typedef struct __anon_0x59558 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x59558; // size = 0x14
 
-struct __anon_0x59699 {
+typedef struct __anon_0x59699 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x59699; // size = 0xC
 
-struct __anon_0x59709 {
+typedef struct __anon_0x59709 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x59699 rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -338,36 +338,36 @@ struct __anon_0x59709 {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x59709; // size = 0x3C
 
-struct __anon_0x59939 {
+typedef struct __anon_0x59939 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x59699 rS;
     /* 0x10 */ struct __anon_0x59699 rT;
     /* 0x1C */ struct __anon_0x59699 rSRaw;
     /* 0x28 */ struct __anon_0x59699 rTRaw;
-}; // size = 0x34
+} __anon_0x59939; // size = 0x34
 
-struct __anon_0x59A22 {
+typedef struct __anon_0x59A22 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x59699 vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x59A22; // size = 0x1C
 
-union __anon_0x59B81 {
+typedef union __anon_0x59B81 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x59B81;
 
-struct __anon_0x59C1E {
+typedef struct __anon_0x59C1E {
     /* 0x0 */ union __anon_0x59B81 data;
-}; // size = 0x1000
+} __anon_0x59C1E; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -394,24 +394,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x59CB7;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x59E79; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x59EE0; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x59F26;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -431,9 +431,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x59F8F; // size = 0x6C
 
-struct __anon_0x5A2EC {
+typedef struct __anon_0x5A2EC {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -450,15 +450,15 @@ struct __anon_0x5A2EC {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x5A2EC; // size = 0x2C
 
-enum __anon_0x5A5CE {
+typedef enum __anon_0x5A5CE {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x5A5CE;
 
-struct __anon_0x5A64F {
+typedef struct __anon_0x5A64F {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -468,16 +468,16 @@ struct __anon_0x5A64F {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x5A5CE eProjection;
-}; // size = 0x24
+} __anon_0x5A64F; // size = 0x24
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x5A7E4; // size = 0x4
 
-struct __anon_0x5A89F {
+typedef struct __anon_0x5A89F {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -568,7 +568,7 @@ struct __anon_0x5A89F {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x5A89F; // size = 0x3D150
 
 // Range: 0x80071D8C -> 0x80071F6C
 s32 rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
@@ -599,7 +599,7 @@ s32 rspEnableABI(struct __anon_0x5845E* pRSP, s32 bFlag) {
     // s32 bFlag; // r1+0x4
 }
 
-struct __anon_0x5B8F2 {
+typedef struct __anon_0x5B8F2 {
     /* 0x00 */ s32 nOffsetCode;
     /* 0x04 */ s32 nLengthCode;
     /* 0x08 */ s32 nOffsetData;
@@ -608,7 +608,7 @@ struct __anon_0x5B8F2 {
     /* 0x50 */ u64 nUCodeCheckSum;
     /* 0x58 */ s32 nCountVertex;
     /* 0x5C */ enum __anon_0x60B3F eType;
-}; // size = 0x60
+} __anon_0x5B8F2; // size = 0x60
 
 // Range: 0x80071FE0 -> 0x800720B8
 s32 rspInvalidateCache(struct __anon_0x5845E* pRSP, s32 nOffset0, s32 nOffset1) {
@@ -699,17 +699,17 @@ s32 rspPut8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
 // Erased
 static s32 rspSaveUCode() {}
 
-struct __anon_0x5C1E6 {
+typedef struct __anon_0x5C1E6 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x5C1E6; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x5C24C; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -728,9 +728,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x5C2BF; // size = 0x48
 
-union __anon_0x5C59B {
+typedef union __anon_0x5C59B {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -761,9 +761,9 @@ union __anon_0x5C59B {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x5C59B;
 
-union __anon_0x5C9AF {
+typedef union __anon_0x5C9AF {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -773,9 +773,9 @@ union __anon_0x5C9AF {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x5C9AF;
 
-struct __anon_0x5CEBD {
+typedef struct __anon_0x5CEBD {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -789,9 +789,9 @@ struct __anon_0x5CEBD {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x5CEBD; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -806,21 +806,21 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x5D18B; // size = 0x84
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x5D3CC; // size = 0xC
 
-struct __anon_0x5D481 {
+typedef struct __anon_0x5D481 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x5D481; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -836,9 +836,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x5D5AC; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -846,9 +846,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x5D803; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -859,9 +859,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x5D91E; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -905,7 +905,7 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x5DACB; // size = 0x12090
 
 // Range: 0x80072A5C -> 0x80072C10
 static s32 rspParseGBI(struct __anon_0x5845E* pRSP, s32* pbDone, s32 nCount) {
@@ -971,20 +971,20 @@ static s32 rspSaveYield(struct __anon_0x5845E* pRSP) {
     struct __anon_0x575BD* pTask; // r4
 }
 
-enum __anon_0x5E613 {
+typedef enum __anon_0x5E613 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x5E613;
 
-struct __anon_0x5E675 {
+typedef struct __anon_0x5E675 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x5E675; // size = 0x10
 
-enum __anon_0x5E726 {
+typedef enum __anon_0x5E726 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -999,9 +999,9 @@ enum __anon_0x5E726 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x5E726;
 
-enum __anon_0x5E852 {
+typedef enum __anon_0x5E852 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -1020,9 +1020,9 @@ enum __anon_0x5E852 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x5E852;
 
-struct __anon_0x5E98D {
+typedef struct __anon_0x5E98D {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -1034,17 +1034,17 @@ struct __anon_0x5E98D {
     /* 0x70 */ enum __anon_0x5E852 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x5E98D; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x5E98D* gpSystem;
 
-struct __anon_0x5EBE0 {
+typedef struct __anon_0x5EBE0 {
     /* 0x0 */ s32 nCount;
     /* 0x4 */ u8 anData[768];
-}; // size = 0x304
+} __anon_0x5EBE0; // size = 0x304
 
-struct __anon_0x5EC3E {
+typedef struct __anon_0x5EC3E {
     /* 0x0 */ s16 sx;
     /* 0x2 */ s16 sy;
     /* 0x4 */ s32 invw;
@@ -1053,9 +1053,9 @@ struct __anon_0x5EC3E {
     /* 0xC */ u8 cc;
     /* 0xD */ u8 fog;
     /* 0xE */ s16 wi;
-}; // size = 0x10
+} __anon_0x5EC3E; // size = 0x10
 
-struct __anon_0x5ED4F {
+typedef struct __anon_0x5ED4F {
     /* 0x00 */ u16 imageX;
     /* 0x02 */ u16 imageW;
     /* 0x04 */ s16 frameX;
@@ -1076,9 +1076,9 @@ struct __anon_0x5ED4F {
     /* 0x22 */ u16 tmemLoadTH;
     /* 0x24 */ u16 tmemSizeW;
     /* 0x26 */ u16 tmemSize;
-}; // size = 0x28
+} __anon_0x5ED4F; // size = 0x28
 
-struct __anon_0x5F05A {
+typedef struct __anon_0x5F05A {
     /* 0x00 */ u16 imageX;
     /* 0x02 */ u16 imageW;
     /* 0x04 */ s16 frameX;
@@ -1097,15 +1097,15 @@ struct __anon_0x5F05A {
     /* 0x1E */ u16 scaleH;
     /* 0x20 */ s32 imageYorig;
     /* 0x24 */ u8 padding[4];
-}; // size = 0x28
+} __anon_0x5F05A; // size = 0x28
 
-union __anon_0x5F2FB {
+typedef union __anon_0x5F2FB {
     /* 0x0 */ struct __anon_0x5ED4F b;
     /* 0x0 */ struct __anon_0x5F05A s;
     /* 0x0 */ s64 force_structure_alignment;
-};
+} __anon_0x5F2FB;
 
-struct __anon_0x5F429 {
+typedef struct __anon_0x5F429 {
     /* 0x00 */ s16 objX;
     /* 0x02 */ u16 scaleW;
     /* 0x04 */ u16 imageW;
@@ -1120,20 +1120,20 @@ struct __anon_0x5F429 {
     /* 0x15 */ u8 imageSiz;
     /* 0x16 */ u8 imagePal;
     /* 0x17 */ u8 imageFlags;
-}; // size = 0x18
+} __anon_0x5F429; // size = 0x18
 
-union __anon_0x5F63B {
+typedef union __anon_0x5F63B {
     /* 0x0 */ struct __anon_0x5F429 s;
     /* 0x0 */ s64 force_structure_alignment;
-};
+} __anon_0x5F63B;
 
-struct __anon_0x5F6E9 {
+typedef struct __anon_0x5F6E9 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x5F6E9; // size = 0xC
 
-struct __anon_0x5F759 {
+typedef struct __anon_0x5F759 {
     /* 0x00 */ s32 bFlip;
     /* 0x04 */ s32 iTile;
     /* 0x08 */ s32 nX0;
@@ -1144,9 +1144,9 @@ struct __anon_0x5F759 {
     /* 0x1C */ float rT;
     /* 0x20 */ float rDeltaS;
     /* 0x24 */ float rDeltaT;
-}; // size = 0x28
+} __anon_0x5F759; // size = 0x28
 
-struct __anon_0x5F8B9 {
+typedef struct __anon_0x5F8B9 {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 tmem;
@@ -1155,9 +1155,9 @@ struct __anon_0x5F8B9 {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x5F8B9; // size = 0x18
 
-struct __anon_0x5F9D9 {
+typedef struct __anon_0x5F9D9 {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 tmem;
@@ -1166,9 +1166,9 @@ struct __anon_0x5F9D9 {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x5F9D9; // size = 0x18
 
-struct __anon_0x5FAFC {
+typedef struct __anon_0x5FAFC {
     /* 0x00 */ u32 type;
     /* 0x04 */ u32 image;
     /* 0x08 */ u16 phead;
@@ -1177,22 +1177,22 @@ struct __anon_0x5FAFC {
     /* 0x0E */ u16 sid;
     /* 0x10 */ u32 flag;
     /* 0x14 */ u32 mask;
-}; // size = 0x18
+} __anon_0x5FAFC; // size = 0x18
 
-union __anon_0x5FC1B {
+typedef union __anon_0x5FC1B {
     /* 0x0 */ struct __anon_0x5F8B9 block;
     /* 0x0 */ struct __anon_0x5F9D9 tile;
     /* 0x0 */ struct __anon_0x5FAFC tlut;
     /* 0x0 */ s64 force_structure_alignment;
-};
+} __anon_0x5FC1B;
 
-enum __anon_0x6029B {
+typedef enum __anon_0x6029B {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
-};
+} __anon_0x6029B;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -1200,9 +1200,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x6034F; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -1215,16 +1215,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x604BF; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x606E5; // size = 0x3C
 
-struct tXL_FILE {
+typedef struct tXL_FILE {
     /* 0x00 */ s32 iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
@@ -1233,9 +1233,9 @@ struct tXL_FILE {
     /* 0x14 */ s32 nOffset;
     /* 0x18 */ enum __anon_0x6029B eType;
     /* 0x1C */ struct DVDFileInfo info;
-}; // size = 0x58
+} __anon_0x6079D; // size = 0x58
 
-enum __anon_0x60B3F {
+typedef enum __anon_0x60B3F {
     RUT_NONE = -1,
     RUT_TURBO = 0,
     RUT_SPRITE2D = 1,
@@ -1251,7 +1251,7 @@ enum __anon_0x60B3F {
     RUT_AUDIO1 = 11,
     RUT_AUDIO2 = 12,
     RUT_JPEG = 13,
-};
+} __anon_0x60B3F;
 
 // Range: 0x8007306C -> 0x800741CC
 static s32 rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {

--- a/debug/Fire/rspASM.c
+++ b/debug/Fire/rspASM.c
@@ -1,469 +1,1026 @@
-﻿int rspDisassemble(__anon_0x5845E *pRSP, __anon_0x575BD *pTask)
-{
-	tXL_FILE *pIMEMFile;
-	int i;
-	int h;
-	int nCodeAddress;
-	int nDataAddress;
-	int nFound;
-	unsigned int nOutData;
-	void *pCode;
-	void *pData;
-	unsigned int nRS;
-	unsigned int nRT;
-	unsigned int nRD;
-	unsigned int nSA;
-	unsigned int nOffset;
-	unsigned int nTarget;
-	unsigned int nE;
-	unsigned int nVT;
-	unsigned int nVS;
-	unsigned int nVD;
-	unsigned int nDE;
-	unsigned int nBase;
-	unsigned int nElement;
-	unsigned int nSize;
-	int nImmediate;
-	int nCount;
-	char acOp[8];
-	char acTemp[8];
-	char acOpString[8];
-	char acTempString[128];
-	char acOpList[500][8];
-	int nFirst;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\rspASM.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C89
+    Code range: 0x8008CF0C -> 0x8008D248
+*/
+
+#include "types.h"
+
+// Erased
+static s32 rspDisassemble(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r22
+    // struct __anon_0x575BD* pTask; // r19
+
+    // Local variables
+    struct tXL_FILE* pIMEMFile; // r1+0x105C
+    s32 i; // r27
+    s32 h; // r20
+    s32 nCodeAddress; // r7
+    s32 nDataAddress; // r9
+    s32 nFound; // r24
+    u32 nOutData; // r31
+    void* pCode; // r1+0x1058
+    void* pData; // r1+0x1054
+    u32 nRS; // r7
+    u32 nRT; // r20
+    u32 nRD; // r21
+    u32 nSA; // r19
+    u32 nOffset; // r6
+    u32 nTarget; // r5
+    u32 nE; // r7
+    u32 nVT; // r7
+    u32 nVS; // r6
+    u32 nVD; // r5
+    u32 nDE; // r6
+    u32 nBase; // r7
+    u32 nElement; // r6
+    u32 nSize; // r1+0x1048
+    s32 nImmediate; // r7
+    s32 nCount; // r29
+    char acOp[8]; // r1+0x1040
+    char acTemp[8]; // r1+0x1038
+    char acOpString[8]; // r1+0x1030
+    char acTempString[128]; // r1+0xFB0
+    char acOpList[500][8]; // r1+0x10
+    s32 nFirst; // r23
 }
 
-int rspDMAWrite(__anon_0x5845E *pRSP, int nDMEMAddress, int nRDRAMAddress, int nLength)
-{
-	int i;
-	int nAddress;
-	signed short *pDMEM;
-	signed short *pRDRAM;
-	void *pData;
+// Erased
+static s32 rspDMAWrite(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nDMEMAddress; // r1+0xC
+    // s32 nRDRAMAddress; // r1+0x10
+    // s32 nLength; // r31
+
+    // Local variables
+    s32 i; // r5
+    s32 nAddress; // r5
+    s16* pDMEM; // r30
+    s16* pRDRAM; // r6
+    void* pData; // r1+0x1C
 }
 
-int rspDMARead(__anon_0x5845E *pRSP, int nDMEMAddress, int nRDRAMAddress, int nLength)
-{
-	int i;
-	int nAddress;
-	signed short *pDMEM;
-	signed short *pRDRAM;
-	void *pData;
+// Erased
+static s32 rspDMARead(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nDMEMAddress; // r1+0xC
+    // s32 nRDRAMAddress; // r1+0x10
+    // s32 nLength; // r30
+
+    // Local variables
+    s32 i; // r5
+    s32 nAddress; // r5
+    s16* pDMEM; // r31
+    s16* pRDRAM; // r6
+    void* pData; // r1+0x1C
 }
 
-int rspAsmVSAR(__anon_0x5845E *pRSP, signed short nVD, signed short nE)
-{
-	signed short i;
+// Erased
+static s32 rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0x4
+    // s16 nE; // r1+0xA
+
+    // Local variables
+    s16 i; // r6
 }
 
-int rspAsmVMACF(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMULF(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMUDN(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMUDM(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMUDL(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r1+0x8
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMUDH(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMADL(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r1+0x8
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMADH(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMADN(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVMADM(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	int i;
-	int j;
-	signed long long product;
-	signed short buffer[8];
+// Erased
+static s32 rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
 }
 
-int rspAsmVCL(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short nLE;
-	signed short nGE;
-	signed short nEQ;
-	signed short nCarry;
-	signed short i;
-	signed short j;
-	signed short nDI;
+// Erased
+static s32 rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r22
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 nLE; // r27
+    s16 nGE; // r26
+    s16 nEQ; // r25
+    s16 nCarry; // r21
+    s16 i; // r24
+    s16 j; // r23
+    s16 nDI; // r25
 }
 
-int rspAsmVGE(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r27
+    s32 nResult; // r24
 }
 
-int rspAsmVSUBC(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r25
 }
 
-int rspAsmVSUB(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r24
 }
 
-int rspAsmVADDC(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r27
 }
 
-int rspAsmVADD(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r24
 }
 
-int rspAsmVXOR(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r1+0x8
+    s32 nResult; // r4
 }
 
-int rspAsmVAND(__anon_0x5845E *pRSP, signed short nVD, signed short nVS, signed short nVT, signed short nE)
-{
-	signed short i;
-	signed short j;
-	int nResult;
+// Erased
+static s32 rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r1+0x8
+    s32 nResult; // r4
 }
 
-int rspAsmLRV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
-	signed short i;
-	signed short nStartAddress;
+// Erased
+static s32 rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r8
+    s16 i; // r7
+    s16 nStartAddress; // r8
 }
 
-int rspAsmLQV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
-	signed short i;
+// Erased
+static s32 rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r9
+    s16 i; // r8
 }
 
-int rspAsmLPV(__anon_0x5845E *pRSP, signed short nVT, signed short nOffset, signed short nBase)
-{
-	int nAddress;
+// Erased
+static s32 rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    s32 nAddress; // r5
 }
 
-int rspAsmLDV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVReg;
-	char *pDMEM;
+// Erased
+static s32 rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVReg; // r4
+    char* pDMEM; // r7
 }
 
-int rspAsmLSV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase);
-
-int rspAsmSQV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
-	signed short i;
+// Erased
+static s32 rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
 }
 
-int rspAsmSDV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
-	char *pDMEM;
+// Erased
+static s32 rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r4
+    s16 i; // r3
 }
 
-int rspAsmSLV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
-	char *pDMEM;
+// Erased
+static s32 rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r5
+    char* pDMEM; // r4
 }
 
-int rspAsmSSV(__anon_0x5845E *pRSP, signed short nVT, signed short nElement, signed short nOffset, signed short nBase)
-{
-	char *pVT;
+// Erased
+static s32 rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r5
+    char* pDMEM; // r4
 }
 
-int rspAsmSW(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short nBase);
+// Erased
+static s32 rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
 
-int rspAsmSUB(__anon_0x5845E *pRSP, signed short rd, signed short rs, signed short rt);
-
-int rspAsmSRLV(__anon_0x5845E *pRSP, signed short rd, signed short rt, signed short rs);
-
-int rspAsmSRL(__anon_0x5845E *pRSP, signed short rd, signed short rt, signed short sa);
-
-int rspAsmSLL(__anon_0x5845E *pRSP, signed short rd, signed short rt, signed short sa);
-
-int rspAsmSH(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmORI(__anon_0x5845E *pRSP, signed short rt, signed short rs, signed short immediate);
-
-int rspAsmOR(__anon_0x5845E *pRSP, signed short rd, signed short rs, signed short rt);
-
-int rspAsmNOP();
-
-int rspAsmMTC2(__anon_0x5845E *pRSP, signed short rt, signed short vd, signed short e);
-
-int rspAsmMTC0(__anon_0x5845E *pRSP, signed short rt, signed short rd);
-
-int rspAsmMFC0(__anon_0x5845E *pRSP, signed short rt, signed short rd);
-
-int rspAsmLW(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmLUI(__anon_0x5845E *pRSP, signed short rt, signed short immediate);
-
-int rspAsmLHU(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmLH(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmLBU(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmLB(__anon_0x5845E *pRSP, signed short rt, signed short offset, signed short base);
-
-int rspAsmANDI(__anon_0x5845E *pRSP, signed short rt, signed short rs, signed short immediate);
-
-int rspAsmAND(__anon_0x5845E *pRSP, signed short rd, signed short rs, signed short rt);
-
-int rspAsmADDI(__anon_0x5845E *pRSP, signed short rt, signed short rs, signed short immediate);
-
-int rspAsmADD(__anon_0x5845E *pRSP, signed short rd, signed short rs, signed short rt);
-
-int rspVSAW(signed short *pResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	int element;
-	unsigned short ri;
+    // Local variables
+    char* pVT; // r4
 }
 
-int rspVCL(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	unsigned short sf;
-	unsigned short tf;
-	int di;
-	int i;
-	int ge;
-	int le;
-	int vce;
-	int eq;
-	int carry;
-	// References: rsp_VCE (0x0)
-	// References: rsp_VCO (0x0)
-	// References: rsp_VCC (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 nBase; // r1+0x8
 }
 
-int rspVGE(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	signed short si;
-	signed short ti;
-	// References: rsp_VCO (0x0)
-	// References: rsp_VCC (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
-	// References: vco_carry (0x0)
-	// References: vco_equal (0x0)
+// Erased
+static s32 rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
 }
 
-int rspVSUBC(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	int di;
-	// References: rsp_VCO (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 rs; // r1+0x8
 }
 
-int rspVADDC(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned int di;
-	// References: rsp_VCO (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 sa; // r1+0x8
 }
 
-int rspVSUB(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	int borrow;
-	int di;
-	// References: rsp_VCO (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 sa; // r1+0x8
 }
 
-int rspVADD(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	int carry;
-	int di;
-	// References: rsp_VCO (0x0)
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
 }
 
-int rspVMADH(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspVMADN(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
 }
 
-int rspVMADM(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmNOP() {}
+
+// Erased
+static s32 rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 vd; // r1+0x6
+    // s16 e; // r1+0x8
 }
 
-int rspVMADL(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rd; // r1+0x6
 }
 
-int rspVMACF(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rd; // r1+0x6
 }
 
-int rspVMUDH(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
 }
 
-// Local to compilation unit
-static int rspVMUDN(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 immediate; // r1+0x6
 }
 
-int rspVMUDM(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
 }
 
-int rspVMUDL(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
 }
 
-int rspVMULF(signed short *pVec1, signed short *pVec2, signed short *pVecResult, unsigned int nElement, signed long long *pAcc)
-{
-	int i;
-	unsigned short du;
-	signed long long taccum;
-	signed long long clampMask;
-	// References: cmask_tab (0x30E20E80)
-	// References: emask_tab (0x50E20E80)
+// Erased
+static s32 rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
 }
 
+// Erased
+static s32 rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspVSAW(s16* pResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pResult; // r4
+    // u32 nElement; // r1+0x10
+    // s32* pAcc; // r6
+
+    // Local variables
+    s32 i; // r29
+    s32 element; // r28
+    u16 ri; // r1+0x8
+}
+
+// Erased
+static s32 rspVCL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    u16 sf; // r30
+    u16 tf; // r29
+    s32 di; // r1+0x8
+    s32 i; // r28
+    s32 ge; // r11
+    s32 le; // r27
+    s32 vce; // r26
+    s32 eq; // r25
+    s32 carry; // r24
+
+    // References
+    // -> static u8 rsp_VCE;
+    // -> static u16 rsp_VCO;
+    // -> static u16 rsp_VCC;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVGE(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r12
+    s16 si; // r1+0x8
+    s16 ti; // r1+0x8
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> static u16 rsp_VCC;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+    // -> static u8 vco_carry[8];
+    // -> static u8 vco_equal[8];
+}
+
+// Erased
+static s32 rspVSUBC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    s32 di; // r29
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVADDC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    u32 di; // r27
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVSUB(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    s32 borrow; // r28
+    s32 di; // r29
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVADD(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    s32 carry; // r28
+    s32 di; // r28
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r18
+    // s16* pVecResult; // r6
+    // u32 nElement; // r19
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r24
+    u16 du; // r1+0x8
+    s64 taccum; // r23
+    s64 clampMask; // r21
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Range: 0x8008CF0C -> 0x8008D0B0
+static s32 rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r30
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s64* pAcc; // r8
+
+    // Local variables
+    s32 i; // r20
+    u16 du; // r1+0x8
+    s64 taccum; // r19
+    s64 clampMask; // r17
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMADM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r17
+    // s16* pVecResult; // r6
+    // u32 nElement; // r18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r23
+    u16 du; // r1+0x8
+    s64 taccum; // r22
+    s64 clampMask; // r20
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMADL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r27
+    // s16* pVecResult; // r6
+    // u32 nElement; // r28
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r31
+    u16 du; // r1+0x8
+    s64 taccum; // r3
+    s64 clampMask; // r30
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r17
+    // s16* pVecResult; // r6
+    // u32 nElement; // r18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r23
+    u16 du; // r1+0x8
+    s64 taccum; // r22
+    s64 clampMask; // r20
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMUDH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r30
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r22
+    u16 du; // r1+0x8
+    s64 taccum; // r21
+    s64 clampMask; // r19
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Range: 0x8008D0B0 -> 0x8008D248
+static s32 rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r30
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s64* pAcc; // r8
+
+    // Local variables
+    s32 i; // r20
+    u16 du; // r1+0x8
+    s64 taccum; // r19
+    s64 clampMask; // r17
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMUDM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r17
+    // s16* pVecResult; // r6
+    // u32 nElement; // r18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r23
+    u16 du; // r1+0x8
+    s64 taccum; // r22
+    s64 clampMask; // r20
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r19
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r22
+    u16 du; // r1+0x8
+    s64 taccum; // r3
+    s64 clampMask; // r21
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMULF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r30
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r20
+    u16 du; // r1+0x8
+    s64 taccum; // r19
+    s64 clampMask; // r17
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}

--- a/debug/Fire/serial.c
+++ b/debug/Fire/serial.c
@@ -1,53 +1,69 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\serial.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008EE20 -> 0x8008F0F4
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EEA28
+struct _XL_OBJECTTYPE gClassSerial;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x78791 {
+    /* 0x0 */ void* pHost;
+    /* 0x4 */ s32 nAddress;
+}; // size = 0x8
 
-// Location: 0x28EA0E80
-_XL_OBJECTTYPE gClassSerial;
-
-// size: 0x8
-struct __anon_0x78791
-{
-	void *pHost; // 0x0
-	int nAddress; // 0x4
-};
-
-int serialEvent(__anon_0x78791 *pSerial, int nEvent, void *pArgument);
-
-int serialGet64();
-
-int serialGet32(__anon_0x78791 *pSerial, unsigned int nAddress, int *pData);
-
-int serialGet16();
-
-int serialGet8();
-
-int serialPut64();
-
-int serialPut32(__anon_0x78791 *pSerial, unsigned int nAddress, int *pData)
-{
-	int nSize;
-	void *aData;
+// Range: 0x8008EE20 -> 0x8008EF20
+s32 serialEvent(struct __anon_0x78791* pSerial, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x78791* pSerial; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int serialPut16();
+// Range: 0x8008EF20 -> 0x8008EF28
+s32 serialGet64() {}
 
-int serialPut8();
+// Range: 0x8008EF28 -> 0x8008EF8C
+s32 serialGet32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x78791* pSerial; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
 
+// Range: 0x8008EF8C -> 0x8008EF94
+s32 serialGet16() {}
+
+// Range: 0x8008EF94 -> 0x8008EF9C
+s32 serialGet8() {}
+
+// Range: 0x8008EF9C -> 0x8008EFA4
+s32 serialPut64() {}
+
+// Range: 0x8008EFA4 -> 0x8008F0E4
+s32 serialPut32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x78791* pSerial; // r31
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 nSize; // r1+0x18
+    void* aData; // r1+0x14
+}
+
+// Range: 0x8008F0E4 -> 0x8008F0EC
+s32 serialPut16() {}
+
+// Range: 0x8008F0EC -> 0x8008F0F4
+s32 serialPut8() {}

--- a/debug/Fire/serial.c
+++ b/debug/Fire/serial.c
@@ -7,20 +7,20 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x7869D; // size = 0x10
 
 // size = 0x10, address = 0x800EEA28
 struct _XL_OBJECTTYPE gClassSerial;
 
-struct __anon_0x78791 {
+typedef struct __anon_0x78791 {
     /* 0x0 */ void* pHost;
     /* 0x4 */ s32 nAddress;
-}; // size = 0x8
+} __anon_0x78791; // size = 0x8
 
 // Range: 0x8008EE20 -> 0x8008EF20
 s32 serialEvent(struct __anon_0x78791* pSerial, s32 nEvent, void* pArgument) {

--- a/debug/Fire/simGCN.c
+++ b/debug/Fire/simGCN.c
@@ -7,9 +7,9 @@
 
 #include "types.h"
 
-struct __anon_0x57A1 {
+typedef struct __anon_0x57A1 {
     /* 0x0 */ s32 nMode;
-}; // size = 0x4
+} __anon_0x57A1; // size = 0x4
 
 // size = 0x4, address = 0x801355D0
 static struct __anon_0x57A1* gpCode;
@@ -173,7 +173,7 @@ u32 gz_iconSize;
 // size = 0x4, address = 0x80134D90
 s32 gHighlightChoice;
 
-enum __anon_0x61D7 {
+typedef enum __anon_0x61D7 {
     S_M_NONE = -1,
     S_M_DISK_COVER_OPEN = 0,
     S_M_DISK_WRONG_DISK = 1,
@@ -223,7 +223,7 @@ enum __anon_0x61D7 {
     S_M_CARD_SV12 = 45,
     S_M_CARD_SV_SHARE = 46,
     S_M_CARD_DEFAULT_ERROR = 47,
-};
+} __anon_0x61D7;
 
 // size = 0x4, address = 0x80134D94
 enum __anon_0x61D7 simulatorMessageCurrent;
@@ -297,14 +297,14 @@ char gpErrorMessageBuffer[20480];
 // size = 0x4, address = 0x801355FC
 s32 gbDisplayedError;
 
-struct __anon_0x6B86 {
+typedef struct __anon_0x6B86 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x6B86; // size = 0x10
 
-enum __anon_0x6C37 {
+typedef enum __anon_0x6C37 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -319,9 +319,9 @@ enum __anon_0x6C37 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x6C37;
 
-enum __anon_0x6D66 {
+typedef enum __anon_0x6D66 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -340,9 +340,9 @@ enum __anon_0x6D66 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x6D66;
 
-struct __anon_0x6EA4 {
+typedef struct __anon_0x6EA4 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -354,19 +354,19 @@ struct __anon_0x6EA4 {
     /* 0x70 */ enum __anon_0x6D66 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x6EA4; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x6EA4* gpSystem;
 
-enum __anon_0x7115 {
+typedef enum __anon_0x7115 {
     SPM_NONE = -1,
     SPM_PLAY = 0,
     SPM_RAMPQUEUED = 1,
     SPM_RAMPPLAYED = 2,
-};
+} __anon_0x7115;
 
-struct __anon_0x7181 {
+typedef struct __anon_0x7181 {
     /* 0x00 */ void* pSrcData;
     /* 0x04 */ s32 nFrequency;
     /* 0x08 */ s32 nDacrate;
@@ -387,33 +387,33 @@ struct __anon_0x7181 {
     /* 0xCC */ s32 nSizeZero;
     /* 0xD0 */ s32 nSizeHold;
     /* 0xD4 */ s32 nSizeRamp;
-}; // size = 0xD8
+} __anon_0x7181; // size = 0xD8
 
 // size = 0x4, address = 0x80135604
 struct __anon_0x7181* gpSound;
 
-struct __anon_0x7511 {
+typedef struct __anon_0x7511 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x7511; // size = 0x10
 
-struct __anon_0x75AB {
+typedef struct __anon_0x75AB {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x75AB; // size = 0x14
 
-struct __anon_0x76EC {
+typedef struct __anon_0x76EC {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x76EC; // size = 0xC
 
-struct __anon_0x775C {
+typedef struct __anon_0x775C {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x76EC rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -428,36 +428,36 @@ struct __anon_0x775C {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x775C; // size = 0x3C
 
-struct __anon_0x798C {
+typedef struct __anon_0x798C {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x76EC rS;
     /* 0x10 */ struct __anon_0x76EC rT;
     /* 0x1C */ struct __anon_0x76EC rSRaw;
     /* 0x28 */ struct __anon_0x76EC rTRaw;
-}; // size = 0x34
+} __anon_0x798C; // size = 0x34
 
-struct __anon_0x7A75 {
+typedef struct __anon_0x7A75 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x76EC vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x7A75; // size = 0x1C
 
-union __anon_0x7BD4 {
+typedef union __anon_0x7BD4 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x7BD4;
 
-struct __anon_0x7C71 {
+typedef struct __anon_0x7C71 {
     /* 0x0 */ union __anon_0x7BD4 data;
-}; // size = 0x1000
+} __anon_0x7C71; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -484,20 +484,20 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x7D0A;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x7ECC; // size = 0xC
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x7F13;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -517,9 +517,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x7F7C; // size = 0x6C
 
-struct __anon_0x82D9 {
+typedef struct __anon_0x82D9 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -536,15 +536,15 @@ struct __anon_0x82D9 {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x82D9; // size = 0x2C
 
-enum __anon_0x85BB {
+typedef enum __anon_0x85BB {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x85BB;
 
-struct __anon_0x863F {
+typedef struct __anon_0x863F {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -554,9 +554,9 @@ struct __anon_0x863F {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x85BB eProjection;
-}; // size = 0x24
+} __anon_0x863F; // size = 0x24
 
-struct __anon_0x87F6 {
+typedef struct __anon_0x87F6 {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -647,7 +647,7 @@ struct __anon_0x87F6 {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x87F6; // size = 0x3D150
 
 // size = 0x4, address = 0x80135608
 struct __anon_0x87F6* gpFrame;
@@ -664,16 +664,16 @@ void* DemoFrameBuffer1;
 // size = 0x4, address = 0x80135A90
 void* DemoFrameBuffer2;
 
-struct __anon_0x9737 {
+typedef struct __anon_0x9737 {
     /* 0x00 */ s32 configuration;
     /* 0x04 */ s32 size;
     /* 0x08 */ s32 offset;
     /* 0x0C */ char* buffer;
     /* 0x10 */ s32* writtenBlocks;
     /* 0x14 */ s32 writtenConfig;
-}; // size = 0x18
+} __anon_0x9737; // size = 0x18
 
-struct OSCalendarTime {
+typedef struct OSCalendarTime {
     /* 0x00 */ s32 sec;
     /* 0x04 */ s32 min;
     /* 0x08 */ s32 hour;
@@ -684,18 +684,18 @@ struct OSCalendarTime {
     /* 0x1C */ s32 yday;
     /* 0x20 */ s32 msec;
     /* 0x24 */ s32 usec;
-}; // size = 0x28
+} __anon_0x98DA; // size = 0x28
 
-struct CARDFileInfo {
+typedef struct CARDFileInfo {
     /* 0x00 */ s32 chan;
     /* 0x04 */ s32 fileNo;
     /* 0x08 */ s32 offset;
     /* 0x0C */ s32 length;
     /* 0x10 */ u16 iBlock;
     /* 0x12 */ u16 __padding;
-}; // size = 0x14
+} __anon_0x9A48; // size = 0x14
 
-struct __anon_0x9B40 {
+typedef struct __anon_0x9B40 {
     /* 0x000 */ s32 currentGame;
     /* 0x004 */ s32 fileSize;
     /* 0x008 */ char name[33];
@@ -709,9 +709,9 @@ struct __anon_0x9B40 {
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
-}; // size = 0x35C
+} __anon_0x9B40; // size = 0x35C
 
-enum __anon_0x9D56 {
+typedef enum __anon_0x9D56 {
     MC_E_NONE = 0,
     MC_E_BUSY = 1,
     MC_E_WRONGDEVICE = 2,
@@ -738,9 +738,9 @@ enum __anon_0x9D56 {
     MC_E_TIME_WRONG = 23,
     MC_E_WRITE_CORRUPTED = 24,
     MC_E_UNKNOWN = 25,
-};
+} __anon_0x9D56;
 
-struct _MCARD {
+typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x9B40 file;
     /* 0x35C */ enum __anon_0x9D56 error;
     /* 0x360 */ s32 slot;
@@ -769,17 +769,17 @@ struct _MCARD {
     /* 0x7AC */ s32 wait;
     /* 0x7B0 */ s32 isBroken;
     /* 0x7B4 */ s32 saveConfiguration;
-}; // size = 0x7B8
+} __anon_0x9FF8; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
 struct _MCARD mCard;
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0xA4E0; // size = 0x10
 
 // size = 0x10, address = 0x800EA7C8
 struct _XL_OBJECTTYPE gClassCode;
@@ -793,18 +793,18 @@ struct _XL_OBJECTTYPE gClassSound;
 // size = 0x10, address = 0x800EB310
 struct _XL_OBJECTTYPE gClassSystem;
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0xA64E; // size = 0x4
 
-enum __anon_0xA6E7 {
+typedef enum __anon_0xA6E7 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0xA6E7;
 
 // Range: 0x80007F80 -> 0x80008538
 s32 xlMain() {
@@ -851,7 +851,7 @@ s32 xlMain() {
     // -> s32 gDVDResetToggle;
 }
 
-enum __anon_0xA982 {
+typedef enum __anon_0xA982 {
     SAT_NONE = -1,
     SAT_NAME = 0,
     SAT_PROGRESSIVE = 1,
@@ -862,7 +862,7 @@ enum __anon_0xA982 {
     SAT_MOVIE = 6,
     SAT_RESET = 7,
     SAT_COUNT_ = 8,
-};
+} __anon_0xA982;
 
 // Range: 0x80008538 -> 0x80008578
 s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
@@ -885,7 +885,7 @@ static s32 simulatorParseArguments() {
     // -> static char* gaszArgument[8];
 }
 
-struct PADStatus {
+typedef struct PADStatus {
     /* 0x0 */ u16 button;
     /* 0x2 */ s8 stickX;
     /* 0x3 */ s8 stickY;
@@ -896,9 +896,9 @@ struct PADStatus {
     /* 0x8 */ u8 analogA;
     /* 0x9 */ u8 analogB;
     /* 0xA */ s8 err;
-}; // size = 0xC
+} __anon_0xAB9F; // size = 0xC
 
-struct __anon_0xAD2F {
+typedef struct __anon_0xAD2F {
     /* 0x00 */ struct PADStatus pst;
     /* 0x0C */ u16 buttonDown;
     /* 0x0E */ u16 buttonUp;
@@ -909,7 +909,7 @@ struct __anon_0xAD2F {
     /* 0x18 */ s16 stickDeltaY;
     /* 0x1A */ s16 substickDeltaX;
     /* 0x1C */ s16 substickDeltaY;
-}; // size = 0x1E
+} __anon_0xAD2F; // size = 0x1E
 
 // size = 0x78, address = 0x80132758
 struct __anon_0xAD2F DemoPad[4];
@@ -1162,7 +1162,7 @@ s32 simulatorReadEEPROM(u8 address, u8* data) {
     // -> struct __anon_0x6EA4* gpSystem;
 }
 
-enum __anon_0xC003 {
+typedef enum __anon_0xC003 {
     CT_NONE = 0,
     CT_CONTROLLER = 1,
     CT_CONTROLLER_W_PAK = 2,
@@ -1172,7 +1172,7 @@ enum __anon_0xC003 {
     CT_4K = 6,
     CT_16K = 7,
     CT_COUNT = 8,
-};
+} __anon_0xC003;
 
 // Range: 0x80008FBC -> 0x80009038
 s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
@@ -1252,14 +1252,14 @@ s32 simulatorReadController(s32 channel, u32* anData) {
     // -> static u32 nPrevButton$701;
 }
 
-struct __anon_0xC654 {
+typedef struct __anon_0xC654 {
     /* 0x000 */ char rom[36];
     /* 0x024 */ s32 controllerConfiguration[4][20];
     /* 0x164 */ s32 rumbleConfiguration;
     /* 0x168 */ s32 storageDevice;
     /* 0x16C */ s32 normalControllerConfig;
     /* 0x170 */ s32 currentControllerConfig;
-}; // size = 0x174
+} __anon_0xC654; // size = 0x174
 
 // Erased
 static s32 simulatorChangeControllerConfig(s32 channel, s32 nCurrButton) {
@@ -1297,11 +1297,11 @@ s32 simulatorSetControllerMap(u32* mapData, s32 channel) {
     // -> static u32 gContMap[4][20];
 }
 
-enum __anon_0xC9F9 {
+typedef enum __anon_0xC9F9 {
     SV_NONE = 0,
     SV_CODE = 1,
     SV_FRAME = 2,
-};
+} __anon_0xC9F9;
 
 // Erased
 static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
@@ -1329,7 +1329,7 @@ static s32 simulatorAddXtraTime() {}
 // Erased
 static s32 simulatorSetPart() {}
 
-enum __anon_0xCB82 {
+typedef enum __anon_0xCB82 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
     VI_TVMODE_NTSC_PROG = 2,
@@ -1342,14 +1342,14 @@ enum __anon_0xCB82 {
     VI_TVMODE_DEBUG_INT = 12,
     VI_TVMODE_DEBUG_PAL_INT = 16,
     VI_TVMODE_DEBUG_PAL_DS = 17,
-};
+} __anon_0xCB82;
 
-enum __anon_0xCCCC {
+typedef enum __anon_0xCCCC {
     VI_XFBMODE_SF = 0,
     VI_XFBMODE_DF = 1,
-};
+} __anon_0xCCCC;
 
-struct _GXRenderModeObj {
+typedef struct _GXRenderModeObj {
     /* 0x00 */ enum __anon_0xCB82 viTVmode;
     /* 0x04 */ u16 fbWidth;
     /* 0x06 */ u16 efbHeight;
@@ -1363,7 +1363,7 @@ struct _GXRenderModeObj {
     /* 0x19 */ u8 aa;
     /* 0x1A */ u8 sample_pattern[12][2];
     /* 0x32 */ u8 vfilter[7];
-}; // size = 0x3C
+} __anon_0xCD7D; // size = 0x3C
 
 // size = 0x4, address = 0x8013559C
 struct _GXRenderModeObj* rmode;
@@ -1397,7 +1397,7 @@ void simulatorReset(s32 IPL, s32 forceMenu) {
     // -> struct _MCARD mCard;
 }
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -1405,9 +1405,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0xD175; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -1420,14 +1420,14 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0xD2E5; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0xD50B; // size = 0x3C
 
 // Range: 0x80009A30 -> 0x8000CB7C
 s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
@@ -1476,16 +1476,16 @@ s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
     // -> u32 gmsg_ld01Size;
 }
 
-enum _GXTexFilter {
+typedef enum _GXTexFilter {
     GX_NEAR = 0,
     GX_LINEAR = 1,
     GX_NEAR_MIP_NEAR = 2,
     GX_LIN_MIP_NEAR = 3,
     GX_NEAR_MIP_LIN = 4,
     GX_LIN_MIP_LIN = 5,
-};
+} __anon_0xD740;
 
-struct __anon_0xD7D1 {
+typedef struct __anon_0xD7D1 {
     /* 0x00 */ u16 height;
     /* 0x02 */ u16 width;
     /* 0x04 */ u32 format;
@@ -1499,33 +1499,33 @@ struct __anon_0xD7D1 {
     /* 0x21 */ u8 minLOD;
     /* 0x22 */ u8 maxLOD;
     /* 0x23 */ u8 unpacked;
-}; // size = 0x24
+} __anon_0xD7D1; // size = 0x24
 
-enum _GXTlutFmt {
+typedef enum _GXTlutFmt {
     GX_TL_IA8 = 0,
     GX_TL_RGB565 = 1,
     GX_TL_RGB5A3 = 2,
     GX_MAX_TLUTFMT = 3,
-};
+} __anon_0xD9C4;
 
-struct __anon_0xDA2C {
+typedef struct __anon_0xDA2C {
     /* 0x0 */ u16 numEntries;
     /* 0x2 */ u8 unpacked;
     /* 0x3 */ u8 pad8;
     /* 0x4 */ enum _GXTlutFmt format;
     /* 0x8 */ char* data;
-}; // size = 0xC
+} __anon_0xDA2C; // size = 0xC
 
-struct __anon_0xDAF8 {
+typedef struct __anon_0xDAF8 {
     /* 0x0 */ struct __anon_0xD7D1* textureHeader;
     /* 0x4 */ struct __anon_0xDA2C* CLUTHeader;
-}; // size = 0x8
+} __anon_0xDAF8; // size = 0x8
 
-struct __anon_0xDB69 {
+typedef struct __anon_0xDB69 {
     /* 0x0 */ u32 versionNumber;
     /* 0x4 */ u32 numDescriptors;
     /* 0x8 */ struct __anon_0xDAF8* descriptorArray;
-}; // size = 0xC
+} __anon_0xDB69; // size = 0xC
 
 // Erased
 static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
@@ -1620,9 +1620,9 @@ s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 draw
     // -> u8 gcoverOpen[10433];
 }
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0xE08E; // size = 0x20
 
 // Range: 0x8000D58C -> 0x8000DBB4
 s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message, struct __anon_0xDB69* tplOK,

--- a/debug/Fire/simGCN.c
+++ b/debug/Fire/simGCN.c
@@ -1,1651 +1,1816 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\simGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x80007F80 -> 0x8000F7CC
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct __anon_0x57A1 {
+    /* 0x0 */ s32 nMode;
+}; // size = 0x4
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x4, address = 0x801355D0
+static struct __anon_0x57A1* gpCode;
 
-// size: 0x4
-struct __anon_0x57A1
-{
-	int nMode; // 0x0
+// size = 0x28C1, address = 0x800DB800
+u8 gcoverOpen[10433];
+
+// size = 0x1F01, address = 0x800DE0E0
+u8 gnoDisk[7937];
+
+// size = 0x2441, address = 0x800E0000
+u8 gretryErr[9281];
+
+// size = 0x32E1, address = 0x800E2460
+u8 gfatalErr[13025];
+
+// size = 0x1F01, address = 0x800E5760
+u8 gwrongDisk[7937];
+
+// size = 0xC41, address = 0x800E7680
+u8 greadingDisk[3137];
+
+// size = 0x741, address = 0x800E82E0
+u8 gbar[1857];
+
+// size = 0x5C1, address = 0x800E8A40
+u8 gyes[1473];
+
+// size = 0x5C1, address = 0x800E9020
+u8 gno[1473];
+
+// size = 0x341, address = 0x800E9600
+u8 gmesgOK[833];
+
+// size = 0x4, address = 0x80134CE8
+u32 gmsg_ld01Size;
+
+// size = 0x4, address = 0x80134CEC
+u32 gmsg_ld02Size;
+
+// size = 0x4, address = 0x80134CF0
+u32 gmsg_ld03Size;
+
+// size = 0x4, address = 0x80134CF4
+u32 gmsg_ld04Size;
+
+// size = 0x4, address = 0x80134CF8
+u32 gmsg_ld05_1Size;
+
+// size = 0x4, address = 0x80134CFC
+u32 gmsg_ld05_2Size;
+
+// size = 0x4, address = 0x80134D00
+u32 gmsg_ld06_1Size;
+
+// size = 0x4, address = 0x80134D04
+u32 gmsg_ld06_2Size;
+
+// size = 0x4, address = 0x80134D08
+u32 gmsg_ld06_3Size;
+
+// size = 0x4, address = 0x80134D0C
+u32 gmsg_ld06_4Size;
+
+// size = 0x4, address = 0x80134D10
+u32 gmsg_ld07Size;
+
+// size = 0x4, address = 0x80134D14
+u32 gmsg_gf01Size;
+
+// size = 0x4, address = 0x80134D18
+u32 gmsg_gf02Size;
+
+// size = 0x4, address = 0x80134D1C
+u32 gmsg_gf03Size;
+
+// size = 0x4, address = 0x80134D20
+u32 gmsg_gf04Size;
+
+// size = 0x4, address = 0x80134D24
+u32 gmsg_gf05Size;
+
+// size = 0x4, address = 0x80134D28
+u32 gmsg_gf06Size;
+
+// size = 0x4, address = 0x80134D2C
+u32 gmsg_in01Size;
+
+// size = 0x4, address = 0x80134D30
+u32 gmsg_in02Size;
+
+// size = 0x4, address = 0x80134D34
+u32 gmsg_in03Size;
+
+// size = 0x4, address = 0x80134D38
+u32 gmsg_in04Size;
+
+// size = 0x4, address = 0x80134D3C
+u32 gmsg_in05Size;
+
+// size = 0x4, address = 0x80134D40
+u32 gmsg_sv01Size;
+
+// size = 0x4, address = 0x80134D44
+u32 gmsg_sv01_2Size;
+
+// size = 0x4, address = 0x80134D48
+u32 gmsg_sv02Size;
+
+// size = 0x4, address = 0x80134D4C
+u32 gmsg_sv03Size;
+
+// size = 0x4, address = 0x80134D50
+u32 gmsg_sv04Size;
+
+// size = 0x4, address = 0x80134D54
+u32 gmsg_sv05_1Size;
+
+// size = 0x4, address = 0x80134D58
+u32 gmsg_sv06_1Size;
+
+// size = 0x4, address = 0x80134D5C
+u32 gmsg_sv06_2Size;
+
+// size = 0x4, address = 0x80134D60
+u32 gmsg_sv06_3Size;
+
+// size = 0x4, address = 0x80134D64
+u32 gmsg_sv06_4Size;
+
+// size = 0x4, address = 0x80134D68
+u32 gmsg_sv06_5Size;
+
+// size = 0x4, address = 0x80134D6C
+u32 gmsg_sv07Size;
+
+// size = 0x4, address = 0x80134D70
+u32 gmsg_sv08Size;
+
+// size = 0x4, address = 0x80134D74
+u32 gmsg_sv09Size;
+
+// size = 0x4, address = 0x80134D78
+u32 gmsg_sv10Size;
+
+// size = 0x4, address = 0x80134D7C
+u32 gmsg_sv11Size;
+
+// size = 0x4, address = 0x80134D80
+u32 gmsg_sv12Size;
+
+// size = 0x4, address = 0x80134D84
+u32 gmsg_sv_shareSize;
+
+// size = 0x4, address = 0x80134D88
+u32 gz_bnrSize;
+
+// size = 0x4, address = 0x80134D8C
+u32 gz_iconSize;
+
+// size = 0x4, address = 0x80134D90
+s32 gHighlightChoice;
+
+enum __anon_0x61D7 {
+    S_M_NONE = -1,
+    S_M_DISK_COVER_OPEN = 0,
+    S_M_DISK_WRONG_DISK = 1,
+    S_M_DISK_READING_DISK = 2,
+    S_M_DISK_FATAL_ERROR = 3,
+    S_M_DISK_RETRY_ERROR = 4,
+    S_M_DISK_NO_DISK = 5,
+    S_M_DISK_DEFAULT_ERROR = 6,
+    S_M_CARD_LD01 = 7,
+    S_M_CARD_LD02 = 8,
+    S_M_CARD_LD03 = 9,
+    S_M_CARD_LD04 = 10,
+    S_M_CARD_LD05_1 = 11,
+    S_M_CARD_LD05_2 = 12,
+    S_M_CARD_LD06_1 = 13,
+    S_M_CARD_LD06_2 = 14,
+    S_M_CARD_LD06_3 = 15,
+    S_M_CARD_LD06_4 = 16,
+    S_M_CARD_LD07 = 17,
+    S_M_CARD_GF01 = 18,
+    S_M_CARD_GF02 = 19,
+    S_M_CARD_GF03 = 20,
+    S_M_CARD_GF04 = 21,
+    S_M_CARD_GF05 = 22,
+    S_M_CARD_GF06 = 23,
+    S_M_CARD_IN01 = 24,
+    S_M_CARD_IN02 = 25,
+    S_M_CARD_IN03 = 26,
+    S_M_CARD_IN04 = 27,
+    S_M_CARD_IN05 = 28,
+    S_M_CARD_SV01 = 29,
+    S_M_CARD_SV01_2 = 30,
+    S_M_CARD_SV02 = 31,
+    S_M_CARD_SV03 = 32,
+    S_M_CARD_SV04 = 33,
+    S_M_CARD_SV05_1 = 34,
+    S_M_CARD_SV06_1 = 35,
+    S_M_CARD_SV06_2 = 36,
+    S_M_CARD_SV06_3 = 37,
+    S_M_CARD_SV06_4 = 38,
+    S_M_CARD_SV06_5 = 39,
+    S_M_CARD_SV07 = 40,
+    S_M_CARD_SV08 = 41,
+    S_M_CARD_SV09 = 42,
+    S_M_CARD_SV10 = 43,
+    S_M_CARD_SV11 = 44,
+    S_M_CARD_SV12 = 45,
+    S_M_CARD_SV_SHARE = 46,
+    S_M_CARD_DEFAULT_ERROR = 47,
 };
 
-// Local to compilation unit
-// Location: 0x801355D0
-static __anon_0x57A1 *gpCode;
+// size = 0x4, address = 0x80134D94
+enum __anon_0x61D7 simulatorMessageCurrent;
 
-// Location: 0x0
-int gDemo;
-
-// Location: 0xB80D80
-unsigned char gcoverOpen[10433];
-
-// Location: 0x800DE0E0
-unsigned char gnoDisk[7937];
-
-// Location: 0xE80
-unsigned char gretryErr[9281];
-
-// Location: 0x60240E80
-unsigned char gfatalErr[13025];
-
-// Location: 0x60570E80
-unsigned char gwrongDisk[7937];
-
-// Location: 0x800E7680
-unsigned char greadingDisk[3137];
-
-// Location: 0x800E82E0
-unsigned char gbar[1857];
-
-// Location: 0x408A0E80
-unsigned char gyes[1473];
-
-// Location: 0x20900E80
-unsigned char gno[1473];
-
-// Location: 0x960E80
-unsigned char gmesgOK[833];
-
-// Location: 0x80134CE8
-unsigned int gmsg_ld01Size;
-
-// Location: 0x80134CEC
-unsigned int gmsg_ld02Size;
-
-// Location: 0x80134CF0
-unsigned int gmsg_ld03Size;
-
-// Location: 0x80134CF4
-unsigned int gmsg_ld04Size;
-
-// Location: 0x80134CF8
-unsigned int gmsg_ld05_1Size;
-
-// Location: 0x80134CFC
-unsigned int gmsg_ld05_2Size;
-
-// Location: 0x4D1380
-unsigned int gmsg_ld06_1Size;
-
-// Location: 0x44D1380
-unsigned int gmsg_ld06_2Size;
-
-// Location: 0x84D1380
-unsigned int gmsg_ld06_3Size;
-
-// Location: 0xC4D1380
-unsigned int gmsg_ld06_4Size;
-
-// Location: 0x104D1380
-unsigned int gmsg_ld07Size;
-
-// Location: 0x144D1380
-unsigned int gmsg_gf01Size;
-
-// Location: 0x184D1380
-unsigned int gmsg_gf02Size;
-
-// Location: 0x1C4D1380
-unsigned int gmsg_gf03Size;
-
-// Location: 0x204D1380
-unsigned int gmsg_gf04Size;
-
-// Location: 0x244D1380
-unsigned int gmsg_gf05Size;
-
-// Location: 0x284D1380
-unsigned int gmsg_gf06Size;
-
-// Location: 0x2C4D1380
-unsigned int gmsg_in01Size;
-
-// Location: 0x304D1380
-unsigned int gmsg_in02Size;
-
-// Location: 0x344D1380
-unsigned int gmsg_in03Size;
-
-// Location: 0x384D1380
-unsigned int gmsg_in04Size;
-
-// Location: 0x3C4D1380
-unsigned int gmsg_in05Size;
-
-// Location: 0x404D1380
-unsigned int gmsg_sv01Size;
-
-// Location: 0x444D1380
-unsigned int gmsg_sv01_2Size;
-
-// Location: 0x484D1380
-unsigned int gmsg_sv02Size;
-
-// Location: 0x4C4D1380
-unsigned int gmsg_sv03Size;
-
-// Location: 0x504D1380
-unsigned int gmsg_sv04Size;
-
-// Location: 0x544D1380
-unsigned int gmsg_sv05_1Size;
-
-// Location: 0x584D1380
-unsigned int gmsg_sv06_1Size;
-
-// Location: 0x5C4D1380
-unsigned int gmsg_sv06_2Size;
-
-// Location: 0x604D1380
-unsigned int gmsg_sv06_3Size;
-
-// Location: 0x644D1380
-unsigned int gmsg_sv06_4Size;
-
-// Location: 0x684D1380
-unsigned int gmsg_sv06_5Size;
-
-// Location: 0x6C4D1380
-unsigned int gmsg_sv07Size;
-
-// Location: 0x704D1380
-unsigned int gmsg_sv08Size;
-
-// Location: 0x744D1380
-unsigned int gmsg_sv09Size;
-
-// Location: 0x784D1380
-unsigned int gmsg_sv10Size;
-
-// Location: 0x7C4D1380
-unsigned int gmsg_sv11Size;
-
-// Location: 0x80134D80
-unsigned int gmsg_sv12Size;
-
-// Location: 0x80134D84
-unsigned int gmsg_sv_shareSize;
-
-// Location: 0x80134D88
-unsigned int gz_bnrSize;
-
-// Location: 0x80134D8C
-unsigned int gz_iconSize;
-
-// Location: 0x80134D90
-int gHighlightChoice;
-
-// size: 0x4
-enum __anon_0x61D7
-{
-	S_M_NONE = 4294967295,
-	S_M_DISK_COVER_OPEN = 0,
-	S_M_DISK_WRONG_DISK = 1,
-	S_M_DISK_READING_DISK = 2,
-	S_M_DISK_FATAL_ERROR = 3,
-	S_M_DISK_RETRY_ERROR = 4,
-	S_M_DISK_NO_DISK = 5,
-	S_M_DISK_DEFAULT_ERROR = 6,
-	S_M_CARD_LD01 = 7,
-	S_M_CARD_LD02 = 8,
-	S_M_CARD_LD03 = 9,
-	S_M_CARD_LD04 = 10,
-	S_M_CARD_LD05_1 = 11,
-	S_M_CARD_LD05_2 = 12,
-	S_M_CARD_LD06_1 = 13,
-	S_M_CARD_LD06_2 = 14,
-	S_M_CARD_LD06_3 = 15,
-	S_M_CARD_LD06_4 = 16,
-	S_M_CARD_LD07 = 17,
-	S_M_CARD_GF01 = 18,
-	S_M_CARD_GF02 = 19,
-	S_M_CARD_GF03 = 20,
-	S_M_CARD_GF04 = 21,
-	S_M_CARD_GF05 = 22,
-	S_M_CARD_GF06 = 23,
-	S_M_CARD_IN01 = 24,
-	S_M_CARD_IN02 = 25,
-	S_M_CARD_IN03 = 26,
-	S_M_CARD_IN04 = 27,
-	S_M_CARD_IN05 = 28,
-	S_M_CARD_SV01 = 29,
-	S_M_CARD_SV01_2 = 30,
-	S_M_CARD_SV02 = 31,
-	S_M_CARD_SV03 = 32,
-	S_M_CARD_SV04 = 33,
-	S_M_CARD_SV05_1 = 34,
-	S_M_CARD_SV06_1 = 35,
-	S_M_CARD_SV06_2 = 36,
-	S_M_CARD_SV06_3 = 37,
-	S_M_CARD_SV06_4 = 38,
-	S_M_CARD_SV06_5 = 39,
-	S_M_CARD_SV07 = 40,
-	S_M_CARD_SV08 = 41,
-	S_M_CARD_SV09 = 42,
-	S_M_CARD_SV10 = 43,
-	S_M_CARD_SV11 = 44,
-	S_M_CARD_SV12 = 45,
-	S_M_CARD_SV_SHARE = 46,
-	S_M_CARD_DEFAULT_ERROR = 47
-};
-
-// Location: 0x80134D94
-__anon_0x61D7 simulatorMessageCurrent;
-
-// Local to compilation unit
-// Location: 0x40450F80
+// size = 0x40, address = 0x800F4540
 static float gOrthoMtx[4][4];
 
-// Location: 0x801355D4
-int gButtonDownToggle;
+// size = 0x4, address = 0x801355D4
+s32 gButtonDownToggle;
 
-// Location: 0x60990E80
-signed short Vert_s16[12];
+// size = 0x18, address = 0x800E9960
+s16 Vert_s16[12];
 
-// Location: 0x800E9980
-signed short VertTitle_s16[12];
+// size = 0x18, address = 0x800E9980
+s16 VertTitle_s16[12];
 
-// Location: 0x800E99A0
-signed short VertYes_s16[12];
+// size = 0x18, address = 0x800E99A0
+s16 VertYes_s16[12];
 
-// Location: 0x800E99C0
-signed short VertNo_s16[12];
+// size = 0x18, address = 0x800E99C0
+s16 VertNo_s16[12];
 
-// Location: 0x800E99E0
-signed short Vert_s16Bar[12];
+// size = 0x18, address = 0x800E99E0
+s16 Vert_s16Bar[12];
 
-// Location: 0x9A0E80
-unsigned long Colors_u32[3];
+// size = 0xC, address = 0x800E9A00
+u32 Colors_u32[3];
 
-// Location: 0x209A0E80
-unsigned char TexCoords_u8[8];
+// size = 0x8, address = 0x800E9A20
+u8 TexCoords_u8[8];
 
-// Location: 0x801355D8
-int gDVDResetToggle;
+// size = 0x4, address = 0x801355D8
+s32 gDVDResetToggle;
 
-// Local to compilation unit
-// Location: 0x801355DC
-static int toggle$192;
+// size = 0x4, address = 0x801355DC
+static s32 toggle$192;
 
-// Local to compilation unit
-// Location: 0x800F4580
-static unsigned int gContMap[4][20];
+// size = 0x140, address = 0x800F4580
+static u32 gContMap[4][20];
 
-// Local to compilation unit
-// Location: 0x801355E0
-static unsigned int nPrevButton$701;
+// size = 0x4, address = 0x801355E0
+static u32 nPrevButton$701;
 
-// Local to compilation unit
-// Location: 0x801355E4
-static unsigned int nCurrButton$702;
+// size = 0x4, address = 0x801355E4
+static u32 nCurrButton$702;
 
-// Local to compilation unit
-// Location: 0x801355E8
-static int gbReset;
+// size = 0x4, address = 0x801355E8
+static s32 gbReset;
 
-// Local to compilation unit
-// Location: 0x801355EC
-static unsigned int gnTickReset;
+// size = 0x4, address = 0x801355EC
+static u32 gnTickReset;
 
-// Location: 0x80134D98
-int gResetBeginFlag;
+// size = 0x4, address = 0x80134D98
+s32 gResetBeginFlag;
 
-// Location: 0x801355F0
-int gPreviousIPLSetting;
+// size = 0x4, address = 0x801355F0
+s32 gPreviousIPLSetting;
 
-// Location: 0x801355F4
-int gPreviousForceMenuSetting;
+// size = 0x4, address = 0x801355F4
+s32 gPreviousForceMenuSetting;
 
-// Location: 0x801355F8
-int gPreviousAllowResetSetting;
+// size = 0x4, address = 0x801355F8
+s32 gPreviousAllowResetSetting;
 
-// Local to compilation unit
-// Location: 0x800F46C0
-static char  *gaszArgument[8];
+// size = 0x20, address = 0x800F46C0
+static char* gaszArgument[8];
 
-// Location: 0x800F46E0
+// size = 0x5000, address = 0x800F46E0
 char gpErrorMessageBuffer[20480];
 
-// Location: 0x801355FC
-int gbDisplayedError;
+// size = 0x4, address = 0x801355FC
+s32 gbDisplayedError;
 
-// size: 0x10
-struct __anon_0x6B86
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+struct __anon_0x6B86 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x6C37 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x4
-enum __anon_0x6C37
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
+enum __anon_0x6D66 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum __anon_0x6D66
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
+struct __anon_0x6EA4 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0xA6E7 eMode;
+    /* 0x10 */ struct __anon_0x6B86 romCopy;
+    /* 0x20 */ enum __anon_0x6C37 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x6D66 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x6EA4* gpSystem;
+
+enum __anon_0x7115 {
+    SPM_NONE = -1,
+    SPM_PLAY = 0,
+    SPM_RAMPQUEUED = 1,
+    SPM_RAMPPLAYED = 2,
 };
 
-// size: 0x88
-struct __anon_0x6EA4
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0xA6E7 eMode; // 0xC
-	__anon_0x6B86 romCopy; // 0x10
-	__anon_0x6C37 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x6D66 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
+struct __anon_0x7181 {
+    /* 0x00 */ void* pSrcData;
+    /* 0x04 */ s32 nFrequency;
+    /* 0x08 */ s32 nDacrate;
+    /* 0x0C */ s32 nSndLen;
+    /* 0x10 */ void* apBuffer[16];
+    /* 0x50 */ s32 anSizeBuffer[16];
+    /* 0x90 */ s32 nCountBeep;
+    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0xA0 */ void* apDataBeep[3];
+    /* 0xAC */ s32 iBufferPlay;
+    /* 0xB0 */ s32 iBufferMake;
+    /* 0xB4 */ enum __anon_0x7115 eMode;
+    /* 0xB8 */ void* pBufferZero;
+    /* 0xBC */ void* pBufferHold;
+    /* 0xC0 */ void* pBufferRampUp;
+    /* 0xC4 */ void* pBufferRampDown;
+    /* 0xC8 */ s32 nSizePlay;
+    /* 0xCC */ s32 nSizeZero;
+    /* 0xD0 */ s32 nSizeHold;
+    /* 0xD4 */ s32 nSizeRamp;
+}; // size = 0xD8
+
+// size = 0x4, address = 0x80135604
+struct __anon_0x7181* gpSound;
+
+struct __anon_0x7511 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x75AB {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x76EC {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x775C {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x76EC rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x798C {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x76EC rS;
+    /* 0x10 */ struct __anon_0x76EC rT;
+    /* 0x1C */ struct __anon_0x76EC rSRaw;
+    /* 0x28 */ struct __anon_0x76EC rTRaw;
+}; // size = 0x34
+
+struct __anon_0x7A75 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x76EC vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x7BD4 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
 };
 
-// Location: 0x561380
-__anon_0x6EA4 *gpSystem;
+struct __anon_0x7C71 {
+    /* 0x0 */ union __anon_0x7BD4 data;
+}; // size = 0x1000
 
-// size: 0x4
-enum __anon_0x7115
-{
-	SPM_NONE = 4294967295,
-	SPM_PLAY = 0,
-	SPM_RAMPQUEUED = 1,
-	SPM_RAMPPLAYED = 2
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
 };
 
-// size: 0xD8
-struct __anon_0x7181
-{
-	void *pSrcData; // 0x0
-	int nFrequency; // 0x4
-	int nDacrate; // 0x8
-	int nSndLen; // 0xC
-	void *apBuffer[16]; // 0x10
-	int anSizeBuffer[16]; // 0x50
-	int nCountBeep; // 0x90
-	int anSizeBeep[3]; // 0x94
-	void *apDataBeep[3]; // 0xA0
-	int iBufferPlay; // 0xAC
-	int iBufferMake; // 0xB0
-	__anon_0x7115 eMode; // 0xB4
-	void *pBufferZero; // 0xB8
-	void *pBufferHold; // 0xBC
-	void *pBufferRampUp; // 0xC0
-	void *pBufferRampDown; // 0xC4
-	int nSizePlay; // 0xC8
-	int nSizeZero; // 0xCC
-	int nSizeHold; // 0xD0
-	int nSizeRamp; // 0xD4
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// Location: 0x4561380
-__anon_0x7181 *gpSound;
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
 
-// size: 0x10
-struct __anon_0x7511
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
+struct __anon_0x82D9 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x85BB {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
 };
 
-// size: 0x14
-struct __anon_0x75AB
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
+struct __anon_0x863F {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x85BB eProjection;
+}; // size = 0x24
+
+struct __anon_0x87F6 {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x7511 viewport;
+    /* 0x000C8 */ struct __anon_0x75AB aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x775C aLight[8];
+    /* 0x00320 */ struct __anon_0x798C lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x7A75 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x7C71 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x82D9 aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x85BB eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x863F aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+// size = 0x4, address = 0x80135608
+struct __anon_0x87F6* gpFrame;
+
+// size = 0x1, address = 0x80135AA8
+u8 DemoStatEnable;
+
+// size = 0x4, address = 0x80135A8C
+void* DemoCurrentBuffer;
+
+// size = 0x4, address = 0x80135A94
+void* DemoFrameBuffer1;
+
+// size = 0x4, address = 0x80135A90
+void* DemoFrameBuffer2;
+
+struct __anon_0x9737 {
+    /* 0x00 */ s32 configuration;
+    /* 0x04 */ s32 size;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ char* buffer;
+    /* 0x10 */ s32* writtenBlocks;
+    /* 0x14 */ s32 writtenConfig;
+}; // size = 0x18
+
+struct OSCalendarTime {
+    /* 0x00 */ s32 sec;
+    /* 0x04 */ s32 min;
+    /* 0x08 */ s32 hour;
+    /* 0x0C */ s32 mday;
+    /* 0x10 */ s32 mon;
+    /* 0x14 */ s32 year;
+    /* 0x18 */ s32 wday;
+    /* 0x1C */ s32 yday;
+    /* 0x20 */ s32 msec;
+    /* 0x24 */ s32 usec;
+}; // size = 0x28
+
+struct CARDFileInfo {
+    /* 0x00 */ s32 chan;
+    /* 0x04 */ s32 fileNo;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ s32 length;
+    /* 0x10 */ u16 iBlock;
+    /* 0x12 */ u16 __padding;
+}; // size = 0x14
+
+struct __anon_0x9B40 {
+    /* 0x000 */ s32 currentGame;
+    /* 0x004 */ s32 fileSize;
+    /* 0x008 */ char name[33];
+    /* 0x02C */ s32 numberOfGames;
+    /* 0x030 */ struct __anon_0x9737 game;
+    /* 0x048 */ s32 changedDate;
+    /* 0x04C */ s32 changedChecksum;
+    /* 0x050 */ s32 gameSize[16];
+    /* 0x090 */ s32 gameOffset[16];
+    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x110 */ char gameName[16][33];
+    /* 0x320 */ struct OSCalendarTime time;
+    /* 0x348 */ struct CARDFileInfo fileInfo;
+}; // size = 0x35C
+
+enum __anon_0x9D56 {
+    MC_E_NONE = 0,
+    MC_E_BUSY = 1,
+    MC_E_WRONGDEVICE = 2,
+    MC_E_NOCARD = 3,
+    MC_E_NOFILE = 4,
+    MC_E_IOERROR = 5,
+    MC_E_BROKEN = 6,
+    MC_E_EXIST = 7,
+    MC_E_NOENT = 8,
+    MC_E_INSSPACE = 9,
+    MC_E_NOPERM = 10,
+    MC_E_LIMIT = 11,
+    MC_E_NAMETOOLONG = 12,
+    MC_E_ENCODING = 13,
+    MC_E_CANCELED = 14,
+    MC_E_FATAL = 15,
+    MC_E_SECTOR_SIZE_INVALID = 16,
+    MC_E_GAME_NOT_FOUND = 17,
+    MC_E_CHECKSUM = 18,
+    MC_E_NO_FREE_SPACE = 19,
+    MC_E_NO_FREE_FILES = 20,
+    MC_E_FILE_EXISTS = 21,
+    MC_E_GAME_EXISTS = 22,
+    MC_E_TIME_WRONG = 23,
+    MC_E_WRITE_CORRUPTED = 24,
+    MC_E_UNKNOWN = 25,
 };
 
-// size: 0xC
-struct __anon_0x76EC
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
+struct _MCARD {
+    /* 0x000 */ struct __anon_0x9B40 file;
+    /* 0x35C */ enum __anon_0x9D56 error;
+    /* 0x360 */ s32 slot;
+    /* 0x364 */ s32 (*pPollFunction)();
+    /* 0x368 */ s32 pollPrevBytes;
+    /* 0x36C */ s32 pollSize;
+    /* 0x370 */ char pollMessage[256];
+    /* 0x470 */ s32 saveToggle;
+    /* 0x474 */ char* writeBuffer;
+    /* 0x478 */ char* readBuffer;
+    /* 0x47C */ s32 writeToggle;
+    /* 0x480 */ s32 soundToggle;
+    /* 0x484 */ s32 writeStatus;
+    /* 0x488 */ s32 writeIndex;
+    /* 0x48C */ s32 accessType;
+    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x494 */ char saveFileName[256];
+    /* 0x594 */ char saveComment[256];
+    /* 0x694 */ char* saveIcon;
+    /* 0x698 */ char* saveBanner;
+    /* 0x69C */ char saveGameName[256];
+    /* 0x79C */ s32 saveFileSize;
+    /* 0x7A0 */ s32 saveGameSize;
+    /* 0x7A4 */ s32 bufferCreated;
+    /* 0x7A8 */ s32 cardSize;
+    /* 0x7AC */ s32 wait;
+    /* 0x7B0 */ s32 isBroken;
+    /* 0x7B4 */ s32 saveConfiguration;
+}; // size = 0x7B8
+
+// size = 0x7B8, address = 0x801079B0
+struct _MCARD mCard;
+
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
+
+// size = 0x10, address = 0x800EA7C8
+struct _XL_OBJECTTYPE gClassCode;
+
+// size = 0x10, address = 0x800EA848
+struct _XL_OBJECTTYPE gClassFrame;
+
+// size = 0x10, address = 0x800EA7D8
+struct _XL_OBJECTTYPE gClassSound;
+
+// size = 0x10, address = 0x800EB310
+struct _XL_OBJECTTYPE gClassSystem;
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+enum __anon_0xA6E7 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// size: 0x3C
-struct __anon_0x775C
-{
-	int bTransformed; // 0x0
-	__anon_0x76EC rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
+// Range: 0x80007F80 -> 0x80008538
+s32 xlMain() {
+    // Local variables
+    struct _GXColor color; // r1+0x3C
+    enum __anon_0xA6E7 eMode; // r1+0x38
+    s32 nSize0; // r1+0x34
+    s32 nSize1; // r1+0x30
+    s32 iName; // r5
+    char* szNameROM; // r1+0x2C
+    char acNameROM[32]; // r1+0xC
+    s32 rumbleYes; // r1+0x8
 
-// size: 0x34
-struct __anon_0x798C
-{
-	int bTransformed; // 0x0
-	__anon_0x76EC rS; // 0x4
-	__anon_0x76EC rT; // 0x10
-	__anon_0x76EC rSRaw; // 0x1C
-	__anon_0x76EC rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x7A75
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x76EC vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x7BD4
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x7C71
-{
-	__anon_0x7BD4 data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x82D9
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x85BB
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x863F
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x85BB eProjection; // 0x20
-};
-
-// size: 0x3D150
-struct __anon_0x87F6
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x7511 viewport; // 0xB8
-	__anon_0x75AB aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x775C aLight[8]; // 0x140
-	__anon_0x798C lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x7A75 aVertex[80]; // 0x358
-	__anon_0x7C71 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x82D9 aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x85BB eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x863F aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-// Location: 0x8561380
-__anon_0x87F6 *gpFrame;
-
-// Location: 0x80135AA8
-unsigned char DemoStatEnable;
-
-// Location: 0x80135A8C
-void *DemoCurrentBuffer;
-
-// Location: 0x80135A94
-void *DemoFrameBuffer1;
-
-// Location: 0x80135A90
-void *DemoFrameBuffer2;
-
-// size: 0x18
-struct __anon_0x9737
-{
-	int configuration; // 0x0
-	int size; // 0x4
-	int offset; // 0x8
-	char *buffer; // 0xC
-	int *writtenBlocks; // 0x10
-	int writtenConfig; // 0x14
-};
-
-// size: 0x28
-struct OSCalendarTime
-{
-	int sec; // 0x0
-	int min; // 0x4
-	int hour; // 0x8
-	int mday; // 0xC
-	int mon; // 0x10
-	int year; // 0x14
-	int wday; // 0x18
-	int yday; // 0x1C
-	int msec; // 0x20
-	int usec; // 0x24
-};
-
-// size: 0x14
-struct CARDFileInfo
-{
-	long chan; // 0x0
-	long fileNo; // 0x4
-	long offset; // 0x8
-	long length; // 0xC
-	unsigned short iBlock; // 0x10
-	unsigned short __padding; // 0x12
-};
-
-// size: 0x35C
-struct __anon_0x9B40
-{
-	int currentGame; // 0x0
-	int fileSize; // 0x4
-	char name[33]; // 0x8
-	int numberOfGames; // 0x2C
-	__anon_0x9737 game; // 0x30
-	int changedDate; // 0x48
-	int changedChecksum; // 0x4C
-	int gameSize[16]; // 0x50
-	int gameOffset[16]; // 0x90
-	int gameConfigIndex[16]; // 0xD0
-	char gameName[16][33]; // 0x110
-	OSCalendarTime time; // 0x320
-	CARDFileInfo fileInfo; // 0x348
-};
-
-// size: 0x4
-enum __anon_0x9D56
-{
-	MC_E_NONE = 0,
-	MC_E_BUSY = 1,
-	MC_E_WRONGDEVICE = 2,
-	MC_E_NOCARD = 3,
-	MC_E_NOFILE = 4,
-	MC_E_IOERROR = 5,
-	MC_E_BROKEN = 6,
-	MC_E_EXIST = 7,
-	MC_E_NOENT = 8,
-	MC_E_INSSPACE = 9,
-	MC_E_NOPERM = 10,
-	MC_E_LIMIT = 11,
-	MC_E_NAMETOOLONG = 12,
-	MC_E_ENCODING = 13,
-	MC_E_CANCELED = 14,
-	MC_E_FATAL = 15,
-	MC_E_SECTOR_SIZE_INVALID = 16,
-	MC_E_GAME_NOT_FOUND = 17,
-	MC_E_CHECKSUM = 18,
-	MC_E_NO_FREE_SPACE = 19,
-	MC_E_NO_FREE_FILES = 20,
-	MC_E_FILE_EXISTS = 21,
-	MC_E_GAME_EXISTS = 22,
-	MC_E_TIME_WRONG = 23,
-	MC_E_WRITE_CORRUPTED = 24,
-	MC_E_UNKNOWN = 25
-};
-
-// size: 0x7B8
-struct _MCARD
-{
-	__anon_0x9B40 file; // 0x0
-	__anon_0x9D56 error; // 0x35C
-	int slot; // 0x360
-	int (*pPollFunction)(); // 0x364
-	int pollPrevBytes; // 0x368
-	int pollSize; // 0x36C
-	char pollMessage[256]; // 0x370
-	int saveToggle; // 0x470
-	char *writeBuffer; // 0x474
-	char *readBuffer; // 0x478
-	int writeToggle; // 0x47C
-	int soundToggle; // 0x480
-	int writeStatus; // 0x484
-	int writeIndex; // 0x488
-	int accessType; // 0x48C
-	int gameIsLoaded; // 0x490
-	char saveFileName[256]; // 0x494
-	char saveComment[256]; // 0x594
-	char *saveIcon; // 0x694
-	char *saveBanner; // 0x698
-	char saveGameName[256]; // 0x69C
-	int saveFileSize; // 0x79C
-	int saveGameSize; // 0x7A0
-	int bufferCreated; // 0x7A4
-	int cardSize; // 0x7A8
-	int wait; // 0x7AC
-	int isBroken; // 0x7B0
-	int saveConfiguration; // 0x7B4
-};
-
-// Location: 0x801079B0
-_MCARD mCard;
-
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
-
-// Location: 0x800EA7C8
-_XL_OBJECTTYPE gClassCode;
-
-// Location: 0x48A80E80
-_XL_OBJECTTYPE gClassFrame;
-
-// Location: 0x800EA7D8
-_XL_OBJECTTYPE gClassSound;
-
-// Location: 0x10B30E80
-_XL_OBJECTTYPE gClassSystem;
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x4
-enum __anon_0xA6E7
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
-
-int xlMain()
-{
-	_GXColor color;
-	__anon_0xA6E7 eMode;
-	int nSize0;
-	int nSize1;
-	int iName;
-	char *szNameROM;
-	char acNameROM[32];
-	int rumbleYes;
-	// References: gpCode (0x801355D0)
-	// References: gpFrame (0x8561380)
-	// References: gpSound (0x4561380)
-	// References: gpSystem (0x561380)
-	// References: gClassSystem (0x10B30E80)
-	// References: gClassSound (0x800EA7D8)
-	// References: gClassFrame (0x48A80E80)
-	// References: gClassCode (0x800EA7C8)
-	// References: gaszArgument (0x800F46C0)
-	// References: mCard (0x801079B0)
-	// References: gnTickReset (0x801355EC)
-	// References: gbReset (0x801355E8)
-	// References: gmesgOK (0x960E80)
-	// References: gno (0x20900E80)
-	// References: gyes (0x408A0E80)
-	// References: gbar (0x800E82E0)
-	// References: greadingDisk (0x800E7680)
-	// References: gwrongDisk (0x60570E80)
-	// References: gfatalErr (0x60240E80)
-	// References: gretryErr (0xE80)
-	// References: gnoDisk (0x800DE0E0)
-	// References: gcoverOpen (0xB80D80)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoStatEnable (0x80135AA8)
-	// References: gResetBeginFlag (0x80134D98)
-	// References: gButtonDownToggle (0x801355D4)
-	// References: gbDisplayedError (0x801355FC)
-	// References: gDVDResetToggle (0x801355D8)
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> struct __anon_0x7181* gpSound;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct _XL_OBJECTTYPE gClassSystem;
+    // -> struct _XL_OBJECTTYPE gClassSound;
+    // -> struct _XL_OBJECTTYPE gClassFrame;
+    // -> struct _XL_OBJECTTYPE gClassCode;
+    // -> static char* gaszArgument[8];
+    // -> struct _MCARD mCard;
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> u8 gmesgOK[833];
+    // -> u8 gno[1473];
+    // -> u8 gyes[1473];
+    // -> u8 gbar[1857];
+    // -> u8 greadingDisk[3137];
+    // -> u8 gwrongDisk[7937];
+    // -> u8 gfatalErr[13025];
+    // -> u8 gretryErr[9281];
+    // -> u8 gnoDisk[7937];
+    // -> u8 gcoverOpen[10433];
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> u8 DemoStatEnable;
+    // -> s32 gResetBeginFlag;
+    // -> s32 gButtonDownToggle;
+    // -> s32 gbDisplayedError;
+    // -> s32 gDVDResetToggle;
 }
 
-// size: 0x4
-enum __anon_0xA982
-{
-	SAT_NONE = 4294967295,
-	SAT_NAME = 0,
-	SAT_PROGRESSIVE = 1,
-	SAT_VIBRATION = 2,
-	SAT_CONTROLLER = 3,
-	SAT_XTRA = 4,
-	SAT_MEMORYCARD = 5,
-	SAT_MOVIE = 6,
-	SAT_RESET = 7,
-	SAT_COUNT_ = 8
+enum __anon_0xA982 {
+    SAT_NONE = -1,
+    SAT_NAME = 0,
+    SAT_PROGRESSIVE = 1,
+    SAT_VIBRATION = 2,
+    SAT_CONTROLLER = 3,
+    SAT_XTRA = 4,
+    SAT_MEMORYCARD = 5,
+    SAT_MOVIE = 6,
+    SAT_RESET = 7,
+    SAT_COUNT_ = 8,
 };
 
-int simulatorGetArgument(__anon_0xA982 eType, char **pszArgument)
-{
-	// References: gaszArgument (0x800F46C0)
+// Range: 0x80008538 -> 0x80008578
+s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
+    // Parameters
+    // enum __anon_0xA982 eType; // r1+0x0
+    // char** pszArgument; // r1+0x4
+
+    // References
+    // -> static char* gaszArgument[8];
 }
 
-// Local to compilation unit
-static int simulatorParseArguments()
-{
-	int iArgument;
-	char *szText;
-	char *szValue;
-	// References: gaszArgument (0x800F46C0)
+// Range: 0x80008578 -> 0x800086DC
+static s32 simulatorParseArguments() {
+    // Local variables
+    s32 iArgument; // r23
+    char* szText; // r1+0x14
+    char* szValue; // r1+0x10
+
+    // References
+    // -> static char* gaszArgument[8];
 }
 
-// size: 0xC
-struct PADStatus
-{
-	unsigned short button; // 0x0
-	signed char stickX; // 0x2
-	signed char stickY; // 0x3
-	signed char substickX; // 0x4
-	signed char substickY; // 0x5
-	unsigned char triggerLeft; // 0x6
-	unsigned char triggerRight; // 0x7
-	unsigned char analogA; // 0x8
-	unsigned char analogB; // 0x9
-	signed char err; // 0xA
+struct PADStatus {
+    /* 0x0 */ u16 button;
+    /* 0x2 */ s8 stickX;
+    /* 0x3 */ s8 stickY;
+    /* 0x4 */ s8 substickX;
+    /* 0x5 */ s8 substickY;
+    /* 0x6 */ u8 triggerLeft;
+    /* 0x7 */ u8 triggerRight;
+    /* 0x8 */ u8 analogA;
+    /* 0x9 */ u8 analogB;
+    /* 0xA */ s8 err;
+}; // size = 0xC
+
+struct __anon_0xAD2F {
+    /* 0x00 */ struct PADStatus pst;
+    /* 0x0C */ u16 buttonDown;
+    /* 0x0E */ u16 buttonUp;
+    /* 0x10 */ u16 dirs;
+    /* 0x12 */ u16 dirsNew;
+    /* 0x14 */ u16 dirsReleased;
+    /* 0x16 */ s16 stickDeltaX;
+    /* 0x18 */ s16 stickDeltaY;
+    /* 0x1A */ s16 substickDeltaX;
+    /* 0x1C */ s16 substickDeltaY;
+}; // size = 0x1E
+
+// size = 0x78, address = 0x80132758
+struct __anon_0xAD2F DemoPad[4];
+
+// Erased
+static s32 editSoundMenu() {
+    // Local variables
+    s32* menuValues[3]; // r1+0x94
+    s32 menuMinMax[3][2]; // r1+0x7C
+    char* menuNames[3]; // r1+0x70
+    char* menuHelp[3]; // r1+0x64
+    char str[32]; // r1+0x44
+    s32 curItem; // r24
+    s32 bDone; // r1+0xA0
+    s32 i; // r6
+    u32 heldButtons; // r7
+    u32 buttons; // r8
+    u32 downButtons; // r1+0x8
+    u8 holdCount[16]; // r1+0x34
+    struct _GXColor color[3]; // r1+0x28
+    s32 step; // r20
+    u32 bit; // r1+0x8
+    struct _GXColor* colorP; // r31
+
+    // References
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Erased
+static void MyGXInit() {
+    // Local variables
+    s32 i; // r31
+    float identity_mtx[3][4]; // r1+0x50
+}
+
+// Erased
+static s32 simulatorMenu() {}
+
+// Erased
+static s32 simulatorPickROM() {}
+
+// Erased
+static s32 simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
+    // Parameters
+    // char* line1; // r22
+    // char* line2; // r23
+    // char* line3; // r24
+
+    // Local variables
+    s32 nCount; // r25
+
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Erased
+static s32 simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, s32* yes) {
+    // Parameters
+    // char* line1; // r21
+    // char* line2; // r22
+    // char* line3; // r23
+    // s32* yes; // r24
+
+    // Local variables
+    s32 nCount; // r25
+
+    // References
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Range: 0x800086DC -> 0x800088E4
+static s32 simulatorDrawCursor(s32 nX, s32 nY) {
+    // Parameters
+    // s32 nX; // r30
+    // s32 nY; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x18
+    s32 nTick; // r4
+}
+
+// Range: 0x800088E4 -> 0x80008A14
+s32 simulatorMCardPollDrawFormatBar() {
+    // Local variables
+    float rate; // r1+0x8
+    s32 nBytes; // r1+0x8
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008A14 -> 0x80008B44
+s32 simulatorMCardPollDrawBar() {
+    // Local variables
+    float rate; // r1+0x8
+    s32 nBytes; // r1+0x8
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008B44 -> 0x80008BDC
+s32 simulatorDrawMCardText() {
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+}
+
+// Erased
+static s32 simulatorDrawText(s32 nX, s32 nY, char* szText, s32 nColorR, s32 nColorG, s32 nColorB) {
+    // Parameters
+    // s32 nX; // r26
+    // s32 nY; // r27
+    // char* szText; // r28
+    // s32 nColorR; // r29
+    // s32 nColorG; // r30
+    // s32 nColorB; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x24
+}
+
+// Range: 0x80008BDC -> 0x80008DBC
+s32 simulatorTestReset(s32 IPL, s32 forceMenu, s32 allowReset, s32 usePreviousSettings) {
+    // Parameters
+    // s32 IPL; // r24
+    // s32 forceMenu; // r25
+    // s32 allowReset; // r26
+    // s32 usePreviousSettings; // r27
+
+    // Local variables
+    u32 bFlag; // r1+0x8
+    u32 nTick; // r1+0x8
+    s32 prevIPLSetting; // r28
+    s32 prevForceMenuSetting; // r27
+    s32 prevAllowResetSetting; // r1+0x8
+
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gResetBeginFlag;
+    // -> s32 gPreviousAllowResetSetting;
+    // -> s32 gPreviousForceMenuSetting;
+    // -> s32 gPreviousIPLSetting;
+}
+
+// Erased
+static void sScreenshotFree() {}
+
+// Erased
+static void* sScreenshotAlloc() {}
+
+// Range: 0x80008DBC -> 0x80008DE4
+s32 simulatorRumbleStop(s32 channel) {
+    // Parameters
+    // s32 channel; // r3
+}
+
+// Range: 0x80008DE4 -> 0x80008E0C
+s32 simulatorRumbleStart(s32 channel) {
+    // Parameters
+    // s32 channel; // r3
+}
+
+// Range: 0x80008E0C -> 0x80008E40
+s32 simulatorWriteFLASH(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008E40 -> 0x80008E74
+s32 simulatorReadFLASH(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008E74 -> 0x80008EA8
+s32 simulatorWriteSRAM(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008EA8 -> 0x80008EDC
+s32 simulatorReadSRAM(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008EDC -> 0x80008F4C
+s32 simulatorWriteEEPROM(u8 address, u8* data) {
+    // Parameters
+    // u8 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    s32 size; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80008F4C -> 0x80008FBC
+s32 simulatorReadEEPROM(u8 address, u8* data) {
+    // Parameters
+    // u8 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    s32 size; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+enum __anon_0xC003 {
+    CT_NONE = 0,
+    CT_CONTROLLER = 1,
+    CT_CONTROLLER_W_PAK = 2,
+    CT_CONTROLLER_W_RPAK = 3,
+    CT_MOUSE = 4,
+    CT_VOICE = 5,
+    CT_4K = 6,
+    CT_16K = 7,
+    CT_COUNT = 8,
 };
 
-// size: 0x1E
-struct __anon_0xAD2F
-{
-	PADStatus pst; // 0x0
-	unsigned short buttonDown; // 0xC
-	unsigned short buttonUp; // 0xE
-	unsigned short dirs; // 0x10
-	unsigned short dirsNew; // 0x12
-	unsigned short dirsReleased; // 0x14
-	signed short stickDeltaX; // 0x16
-	signed short stickDeltaY; // 0x18
-	signed short substickDeltaX; // 0x1A
-	signed short substickDeltaY; // 0x1C
+// Range: 0x80008FBC -> 0x80009038
+s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r29
+    // u16 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    enum __anon_0xC003 type; // r1+0x14
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80009038 -> 0x800090B4
+s32 simulatorReadPak(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r29
+    // u16 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    enum __anon_0xC003 type; // r1+0x14
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x800090B4 -> 0x80009108
+s32 simulatorDetectController(s32 channel) {
+    // Parameters
+    // s32 channel; // r31
+
+    // Local variables
+    struct PADStatus status[4]; // r1+0xC
+}
+
+// Erased
+static s32 simulatorResetController() {}
+
+// Range: 0x80009108 -> 0x80009110
+s32 simulatorShowLoad() {}
+
+// Erased
+static void DEMOInitWindow(s32 nSizeX, s32 nSizeY, s32 nColorR, s32 nColorG, s32 nColorB) {
+    // Parameters
+    // s32 nSizeX; // r3
+    // s32 nSizeY; // r1+0xC
+    // s32 nColorR; // r29
+    // s32 nColorG; // r30
+    // s32 nColorB; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x20
+}
+
+// Range: 0x80009110 -> 0x80009684
+s32 simulatorReadController(s32 channel, u32* anData) {
+    // Parameters
+    // s32 channel; // r29
+    // u32* anData; // r30
+
+    // Local variables
+    float subStickTest; // f1
+    s32 stickX; // r1+0x8
+    s32 stickY; // r1+0x8
+    s32 subStickX; // r6
+    s32 subStickY; // r7
+    s32 nDirButton; // r3
+
+    // References
+    // -> static u32 gContMap[4][20];
+    // -> static u32 nCurrButton$702;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> static u32 nPrevButton$701;
+}
+
+struct __anon_0xC654 {
+    /* 0x000 */ char rom[36];
+    /* 0x024 */ s32 controllerConfiguration[4][20];
+    /* 0x164 */ s32 rumbleConfiguration;
+    /* 0x168 */ s32 storageDevice;
+    /* 0x16C */ s32 normalControllerConfig;
+    /* 0x170 */ s32 currentControllerConfig;
+}; // size = 0x174
+
+// Erased
+static s32 simulatorChangeControllerConfig(s32 channel, s32 nCurrButton) {
+    // Parameters
+    // s32 channel; // r31
+    // s32 nCurrButton; // r1+0xC
+
+    // References
+    // -> static u32 gContMap[4][20];
+    // -> static struct __anon_0xC654 gSystemRomConfigurationList[1];
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80009684 -> 0x8000974C
+s32 simulatorCopyControllerMap(u32* mapDataOutput, u32* mapDataInput) {
+    // Parameters
+    // u32* mapDataOutput; // r1+0x0
+    // u32* mapDataInput; // r1+0x4
+
+    // Local variables
+    s32 i; // r7
+}
+
+// Range: 0x8000974C -> 0x80009824
+s32 simulatorSetControllerMap(u32* mapData, s32 channel) {
+    // Parameters
+    // u32* mapData; // r1+0x0
+    // s32 channel; // r1+0x4
+
+    // Local variables
+    s32 i; // r7
+
+    // References
+    // -> static u32 gContMap[4][20];
+}
+
+enum __anon_0xC9F9 {
+    SV_NONE = 0,
+    SV_CODE = 1,
+    SV_FRAME = 2,
 };
 
-// Location: 0x58271380
-__anon_0xAD2F DemoPad[4];
+// Erased
+static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
+    // Parameters
+    // enum __anon_0xC9F9 eView; // r1+0x8
 
-int editSoundMenu()
-{
-	long  *menuValues[3];
-	long menuMinMax[3][2];
-	char  *menuNames[3];
-	char  *menuHelp[3];
-	char str[32];
-	long curItem;
-	long bDone;
-	long i;
-	unsigned long heldButtons;
-	unsigned long buttons;
-	unsigned long downButtons;
-	unsigned char holdCount[16];
-	_GXColor color[3];
-	long step;
-	unsigned long bit;
-	_GXColor *colorP;
-	// References: DemoPad (0x58271380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
 }
 
-void MyGXInit()
-{
-	long i;
-	float identity_mtx[3][4];
+// Erased
+static enum __anon_0xC9F9 simulatorGetView() {
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
 }
 
-int simulatorMenu();
+// Erased
+static s32 simulatorShowParts() {}
 
-int simulatorPickROM();
+// Erased
+static s32 simulatorAddXtraTime() {}
 
-int simulatorDrawOKScreen(char *line1, char *line2, char *line3)
-{
-	int nCount;
-	// References: gButtonDownToggle (0x801355D4)
-	// References: DemoPad (0x58271380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-}
+// Erased
+static s32 simulatorSetPart() {}
 
-int simulatorDrawYesNoScreen(char *line1, char *line2, char *line3, int *yes)
-{
-	int nCount;
-	// References: DemoPad (0x58271380)
-	// References: gButtonDownToggle (0x801355D4)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-}
-
-// Local to compilation unit
-static int simulatorDrawCursor(int nX, int nY)
-{
-	_GXColor color;
-	int nTick;
-}
-
-int simulatorMCardPollDrawFormatBar()
-{
-	float rate;
-	int nBytes;
-	// References: gpErrorMessageBuffer (0x800F46E0)
-	// References: mCard (0x801079B0)
-}
-
-int simulatorMCardPollDrawBar()
-{
-	float rate;
-	int nBytes;
-	// References: gpErrorMessageBuffer (0x800F46E0)
-	// References: mCard (0x801079B0)
-}
-
-int simulatorDrawMCardText()
-{
-	// References: gpErrorMessageBuffer (0x800F46E0)
-}
-
-int simulatorDrawText(int nX, int nY, char *szText, int nColorR, int nColorG, int nColorB)
-{
-	_GXColor color;
-}
-
-int simulatorTestReset(int IPL, int forceMenu, int allowReset, int usePreviousSettings)
-{
-	unsigned int bFlag;
-	unsigned int nTick;
-	int prevIPLSetting;
-	int prevForceMenuSetting;
-	int prevAllowResetSetting;
-	// References: gnTickReset (0x801355EC)
-	// References: gbReset (0x801355E8)
-	// References: DemoPad (0x58271380)
-	// References: gResetBeginFlag (0x80134D98)
-	// References: gPreviousAllowResetSetting (0x801355F8)
-	// References: gPreviousForceMenuSetting (0x801355F4)
-	// References: gPreviousIPLSetting (0x801355F0)
-}
-
-void sScreenshotFree();
-
-void *sScreenshotAlloc();
-
-int simulatorRumbleStop(int channel);
-
-int simulatorRumbleStart(int channel);
-
-int simulatorWriteFLASH(unsigned int address, unsigned char *data, int size)
-{
-	// References: mCard (0x801079B0)
-}
-
-int simulatorReadFLASH(unsigned int address, unsigned char *data, int size)
-{
-	// References: mCard (0x801079B0)
-}
-
-int simulatorWriteSRAM(unsigned int address, unsigned char *data, int size)
-{
-	// References: mCard (0x801079B0)
-}
-
-int simulatorReadSRAM(unsigned int address, unsigned char *data, int size)
-{
-	// References: mCard (0x801079B0)
-}
-
-int simulatorWriteEEPROM(unsigned char address, unsigned char *data)
-{
-	int size;
-	// References: mCard (0x801079B0)
-	// References: gpSystem (0x561380)
-}
-
-int simulatorReadEEPROM(unsigned char address, unsigned char *data)
-{
-	int size;
-	// References: mCard (0x801079B0)
-	// References: gpSystem (0x561380)
-}
-
-// size: 0x4
-enum __anon_0xC003
-{
-	CT_NONE = 0,
-	CT_CONTROLLER = 1,
-	CT_CONTROLLER_W_PAK = 2,
-	CT_CONTROLLER_W_RPAK = 3,
-	CT_MOUSE = 4,
-	CT_VOICE = 5,
-	CT_4K = 6,
-	CT_16K = 7,
-	CT_COUNT = 8
+enum __anon_0xCB82 {
+    VI_TVMODE_NTSC_INT = 0,
+    VI_TVMODE_NTSC_DS = 1,
+    VI_TVMODE_NTSC_PROG = 2,
+    VI_TVMODE_PAL_INT = 4,
+    VI_TVMODE_PAL_DS = 5,
+    VI_TVMODE_EURGB60_INT = 20,
+    VI_TVMODE_EURGB60_DS = 21,
+    VI_TVMODE_MPAL_INT = 8,
+    VI_TVMODE_MPAL_DS = 9,
+    VI_TVMODE_DEBUG_INT = 12,
+    VI_TVMODE_DEBUG_PAL_INT = 16,
+    VI_TVMODE_DEBUG_PAL_DS = 17,
 };
 
-int simulatorWritePak(int channel, unsigned short address, unsigned char *data)
-{
-	__anon_0xC003 type;
-	// References: gpSystem (0x561380)
-}
-
-int simulatorReadPak(int channel, unsigned short address, unsigned char *data)
-{
-	__anon_0xC003 type;
-	// References: gpSystem (0x561380)
-}
-
-int simulatorDetectController(int channel)
-{
-	PADStatus status[4];
-}
-
-int simulatorResetController();
-
-int simulatorShowLoad();
-
-void DEMOInitWindow(int nSizeX, int nSizeY, int nColorR, int nColorG, int nColorB)
-{
-	_GXColor color;
-}
-
-int simulatorReadController(int channel, unsigned int *anData)
-{
-	float subStickTest;
-	int stickX;
-	int stickY;
-	int subStickX;
-	int subStickY;
-	int nDirButton;
-	// References: gContMap (0x800F4580)
-	// References: nCurrButton$702 (0x801355E4)
-	// References: DemoPad (0x58271380)
-	// References: gButtonDownToggle (0x801355D4)
-	// References: nPrevButton$701 (0x801355E0)
-}
-
-// size: 0x174
-struct __anon_0xC654
-{
-	char rom[36]; // 0x0
-	int controllerConfiguration[4][20]; // 0x24
-	int rumbleConfiguration; // 0x164
-	int storageDevice; // 0x168
-	int normalControllerConfig; // 0x16C
-	int currentControllerConfig; // 0x170
+enum __anon_0xCCCC {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF = 1,
 };
 
-// Location: 0x0
-__anon_0xC654 gSystemRomConfigurationList[1];
+struct _GXRenderModeObj {
+    /* 0x00 */ enum __anon_0xCB82 viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ enum __anon_0xCCCC xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x1A */ u8 sample_pattern[12][2];
+    /* 0x32 */ u8 vfilter[7];
+}; // size = 0x3C
 
-int simulatorChangeControllerConfig(int channel, int nCurrButton)
-{
-	// References: gContMap (0x800F4580)
-	// References: gSystemRomConfigurationList (0x0)
-	// References: gpSystem (0x561380)
-	// References: mCard (0x801079B0)
+// size = 0x4, address = 0x8013559C
+struct _GXRenderModeObj* rmode;
+
+// size = 0x4, address = 0x80135644
+s32 gMovieErrorToggle;
+
+// Range: 0x80009824 -> 0x80009980
+void simulatorResetAndPlayMovie() {
+    // Local variables
+    struct _GXColor color; // r1+0x14
+    struct _GXRenderModeObj* simrmode; // r31
+
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> s32 gMovieErrorToggle;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> struct _MCARD mCard;
 }
 
-int simulatorCopyControllerMap(unsigned int *mapDataOutput, unsigned int *mapDataInput)
-{
-	int i;
+// Range: 0x80009980 -> 0x80009A30
+void simulatorReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r30
+    // s32 forceMenu; // r31
+
+    // References
+    // -> struct _MCARD mCard;
 }
 
-int simulatorSetControllerMap(unsigned int *mapData, int channel)
-{
-	int i;
-	// References: gContMap (0x800F4580)
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+// Range: 0x80009A30 -> 0x8000CB7C
+s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
+    // Parameters
+    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
+
+    // Local variables
+    struct DVDFileInfo fileInfo; // r1+0x80
+
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> u8 gmesgOK[833];
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u8 gyes[1473];
+    // -> u32 gmsg_sv_shareSize;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv12Size;
+    // -> u32 gmsg_sv11Size;
+    // -> u32 gmsg_sv10Size;
+    // -> u32 gmsg_sv07Size;
+    // -> u32 gmsg_sv06_3Size;
+    // -> u32 gmsg_sv06_2Size;
+    // -> u32 gmsg_sv06_1Size;
+    // -> u32 gmsg_sv05_1Size;
+    // -> u32 gmsg_sv04Size;
+    // -> u32 gmsg_sv03Size;
+    // -> u32 gmsg_sv02Size;
+    // -> u32 gmsg_sv01_2Size;
+    // -> u32 gmsg_sv01Size;
+    // -> u32 gmsg_in05Size;
+    // -> u32 gmsg_in04Size;
+    // -> u32 gmsg_in03Size;
+    // -> u32 gmsg_gf06Size;
+    // -> u32 gmsg_gf05Size;
+    // -> u32 gmsg_gf04Size;
+    // -> u32 gmsg_gf03Size;
+    // -> u32 gmsg_ld06_3Size;
+    // -> u32 gmsg_ld06_2Size;
+    // -> u32 gmsg_ld06_1Size;
+    // -> u32 gmsg_ld05_1Size;
+    // -> u32 gmsg_ld04Size;
+    // -> u32 gmsg_ld03Size;
+    // -> u32 gmsg_ld02Size;
+    // -> u32 gmsg_ld01Size;
 }
 
-// size: 0x4
-enum __anon_0xC9F9
-{
-	SV_NONE = 0,
-	SV_CODE = 1,
-	SV_FRAME = 2
+enum _GXTexFilter {
+    GX_NEAR = 0,
+    GX_LINEAR = 1,
+    GX_NEAR_MIP_NEAR = 2,
+    GX_LIN_MIP_NEAR = 3,
+    GX_NEAR_MIP_LIN = 4,
+    GX_LIN_MIP_LIN = 5,
 };
 
-int simulatorSetView(__anon_0xC9F9 eView)
-{
-	// References: gpCode (0x801355D0)
-	// References: gpFrame (0x8561380)
-}
+struct __anon_0xD7D1 {
+    /* 0x00 */ u16 height;
+    /* 0x02 */ u16 width;
+    /* 0x04 */ u32 format;
+    /* 0x08 */ char* data;
+    /* 0x0C */ enum _GXTexWrapMode wrapS;
+    /* 0x10 */ enum _GXTexWrapMode wrapT;
+    /* 0x14 */ enum _GXTexFilter minFilter;
+    /* 0x18 */ enum _GXTexFilter magFilter;
+    /* 0x1C */ float LODBias;
+    /* 0x20 */ u8 edgeLODEnable;
+    /* 0x21 */ u8 minLOD;
+    /* 0x22 */ u8 maxLOD;
+    /* 0x23 */ u8 unpacked;
+}; // size = 0x24
 
-__anon_0xC9F9 simulatorGetView()
-{
-	// References: gpCode (0x801355D0)
-	// References: gpFrame (0x8561380)
-}
-
-int simulatorShowParts();
-
-int simulatorAddXtraTime();
-
-int simulatorSetPart();
-
-// size: 0x4
-enum __anon_0xCB82
-{
-	VI_TVMODE_NTSC_INT = 0,
-	VI_TVMODE_NTSC_DS = 1,
-	VI_TVMODE_NTSC_PROG = 2,
-	VI_TVMODE_PAL_INT = 4,
-	VI_TVMODE_PAL_DS = 5,
-	VI_TVMODE_EURGB60_INT = 20,
-	VI_TVMODE_EURGB60_DS = 21,
-	VI_TVMODE_MPAL_INT = 8,
-	VI_TVMODE_MPAL_DS = 9,
-	VI_TVMODE_DEBUG_INT = 12,
-	VI_TVMODE_DEBUG_PAL_INT = 16,
-	VI_TVMODE_DEBUG_PAL_DS = 17
+enum _GXTlutFmt {
+    GX_TL_IA8 = 0,
+    GX_TL_RGB565 = 1,
+    GX_TL_RGB5A3 = 2,
+    GX_MAX_TLUTFMT = 3,
 };
 
-// size: 0x4
-enum __anon_0xCCCC
-{
-	VI_XFBMODE_SF = 0,
-	VI_XFBMODE_DF = 1
-};
+struct __anon_0xDA2C {
+    /* 0x0 */ u16 numEntries;
+    /* 0x2 */ u8 unpacked;
+    /* 0x3 */ u8 pad8;
+    /* 0x4 */ enum _GXTlutFmt format;
+    /* 0x8 */ char* data;
+}; // size = 0xC
 
-// size: 0x3C
-struct _GXRenderModeObj
-{
-	__anon_0xCB82 viTVmode; // 0x0
-	unsigned short fbWidth; // 0x4
-	unsigned short efbHeight; // 0x6
-	unsigned short xfbHeight; // 0x8
-	unsigned short viXOrigin; // 0xA
-	unsigned short viYOrigin; // 0xC
-	unsigned short viWidth; // 0xE
-	unsigned short viHeight; // 0x10
-	__anon_0xCCCC xFBmode; // 0x14
-	unsigned char field_rendering; // 0x18
-	unsigned char aa; // 0x19
-	unsigned char sample_pattern[12][2]; // 0x1A
-	unsigned char vfilter[7]; // 0x32
-};
+struct __anon_0xDAF8 {
+    /* 0x0 */ struct __anon_0xD7D1* textureHeader;
+    /* 0x4 */ struct __anon_0xDA2C* CLUTHeader;
+}; // size = 0x8
 
-// Location: 0x8013559C
-_GXRenderModeObj *rmode;
+struct __anon_0xDB69 {
+    /* 0x0 */ u32 versionNumber;
+    /* 0x4 */ u32 numDescriptors;
+    /* 0x8 */ struct __anon_0xDAF8* descriptorArray;
+}; // size = 0xC
 
-// Location: 0x44561380
-int gMovieErrorToggle;
+// Erased
+static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
+    // Parameters
+    // struct __anon_0xDB69* simulatorMessage; // r27
 
-void simulatorResetAndPlayMovie()
-{
-	_GXColor color;
-	_GXRenderModeObj *simrmode;
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-	// References: gMovieErrorToggle (0x44561380)
-	// References: rmode (0x8013559C)
-	// References: mCard (0x801079B0)
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> u8 gmesgOK[833];
+    // -> u8 gyes[1473];
 }
 
-void simulatorReset(int IPL, int forceMenu)
-{
-	// References: mCard (0x801079B0)
+// Range: 0x8000CB7C -> 0x8000CF24
+s32 simulatorDrawYesNoMessage(enum __anon_0x61D7 simulatorMessage, s32* yes) {
+    // Parameters
+    // enum __anon_0x61D7 simulatorMessage; // r1+0x8
+    // s32* yes; // r30
+
+    // Local variables
+    struct DVDFileInfo fileInfo; // r1+0x10
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u32 gmsg_sv08Size;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv06_5Size;
+    // -> u32 gmsg_sv06_4Size;
+    // -> u32 gmsg_in01Size;
+    // -> u32 gmsg_gf01Size;
+    // -> u32 gmsg_ld07Size;
+    // -> u32 gmsg_ld06_4Size;
+    // -> u32 gmsg_ld05_2Size;
 }
 
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
+// Range: 0x8000CF24 -> 0x8000D1F0
+s32 simulatorDrawYesNoMessageLoop(struct __anon_0xDB69* simulatorQuestion, s32* yes) {
+    // Parameters
+    // struct __anon_0xDB69* simulatorQuestion; // r26
+    // s32* yes; // r27
 
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-int simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage)
-{
-	DVDFileInfo fileInfo;
-	// References: gButtonDownToggle (0x801355D4)
-	// References: gpSystem (0x561380)
-	// References: DemoPad (0x58271380)
-	// References: gmesgOK (0x960E80)
-	// References: gpErrorMessageBuffer (0x800F46E0)
-	// References: gyes (0x408A0E80)
-	// References: gmsg_sv_shareSize (0x80134D84)
-	// References: simulatorMessageCurrent (0x80134D94)
-	// References: gmsg_sv12Size (0x80134D80)
-	// References: gmsg_sv11Size (0x7C4D1380)
-	// References: gmsg_sv10Size (0x784D1380)
-	// References: gmsg_sv07Size (0x6C4D1380)
-	// References: gmsg_sv06_3Size (0x604D1380)
-	// References: gmsg_sv06_2Size (0x5C4D1380)
-	// References: gmsg_sv06_1Size (0x584D1380)
-	// References: gmsg_sv05_1Size (0x544D1380)
-	// References: gmsg_sv04Size (0x504D1380)
-	// References: gmsg_sv03Size (0x4C4D1380)
-	// References: gmsg_sv02Size (0x484D1380)
-	// References: gmsg_sv01_2Size (0x444D1380)
-	// References: gmsg_sv01Size (0x404D1380)
-	// References: gmsg_in05Size (0x3C4D1380)
-	// References: gmsg_in04Size (0x384D1380)
-	// References: gmsg_in03Size (0x344D1380)
-	// References: gmsg_gf06Size (0x284D1380)
-	// References: gmsg_gf05Size (0x244D1380)
-	// References: gmsg_gf04Size (0x204D1380)
-	// References: gmsg_gf03Size (0x1C4D1380)
-	// References: gmsg_ld06_3Size (0x84D1380)
-	// References: gmsg_ld06_2Size (0x44D1380)
-	// References: gmsg_ld06_1Size (0x4D1380)
-	// References: gmsg_ld05_1Size (0x80134CF8)
-	// References: gmsg_ld04Size (0x80134CF4)
-	// References: gmsg_ld03Size (0x80134CF0)
-	// References: gmsg_ld02Size (0x80134CEC)
-	// References: gmsg_ld01Size (0x80134CE8)
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> u8 gno[1473];
+    // -> u8 gyes[1473];
+    // -> s32 gHighlightChoice;
 }
 
-// size: 0x4
-enum _GXTexFilter
-{
-	GX_NEAR = 0,
-	GX_LINEAR = 1,
-	GX_NEAR_MIP_NEAR = 2,
-	GX_LIN_MIP_NEAR = 3,
-	GX_NEAR_MIP_LIN = 4,
-	GX_LIN_MIP_LIN = 5
-};
+// Erased
+static s32 simulatorDrawErrorMessageFromDVD(s32 drawBar, s32 percent) {
+    // Parameters
+    // s32 drawBar; // r29
+    // s32 percent; // r30
 
-// size: 0x24
-struct __anon_0xD7D1
-{
-	unsigned short height; // 0x0
-	unsigned short width; // 0x2
-	unsigned long format; // 0x4
-	char *data; // 0x8
-	_GXTexWrapMode wrapS; // 0xC
-	_GXTexWrapMode wrapT; // 0x10
-	_GXTexFilter minFilter; // 0x14
-	_GXTexFilter magFilter; // 0x18
-	float LODBias; // 0x1C
-	unsigned char edgeLODEnable; // 0x20
-	unsigned char minLOD; // 0x21
-	unsigned char maxLOD; // 0x22
-	unsigned char unpacked; // 0x23
-};
-
-// size: 0x4
-enum _GXTlutFmt
-{
-	GX_TL_IA8 = 0,
-	GX_TL_RGB565 = 1,
-	GX_TL_RGB5A3 = 2,
-	GX_MAX_TLUTFMT = 3
-};
-
-// size: 0xC
-struct __anon_0xDA2C
-{
-	unsigned short numEntries; // 0x0
-	unsigned char unpacked; // 0x2
-	unsigned char pad8; // 0x3
-	_GXTlutFmt format; // 0x4
-	char *data; // 0x8
-};
-
-// size: 0x8
-struct __anon_0xDAF8
-{
-	__anon_0xD7D1 *textureHeader; // 0x0
-	__anon_0xDA2C *CLUTHeader; // 0x4
-};
-
-// size: 0xC
-struct __anon_0xDB69
-{
-	unsigned long versionNumber; // 0x0
-	unsigned long numDescriptors; // 0x4
-	__anon_0xDAF8 *descriptorArray; // 0x8
-};
-
-int simulatorDrawOKMessageLoop(__anon_0xDB69 *simulatorMessage)
-{
-	// References: gButtonDownToggle (0x801355D4)
-	// References: gpSystem (0x561380)
-	// References: DemoPad (0x58271380)
-	// References: gmesgOK (0x960E80)
-	// References: gyes (0x408A0E80)
+    // References
+    // -> char gpErrorMessageBuffer[20480];
 }
 
-int simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, int *yes)
-{
-	DVDFileInfo fileInfo;
-	// References: gpErrorMessageBuffer (0x800F46E0)
-	// References: gmsg_sv08Size (0x704D1380)
-	// References: simulatorMessageCurrent (0x80134D94)
-	// References: gmsg_sv06_5Size (0x684D1380)
-	// References: gmsg_sv06_4Size (0x644D1380)
-	// References: gmsg_in01Size (0x2C4D1380)
-	// References: gmsg_gf01Size (0x144D1380)
-	// References: gmsg_ld07Size (0x104D1380)
-	// References: gmsg_ld06_4Size (0xC4D1380)
-	// References: gmsg_ld05_2Size (0x80134CFC)
+// Range: 0x8000D1F0 -> 0x8000D35C
+s32 simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
+    // Parameters
+    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
+
+    // Local variables
+    struct DVDFileInfo fileInfo; // r1+0xC
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u32 gmsg_gf02Size;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv09Size;
+    // -> u32 gmsg_in02Size;
 }
 
-int simulatorDrawYesNoMessageLoop(__anon_0xDB69 *simulatorQuestion, int *yes)
-{
-	// References: gpSystem (0x561380)
-	// References: DemoPad (0x58271380)
-	// References: gButtonDownToggle (0x801355D4)
-	// References: gno (0x20900E80)
-	// References: gyes (0x408A0E80)
-	// References: gHighlightChoice (0x80134D90)
+// Range: 0x8000D35C -> 0x8000D58C
+s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 drawBar, s32 percent) {
+    // Parameters
+    // enum __anon_0x61D7 simulatorErrorMessage; // r28
+    // s32 drawBar; // r29
+    // s32 percent; // r31
+
+    // References
+    // -> s32 gbDisplayedError;
+    // -> u8 gfatalErr[13025];
+    // -> u8 gnoDisk[7937];
+    // -> u8 gretryErr[9281];
+    // -> u8 greadingDisk[3137];
+    // -> u8 gwrongDisk[7937];
+    // -> u8 gcoverOpen[10433];
 }
 
-int simulatorDrawErrorMessageFromDVD(int drawBar, int percent)
-{
-	// References: gpErrorMessageBuffer (0x800F46E0)
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+// Range: 0x8000D58C -> 0x8000DBB4
+s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message, struct __anon_0xDB69* tplOK,
+                         s32 nX0OK, s32 nY0OK) {
+    // Parameters
+    // struct __anon_0xDB69* tplMessage; // r29
+    // s32 nX0Message; // r28
+    // s32 nY0Message; // r27
+    // struct __anon_0xDB69* tplOK; // r23
+    // s32 nX0OK; // r24
+    // s32 nY0OK; // r25
+
+    // Local variables
+    struct _GXTexObj texObj; // r1+0x98
+    struct _GXColor color0; // r1+0x94
+    struct _GXColor color1; // r1+0x90
+    float identity_mtx[3][4]; // r1+0x5C
+    float g2DviewMtx[3][4]; // r1+0x2C
+
+    // References
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> u8 TexCoords_u8[8];
+    // -> u32 Colors_u32[3];
+    // -> s16 VertYes_s16[12];
+    // -> s16 Vert_s16[12];
+    // -> static float gOrthoMtx[4][4];
 }
 
-int simulatorPrepareMessage(__anon_0x61D7 simulatorErrorMessage)
-{
-	DVDFileInfo fileInfo;
-	// References: gpErrorMessageBuffer (0x800F46E0)
-	// References: gmsg_gf02Size (0x184D1380)
-	// References: simulatorMessageCurrent (0x80134D94)
-	// References: gmsg_sv09Size (0x744D1380)
-	// References: gmsg_in02Size (0x304D1380)
+// Range: 0x8000DBB4 -> 0x8000E484
+s32 simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message,
+                            struct __anon_0xDB69* tplYes, s32 nX0Yes, s32 nY0Yes, struct __anon_0xDB69* tplNo,
+                            s32 nX0No, s32 nY0No) {
+    // Parameters
+    // struct __anon_0xDB69* tplMessage; // r21
+    // s32 nX0Message; // r22
+    // s32 nY0Message; // r30
+    // struct __anon_0xDB69* tplYes; // r23
+    // s32 nX0Yes; // r24
+    // s32 nY0Yes; // r25
+    // struct __anon_0xDB69* tplNo; // r26
+    // s32 nX0No; // r27
+    // s32 nY0No; // r28
+
+    // Local variables
+    struct _GXTexObj texObj; // r1+0xAC
+    struct _GXColor color0; // r1+0xA4
+    struct _GXColor color1; // r1+0xA0
+    float identity_mtx[3][4]; // r1+0x70
+    float g2DviewMtx[3][4]; // r1+0x40
+
+    // References
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> s32 gHighlightChoice;
+    // -> u8 TexCoords_u8[8];
+    // -> u32 Colors_u32[3];
+    // -> s16 VertNo_s16[12];
+    // -> s16 VertYes_s16[12];
+    // -> s16 Vert_s16[12];
+    // -> static float gOrthoMtx[4][4];
 }
 
-int simulatorDrawErrorMessage(__anon_0x61D7 simulatorErrorMessage, int drawBar, int percent)
-{
-	// References: gbDisplayedError (0x801355FC)
-	// References: gfatalErr (0x60240E80)
-	// References: gnoDisk (0x800DE0E0)
-	// References: gretryErr (0xE80)
-	// References: greadingDisk (0x800E7680)
-	// References: gwrongDisk (0x60570E80)
-	// References: gcoverOpen (0xB80D80)
+// Range: 0x8000E484 -> 0x8000ECA0
+s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
+    // Parameters
+    // struct __anon_0xDB69* tpl; // r22
+    // s32 nX0; // r30
+    // s32 nY0; // r23
+    // s32 drawBar; // r24
+    // s32 percent; // r25
+
+    // Local variables
+    struct _GXTexObj texObj; // r1+0xDC
+    struct _GXTexObj texObj2; // r1+0xBC
+    struct _GXColor color; // r1+0xB4
+    float identity_mtx[3][4]; // r1+0x84
+    float g2DviewMtx[3][4]; // r1+0x54
+    float g2[3][4]; // r1+0x24
+
+    // References
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> u8 gbar[1857];
+    // -> u8 TexCoords_u8[8];
+    // -> u32 Colors_u32[3];
+    // -> s16 Vert_s16Bar[12];
+    // -> s16 Vert_s16[12];
+    // -> static float gOrthoMtx[4][4];
 }
 
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
+// Range: 0x8000ECA0 -> 0x8000ECC4
+s32 simulatorPlayMovie() {}
 
-int simulatorDrawOKImage(__anon_0xDB69 *tplMessage, int nX0Message, int nY0Message, __anon_0xDB69 *tplOK, int nX0OK, int nY0OK)
-{
-	_GXTexObj texObj;
-	_GXColor color0;
-	_GXColor color1;
-	float identity_mtx[3][4];
-	float g2DviewMtx[3][4];
-	// References: gpFrame (0x8561380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-	// References: TexCoords_u8 (0x209A0E80)
-	// References: Colors_u32 (0x9A0E80)
-	// References: VertYes_s16 (0x800E99A0)
-	// References: Vert_s16 (0x60990E80)
-	// References: gOrthoMtx (0x40450F80)
+// Range: 0x8000ECC4 -> 0x8000EDA8
+s32 simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset,
+                     void (*callback)(s32, struct DVDFileInfo*)) {
+    // Parameters
+    // struct DVDFileInfo* pFileInfo; // r26
+    // void* anData; // r27
+    // s32 nSizeRead; // r28
+    // s32 nOffset; // r29
+    // void (* callback)(s32, struct DVDFileInfo*); // r7
+
+    // Local variables
+    s32 nStatus; // r31
+    s32 bRetry; // r30
 }
 
-int simulatorDrawYesNoImage(__anon_0xDB69 *tplMessage, int nX0Message, int nY0Message, __anon_0xDB69 *tplYes, int nX0Yes, int nY0Yes, __anon_0xDB69 *tplNo, int nX0No, int nY0No)
-{
-	_GXTexObj texObj;
-	_GXColor color0;
-	_GXColor color1;
-	float identity_mtx[3][4];
-	float g2DviewMtx[3][4];
-	// References: gpFrame (0x8561380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-	// References: gHighlightChoice (0x80134D90)
-	// References: TexCoords_u8 (0x209A0E80)
-	// References: Colors_u32 (0x9A0E80)
-	// References: VertNo_s16 (0x800E99C0)
-	// References: VertYes_s16 (0x800E99A0)
-	// References: Vert_s16 (0x60990E80)
-	// References: gOrthoMtx (0x40450F80)
+// Range: 0x8000EDA8 -> 0x8000EE18
+s32 simulatorDVDOpen(char* szNameFile, struct DVDFileInfo* pFileInfo) {
+    // Parameters
+    // char* szNameFile; // r30
+    // struct DVDFileInfo* pFileInfo; // r31
+
+    // Local variables
+    s32 nStatus; // r3
 }
 
-int simulatorDrawImage(__anon_0xDB69 *tpl, int nX0, int nY0, int drawBar, int percent)
-{
-	_GXTexObj texObj;
-	_GXTexObj texObj2;
-	_GXColor color;
-	float identity_mtx[3][4];
-	float g2DviewMtx[3][4];
-	float g2[3][4];
-	// References: gpFrame (0x8561380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
-	// References: gbar (0x800E82E0)
-	// References: TexCoords_u8 (0x209A0E80)
-	// References: Colors_u32 (0x9A0E80)
-	// References: Vert_s16Bar (0x800E99E0)
-	// References: Vert_s16 (0x60990E80)
-	// References: gOrthoMtx (0x40450F80)
+// Range: 0x8000EE18 -> 0x8000F020
+s32 simulatorDVDShowError(s32 nStatus) {
+    // Parameters
+    // s32 nStatus; // r26
+
+    // Local variables
+    s32 continueToggle; // r28
+    enum __anon_0x61D7 nMessage; // r27
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> s32 gDVDResetToggle;
+    // -> static s32 toggle$192;
 }
 
-int simulatorPlayMovie();
+// Erased
+static s32 simulatorDrawBlack() {
+    // Local variables
+    struct _GXColor color; // r1+0x6C
 
-int simulatorDVDRead(DVDFileInfo *pFileInfo, void *anData, long nSizeRead, long nOffset, void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */))
-{
-	int nStatus;
-	int bRetry;
+    // References
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
 }
 
-int simulatorDVDOpen(char *szNameFile, DVDFileInfo *pFileInfo)
-{
-	int nStatus;
+// Erased
+static void simulatorDEMODoneRender() {
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
 }
 
-int simulatorDVDShowError(int nStatus)
-{
-	int continueToggle;
-	__anon_0x61D7 nMessage;
-	// References: gpSystem (0x561380)
-	// References: gDVDResetToggle (0x801355D8)
-	// References: toggle$192 (0x801355DC)
+// Erased
+static void simulatorDEMOSwapBuffers() {
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
 }
 
-int simulatorDrawBlack()
-{
-	_GXColor color;
-	// References: gpFrame (0x8561380)
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
+// Range: 0x8000F020 -> 0x8000F0FC
+void simulatorUnpackTexPalette(struct __anon_0xDB69* pal) {
+    // Parameters
+    // struct __anon_0xDB69* pal; // r1+0x0
+
+    // Local variables
+    u16 i; // r4
 }
 
-void simulatorDEMODoneRender()
-{
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-	// References: DemoStatEnable (0x80135AA8)
+// Range: 0x8000F0FC -> 0x8000F7CC
+s32 simulatorGXInit() {
+    // Local variables
+    s32 i; // r31
+    struct _GXColor GX_DEFAULT_BG; // r1+0x58
+    struct _GXColor BLACK; // r1+0x54
+    struct _GXColor WHITE; // r1+0x50
+    float identity_mtx[3][4]; // r1+0x20
 }
-
-void simulatorDEMOSwapBuffers()
-{
-	// References: DemoCurrentBuffer (0x80135A8C)
-	// References: DemoFrameBuffer2 (0x80135A90)
-	// References: DemoFrameBuffer1 (0x80135A94)
-}
-
-void simulatorUnpackTexPalette(__anon_0xDB69 *pal)
-{
-	unsigned short i;
-}
-
-int simulatorGXInit()
-{
-	int i;
-	_GXColor GX_DEFAULT_BG;
-	_GXColor BLACK;
-	_GXColor WHITE;
-	float identity_mtx[3][4];
-}
-

--- a/debug/Fire/soundGCN.c
+++ b/debug/Fire/soundGCN.c
@@ -1,321 +1,359 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\soundGCN.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8001C498 -> 0x8001D34C
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EA7D8
+struct _XL_OBJECTTYPE gClassSound;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+// size = 0x404, address = 0x80108180
+s32 gVolumeCurve[257];
+
+enum __anon_0x2084C {
+    SPM_NONE = -1,
+    SPM_PLAY = 0,
+    SPM_RAMPQUEUED = 1,
+    SPM_RAMPPLAYED = 2,
 };
 
-// Location: 0x800EA7D8
-_XL_OBJECTTYPE gClassSound;
+struct __anon_0x208BA {
+    /* 0x00 */ void* pSrcData;
+    /* 0x04 */ s32 nFrequency;
+    /* 0x08 */ s32 nDacrate;
+    /* 0x0C */ s32 nSndLen;
+    /* 0x10 */ void* apBuffer[16];
+    /* 0x50 */ s32 anSizeBuffer[16];
+    /* 0x90 */ s32 nCountBeep;
+    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0xA0 */ void* apDataBeep[3];
+    /* 0xAC */ s32 iBufferPlay;
+    /* 0xB0 */ s32 iBufferMake;
+    /* 0xB4 */ enum __anon_0x2084C eMode;
+    /* 0xB8 */ void* pBufferZero;
+    /* 0xBC */ void* pBufferHold;
+    /* 0xC0 */ void* pBufferRampUp;
+    /* 0xC4 */ void* pBufferRampDown;
+    /* 0xC8 */ s32 nSizePlay;
+    /* 0xCC */ s32 nSizeZero;
+    /* 0xD0 */ s32 nSizeHold;
+    /* 0xD4 */ s32 nSizeRamp;
+}; // size = 0xD8
 
-// Location: 0x0
-int sCapture$219;
+// Range: 0x8001C498 -> 0x8001C690
+s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r3
+    // s32 nEvent; // r1+0xC
 
-// Location: 0x80108180
-long gVolumeCurve[257];
+    // Local variables
+    s32 iBuffer; // r1+0x8
 
-// size: 0x4
-enum __anon_0x2084C
-{
-	SPM_NONE = 4294967295,
-	SPM_PLAY = 0,
-	SPM_RAMPQUEUED = 1,
-	SPM_RAMPPLAYED = 2
-};
-
-// size: 0xD8
-struct __anon_0x208BA
-{
-	void *pSrcData; // 0x0
-	int nFrequency; // 0x4
-	int nDacrate; // 0x8
-	int nSndLen; // 0xC
-	void *apBuffer[16]; // 0x10
-	int anSizeBuffer[16]; // 0x50
-	int nCountBeep; // 0x90
-	int anSizeBeep[3]; // 0x94
-	void *apDataBeep[3]; // 0xA0
-	int iBufferPlay; // 0xAC
-	int iBufferMake; // 0xB0
-	__anon_0x2084C eMode; // 0xB4
-	void *pBufferZero; // 0xB8
-	void *pBufferHold; // 0xBC
-	void *pBufferRampUp; // 0xC0
-	void *pBufferRampDown; // 0xC4
-	int nSizePlay; // 0xC8
-	int nSizeZero; // 0xCC
-	int nSizeHold; // 0xD0
-	int nSizeRamp; // 0xD4
-};
-
-int soundEvent(__anon_0x208BA *pSound, int nEvent)
-{
-	int iBuffer;
-	// References: gVolumeCurve (0x80108180)
+    // References
+    // -> s32 gVolumeCurve[257];
 }
 
-// size: 0x4
-enum __anon_0x20C8D
-{
-	SOUND_BEEP_ACCEPT = 0,
-	SOUND_BEEP_DECLINE = 1,
-	SOUND_BEEP_SELECT = 2,
-	SOUND_BEEP_COUNT = 3
+enum __anon_0x20C8D {
+    SOUND_BEEP_ACCEPT = 0,
+    SOUND_BEEP_DECLINE = 1,
+    SOUND_BEEP_SELECT = 2,
+    SOUND_BEEP_COUNT = 3,
 };
 
-int soundFreeBeep(__anon_0x208BA *pSound, __anon_0x20C8D iBeep);
-
-int soundPlayBeep(__anon_0x208BA *pSound, __anon_0x20C8D iBeep);
-
-// size: 0x4
-enum __anon_0x20E13
-{
-	XLFT_NONE = 4294967295,
-	XLFT_TEXT = 0,
-	XLFT_BINARY = 1
-};
-
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
-
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// size: 0x58
-struct tXL_FILE
-{
-	int iBuffer; // 0x0
-	void *pData; // 0x4
-	void *pBuffer; // 0x8
-	int nAttributes; // 0xC
-	int nSize; // 0x10
-	int nOffset; // 0x14
-	__anon_0x20E13 eType; // 0x18
-	DVDFileInfo info; // 0x1C
-};
-
-int soundLoadBeep(__anon_0x208BA *pSound, __anon_0x20C8D iBeep, char *szNameFile)
-{
-	tXL_FILE *pFile;
+// Erased
+static s32 soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r5
+    // enum __anon_0x20C8D iBeep; // r1+0xC
 }
 
-// size: 0x4
-enum __anon_0x2152F
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
+// Range: 0x8001C690 -> 0x8001C70C
+s32 soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r29
+    // enum __anon_0x20C8D iBeep; // r1+0xC
+}
+
+enum __anon_0x20E13 {
+    XLFT_NONE = -1,
+    XLFT_TEXT = 0,
+    XLFT_BINARY = 1,
 };
 
-// size: 0x10
-struct __anon_0x21596
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+struct tXL_FILE {
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ enum __anon_0x20E13 eType;
+    /* 0x1C */ struct DVDFileInfo info;
+}; // size = 0x58
+
+// Range: 0x8001C70C -> 0x8001C824
+s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r28
+    // enum __anon_0x20C8D iBeep; // r1+0xC
+    // char* szNameFile; // r5
+
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x14
+}
+
+enum __anon_0x2152F {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 };
 
-// size: 0x4
-enum __anon_0x21647
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
+struct __anon_0x21596 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x21647 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x4
-enum __anon_0x21778
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
+enum __anon_0x21778 {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x88
-struct __anon_0x218B8
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x2152F eMode; // 0xC
-	__anon_0x21596 romCopy; // 0x10
-	__anon_0x21647 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x21778 storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
+struct __anon_0x218B8 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x2152F eMode;
+    /* 0x10 */ struct __anon_0x21596 romCopy;
+    /* 0x20 */ enum __anon_0x21647 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x21778 storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+// size = 0x4, address = 0x80135600
+struct __anon_0x218B8* gpSystem;
+
+// Range: 0x8001C824 -> 0x8001C880
+static void soundCallbackBeep() {
+    // Local variables
+    struct __anon_0x208BA* pSound; // r31
+
+    // References
+    // -> struct __anon_0x218B8* gpSystem;
+}
+
+// Erased
+static void InitVolumeCurve() {
+    // Local variables
+    s32 i; // r29
+
+    // References
+    // -> s32 gVolumeCurve[257];
+}
+
+// Range: 0x8001C880 -> 0x8001CA20
+s32 soundSetBufferSize(struct __anon_0x208BA* pSound, s32 nSize) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r31
+    // s32 nSize; // r29
+
+    // Local variables
+    s32 iBuffer; // r29
+}
+
+// Range: 0x8001CA20 -> 0x8001CA54
+s32 soundGetDMABuffer(u32* pnSize) {
+    // Parameters
+    // u32* pnSize; // r31
+}
+
+// Range: 0x8001CA54 -> 0x8001CA60
+s32 soundSetAddress(struct __anon_0x208BA* pSound, void* pData) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x0
+    // void* pData; // r1+0x4
+}
+
+// Erased
+static s32 soundSetBitRate() {}
+
+// Range: 0x8001CA60 -> 0x8001CA80
+s32 soundSetDACRate(struct __anon_0x208BA* pSound, s32 nDacRate) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x0
+    // s32 nDacRate; // r1+0x4
+}
+
+// Range: 0x8001CA80 -> 0x8001CAB8
+s32 soundSetLength(struct __anon_0x208BA* pSound, s32 nSize) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r3
+    // s32 nSize; // r1+0xC
+}
+
+// Range: 0x8001CAB8 -> 0x8001CCA4
+static s32 soundMakeBuffer(struct __anon_0x208BA* pSound) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r29
+
+    // Local variables
+    u32 nSamples; // r5
+    s16* curBufP; // r3
+    u32 sampleStep; // r1+0x8
+    u32 sample; // r6
+    s32 j; // r7
+    s32 nSize; // r4
+    s32 samp; // r11
+    s32 iBuffer; // r31
+    s32 vol; // r8
+    s32 bFlag; // r28
+    s32 bPlay; // r30
+    s32 volAdjust; // r11
+
+    // References
+    // -> s32 gVolumeCurve[257];
+}
+
+// Range: 0x8001CCA4 -> 0x8001CCCC
+static void soundCallbackDMA() {
+    // References
+    // -> struct __anon_0x218B8* gpSystem;
+}
+
+// Range: 0x8001CCCC -> 0x8001CD8C
+static s32 soundPlayBuffer(struct __anon_0x208BA* pSound) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x8
+
+    // Local variables
+    void* pData; // r6
+    s32 iBuffer; // r4
+    s32 nSize; // r4
+}
+
+// Erased
+static s32 soundMakeHold() {}
+
+// Erased
+static s32 soundMakeZero(struct __anon_0x208BA* pSound) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r3
+
+    // Local variables
+    s32 iData; // r7
+}
+
+enum __anon_0x221A3 {
+    SR_NONE = -1,
+    SR_DECREASE = 0,
+    SR_INCREASE = 1,
 };
 
-// Location: 0x561380
-__anon_0x218B8 *gpSystem;
+// Range: 0x8001CD8C -> 0x8001D250
+static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon_0x221A3 eRamp) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x8
+    // s32 iBuffer; // r1+0xC
+    // enum __anon_0x221A3 eRamp; // r1+0x10
 
-// Local to compilation unit
-static void soundCallbackBeep()
-{
-	__anon_0x208BA *pSound;
-	// References: gpSystem (0x561380)
+    // Local variables
+    s32 bFlag; // r8
+    s32 iData; // r1+0x8
+    s16* anData; // r9
+    s16 nData0; // r10
+    s16 nData1; // r11
+    s16 nGoal0; // r12
+    s16 nGoal1; // r31
+    s16 nStep0; // r5
+    s16 nStep1; // r4
+    s16 nLast0; // r27
+    s16 nLast1; // r27
 }
 
-void InitVolumeCurve()
-{
-	long i;
-	// References: gVolumeCurve (0x80108180)
+// Range: 0x8001D250 -> 0x8001D34C
+s32 soundWipeBuffers(struct __anon_0x208BA* pSound) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r31
+
+    // Local variables
+    s32 iBuffer; // r30
 }
-
-int soundSetBufferSize(__anon_0x208BA *pSound, int nSize)
-{
-	int iBuffer;
-}
-
-int soundGetDMABuffer(unsigned int *pnSize);
-
-int soundSetAddress(__anon_0x208BA *pSound, void *pData);
-
-int soundSetBitRate();
-
-int soundSetDACRate(__anon_0x208BA *pSound, int nDacRate);
-
-int soundSetLength(__anon_0x208BA *pSound, int nSize);
-
-// Local to compilation unit
-static int soundMakeBuffer(__anon_0x208BA *pSound)
-{
-	unsigned long nSamples;
-	signed short *curBufP;
-	unsigned long sampleStep;
-	unsigned long sample;
-	int j;
-	int nSize;
-	int samp;
-	int iBuffer;
-	long vol;
-	int bFlag;
-	int bPlay;
-	long volAdjust;
-	// References: gVolumeCurve (0x80108180)
-}
-
-// Local to compilation unit
-static void soundCallbackDMA()
-{
-	// References: gpSystem (0x561380)
-}
-
-// Local to compilation unit
-static int soundPlayBuffer(__anon_0x208BA *pSound)
-{
-	void *pData;
-	int iBuffer;
-	int nSize;
-}
-
-int soundMakeHold();
-
-int soundMakeZero(__anon_0x208BA *pSound)
-{
-	int iData;
-}
-
-// size: 0x4
-enum __anon_0x221A3
-{
-	SR_NONE = 4294967295,
-	SR_DECREASE = 0,
-	SR_INCREASE = 1
-};
-
-// Local to compilation unit
-static int soundMakeRamp(__anon_0x208BA *pSound, int iBuffer, __anon_0x221A3 eRamp)
-{
-	int bFlag;
-	int iData;
-	signed short *anData;
-	signed short nData0;
-	signed short nData1;
-	signed short nGoal0;
-	signed short nGoal1;
-	signed short nStep0;
-	signed short nStep1;
-	signed short nLast0;
-	signed short nLast1;
-}
-
-int soundWipeBuffers(__anon_0x208BA *pSound)
-{
-	int iBuffer;
-}
-

--- a/debug/Fire/soundGCN.c
+++ b/debug/Fire/soundGCN.c
@@ -7,12 +7,12 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x20667; // size = 0x10
 
 // size = 0x10, address = 0x800EA7D8
 struct _XL_OBJECTTYPE gClassSound;
@@ -20,14 +20,14 @@ struct _XL_OBJECTTYPE gClassSound;
 // size = 0x404, address = 0x80108180
 s32 gVolumeCurve[257];
 
-enum __anon_0x2084C {
+typedef enum __anon_0x2084C {
     SPM_NONE = -1,
     SPM_PLAY = 0,
     SPM_RAMPQUEUED = 1,
     SPM_RAMPPLAYED = 2,
-};
+} __anon_0x2084C;
 
-struct __anon_0x208BA {
+typedef struct __anon_0x208BA {
     /* 0x00 */ void* pSrcData;
     /* 0x04 */ s32 nFrequency;
     /* 0x08 */ s32 nDacrate;
@@ -48,7 +48,7 @@ struct __anon_0x208BA {
     /* 0xCC */ s32 nSizeZero;
     /* 0xD0 */ s32 nSizeHold;
     /* 0xD4 */ s32 nSizeRamp;
-}; // size = 0xD8
+} __anon_0x208BA; // size = 0xD8
 
 // Range: 0x8001C498 -> 0x8001C690
 s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
@@ -63,12 +63,12 @@ s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
     // -> s32 gVolumeCurve[257];
 }
 
-enum __anon_0x20C8D {
+typedef enum __anon_0x20C8D {
     SOUND_BEEP_ACCEPT = 0,
     SOUND_BEEP_DECLINE = 1,
     SOUND_BEEP_SELECT = 2,
     SOUND_BEEP_COUNT = 3,
-};
+} __anon_0x20C8D;
 
 // Erased
 static s32 soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
@@ -84,13 +84,13 @@ s32 soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
     // enum __anon_0x20C8D iBeep; // r1+0xC
 }
 
-enum __anon_0x20E13 {
+typedef enum __anon_0x20E13 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
-};
+} __anon_0x20E13;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -98,9 +98,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x20ECC; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -113,16 +113,16 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x2103C; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x21262; // size = 0x3C
 
-struct tXL_FILE {
+typedef struct tXL_FILE {
     /* 0x00 */ s32 iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
@@ -131,7 +131,7 @@ struct tXL_FILE {
     /* 0x14 */ s32 nOffset;
     /* 0x18 */ enum __anon_0x20E13 eType;
     /* 0x1C */ struct DVDFileInfo info;
-}; // size = 0x58
+} __anon_0x2131A; // size = 0x58
 
 // Range: 0x8001C70C -> 0x8001C824
 s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
@@ -144,20 +144,20 @@ s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char
     struct tXL_FILE* pFile; // r1+0x14
 }
 
-enum __anon_0x2152F {
+typedef enum __anon_0x2152F {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x2152F;
 
-struct __anon_0x21596 {
+typedef struct __anon_0x21596 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x21596; // size = 0x10
 
-enum __anon_0x21647 {
+typedef enum __anon_0x21647 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -172,9 +172,9 @@ enum __anon_0x21647 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x21647;
 
-enum __anon_0x21778 {
+typedef enum __anon_0x21778 {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -193,9 +193,9 @@ enum __anon_0x21778 {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x21778;
 
-struct __anon_0x218B8 {
+typedef struct __anon_0x218B8 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -207,7 +207,7 @@ struct __anon_0x218B8 {
     /* 0x70 */ enum __anon_0x21778 storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x218B8; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x218B8* gpSystem;
@@ -322,11 +322,11 @@ static s32 soundMakeZero(struct __anon_0x208BA* pSound) {
     s32 iData; // r7
 }
 
-enum __anon_0x221A3 {
+typedef enum __anon_0x221A3 {
     SR_NONE = -1,
     SR_DECREASE = 0,
     SR_INCREASE = 1,
-};
+} __anon_0x221A3;
 
 // Range: 0x8001CD8C -> 0x8001D250
 static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon_0x221A3 eRamp) {

--- a/debug/Fire/sram.c
+++ b/debug/Fire/sram.c
@@ -7,19 +7,19 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x749C7; // size = 0x10
 
 // size = 0x10, address = 0x800EE768
 struct _XL_OBJECTTYPE gClassSram;
 
-struct __anon_0x74AB9 {
+typedef struct __anon_0x74AB9 {
     /* 0x0 */ void* pHost;
-}; // size = 0x4
+} __anon_0x74AB9; // size = 0x4
 
 // Range: 0x8008E138 -> 0x8008E238
 s32 sramEvent(struct __anon_0x74AB9* pSram, s32 nEvent, void* pArgument) {

--- a/debug/Fire/sram.c
+++ b/debug/Fire/sram.c
@@ -1,66 +1,110 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\sram.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008E138 -> 0x8008E4A8
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE768
+struct _XL_OBJECTTYPE gClassSram;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x74AB9 {
+    /* 0x0 */ void* pHost;
+}; // size = 0x4
 
-// Location: 0x68E70E80
-_XL_OBJECTTYPE gClassSram;
-
-// size: 0x4
-struct __anon_0x74AB9
-{
-	void *pHost; // 0x0
-};
-
-int sramEvent(__anon_0x74AB9 *pSram, int nEvent, void *pArgument);
-
-// Local to compilation unit
-static int sramGet64(unsigned int nAddress, signed long long *pData);
-
-// Local to compilation unit
-static int sramGet32(unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int sramGet16(unsigned int nAddress, signed short *pData);
-
-// Local to compilation unit
-static int sramGet8(unsigned int nAddress, char *pData);
-
-// Local to compilation unit
-static int sramPut64(unsigned int nAddress, signed long long *pData);
-
-// Local to compilation unit
-static int sramPut32(unsigned int nAddress, int *pData);
-
-// Local to compilation unit
-static int sramPut16(unsigned int nAddress, signed short *pData);
-
-// Local to compilation unit
-static int sramPut8(unsigned int nAddress, char *pData);
-
-int sramTransferSRAM(__anon_0x74AB9 *pSRAM, int nOffsetRAM, int nOffsetSRAM, int nSize)
-{
-	void *pTarget;
+// Range: 0x8008E138 -> 0x8008E238
+s32 sramEvent(struct __anon_0x74AB9* pSram, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x74AB9* pSram; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int sramCopySRAM(__anon_0x74AB9 *pSRAM, int nOffsetRAM, int nOffsetSRAM, int nSize)
-{
-	void *pTarget;
+// Range: 0x8008E238 -> 0x8008E268
+static s32 sramGet64(u32 nAddress, s64* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s64* pData; // r5
 }
 
+// Range: 0x8008E268 -> 0x8008E298
+static s32 sramGet32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r5
+}
+
+// Range: 0x8008E298 -> 0x8008E2C8
+static s32 sramGet16(u32 nAddress, s16* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s16* pData; // r5
+}
+
+// Range: 0x8008E2C8 -> 0x8008E2F8
+static s32 sramGet8(u32 nAddress, char* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // char* pData; // r5
+}
+
+// Range: 0x8008E2F8 -> 0x8008E328
+static s32 sramPut64(u32 nAddress, s64* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s64* pData; // r5
+}
+
+// Range: 0x8008E328 -> 0x8008E358
+static s32 sramPut32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r5
+}
+
+// Range: 0x8008E358 -> 0x8008E388
+static s32 sramPut16(u32 nAddress, s16* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s16* pData; // r5
+}
+
+// Range: 0x8008E388 -> 0x8008E3B8
+static s32 sramPut8(u32 nAddress, char* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // char* pData; // r5
+}
+
+// Range: 0x8008E3B8 -> 0x8008E430
+s32 sramTransferSRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
+    // Parameters
+    // struct __anon_0x74AB9* pSRAM; // r1+0x8
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetSRAM; // r31
+    // s32 nSize; // r1+0x14
+
+    // Local variables
+    void* pTarget; // r1+0x18
+}
+
+// Range: 0x8008E430 -> 0x8008E4A8
+s32 sramCopySRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
+    // Parameters
+    // struct __anon_0x74AB9* pSRAM; // r1+0x8
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetSRAM; // r31
+    // s32 nSize; // r1+0x14
+
+    // Local variables
+    void* pTarget; // r1+0x18
+}

--- a/debug/Fire/system.c
+++ b/debug/Fire/system.c
@@ -13,12 +13,12 @@ u32 nTickMultiplier;
 // size = 0x4, address = 0x80134E64
 float fTickScale;
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x343BA; // size = 0x10
 
 // size = 0x10, address = 0x800EB310
 struct _XL_OBJECTTYPE gClassSystem;
@@ -29,40 +29,40 @@ static u32 contMap[4][20];
 // size = 0x4, address = 0x801356D8
 u32 gnFlagZelda;
 
-struct __anon_0x3459E {
+typedef struct __anon_0x3459E {
     /* 0x000 */ char rom[36];
     /* 0x024 */ s32 controllerConfiguration[4][20];
     /* 0x164 */ s32 rumbleConfiguration;
     /* 0x168 */ s32 storageDevice;
     /* 0x16C */ s32 normalControllerConfig;
     /* 0x170 */ s32 currentControllerConfig;
-}; // size = 0x174
+} __anon_0x3459E; // size = 0x174
 
 // size = 0x174, address = 0x801308E0
 struct __anon_0x3459E gSystemRomConfigurationList[1];
 
-struct __anon_0x34768 {
+typedef struct __anon_0x34768 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x34768; // size = 0x10
 
-struct __anon_0x34802 {
+typedef struct __anon_0x34802 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x34802; // size = 0x14
 
-struct __anon_0x34943 {
+typedef struct __anon_0x34943 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x34943; // size = 0xC
 
-struct __anon_0x349B3 {
+typedef struct __anon_0x349B3 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x34943 rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -77,36 +77,36 @@ struct __anon_0x349B3 {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x349B3; // size = 0x3C
 
-struct __anon_0x34BE3 {
+typedef struct __anon_0x34BE3 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x34943 rS;
     /* 0x10 */ struct __anon_0x34943 rT;
     /* 0x1C */ struct __anon_0x34943 rSRaw;
     /* 0x28 */ struct __anon_0x34943 rTRaw;
-}; // size = 0x34
+} __anon_0x34BE3; // size = 0x34
 
-struct __anon_0x34CCC {
+typedef struct __anon_0x34CCC {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x34943 vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x34CCC; // size = 0x1C
 
-union __anon_0x34E2B {
+typedef union __anon_0x34E2B {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x34E2B;
 
-struct __anon_0x34EC8 {
+typedef struct __anon_0x34EC8 {
     /* 0x0 */ union __anon_0x34E2B data;
-}; // size = 0x1000
+} __anon_0x34EC8; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -133,24 +133,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x34F61;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x35123; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x3518A; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x351D0;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -170,9 +170,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x35239; // size = 0x6C
 
-struct __anon_0x35596 {
+typedef struct __anon_0x35596 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -189,15 +189,15 @@ struct __anon_0x35596 {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x35596; // size = 0x2C
 
-enum __anon_0x35878 {
+typedef enum __anon_0x35878 {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x35878;
 
-struct __anon_0x358FC {
+typedef struct __anon_0x358FC {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -207,16 +207,16 @@ struct __anon_0x358FC {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x35878 eProjection;
-}; // size = 0x24
+} __anon_0x358FC; // size = 0x24
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x35A91; // size = 0x4
 
-struct __anon_0x35B4C {
+typedef struct __anon_0x35B4C {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -307,19 +307,19 @@ struct __anon_0x35B4C {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x35B4C; // size = 0x3D150
 
 // size = 0x4, address = 0x80135608
 struct __anon_0x35B4C* gpFrame;
 
-enum __anon_0x36A3E {
+typedef enum __anon_0x36A3E {
     SPM_NONE = -1,
     SPM_PLAY = 0,
     SPM_RAMPQUEUED = 1,
     SPM_RAMPPLAYED = 2,
-};
+} __anon_0x36A3E;
 
-struct __anon_0x36AAA {
+typedef struct __anon_0x36AAA {
     /* 0x00 */ void* pSrcData;
     /* 0x04 */ s32 nFrequency;
     /* 0x08 */ s32 nDacrate;
@@ -340,7 +340,7 @@ struct __anon_0x36AAA {
     /* 0xCC */ s32 nSizeZero;
     /* 0xD0 */ s32 nSizeHold;
     /* 0xD4 */ s32 nSizeRamp;
-}; // size = 0xD8
+} __anon_0x36AAA; // size = 0xD8
 
 // size = 0x4, address = 0x80135604
 struct __anon_0x36AAA* gpSound;
@@ -387,14 +387,14 @@ struct _XL_OBJECTTYPE gClassPeripheral;
 // size = 0x10, address = 0x800EE1B0
 struct _XL_OBJECTTYPE gClassRdb;
 
-struct __anon_0x37040 {
+typedef struct __anon_0x37040 {
     /* 0x0 */ s32 nSize;
     /* 0x4 */ s32 nOffsetRAM;
     /* 0x8 */ s32 nOffsetROM;
     /* 0xC */ s32 (*pCallback)();
-}; // size = 0x10
+} __anon_0x37040; // size = 0x10
 
-enum __anon_0x370F1 {
+typedef enum __anon_0x370F1 {
     SRT_NONE = -1,
     SRT_MARIO = 0,
     SRT_WAVERACE = 1,
@@ -409,9 +409,9 @@ enum __anon_0x370F1 {
     SRT_MARIOPARTY3 = 10,
     SRT_DRMARIO = 11,
     SRT_UNKNOWN = 12,
-};
+} __anon_0x370F1;
 
-struct __anon_0x37240 {
+typedef struct __anon_0x37240 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
     /* 0x08 */ s32 bException;
@@ -423,19 +423,19 @@ struct __anon_0x37240 {
     /* 0x70 */ enum __anon_0x394CD storageDevice;
     /* 0x74 */ u8 anException[16];
     /* 0x84 */ s32 bJapaneseVersion;
-}; // size = 0x88
+} __anon_0x37240; // size = 0x88
 
-struct __anon_0x37408 {
+typedef struct __anon_0x37408 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
-}; // size = 0x8
+} __anon_0x37408; // size = 0x8
 
-struct cpu_callerID {
+typedef struct cpu_callerID {
     /* 0x0 */ s32 N64address;
     /* 0x4 */ s32 GCNaddress;
-}; // size = 0x8
+} __anon_0x3746E; // size = 0x8
 
-struct cpu_function {
+typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
     /* 0x08 */ s32 nCountJump;
@@ -454,9 +454,9 @@ struct cpu_function {
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
-}; // size = 0x48
+} __anon_0x374E1; // size = 0x48
 
-union __anon_0x377BD {
+typedef union __anon_0x377BD {
     /* 0x0 */ char _0s8;
     /* 0x1 */ char _1s8;
     /* 0x2 */ char _2s8;
@@ -487,9 +487,9 @@ union __anon_0x377BD {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x377BD;
 
-union __anon_0x37BD1 {
+typedef union __anon_0x37BD1 {
     /* 0x0 */ float _0f32;
     /* 0x4 */ float f32;
     /* 0x0 */ double f64;
@@ -499,9 +499,9 @@ union __anon_0x37BD1 {
     /* 0x0 */ u32 _0u32;
     /* 0x4 */ u32 u32;
     /* 0x0 */ u64 u64;
-};
+} __anon_0x37BD1;
 
-struct __anon_0x380DF {
+typedef struct __anon_0x380DF {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -515,9 +515,9 @@ struct __anon_0x380DF {
     /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-}; // size = 0x34
+} __anon_0x380DF; // size = 0x34
 
-struct cpu_treeRoot {
+typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
     /* 0x04 */ s32 total_memory;
     /* 0x08 */ s32 root_address;
@@ -532,21 +532,21 @@ struct cpu_treeRoot {
     /* 0x78 */ s32 side;
     /* 0x7C */ struct cpu_function* restore;
     /* 0x80 */ s32 restore_side;
-}; // size = 0x84
+} __anon_0x383AD; // size = 0x84
 
-struct _CPU_ADDRESS {
+typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
-}; // size = 0xC
+} __anon_0x385EE; // size = 0xC
 
-struct __anon_0x386A3 {
+typedef struct __anon_0x386A3 {
     /* 0x0 */ u32 nAddress;
     /* 0x4 */ u32 nOpcodeOld;
     /* 0x8 */ u32 nOpcodeNew;
-}; // size = 0xC
+} __anon_0x386A3; // size = 0xC
 
-struct OSContext {
+typedef struct OSContext {
     /* 0x000 */ u32 gpr[32];
     /* 0x080 */ u32 cr;
     /* 0x084 */ u32 lr;
@@ -562,9 +562,9 @@ struct OSContext {
     /* 0x1A4 */ u32 gqr[8];
     /* 0x1C4 */ u32 psf_pad;
     /* 0x1C8 */ double psf[32];
-}; // size = 0x2C8
+} __anon_0x387CE; // size = 0x2C8
 
-struct OSAlarm {
+typedef struct OSAlarm {
     /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
     /* 0x04 */ u32 tag;
     /* 0x08 */ s64 fire;
@@ -572,9 +572,9 @@ struct OSAlarm {
     /* 0x14 */ struct OSAlarm* next;
     /* 0x18 */ s64 period;
     /* 0x20 */ s64 start;
-}; // size = 0x28
+} __anon_0x38A25; // size = 0x28
 
-struct cpu_optimize {
+typedef struct cpu_optimize {
     /* 0x00 */ u32 validCheck;
     /* 0x04 */ u32 destGPR_check;
     /* 0x08 */ s32 destGPR;
@@ -585,9 +585,9 @@ struct cpu_optimize {
     /* 0x1C */ s32 addr_last;
     /* 0x20 */ u32 checkType;
     /* 0x24 */ u32 checkNext;
-}; // size = 0x28
+} __anon_0x38B40; // size = 0x28
 
-struct _CPU {
+typedef struct _CPU {
     /* 0x00000 */ s32 nMode;
     /* 0x00004 */ s32 nTick;
     /* 0x00008 */ void* pHost;
@@ -631,9 +631,9 @@ struct _CPU {
     /* 0x1205C */ u32 nFlagCODE;
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
-}; // size = 0x12090
+} __anon_0x38CED; // size = 0x12090
 
-enum __anon_0x39384 {
+typedef enum __anon_0x39384 {
     MIT_NONE = -1,
     MIT_SP = 0,
     MIT_SI = 1,
@@ -641,17 +641,17 @@ enum __anon_0x39384 {
     MIT_VI = 3,
     MIT_PI = 4,
     MIT_DP = 5,
-};
+} __anon_0x39384;
 
-struct __anon_0x393FF {
+typedef struct __anon_0x393FF {
     /* 0x00 */ char* szType;
     /* 0x04 */ u32 nMask;
     /* 0x08 */ enum __anon_0x3994B eCode;
     /* 0x0C */ enum __anon_0x3979C eType;
     /* 0x10 */ enum __anon_0x39384 eTypeMips;
-}; // size = 0x14
+} __anon_0x393FF; // size = 0x14
 
-enum __anon_0x394CD {
+typedef enum __anon_0x394CD {
     SOT_NONE = -1,
     SOT_CPU = 0,
     SOT_PIF = 1,
@@ -670,7 +670,7 @@ enum __anon_0x394CD {
     SOT_PERIPHERAL = 14,
     SOT_RDB = 15,
     SOT_COUNT = 16,
-};
+} __anon_0x394CD;
 
 // Range: 0x8002CA14 -> 0x8002D2EC
 s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
@@ -704,7 +704,7 @@ s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
     // -> struct __anon_0x35B4C* gpFrame;
 }
 
-enum __anon_0x3979C {
+typedef enum __anon_0x3979C {
     SIT_NONE = -1,
     SIT_SW0 = 0,
     SIT_SW1 = 1,
@@ -723,7 +723,7 @@ enum __anon_0x3979C {
     SIT_THREADSTATUS = 14,
     SIT_PRENMI = 15,
     SIT_COUNT_ = 16,
-};
+} __anon_0x3979C;
 
 // Range: 0x8002D2EC -> 0x8002D324
 s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
@@ -732,7 +732,7 @@ s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C e
     // enum __anon_0x3979C eType; // r1+0x4
 }
 
-enum __anon_0x3994B {
+typedef enum __anon_0x3994B {
     CEC_NONE = -1,
     CEC_INTERRUPT = 0,
     CEC_TLB_MODIFICATION = 1,
@@ -767,7 +767,7 @@ enum __anon_0x3994B {
     CEC_RESERVED_30 = 30,
     CEC_VCE_DATA = 31,
     CEC_COUNT = 32,
-};
+} __anon_0x3994B;
 
 // Range: 0x8002D324 -> 0x8002D47C
 s32 systemCheckInterrupts(struct __anon_0x37240* pSystem) {
@@ -838,11 +838,11 @@ s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
     // -> struct _XL_OBJECTTYPE gClassSystem;
 }
 
-enum __anon_0x3A085 {
+typedef enum __anon_0x3A085 {
     SM_NONE = -1,
     SM_RUNNING = 0,
     SM_STOPPED = 1,
-};
+} __anon_0x3A085;
 
 // Range: 0x8002D894 -> 0x8002D904
 s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
@@ -948,16 +948,16 @@ static s32 systemClearExceptions(struct __anon_0x37240* pSystem) {
     s32 iException; // r1+0x0
 }
 
-struct __anon_0x3A807 {
+typedef struct __anon_0x3A807 {
     /* 0x00 */ s32 configuration;
     /* 0x04 */ s32 size;
     /* 0x08 */ s32 offset;
     /* 0x0C */ char* buffer;
     /* 0x10 */ s32* writtenBlocks;
     /* 0x14 */ s32 writtenConfig;
-}; // size = 0x18
+} __anon_0x3A807; // size = 0x18
 
-struct OSCalendarTime {
+typedef struct OSCalendarTime {
     /* 0x00 */ s32 sec;
     /* 0x04 */ s32 min;
     /* 0x08 */ s32 hour;
@@ -968,18 +968,18 @@ struct OSCalendarTime {
     /* 0x1C */ s32 yday;
     /* 0x20 */ s32 msec;
     /* 0x24 */ s32 usec;
-}; // size = 0x28
+} __anon_0x3A9AA; // size = 0x28
 
-struct CARDFileInfo {
+typedef struct CARDFileInfo {
     /* 0x00 */ s32 chan;
     /* 0x04 */ s32 fileNo;
     /* 0x08 */ s32 offset;
     /* 0x0C */ s32 length;
     /* 0x10 */ u16 iBlock;
     /* 0x12 */ u16 __padding;
-}; // size = 0x14
+} __anon_0x3AB18; // size = 0x14
 
-struct __anon_0x3AC10 {
+typedef struct __anon_0x3AC10 {
     /* 0x000 */ s32 currentGame;
     /* 0x004 */ s32 fileSize;
     /* 0x008 */ char name[33];
@@ -993,9 +993,9 @@ struct __anon_0x3AC10 {
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
-}; // size = 0x35C
+} __anon_0x3AC10; // size = 0x35C
 
-enum __anon_0x3AE26 {
+typedef enum __anon_0x3AE26 {
     MC_E_NONE = 0,
     MC_E_BUSY = 1,
     MC_E_WRONGDEVICE = 2,
@@ -1022,9 +1022,9 @@ enum __anon_0x3AE26 {
     MC_E_TIME_WRONG = 23,
     MC_E_WRITE_CORRUPTED = 24,
     MC_E_UNKNOWN = 25,
-};
+} __anon_0x3AE26;
 
-struct _MCARD {
+typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x3AC10 file;
     /* 0x35C */ enum __anon_0x3AE26 error;
     /* 0x360 */ s32 slot;
@@ -1053,7 +1053,7 @@ struct _MCARD {
     /* 0x7AC */ s32 wait;
     /* 0x7B0 */ s32 isBroken;
     /* 0x7B4 */ s32 saveConfiguration;
-}; // size = 0x7B8
+} __anon_0x3B0C8; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
 struct _MCARD mCard;
@@ -1064,7 +1064,7 @@ u32 gz_iconSize;
 // size = 0x4, address = 0x80134D88
 u32 gz_bnrSize;
 
-struct DVDDiskID {
+typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
     /* 0x6 */ u8 diskNumber;
@@ -1072,9 +1072,9 @@ struct DVDDiskID {
     /* 0x8 */ u8 streaming;
     /* 0x9 */ u8 streamingBufSize;
     /* 0xA */ u8 padding[22];
-}; // size = 0x20
+} __anon_0x3B639; // size = 0x20
 
-struct DVDCommandBlock {
+typedef struct DVDCommandBlock {
     /* 0x00 */ struct DVDCommandBlock* next;
     /* 0x04 */ struct DVDCommandBlock* prev;
     /* 0x08 */ u32 command;
@@ -1087,38 +1087,38 @@ struct DVDCommandBlock {
     /* 0x24 */ struct DVDDiskID* id;
     /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
     /* 0x2C */ void* userData;
-}; // size = 0x30
+} __anon_0x3B7A9; // size = 0x30
 
-struct DVDFileInfo {
+typedef struct DVDFileInfo {
     /* 0x00 */ struct DVDCommandBlock cb;
     /* 0x30 */ u32 startAddr;
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
-}; // size = 0x3C
+} __anon_0x3B9CF; // size = 0x3C
 
-enum __anon_0x3BAA7 {
+typedef enum __anon_0x3BAA7 {
     RLM_NONE = -1,
     RLM_PART = 0,
     RLM_FULL = 1,
     RLM_COUNT_ = 2,
-};
+} __anon_0x3BAA7;
 
-struct __anon_0x3BB09 {
+typedef struct __anon_0x3BB09 {
     /* 0x0 */ s32 iCache;
     /* 0x4 */ u32 nSize;
     /* 0x8 */ u32 nTickUsed;
     /* 0xC */ char keep;
-}; // size = 0x10
+} __anon_0x3BB09; // size = 0x10
 
-struct __anon_0x3BC1D {
+typedef struct __anon_0x3BC1D {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 (*pCallback)();
     /* 0x08 */ u8* pTarget;
     /* 0x0C */ u32 nSize;
     /* 0x10 */ u32 nOffset;
-}; // size = 0x14
+} __anon_0x3BC1D; // size = 0x14
 
-struct __anon_0x3BCFD {
+typedef struct __anon_0x3BCFD {
     /* 0x00 */ s32 bWait;
     /* 0x04 */ s32 bDone;
     /* 0x08 */ s32 nResult;
@@ -1131,9 +1131,9 @@ struct __anon_0x3BCFD {
     /* 0x24 */ u32 nOffset1;
     /* 0x28 */ u32 nSize;
     /* 0x2C */ u32 nSizeRead;
-}; // size = 0x30
+} __anon_0x3BCFD; // size = 0x30
 
-struct __anon_0x3BEE8 {
+typedef struct __anon_0x3BEE8 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
     /* 0x00008 */ s32 bFlip;
@@ -1155,9 +1155,9 @@ struct __anon_0x3BEE8 {
     /* 0x10EB4 */ s32 nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
     /* 0x10EF4 */ s32 offsetToRom;
-}; // size = 0x10EF8
+} __anon_0x3BEE8; // size = 0x10EF8
 
-enum __anon_0x3C277 {
+typedef enum __anon_0x3C277 {
     CT_NONE = 0,
     CT_CONTROLLER = 1,
     CT_CONTROLLER_W_PAK = 2,
@@ -1167,16 +1167,16 @@ enum __anon_0x3C277 {
     CT_4K = 6,
     CT_16K = 7,
     CT_COUNT = 8,
-};
+} __anon_0x3C277;
 
-struct __anon_0x3C350 {
+typedef struct __anon_0x3C350 {
     /* 0x00 */ void* pROM;
     /* 0x04 */ void* pRAM;
     /* 0x08 */ void* pHost;
     /* 0x0C */ u16 controllerType[5];
     /* 0x16 */ char controllerStatus[5];
     /* 0x1C */ enum __anon_0x3C277 eControllerType[5];
-}; // size = 0x30
+} __anon_0x3C350; // size = 0x30
 
 // Range: 0x8002DD70 -> 0x80030364
 static s32 systemSetupGameALL(struct __anon_0x37240* pSystem) {

--- a/debug/Fire/system.c
+++ b/debug/Fire/system.c
@@ -1,1274 +1,1258 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\system.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8002CA14 -> 0x80030E70
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+// size = 0x4, address = 0x80134E60
+u32 nTickMultiplier;
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
-
-// Location: 0x604E1380
-unsigned int nTickMultiplier;
-
-// Location: 0x644E1380
+// size = 0x4, address = 0x80134E64
 float fTickScale;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
+
+// size = 0x10, address = 0x800EB310
+struct _XL_OBJECTTYPE gClassSystem;
+
+// size = 0x140, address = 0x800EB320
+static u32 contMap[4][20];
+
+// size = 0x4, address = 0x801356D8
+u32 gnFlagZelda;
+
+struct __anon_0x3459E {
+    /* 0x000 */ char rom[36];
+    /* 0x024 */ s32 controllerConfiguration[4][20];
+    /* 0x164 */ s32 rumbleConfiguration;
+    /* 0x168 */ s32 storageDevice;
+    /* 0x16C */ s32 normalControllerConfig;
+    /* 0x170 */ s32 currentControllerConfig;
+}; // size = 0x174
+
+// size = 0x174, address = 0x801308E0
+struct __anon_0x3459E gSystemRomConfigurationList[1];
+
+struct __anon_0x34768 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x34802 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x34943 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x349B3 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x34943 rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x34BE3 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x34943 rS;
+    /* 0x10 */ struct __anon_0x34943 rT;
+    /* 0x1C */ struct __anon_0x34943 rSRaw;
+    /* 0x28 */ struct __anon_0x34943 rTRaw;
+}; // size = 0x34
+
+struct __anon_0x34CCC {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x34943 vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x34E2B {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
 };
 
-// Location: 0x10B30E80
-_XL_OBJECTTYPE gClassSystem;
+struct __anon_0x34EC8 {
+    /* 0x0 */ union __anon_0x34E2B data;
+}; // size = 0x1000
 
-// Local to compilation unit
-// Location: 0x20B30E80
-static unsigned int contMap[4][20];
-
-// Location: 0x801356D8
-unsigned int gnFlagZelda;
-
-// size: 0x174
-struct __anon_0x3459E
-{
-	char rom[36]; // 0x0
-	int controllerConfiguration[4][20]; // 0x24
-	int rumbleConfiguration; // 0x164
-	int storageDevice; // 0x168
-	int normalControllerConfig; // 0x16C
-	int currentControllerConfig; // 0x170
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
 };
 
-// Location: 0x801308E0
-__anon_0x3459E gSystemRomConfigurationList[1];
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
 
-// size: 0x10
-struct __anon_0x34768
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
 };
 
-// size: 0x14
-struct __anon_0x34802
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x35596 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x35878 {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
 };
 
-// size: 0xC
-struct __anon_0x34943
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
+struct __anon_0x358FC {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x35878 eProjection;
+}; // size = 0x24
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+struct __anon_0x35B4C {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x34768 viewport;
+    /* 0x000C8 */ struct __anon_0x34802 aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x349B3 aLight[8];
+    /* 0x00320 */ struct __anon_0x34BE3 lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x34CCC aVertex[80];
+    /* 0x00C18 */ struct __anon_0x34EC8 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x35596 aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x35878 eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x358FC aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+// size = 0x4, address = 0x80135608
+struct __anon_0x35B4C* gpFrame;
+
+enum __anon_0x36A3E {
+    SPM_NONE = -1,
+    SPM_PLAY = 0,
+    SPM_RAMPQUEUED = 1,
+    SPM_RAMPPLAYED = 2,
 };
 
-// size: 0x3C
-struct __anon_0x349B3
-{
-	int bTransformed; // 0x0
-	__anon_0x34943 rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
+struct __anon_0x36AAA {
+    /* 0x00 */ void* pSrcData;
+    /* 0x04 */ s32 nFrequency;
+    /* 0x08 */ s32 nDacrate;
+    /* 0x0C */ s32 nSndLen;
+    /* 0x10 */ void* apBuffer[16];
+    /* 0x50 */ s32 anSizeBuffer[16];
+    /* 0x90 */ s32 nCountBeep;
+    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0xA0 */ void* apDataBeep[3];
+    /* 0xAC */ s32 iBufferPlay;
+    /* 0xB0 */ s32 iBufferMake;
+    /* 0xB4 */ enum __anon_0x36A3E eMode;
+    /* 0xB8 */ void* pBufferZero;
+    /* 0xBC */ void* pBufferHold;
+    /* 0xC0 */ void* pBufferRampUp;
+    /* 0xC4 */ void* pBufferRampDown;
+    /* 0xC8 */ s32 nSizePlay;
+    /* 0xCC */ s32 nSizeZero;
+    /* 0xD0 */ s32 nSizeHold;
+    /* 0xD4 */ s32 nSizeRamp;
+}; // size = 0xD8
+
+// size = 0x4, address = 0x80135604
+struct __anon_0x36AAA* gpSound;
+
+// size = 0x10, address = 0x800EB658
+struct _XL_OBJECTTYPE gClassCPU;
+
+// size = 0x10, address = 0x800ED6B8
+struct _XL_OBJECTTYPE gClassPIF;
+
+// size = 0x10, address = 0x800ED6C8
+struct _XL_OBJECTTYPE gClassRAM;
+
+// size = 0x10, address = 0x800ED8E8
+struct _XL_OBJECTTYPE gClassROM;
+
+// size = 0x10, address = 0x800EE220
+struct _XL_OBJECTTYPE gClassRSP;
+
+// size = 0x10, address = 0x800EDF40
+struct _XL_OBJECTTYPE gClassRDP;
+
+// size = 0x10, address = 0x800EE6D0
+struct _XL_OBJECTTYPE gClassMips;
+
+// size = 0x10, address = 0x800EE748
+struct _XL_OBJECTTYPE gClassDisk;
+
+// size = 0x10, address = 0x800EE778
+struct _XL_OBJECTTYPE gClassAudio;
+
+// size = 0x10, address = 0x800EE870
+struct _XL_OBJECTTYPE gClassVideo;
+
+// size = 0x10, address = 0x800EEA28
+struct _XL_OBJECTTYPE gClassSerial;
+
+// size = 0x10, address = 0x800EEB0C
+struct _XL_OBJECTTYPE gClassLibrary;
+
+// size = 0x10, address = 0x800EFFBC
+struct _XL_OBJECTTYPE gClassPeripheral;
+
+// size = 0x10, address = 0x800EE1B0
+struct _XL_OBJECTTYPE gClassRdb;
+
+struct __anon_0x37040 {
+    /* 0x0 */ s32 nSize;
+    /* 0x4 */ s32 nOffsetRAM;
+    /* 0x8 */ s32 nOffsetROM;
+    /* 0xC */ s32 (*pCallback)();
+}; // size = 0x10
+
+enum __anon_0x370F1 {
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 };
 
-// size: 0x34
-struct __anon_0x34BE3
-{
-	int bTransformed; // 0x0
-	__anon_0x34943 rS; // 0x4
-	__anon_0x34943 rT; // 0x10
-	__anon_0x34943 rSRaw; // 0x1C
-	__anon_0x34943 rTRaw; // 0x28
+struct __anon_0x37240 {
+    /* 0x00 */ void* pFrame;
+    /* 0x04 */ void* pSound;
+    /* 0x08 */ s32 bException;
+    /* 0x0C */ enum __anon_0x3A085 eMode;
+    /* 0x10 */ struct __anon_0x37040 romCopy;
+    /* 0x20 */ enum __anon_0x370F1 eTypeROM;
+    /* 0x24 */ void* apObject[16];
+    /* 0x68 */ u64 nAddressBreak;
+    /* 0x70 */ enum __anon_0x394CD storageDevice;
+    /* 0x74 */ u8 anException[16];
+    /* 0x84 */ s32 bJapaneseVersion;
+}; // size = 0x88
+
+struct __anon_0x37408 {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+}; // size = 0x8
+
+struct cpu_callerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+}; // size = 0x8
+
+struct cpu_function {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct __anon_0x37408* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ struct cpu_callerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ struct cpu_function* prev;
+    /* 0x40 */ struct cpu_function* left;
+    /* 0x44 */ struct cpu_function* right;
+}; // size = 0x48
+
+union __anon_0x377BD {
+    /* 0x0 */ char _0s8;
+    /* 0x1 */ char _1s8;
+    /* 0x2 */ char _2s8;
+    /* 0x3 */ char _3s8;
+    /* 0x4 */ char _4s8;
+    /* 0x5 */ char _5s8;
+    /* 0x6 */ char _6s8;
+    /* 0x7 */ char s8;
+    /* 0x0 */ s16 _0s16;
+    /* 0x2 */ s16 _1s16;
+    /* 0x4 */ s16 _2s16;
+    /* 0x6 */ s16 s16;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u8 _0u8;
+    /* 0x1 */ u8 _1u8;
+    /* 0x2 */ u8 _2u8;
+    /* 0x3 */ u8 _3u8;
+    /* 0x4 */ u8 _4u8;
+    /* 0x5 */ u8 _5u8;
+    /* 0x6 */ u8 _6u8;
+    /* 0x7 */ u8 u8;
+    /* 0x0 */ u16 _0u16;
+    /* 0x2 */ u16 _1u16;
+    /* 0x4 */ u16 _2u16;
+    /* 0x6 */ u16 u16;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x1C
-struct __anon_0x34CCC
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x34943 vec; // 0xC
-	unsigned char anColor[4]; // 0x18
+union __anon_0x37BD1 {
+    /* 0x0 */ float _0f32;
+    /* 0x4 */ float f32;
+    /* 0x0 */ double f64;
+    /* 0x0 */ s32 _0s32;
+    /* 0x4 */ s32 s32;
+    /* 0x0 */ s64 s64;
+    /* 0x0 */ u32 _0u32;
+    /* 0x4 */ u32 u32;
+    /* 0x0 */ u64 u64;
 };
 
-// size: 0x1000
-union __anon_0x34E2B
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
+struct __anon_0x380DF {
+    /* 0x00 */ s32 nType;
+    /* 0x04 */ void* pObject;
+    /* 0x08 */ s32 nOffsetAddress;
+    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
+    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
+    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
+    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
+    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
+    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
+    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
+    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
+    /* 0x2C */ u32 nAddressPhysical0;
+    /* 0x30 */ u32 nAddressPhysical1;
+}; // size = 0x34
+
+struct cpu_treeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ struct cpu_function* left;
+    /* 0x6C */ struct cpu_function* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ struct cpu_function* restore;
+    /* 0x80 */ s32 restore_side;
+}; // size = 0x84
+
+struct _CPU_ADDRESS {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ struct cpu_function* pFunction;
+}; // size = 0xC
+
+struct __anon_0x386A3 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+}; // size = 0xC
+
+struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ double fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ double psf[32];
+}; // size = 0x2C8
+
+struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+}; // size = 0x28
+
+struct cpu_optimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+}; // size = 0x28
+
+struct _CPU {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ struct cpu_function* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ union __anon_0x377BD aGPR[32];
+    /* 0x00140 */ union __anon_0x37BD1 aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ struct __anon_0x380DF* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ struct cpu_treeRoot* gTree;
+    /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ struct __anon_0x386A3 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ struct OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ struct cpu_optimize nOptimize;
+}; // size = 0x12090
+
+enum __anon_0x39384 {
+    MIT_NONE = -1,
+    MIT_SP = 0,
+    MIT_SI = 1,
+    MIT_AI = 2,
+    MIT_VI = 3,
+    MIT_PI = 4,
+    MIT_DP = 5,
 };
 
-// size: 0x1000
-struct __anon_0x34EC8
-{
-	__anon_0x34E2B data; // 0x0
+struct __anon_0x393FF {
+    /* 0x00 */ char* szType;
+    /* 0x04 */ u32 nMask;
+    /* 0x08 */ enum __anon_0x3994B eCode;
+    /* 0x0C */ enum __anon_0x3979C eType;
+    /* 0x10 */ enum __anon_0x39384 eTypeMips;
+}; // size = 0x14
+
+enum __anon_0x394CD {
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 };
 
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
+// Range: 0x8002CA14 -> 0x8002D2EC
+s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r31
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r26
 
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
+    // Local variables
+    struct _CPU* pCPU; // r30
+    struct __anon_0x393FF exception; // r1+0x1C
+    enum __anon_0x394CD eObject; // r1+0x8
+    enum __anon_0x394CD storageDevice; // r1+0x8
 
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x35596
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x35878
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x358FC
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x35878 eProjection; // 0x20
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x3D150
-struct __anon_0x35B4C
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x34768 viewport; // 0xB8
-	__anon_0x34802 aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x349B3 aLight[8]; // 0x140
-	__anon_0x34BE3 lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x34CCC aVertex[80]; // 0x358
-	__anon_0x34EC8 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x35596 aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x35878 eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x358FC aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-// Location: 0x8561380
-__anon_0x35B4C *gpFrame;
-
-// size: 0x4
-enum __anon_0x36A3E
-{
-	SPM_NONE = 4294967295,
-	SPM_PLAY = 0,
-	SPM_RAMPQUEUED = 1,
-	SPM_RAMPPLAYED = 2
-};
-
-// size: 0xD8
-struct __anon_0x36AAA
-{
-	void *pSrcData; // 0x0
-	int nFrequency; // 0x4
-	int nDacrate; // 0x8
-	int nSndLen; // 0xC
-	void *apBuffer[16]; // 0x10
-	int anSizeBuffer[16]; // 0x50
-	int nCountBeep; // 0x90
-	int anSizeBeep[3]; // 0x94
-	void *apDataBeep[3]; // 0xA0
-	int iBufferPlay; // 0xAC
-	int iBufferMake; // 0xB0
-	__anon_0x36A3E eMode; // 0xB4
-	void *pBufferZero; // 0xB8
-	void *pBufferHold; // 0xBC
-	void *pBufferRampUp; // 0xC0
-	void *pBufferRampDown; // 0xC4
-	int nSizePlay; // 0xC8
-	int nSizeZero; // 0xCC
-	int nSizeHold; // 0xD0
-	int nSizeRamp; // 0xD4
-};
-
-// Location: 0x4561380
-__anon_0x36AAA *gpSound;
-
-// Location: 0x58B60E80
-_XL_OBJECTTYPE gClassCPU;
-
-// Location: 0x800ED6B8
-_XL_OBJECTTYPE gClassPIF;
-
-// Location: 0x800ED6C8
-_XL_OBJECTTYPE gClassRAM;
-
-// Location: 0x800ED8E8
-_XL_OBJECTTYPE gClassROM;
-
-// Location: 0x20E20E80
-_XL_OBJECTTYPE gClassRSP;
-
-// Location: 0x40DF0E80
-_XL_OBJECTTYPE gClassRDP;
-
-// Location: 0x800EE6D0
-_XL_OBJECTTYPE gClassMips;
-
-// Location: 0x48E70E80
-_XL_OBJECTTYPE gClassDisk;
-
-// Location: 0x78E70E80
-_XL_OBJECTTYPE gClassAudio;
-
-// Location: 0x70E80E80
-_XL_OBJECTTYPE gClassVideo;
-
-// Location: 0x28EA0E80
-_XL_OBJECTTYPE gClassSerial;
-
-// Location: 0xCEB0E80
-_XL_OBJECTTYPE gClassLibrary;
-
-// Location: 0x800EFFBC
-_XL_OBJECTTYPE gClassPeripheral;
-
-// Location: 0x800EE1B0
-_XL_OBJECTTYPE gClassRdb;
-
-// size: 0x10
-struct __anon_0x37040
-{
-	int nSize; // 0x0
-	int nOffsetRAM; // 0x4
-	int nOffsetROM; // 0x8
-	int (*pCallback)(); // 0xC
-};
-
-// size: 0x4
-enum __anon_0x370F1
-{
-	SRT_NONE = 4294967295,
-	SRT_MARIO = 0,
-	SRT_WAVERACE = 1,
-	SRT_MARIOKART = 2,
-	SRT_STARFOX = 3,
-	SRT_ZELDA1 = 4,
-	SRT_ZELDA2 = 5,
-	SRT_1080 = 6,
-	SRT_PANEL = 7,
-	SRT_MARIOPARTY1 = 8,
-	SRT_MARIOPARTY2 = 9,
-	SRT_MARIOPARTY3 = 10,
-	SRT_DRMARIO = 11,
-	SRT_UNKNOWN = 12
-};
-
-// size: 0x88
-struct __anon_0x37240
-{
-	void *pFrame; // 0x0
-	void *pSound; // 0x4
-	int bException; // 0x8
-	__anon_0x3A085 eMode; // 0xC
-	__anon_0x37040 romCopy; // 0x10
-	__anon_0x370F1 eTypeROM; // 0x20
-	void *apObject[16]; // 0x24
-	unsigned long long nAddressBreak; // 0x68
-	__anon_0x394CD storageDevice; // 0x70
-	unsigned char anException[16]; // 0x74
-	int bJapaneseVersion; // 0x84
-};
-
-// size: 0x8
-struct __anon_0x37408
-{
-	int nOffsetHost; // 0x0
-	int nAddressN64; // 0x4
-};
-
-// size: 0x8
-struct cpu_callerID
-{
-	int N64address; // 0x0
-	int GCNaddress; // 0x4
-};
-
-// size: 0x48
-struct cpu_function
-{
-	void *pnBase; // 0x0
-	void *pfCode; // 0x4
-	int nCountJump; // 0x8
-	__anon_0x37408 *aJump; // 0xC
-	int nAddress0; // 0x10
-	int nAddress1; // 0x14
-	cpu_callerID *block; // 0x18
-	int callerID_total; // 0x1C
-	int callerID_flag; // 0x20
-	unsigned int nChecksum; // 0x24
-	int timeToLive; // 0x28
-	int memory_size; // 0x2C
-	int heapID; // 0x30
-	int heapWhere; // 0x34
-	int treeheapWhere; // 0x38
-	cpu_function *prev; // 0x3C
-	cpu_function *left; // 0x40
-	cpu_function *right; // 0x44
-};
-
-// size: 0x8
-union __anon_0x377BD
-{
-	char _0s8; // 0x0
-	char _1s8; // 0x1
-	char _2s8; // 0x2
-	char _3s8; // 0x3
-	char _4s8; // 0x4
-	char _5s8; // 0x5
-	char _6s8; // 0x6
-	char s8; // 0x7
-	signed short _0s16; // 0x0
-	signed short _1s16; // 0x2
-	signed short _2s16; // 0x4
-	signed short s16; // 0x6
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned char _0u8; // 0x0
-	unsigned char _1u8; // 0x1
-	unsigned char _2u8; // 0x2
-	unsigned char _3u8; // 0x3
-	unsigned char _4u8; // 0x4
-	unsigned char _5u8; // 0x5
-	unsigned char _6u8; // 0x6
-	unsigned char u8; // 0x7
-	unsigned short _0u16; // 0x0
-	unsigned short _1u16; // 0x2
-	unsigned short _2u16; // 0x4
-	unsigned short u16; // 0x6
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x8
-union __anon_0x37BD1
-{
-	float _0f32; // 0x0
-	float f32; // 0x4
-	long float f64; // 0x0
-	int _0s32; // 0x0
-	int s32; // 0x4
-	signed long long s64; // 0x0
-	unsigned int _0u32; // 0x0
-	unsigned int u32; // 0x4
-	unsigned long long u64; // 0x0
-};
-
-// size: 0x34
-struct __anon_0x380DF
-{
-	int nType; // 0x0
-	void *pObject; // 0x4
-	int nOffsetAddress; // 0x8
-	int (*pfGet8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0xC
-	int (*pfGet16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x10
-	int (*pfGet32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x14
-	int (*pfGet64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x18
-	int (*pfPut8)(void */* unknown0 */, unsigned int /* unknown1 */, char */* unknown2 */); // 0x1C
-	int (*pfPut16)(void */* unknown0 */, unsigned int /* unknown1 */, signed short */* unknown2 */); // 0x20
-	int (*pfPut32)(void */* unknown0 */, unsigned int /* unknown1 */, int */* unknown2 */); // 0x24
-	int (*pfPut64)(void */* unknown0 */, unsigned int /* unknown1 */, signed long long */* unknown2 */); // 0x28
-	unsigned int nAddressPhysical0; // 0x2C
-	unsigned int nAddressPhysical1; // 0x30
-};
-
-// size: 0x84
-struct cpu_treeRoot
-{
-	unsigned short total; // 0x0
-	int total_memory; // 0x4
-	int root_address; // 0x8
-	int start_range; // 0xC
-	int end_range; // 0x10
-	int cache_miss; // 0x14
-	int cache[20]; // 0x18
-	cpu_function *left; // 0x68
-	cpu_function *right; // 0x6C
-	int kill_limit; // 0x70
-	int kill_number; // 0x74
-	int side; // 0x78
-	cpu_function *restore; // 0x7C
-	int restore_side; // 0x80
-};
-
-// size: 0xC
-struct _CPU_ADDRESS
-{
-	int nN64; // 0x0
-	int nHost; // 0x4
-	cpu_function *pFunction; // 0x8
-};
-
-// size: 0xC
-struct __anon_0x386A3
-{
-	unsigned int nAddress; // 0x0
-	unsigned int nOpcodeOld; // 0x4
-	unsigned int nOpcodeNew; // 0x8
-};
-
-// size: 0x2C8
-struct OSContext
-{
-	unsigned long gpr[32]; // 0x0
-	unsigned long cr; // 0x80
-	unsigned long lr; // 0x84
-	unsigned long ctr; // 0x88
-	unsigned long xer; // 0x8C
-	long float fpr[32]; // 0x90
-	unsigned long fpscr_pad; // 0x190
-	unsigned long fpscr; // 0x194
-	unsigned long srr0; // 0x198
-	unsigned long srr1; // 0x19C
-	unsigned short mode; // 0x1A0
-	unsigned short state; // 0x1A2
-	unsigned long gqr[8]; // 0x1A4
-	unsigned long psf_pad; // 0x1C4
-	long float psf[32]; // 0x1C8
-};
-
-// size: 0x28
-struct OSAlarm
-{
-	void (*handler)(OSAlarm */* unknown0 */, OSContext */* unknown1 */); // 0x0
-	unsigned long tag; // 0x4
-	signed long long fire; // 0x8
-	OSAlarm *prev; // 0x10
-	OSAlarm *next; // 0x14
-	signed long long period; // 0x18
-	signed long long start; // 0x20
-};
-
-// size: 0x28
-struct cpu_optimize
-{
-	unsigned int validCheck; // 0x0
-	unsigned int destGPR_check; // 0x4
-	int destGPR; // 0x8
-	int destGPR_mapping; // 0xC
-	unsigned int destFPR_check; // 0x10
-	int destFPR; // 0x14
-	unsigned int addr_check; // 0x18
-	int addr_last; // 0x1C
-	unsigned int checkType; // 0x20
-	unsigned int checkNext; // 0x24
-};
-
-// size: 0x12090
-struct _CPU
-{
-	int nMode; // 0x0
-	int nTick; // 0x4
-	void *pHost; // 0x8
-	signed long long nLo; // 0x10
-	signed long long nHi; // 0x18
-	int nCountAddress; // 0x20
-	int iDeviceDefault; // 0x24
-	unsigned int nPC; // 0x28
-	unsigned int nWaitPC; // 0x2C
-	unsigned int nCallLast; // 0x30
-	cpu_function *pFunctionLast; // 0x34
-	int nReturnAddrLast; // 0x38
-	int survivalTimer; // 0x3C
-	__anon_0x377BD aGPR[32]; // 0x40
-	__anon_0x37BD1 aFPR[32]; // 0x140
-	unsigned long long aTLB[48][5]; // 0x240
-	int anFCR[32]; // 0x9C0
-	signed long long anCP0[32]; // 0xA40
-	int (*pfStep)(_CPU */* unknown0 */); // 0xB40
-	int (*pfJump)(_CPU */* unknown0 */); // 0xB44
-	int (*pfCall)(_CPU */* unknown0 */); // 0xB48
-	int (*pfIdle)(_CPU */* unknown0 */); // 0xB4C
-	int (*pfRam)(_CPU */* unknown0 */); // 0xB50
-	int (*pfRamF)(_CPU */* unknown0 */); // 0xB54
-	unsigned int nTickLast; // 0xB58
-	unsigned int nRetrace; // 0xB5C
-	unsigned int nRetraceUsed; // 0xB60
-	__anon_0x380DF *apDevice[256]; // 0xB64
-	unsigned char aiDevice[65536]; // 0xF64
-	void *gHeap1; // 0x10F64
-	void *gHeap2; // 0x10F68
-	unsigned int aHeap1Flag[192]; // 0x10F6C
-	unsigned int aHeap2Flag[13]; // 0x1126C
-	cpu_treeRoot *gTree; // 0x112A0
-	_CPU_ADDRESS aAddressCache[256]; // 0x112A4
-	int nCountCodeHack; // 0x11EA4
-	__anon_0x386A3 aCodeHack[32]; // 0x11EA8
-	signed long long nTimeRetrace; // 0x12028
-	OSAlarm alarmRetrace; // 0x12030
-	unsigned int nFlagRAM; // 0x12058
-	unsigned int nFlagCODE; // 0x1205C
-	unsigned int nCompileFlag; // 0x12060
-	cpu_optimize nOptimize; // 0x12064
-};
-
-// size: 0x4
-enum __anon_0x39384
-{
-	MIT_NONE = 4294967295,
-	MIT_SP = 0,
-	MIT_SI = 1,
-	MIT_AI = 2,
-	MIT_VI = 3,
-	MIT_PI = 4,
-	MIT_DP = 5
-};
-
-// size: 0x14
-struct __anon_0x393FF
-{
-	char *szType; // 0x0
-	unsigned int nMask; // 0x4
-	__anon_0x3994B eCode; // 0x8
-	__anon_0x3979C eType; // 0xC
-	__anon_0x39384 eTypeMips; // 0x10
-};
-
-// size: 0x4
-enum __anon_0x394CD
-{
-	SOT_NONE = 4294967295,
-	SOT_CPU = 0,
-	SOT_PIF = 1,
-	SOT_RAM = 2,
-	SOT_ROM = 3,
-	SOT_RSP = 4,
-	SOT_RDP = 5,
-	SOT_MIPS = 6,
-	SOT_DISK = 7,
-	SOT_FLASH = 8,
-	SOT_SRAM = 9,
-	SOT_AUDIO = 10,
-	SOT_VIDEO = 11,
-	SOT_SERIAL = 12,
-	SOT_LIBRARY = 13,
-	SOT_PERIPHERAL = 14,
-	SOT_RDB = 15,
-	SOT_COUNT = 16
-};
-
-int systemEvent(__anon_0x37240 *pSystem, int nEvent, void *pArgument)
-{
-	_CPU *pCPU;
-	__anon_0x393FF exception;
-	__anon_0x394CD eObject;
-	__anon_0x394CD storageDevice;
-	// References: gClassRdb (0x800EE1B0)
-	// References: gClassPeripheral (0x800EFFBC)
-	// References: gClassLibrary (0xCEB0E80)
-	// References: gClassSerial (0x28EA0E80)
-	// References: gClassVideo (0x70E80E80)
-	// References: gClassAudio (0x78E70E80)
-	// References: gClassDisk (0x48E70E80)
-	// References: gClassMips (0x800EE6D0)
-	// References: gClassRDP (0x40DF0E80)
-	// References: gClassRSP (0x20E20E80)
-	// References: gClassROM (0x800ED8E8)
-	// References: gClassRAM (0x800ED6C8)
-	// References: gClassPIF (0x800ED6B8)
-	// References: gClassCPU (0x58B60E80)
-	// References: gpSound (0x4561380)
-	// References: gpFrame (0x8561380)
+    // References
+    // -> struct _XL_OBJECTTYPE gClassRdb;
+    // -> struct _XL_OBJECTTYPE gClassPeripheral;
+    // -> struct _XL_OBJECTTYPE gClassLibrary;
+    // -> struct _XL_OBJECTTYPE gClassSerial;
+    // -> struct _XL_OBJECTTYPE gClassVideo;
+    // -> struct _XL_OBJECTTYPE gClassAudio;
+    // -> struct _XL_OBJECTTYPE gClassDisk;
+    // -> struct _XL_OBJECTTYPE gClassMips;
+    // -> struct _XL_OBJECTTYPE gClassRDP;
+    // -> struct _XL_OBJECTTYPE gClassRSP;
+    // -> struct _XL_OBJECTTYPE gClassROM;
+    // -> struct _XL_OBJECTTYPE gClassRAM;
+    // -> struct _XL_OBJECTTYPE gClassPIF;
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+    // -> struct __anon_0x36AAA* gpSound;
+    // -> struct __anon_0x35B4C* gpFrame;
 }
 
-// size: 0x4
-enum __anon_0x3979C
-{
-	SIT_NONE = 4294967295,
-	SIT_SW0 = 0,
-	SIT_SW1 = 1,
-	SIT_CART = 2,
-	SIT_COUNTER = 3,
-	SIT_RDB = 4,
-	SIT_SP = 5,
-	SIT_SI = 6,
-	SIT_AI = 7,
-	SIT_VI = 8,
-	SIT_PI = 9,
-	SIT_DP = 10,
-	SIT_CPU_BREAK = 11,
-	SIT_SP_BREAK = 12,
-	SIT_FAULT = 13,
-	SIT_THREADSTATUS = 14,
-	SIT_PRENMI = 15,
-	SIT_COUNT_ = 16
+enum __anon_0x3979C {
+    SIT_NONE = -1,
+    SIT_SW0 = 0,
+    SIT_SW1 = 1,
+    SIT_CART = 2,
+    SIT_COUNTER = 3,
+    SIT_RDB = 4,
+    SIT_SP = 5,
+    SIT_SI = 6,
+    SIT_AI = 7,
+    SIT_VI = 8,
+    SIT_PI = 9,
+    SIT_DP = 10,
+    SIT_CPU_BREAK = 11,
+    SIT_SP_BREAK = 12,
+    SIT_FAULT = 13,
+    SIT_THREADSTATUS = 14,
+    SIT_PRENMI = 15,
+    SIT_COUNT_ = 16,
 };
 
-int systemExceptionPending(__anon_0x37240 *pSystem, __anon_0x3979C eType);
-
-// size: 0x4
-enum __anon_0x3994B
-{
-	CEC_NONE = 4294967295,
-	CEC_INTERRUPT = 0,
-	CEC_TLB_MODIFICATION = 1,
-	CEC_TLB_LOAD = 2,
-	CEC_TLB_STORE = 3,
-	CEC_ADDRESS_LOAD = 4,
-	CEC_ADDRESS_STORE = 5,
-	CEC_BUS_INSTRUCTION = 6,
-	CEC_BUS_DATA = 7,
-	CEC_SYSCALL = 8,
-	CEC_BREAK = 9,
-	CEC_RESERVED = 10,
-	CEC_COPROCESSOR = 11,
-	CEC_OVERFLOW = 12,
-	CEC_TRAP = 13,
-	CEC_VCE_INSTRUCTION = 14,
-	CEC_FLOAT = 15,
-	CEC_RESERVED_16 = 16,
-	CEC_RESERVED_17 = 17,
-	CEC_RESERVED_18 = 18,
-	CEC_RESERVED_19 = 19,
-	CEC_RESERVED_20 = 20,
-	CEC_RESERVED_21 = 21,
-	CEC_RESERVED_22 = 22,
-	CEC_WATCH = 23,
-	CEC_RESERVED_24 = 24,
-	CEC_RESERVED_25 = 25,
-	CEC_RESERVED_26 = 26,
-	CEC_RESERVED_27 = 27,
-	CEC_RESERVED_28 = 28,
-	CEC_RESERVED_29 = 29,
-	CEC_RESERVED_30 = 30,
-	CEC_VCE_DATA = 31,
-	CEC_COUNT = 32
-};
-
-int systemCheckInterrupts(__anon_0x37240 *pSystem)
-{
-	int iException;
-	int nMaskFinal;
-	int bUsed;
-	int bDone;
-	__anon_0x393FF exception;
-	__anon_0x3994B eCodeFinal;
+// Range: 0x8002D2EC -> 0x8002D324
+s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // enum __anon_0x3979C eType; // r1+0x4
 }
 
-int systemExecute(__anon_0x37240 *pSystem, int nCount)
-{
-	// References: gClassSystem (0x10B30E80)
+enum __anon_0x3994B {
+    CEC_NONE = -1,
+    CEC_INTERRUPT = 0,
+    CEC_TLB_MODIFICATION = 1,
+    CEC_TLB_LOAD = 2,
+    CEC_TLB_STORE = 3,
+    CEC_ADDRESS_LOAD = 4,
+    CEC_ADDRESS_STORE = 5,
+    CEC_BUS_INSTRUCTION = 6,
+    CEC_BUS_DATA = 7,
+    CEC_SYSCALL = 8,
+    CEC_BREAK = 9,
+    CEC_RESERVED = 10,
+    CEC_COPROCESSOR = 11,
+    CEC_OVERFLOW = 12,
+    CEC_TRAP = 13,
+    CEC_VCE_INSTRUCTION = 14,
+    CEC_FLOAT = 15,
+    CEC_RESERVED_16 = 16,
+    CEC_RESERVED_17 = 17,
+    CEC_RESERVED_18 = 18,
+    CEC_RESERVED_19 = 19,
+    CEC_RESERVED_20 = 20,
+    CEC_RESERVED_21 = 21,
+    CEC_RESERVED_22 = 22,
+    CEC_WATCH = 23,
+    CEC_RESERVED_24 = 24,
+    CEC_RESERVED_25 = 25,
+    CEC_RESERVED_26 = 26,
+    CEC_RESERVED_27 = 27,
+    CEC_RESERVED_28 = 28,
+    CEC_RESERVED_29 = 29,
+    CEC_RESERVED_30 = 30,
+    CEC_VCE_DATA = 31,
+    CEC_COUNT = 32,
+};
+
+// Range: 0x8002D324 -> 0x8002D47C
+s32 systemCheckInterrupts(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r25
+
+    // Local variables
+    s32 iException; // r30
+    s32 nMaskFinal; // r29
+    s32 bUsed; // r28
+    s32 bDone; // r27
+    struct __anon_0x393FF exception; // r1+0xC
+    enum __anon_0x3994B eCodeFinal; // r26
 }
 
-int systemReset(__anon_0x37240 *pSystem)
-{
-	signed long long nPC;
-	int nOffsetRAM;
-	__anon_0x394CD eObject;
+// Range: 0x8002D47C -> 0x8002D578
+s32 systemExecute(struct __anon_0x37240* pSystem, s32 nCount) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r31
+    // s32 nCount; // r4
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSystem;
 }
 
-int systemGetStorageDevice(__anon_0x37240 *pSystem, __anon_0x394CD *pStorageDevice);
+// Range: 0x8002D578 -> 0x8002D730
+s32 systemReset(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r29
 
-// Location: 0x58E70E80
-_XL_OBJECTTYPE gClassFlash;
-
-// Location: 0x68E70E80
-_XL_OBJECTTYPE gClassSram;
-
-int systemSetStorageDevice(__anon_0x37240 *pSystem, __anon_0x394CD storageDevice)
-{
-	// References: gClassSram (0x68E70E80)
-	// References: gClassFlash (0x58E70E80)
+    // Local variables
+    s64 nPC; // r1+0x10
+    s32 nOffsetRAM; // r4
+    enum __anon_0x394CD eObject; // r30
 }
 
-int systemGetMode(__anon_0x37240 *pSystem, __anon_0x3A085 *peMode)
-{
-	// References: gClassSystem (0x10B30E80)
+// Range: 0x8002D730 -> 0x8002D740
+s32 systemGetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD* pStorageDevice) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // enum __anon_0x394CD* pStorageDevice; // r1+0x4
 }
 
-// size: 0x4
-enum __anon_0x3A085
-{
-	SM_NONE = 4294967295,
-	SM_RUNNING = 0,
-	SM_STOPPED = 1
-};
+// size = 0x10, address = 0x800EE758
+struct _XL_OBJECTTYPE gClassFlash;
 
-int systemSetMode(__anon_0x37240 *pSystem, __anon_0x3A085 eMode)
-{
-	// References: gClassSystem (0x10B30E80)
+// size = 0x10, address = 0x800EE768
+struct _XL_OBJECTTYPE gClassSram;
+
+// Range: 0x8002D740 -> 0x8002D82C
+s32 systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD storageDevice) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x394CD storageDevice; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSram;
+    // -> struct _XL_OBJECTTYPE gClassFlash;
 }
 
-int systemClearBreak(__anon_0x37240 *pSystem);
+// Range: 0x8002D82C -> 0x8002D894
+s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x3A085* peMode; // r31
 
-int systemSetBreak(__anon_0x37240 *pSystem, signed long long nAddress);
-
-int systemCopyROM(__anon_0x37240 *pSystem, int nOffsetRAM, int nOffsetROM, int nSize, int (*pCallback)())
-{
-	void *pTarget;
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSystem;
 }
 
-// Location: 0x561380
-__anon_0x37240 *gpSystem;
+enum __anon_0x3A085 {
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
+};
 
-// Local to compilation unit
-static int __systemCopyROM_Complete()
-{
-	int iAddress;
-	int nCount;
-	unsigned int nAddress0;
-	unsigned int nAddress1;
-	unsigned int anAddress[32];
-	// References: gpSystem (0x561380)
+// Range: 0x8002D894 -> 0x8002D904
+s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x3A085 eMode; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSystem;
 }
 
-// Local to compilation unit
-static int systemPut64();
-
-// Local to compilation unit
-static int systemPut32();
-
-// Local to compilation unit
-static int systemPut16();
-
-// Local to compilation unit
-static int systemPut8();
-
-// Local to compilation unit
-static int systemGet64(signed long long *pData);
-
-// Local to compilation unit
-static int systemGet32(int *pData);
-
-// Local to compilation unit
-static int systemGet16(signed short *pData);
-
-// Local to compilation unit
-static int systemGet8(char *pData);
-
-// Local to compilation unit
-static int systemGetException(__anon_0x3979C eType, __anon_0x393FF *pException);
-
-int systemClearExceptions(__anon_0x37240 *pSystem)
-{
-	int iException;
+// Erased
+static s32 systemClearBreak(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
 }
 
-// size: 0x18
-struct __anon_0x3A807
-{
-	int configuration; // 0x0
-	int size; // 0x4
-	int offset; // 0x8
-	char *buffer; // 0xC
-	int *writtenBlocks; // 0x10
-	int writtenConfig; // 0x14
-};
-
-// size: 0x28
-struct OSCalendarTime
-{
-	int sec; // 0x0
-	int min; // 0x4
-	int hour; // 0x8
-	int mday; // 0xC
-	int mon; // 0x10
-	int year; // 0x14
-	int wday; // 0x18
-	int yday; // 0x1C
-	int msec; // 0x20
-	int usec; // 0x24
-};
-
-// size: 0x14
-struct CARDFileInfo
-{
-	long chan; // 0x0
-	long fileNo; // 0x4
-	long offset; // 0x8
-	long length; // 0xC
-	unsigned short iBlock; // 0x10
-	unsigned short __padding; // 0x12
-};
-
-// size: 0x35C
-struct __anon_0x3AC10
-{
-	int currentGame; // 0x0
-	int fileSize; // 0x4
-	char name[33]; // 0x8
-	int numberOfGames; // 0x2C
-	__anon_0x3A807 game; // 0x30
-	int changedDate; // 0x48
-	int changedChecksum; // 0x4C
-	int gameSize[16]; // 0x50
-	int gameOffset[16]; // 0x90
-	int gameConfigIndex[16]; // 0xD0
-	char gameName[16][33]; // 0x110
-	OSCalendarTime time; // 0x320
-	CARDFileInfo fileInfo; // 0x348
-};
-
-// size: 0x4
-enum __anon_0x3AE26
-{
-	MC_E_NONE = 0,
-	MC_E_BUSY = 1,
-	MC_E_WRONGDEVICE = 2,
-	MC_E_NOCARD = 3,
-	MC_E_NOFILE = 4,
-	MC_E_IOERROR = 5,
-	MC_E_BROKEN = 6,
-	MC_E_EXIST = 7,
-	MC_E_NOENT = 8,
-	MC_E_INSSPACE = 9,
-	MC_E_NOPERM = 10,
-	MC_E_LIMIT = 11,
-	MC_E_NAMETOOLONG = 12,
-	MC_E_ENCODING = 13,
-	MC_E_CANCELED = 14,
-	MC_E_FATAL = 15,
-	MC_E_SECTOR_SIZE_INVALID = 16,
-	MC_E_GAME_NOT_FOUND = 17,
-	MC_E_CHECKSUM = 18,
-	MC_E_NO_FREE_SPACE = 19,
-	MC_E_NO_FREE_FILES = 20,
-	MC_E_FILE_EXISTS = 21,
-	MC_E_GAME_EXISTS = 22,
-	MC_E_TIME_WRONG = 23,
-	MC_E_WRITE_CORRUPTED = 24,
-	MC_E_UNKNOWN = 25
-};
-
-// size: 0x7B8
-struct _MCARD
-{
-	__anon_0x3AC10 file; // 0x0
-	__anon_0x3AE26 error; // 0x35C
-	int slot; // 0x360
-	int (*pPollFunction)(); // 0x364
-	int pollPrevBytes; // 0x368
-	int pollSize; // 0x36C
-	char pollMessage[256]; // 0x370
-	int saveToggle; // 0x470
-	char *writeBuffer; // 0x474
-	char *readBuffer; // 0x478
-	int writeToggle; // 0x47C
-	int soundToggle; // 0x480
-	int writeStatus; // 0x484
-	int writeIndex; // 0x488
-	int accessType; // 0x48C
-	int gameIsLoaded; // 0x490
-	char saveFileName[256]; // 0x494
-	char saveComment[256]; // 0x594
-	char *saveIcon; // 0x694
-	char *saveBanner; // 0x698
-	char saveGameName[256]; // 0x69C
-	int saveFileSize; // 0x79C
-	int saveGameSize; // 0x7A0
-	int bufferCreated; // 0x7A4
-	int cardSize; // 0x7A8
-	int wait; // 0x7AC
-	int isBroken; // 0x7B0
-	int saveConfiguration; // 0x7B4
-};
-
-// Location: 0x801079B0
-_MCARD mCard;
-
-// Location: 0x80134D8C
-unsigned int gz_iconSize;
-
-// Location: 0x80134D88
-unsigned int gz_bnrSize;
-
-// size: 0x20
-struct DVDDiskID
-{
-	char gameName[4]; // 0x0
-	char company[2]; // 0x4
-	unsigned char diskNumber; // 0x6
-	unsigned char gameVersion; // 0x7
-	unsigned char streaming; // 0x8
-	unsigned char streamingBufSize; // 0x9
-	unsigned char padding[22]; // 0xA
-};
-
-// size: 0x30
-struct DVDCommandBlock
-{
-	DVDCommandBlock *next; // 0x0
-	DVDCommandBlock *prev; // 0x4
-	unsigned long command; // 0x8
-	long state; // 0xC
-	unsigned long offset; // 0x10
-	unsigned long length; // 0x14
-	void *addr; // 0x18
-	unsigned long currTransferSize; // 0x1C
-	unsigned long transferredSize; // 0x20
-	DVDDiskID *id; // 0x24
-	void (*callback)(long /* unknown0 */, DVDCommandBlock */* unknown1 */); // 0x28
-	void *userData; // 0x2C
-};
-
-// size: 0x3C
-struct DVDFileInfo
-{
-	DVDCommandBlock cb; // 0x0
-	unsigned long startAddr; // 0x30
-	unsigned long length; // 0x34
-	void (*callback)(long /* unknown0 */, DVDFileInfo */* unknown1 */); // 0x38
-};
-
-// size: 0x4
-enum __anon_0x3BAA7
-{
-	RLM_NONE = 4294967295,
-	RLM_PART = 0,
-	RLM_FULL = 1,
-	RLM_COUNT_ = 2
-};
-
-// size: 0x10
-struct __anon_0x3BB09
-{
-	int iCache; // 0x0
-	unsigned int nSize; // 0x4
-	unsigned int nTickUsed; // 0x8
-	char keep; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x3BC1D
-{
-	int bWait; // 0x0
-	int (*pCallback)(); // 0x4
-	unsigned char *pTarget; // 0x8
-	unsigned int nSize; // 0xC
-	unsigned int nOffset; // 0x10
-};
-
-// size: 0x30
-struct __anon_0x3BCFD
-{
-	int bWait; // 0x0
-	int bDone; // 0x4
-	int nResult; // 0x8
-	unsigned char *anData; // 0xC
-	int (*pCallback)(); // 0x10
-	int iCache; // 0x14
-	int iBlock; // 0x18
-	int nOffset; // 0x1C
-	unsigned int nOffset0; // 0x20
-	unsigned int nOffset1; // 0x24
-	unsigned int nSize; // 0x28
-	unsigned int nSizeRead; // 0x2C
-};
-
-// size: 0x10EF8
-struct __anon_0x3BEE8
-{
-	void *pHost; // 0x0
-	void *pBuffer; // 0x4
-	int bFlip; // 0x8
-	int bLoad; // 0xC
-	char acNameFile[513]; // 0x10
-	unsigned int nSize; // 0x214
-	__anon_0x3BAA7 eModeLoad; // 0x218
-	__anon_0x3BB09 aBlock[4096]; // 0x21C
-	unsigned int nTick; // 0x1021C
-	unsigned char *pCacheRAM; // 0x10220
-	unsigned char anBlockCachedRAM[1024]; // 0x10224
-	unsigned char anBlockCachedARAM[2046]; // 0x10624
-	__anon_0x3BC1D copy; // 0x10E24
-	__anon_0x3BCFD load; // 0x10E38
-	int nCountBlockRAM; // 0x10E68
-	int nSizeCacheRAM; // 0x10E6C
-	unsigned char acHeader[64]; // 0x10E70
-	unsigned int *anOffsetBlock; // 0x10EB0
-	int nCountOffsetBlocks; // 0x10EB4
-	DVDFileInfo fileInfo; // 0x10EB8
-	int offsetToRom; // 0x10EF4
-};
-
-// size: 0x4
-enum __anon_0x3C277
-{
-	CT_NONE = 0,
-	CT_CONTROLLER = 1,
-	CT_CONTROLLER_W_PAK = 2,
-	CT_CONTROLLER_W_RPAK = 3,
-	CT_MOUSE = 4,
-	CT_VOICE = 5,
-	CT_4K = 6,
-	CT_16K = 7,
-	CT_COUNT = 8
-};
-
-// size: 0x30
-struct __anon_0x3C350
-{
-	void *pROM; // 0x0
-	void *pRAM; // 0x4
-	void *pHost; // 0x8
-	unsigned short controllerType[5]; // 0xC
-	char controllerStatus[5]; // 0x16
-	__anon_0x3C277 eControllerType[5]; // 0x1C
-};
-
-// Local to compilation unit
-static int systemSetupGameALL(__anon_0x37240 *pSystem)
-{
-	int nSizeSound;
-	int iController;
-	int nSize;
-	unsigned int *anMode;
-	int i;
-	unsigned long long nTimeRetrace;
-	char acCode[5];
-	DVDFileInfo fileInfo;
-	_CPU *pCPU;
-	__anon_0x3BEE8 *pROM;
-	__anon_0x3C350 *pPIF;
-	int defaultConfiguration;
-	// References: contMap (0x20B30E80)
-	// References: gSystemRomConfigurationList (0x801308E0)
-	// References: mCard (0x801079B0)
-	// References: gpSystem (0x561380)
-	// References: gz_bnrSize (0x80134D88)
-	// References: gz_iconSize (0x80134D8C)
-	// References: nTickMultiplier (0x604E1380)
-	// References: gnFlagZelda (0x801356D8)
-	// References: fTickScale (0x644E1380)
+// Erased
+static s32 systemSetBreak(struct __anon_0x37240* pSystem, s64 nAddress) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // s64 nAddress; // r1+0x8
 }
 
-int systemGetInitialConfiguration(__anon_0x3BEE8 *pROM, int index)
-{
-	char *szText;
-	// References: gSystemRomConfigurationList (0x801308E0)
-	// References: contMap (0x20B30E80)
+// Range: 0x8002D904 -> 0x8002D9F8
+s32 systemCopyROM(struct __anon_0x37240* pSystem, s32 nOffsetRAM, s32 nOffsetROM, s32 nSize, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r29
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetROM; // r30
+    // s32 nSize; // r1+0x14
+    // s32 (* pCallback)(); // r31
+
+    // Local variables
+    void* pTarget; // r1+0x1C
 }
 
-int systemMapControllerIndex(int gameIndex, int configIndex)
-{
-	int i;
-	// References: contMap (0x20B30E80)
-	// References: gSystemRomConfigurationList (0x801308E0)
+// size = 0x4, address = 0x80135600
+struct __anon_0x37240* gpSystem;
+
+// Range: 0x8002D9F8 -> 0x8002DB30
+static s32 __systemCopyROM_Complete() {
+    // Local variables
+    s32 iAddress; // r30
+    s32 nCount; // r1+0x88
+    u32 nAddress0; // r30
+    u32 nAddress1; // r31
+    u32 anAddress[32]; // r1+0x8
+
+    // References
+    // -> struct __anon_0x37240* gpSystem;
 }
 
-// Local to compilation unit
-static int systemSetupGameRAM(__anon_0x37240 *pSystem)
-{
-	char *szExtra;
-	int bExpansion;
-	int nSizeRAM;
-	int nSizeCacheROM;
-	int nSizeExtra;
-	__anon_0x3BEE8 *pROM;
-	unsigned int nCode;
-	unsigned int iCode;
-	unsigned int anCode[256];
-	// References: gnFlagZelda (0x801356D8)
+// Range: 0x8002DB30 -> 0x8002DB38
+static s32 systemPut64() {}
+
+// Range: 0x8002DB38 -> 0x8002DB40
+static s32 systemPut32() {}
+
+// Range: 0x8002DB40 -> 0x8002DB48
+static s32 systemPut16() {}
+
+// Range: 0x8002DB48 -> 0x8002DB50
+static s32 systemPut8() {}
+
+// Range: 0x8002DB50 -> 0x8002DB64
+static s32 systemGet64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
 }
 
+// Range: 0x8002DB64 -> 0x8002DB74
+static s32 systemGet32(s32* pData) {
+    // Parameters
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8002DB74 -> 0x8002DB84
+static s32 systemGet16(s16* pData) {
+    // Parameters
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8002DB84 -> 0x8002DB94
+static s32 systemGet8(char* pData) {
+    // Parameters
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8002DB94 -> 0x8002DD70
+static s32 systemGetException(enum __anon_0x3979C eType, struct __anon_0x393FF* pException) {
+    // Parameters
+    // enum __anon_0x3979C eType; // r1+0x4
+    // struct __anon_0x393FF* pException; // r1+0x8
+}
+
+// Erased
+static s32 systemClearExceptions(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+
+    // Local variables
+    s32 iException; // r1+0x0
+}
+
+struct __anon_0x3A807 {
+    /* 0x00 */ s32 configuration;
+    /* 0x04 */ s32 size;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ char* buffer;
+    /* 0x10 */ s32* writtenBlocks;
+    /* 0x14 */ s32 writtenConfig;
+}; // size = 0x18
+
+struct OSCalendarTime {
+    /* 0x00 */ s32 sec;
+    /* 0x04 */ s32 min;
+    /* 0x08 */ s32 hour;
+    /* 0x0C */ s32 mday;
+    /* 0x10 */ s32 mon;
+    /* 0x14 */ s32 year;
+    /* 0x18 */ s32 wday;
+    /* 0x1C */ s32 yday;
+    /* 0x20 */ s32 msec;
+    /* 0x24 */ s32 usec;
+}; // size = 0x28
+
+struct CARDFileInfo {
+    /* 0x00 */ s32 chan;
+    /* 0x04 */ s32 fileNo;
+    /* 0x08 */ s32 offset;
+    /* 0x0C */ s32 length;
+    /* 0x10 */ u16 iBlock;
+    /* 0x12 */ u16 __padding;
+}; // size = 0x14
+
+struct __anon_0x3AC10 {
+    /* 0x000 */ s32 currentGame;
+    /* 0x004 */ s32 fileSize;
+    /* 0x008 */ char name[33];
+    /* 0x02C */ s32 numberOfGames;
+    /* 0x030 */ struct __anon_0x3A807 game;
+    /* 0x048 */ s32 changedDate;
+    /* 0x04C */ s32 changedChecksum;
+    /* 0x050 */ s32 gameSize[16];
+    /* 0x090 */ s32 gameOffset[16];
+    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x110 */ char gameName[16][33];
+    /* 0x320 */ struct OSCalendarTime time;
+    /* 0x348 */ struct CARDFileInfo fileInfo;
+}; // size = 0x35C
+
+enum __anon_0x3AE26 {
+    MC_E_NONE = 0,
+    MC_E_BUSY = 1,
+    MC_E_WRONGDEVICE = 2,
+    MC_E_NOCARD = 3,
+    MC_E_NOFILE = 4,
+    MC_E_IOERROR = 5,
+    MC_E_BROKEN = 6,
+    MC_E_EXIST = 7,
+    MC_E_NOENT = 8,
+    MC_E_INSSPACE = 9,
+    MC_E_NOPERM = 10,
+    MC_E_LIMIT = 11,
+    MC_E_NAMETOOLONG = 12,
+    MC_E_ENCODING = 13,
+    MC_E_CANCELED = 14,
+    MC_E_FATAL = 15,
+    MC_E_SECTOR_SIZE_INVALID = 16,
+    MC_E_GAME_NOT_FOUND = 17,
+    MC_E_CHECKSUM = 18,
+    MC_E_NO_FREE_SPACE = 19,
+    MC_E_NO_FREE_FILES = 20,
+    MC_E_FILE_EXISTS = 21,
+    MC_E_GAME_EXISTS = 22,
+    MC_E_TIME_WRONG = 23,
+    MC_E_WRITE_CORRUPTED = 24,
+    MC_E_UNKNOWN = 25,
+};
+
+struct _MCARD {
+    /* 0x000 */ struct __anon_0x3AC10 file;
+    /* 0x35C */ enum __anon_0x3AE26 error;
+    /* 0x360 */ s32 slot;
+    /* 0x364 */ s32 (*pPollFunction)();
+    /* 0x368 */ s32 pollPrevBytes;
+    /* 0x36C */ s32 pollSize;
+    /* 0x370 */ char pollMessage[256];
+    /* 0x470 */ s32 saveToggle;
+    /* 0x474 */ char* writeBuffer;
+    /* 0x478 */ char* readBuffer;
+    /* 0x47C */ s32 writeToggle;
+    /* 0x480 */ s32 soundToggle;
+    /* 0x484 */ s32 writeStatus;
+    /* 0x488 */ s32 writeIndex;
+    /* 0x48C */ s32 accessType;
+    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x494 */ char saveFileName[256];
+    /* 0x594 */ char saveComment[256];
+    /* 0x694 */ char* saveIcon;
+    /* 0x698 */ char* saveBanner;
+    /* 0x69C */ char saveGameName[256];
+    /* 0x79C */ s32 saveFileSize;
+    /* 0x7A0 */ s32 saveGameSize;
+    /* 0x7A4 */ s32 bufferCreated;
+    /* 0x7A8 */ s32 cardSize;
+    /* 0x7AC */ s32 wait;
+    /* 0x7B0 */ s32 isBroken;
+    /* 0x7B4 */ s32 saveConfiguration;
+}; // size = 0x7B8
+
+// size = 0x7B8, address = 0x801079B0
+struct _MCARD mCard;
+
+// size = 0x4, address = 0x80134D8C
+u32 gz_iconSize;
+
+// size = 0x4, address = 0x80134D88
+u32 gz_bnrSize;
+
+struct DVDDiskID {
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+}; // size = 0x20
+
+struct DVDCommandBlock {
+    /* 0x00 */ struct DVDCommandBlock* next;
+    /* 0x04 */ struct DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ s32 state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ struct DVDDiskID* id;
+    /* 0x28 */ void (*callback)(s32, struct DVDCommandBlock*);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
+
+struct DVDFileInfo {
+    /* 0x00 */ struct DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
+}; // size = 0x3C
+
+enum __anon_0x3BAA7 {
+    RLM_NONE = -1,
+    RLM_PART = 0,
+    RLM_FULL = 1,
+    RLM_COUNT_ = 2,
+};
+
+struct __anon_0x3BB09 {
+    /* 0x0 */ s32 iCache;
+    /* 0x4 */ u32 nSize;
+    /* 0x8 */ u32 nTickUsed;
+    /* 0xC */ char keep;
+}; // size = 0x10
+
+struct __anon_0x3BC1D {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 (*pCallback)();
+    /* 0x08 */ u8* pTarget;
+    /* 0x0C */ u32 nSize;
+    /* 0x10 */ u32 nOffset;
+}; // size = 0x14
+
+struct __anon_0x3BCFD {
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 bDone;
+    /* 0x08 */ s32 nResult;
+    /* 0x0C */ u8* anData;
+    /* 0x10 */ s32 (*pCallback)();
+    /* 0x14 */ s32 iCache;
+    /* 0x18 */ s32 iBlock;
+    /* 0x1C */ s32 nOffset;
+    /* 0x20 */ u32 nOffset0;
+    /* 0x24 */ u32 nOffset1;
+    /* 0x28 */ u32 nSize;
+    /* 0x2C */ u32 nSizeRead;
+}; // size = 0x30
+
+struct __anon_0x3BEE8 {
+    /* 0x00000 */ void* pHost;
+    /* 0x00004 */ void* pBuffer;
+    /* 0x00008 */ s32 bFlip;
+    /* 0x0000C */ s32 bLoad;
+    /* 0x00010 */ char acNameFile[513];
+    /* 0x00214 */ u32 nSize;
+    /* 0x00218 */ enum __anon_0x3BAA7 eModeLoad;
+    /* 0x0021C */ struct __anon_0x3BB09 aBlock[4096];
+    /* 0x1021C */ u32 nTick;
+    /* 0x10220 */ u8* pCacheRAM;
+    /* 0x10224 */ u8 anBlockCachedRAM[1024];
+    /* 0x10624 */ u8 anBlockCachedARAM[2046];
+    /* 0x10E24 */ struct __anon_0x3BC1D copy;
+    /* 0x10E38 */ struct __anon_0x3BCFD load;
+    /* 0x10E68 */ s32 nCountBlockRAM;
+    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E70 */ u8 acHeader[64];
+    /* 0x10EB0 */ u32* anOffsetBlock;
+    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB8 */ struct DVDFileInfo fileInfo;
+    /* 0x10EF4 */ s32 offsetToRom;
+}; // size = 0x10EF8
+
+enum __anon_0x3C277 {
+    CT_NONE = 0,
+    CT_CONTROLLER = 1,
+    CT_CONTROLLER_W_PAK = 2,
+    CT_CONTROLLER_W_RPAK = 3,
+    CT_MOUSE = 4,
+    CT_VOICE = 5,
+    CT_4K = 6,
+    CT_16K = 7,
+    CT_COUNT = 8,
+};
+
+struct __anon_0x3C350 {
+    /* 0x00 */ void* pROM;
+    /* 0x04 */ void* pRAM;
+    /* 0x08 */ void* pHost;
+    /* 0x0C */ u16 controllerType[5];
+    /* 0x16 */ char controllerStatus[5];
+    /* 0x1C */ enum __anon_0x3C277 eControllerType[5];
+}; // size = 0x30
+
+// Range: 0x8002DD70 -> 0x80030364
+static s32 systemSetupGameALL(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r18
+
+    // Local variables
+    s32 nSizeSound; // r23
+    s32 iController; // r21
+    s32 nSize; // r1+0x60
+    u32* anMode; // r1+0x5C
+    s32 i; // r25
+    u64 nTimeRetrace; // r1+0x10
+    char acCode[5]; // r1+0x54
+    struct DVDFileInfo fileInfo; // r1+0x18
+    struct _CPU* pCPU; // r31
+    struct __anon_0x3BEE8* pROM; // r19
+    struct __anon_0x3C350* pPIF; // r29
+    s32 defaultConfiguration; // r1+0x14
+
+    // References
+    // -> static u32 contMap[4][20];
+    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+    // -> struct _MCARD mCard;
+    // -> struct __anon_0x37240* gpSystem;
+    // -> u32 gz_bnrSize;
+    // -> u32 gz_iconSize;
+    // -> u32 nTickMultiplier;
+    // -> u32 gnFlagZelda;
+    // -> float fTickScale;
+}
+
+// Range: 0x80030364 -> 0x80030B38
+s32 systemGetInitialConfiguration(struct __anon_0x3BEE8* pROM, s32 index) {
+    // Parameters
+    // struct __anon_0x3BEE8* pROM; // r24
+    // s32 index; // r1+0x10
+
+    // Local variables
+    char* szText; // r1+0x14
+
+    // References
+    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+    // -> static u32 contMap[4][20];
+}
+
+// Erased
+static s32 systemMapControllerIndex(s32 gameIndex, s32 configIndex) {
+    // Parameters
+    // s32 gameIndex; // r1+0xC
+    // s32 configIndex; // r30
+
+    // Local variables
+    s32 i; // r31
+
+    // References
+    // -> static u32 contMap[4][20];
+    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+}
+
+// Range: 0x80030B38 -> 0x80030E70
+static s32 systemSetupGameRAM(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r27
+
+    // Local variables
+    char* szExtra; // r1+0x414
+    s32 bExpansion; // r30
+    s32 nSizeRAM; // r28
+    s32 nSizeCacheROM; // r29
+    s32 nSizeExtra; // r3
+    struct __anon_0x3BEE8* pROM; // r29
+    u32 nCode; // r28
+    u32 iCode; // r1+0x8
+    u32 anCode[256]; // r1+0x14
+
+    // References
+    // -> u32 gnFlagZelda;
+}

--- a/debug/Fire/video.c
+++ b/debug/Fire/video.c
@@ -1,382 +1,374 @@
-﻿// Location: 0x0
-long float _half$localstatic0$sqrtf__Ff;
+/*
+    Compile unit: C:\HOMEBOY\STEPHEN\Japanese Ocarina\Fire\video.c
+    Producer: MW EABI PPC C-Compiler
+    Language: C++
+    Code range: 0x8008E8A0 -> 0x8008EE20
+*/
 
-// Location: 0x0
-long float _three$localstatic1$sqrtf__Ff;
+#include "types.h"
 
-// Location: 0x0
-long float _half$localstatic0$sqrt__Ff;
+struct _XL_OBJECTTYPE {
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+}; // size = 0x10
 
-// Location: 0x0
-long float _three$localstatic1$sqrt__Ff;
+// size = 0x10, address = 0x800EE870
+struct _XL_OBJECTTYPE gClassVideo;
 
-// size: 0x10
-struct _XL_OBJECTTYPE
-{
-	char *szName; // 0x0
-	int nSizeObject; // 0x4
-	_XL_OBJECTTYPE *pClassBase; // 0x8
-	int (*pfEvent)(void */* unknown0 */, int /* unknown1 */, void */* unknown2 */); // 0xC
-};
+struct __anon_0x75B37 {
+    /* 0x00 */ s32 nScan;
+    /* 0x04 */ s32 bBlack;
+    /* 0x08 */ s32 nBurst;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ void* pHost;
+    /* 0x14 */ s32 nStatus;
+    /* 0x18 */ s32 nTiming;
+    /* 0x1C */ s32 nAddress;
+    /* 0x20 */ s32 nScanInterrupt;
+    /* 0x24 */ s32 nScaleX;
+    /* 0x28 */ s32 nScaleY;
+    /* 0x2C */ s32 nStartH;
+    /* 0x30 */ s32 nStartV;
+    /* 0x34 */ s32 nSyncH;
+    /* 0x38 */ s32 nSyncV;
+    /* 0x3C */ s32 nSyncLeap;
+}; // size = 0x40
 
-// Location: 0x70E80E80
-_XL_OBJECTTYPE gClassVideo;
-
-// size: 0x40
-struct __anon_0x75B37
-{
-	int nScan; // 0x0
-	int bBlack; // 0x4
-	int nBurst; // 0x8
-	int nSizeX; // 0xC
-	void *pHost; // 0x10
-	int nStatus; // 0x14
-	int nTiming; // 0x18
-	int nAddress; // 0x1C
-	int nScanInterrupt; // 0x20
-	int nScaleX; // 0x24
-	int nScaleY; // 0x28
-	int nStartH; // 0x2C
-	int nStartV; // 0x30
-	int nSyncH; // 0x34
-	int nSyncV; // 0x38
-	int nSyncLeap; // 0x3C
-};
-
-int videoEvent(__anon_0x75B37 *pVideo, int nEvent, void *pArgument);
-
-int videoGetMode(__anon_0x75B37 *pVideo, int *pbBlack, int *pnSizeX, int *pnSizeY)
-{
-	int nSizeX;
-	int nSizeY;
+// Range: 0x8008E8A0 -> 0x8008E9F4
+s32 videoEvent(struct __anon_0x75B37* pVideo, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
 
-int videoForceRetrace(__anon_0x75B37 *pVideo);
+// Erased
+static s32 videoGetMode(struct __anon_0x75B37* pVideo, s32* pbBlack, s32* pnSizeX, s32* pnSizeY) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r1+0x8
+    // s32* pbBlack; // r1+0xC
+    // s32* pnSizeX; // r1+0x10
+    // s32* pnSizeY; // r1+0x14
 
-int videoTickScan();
-
-int videoGet64();
-
-int videoGet32(__anon_0x75B37 *pVideo, unsigned int nAddress, int *pData);
-
-int videoGet16();
-
-int videoGet8();
-
-int videoPut64();
-
-// size: 0x10
-struct __anon_0x76165
-{
-	float rX; // 0x0
-	float rY; // 0x4
-	float rSizeX; // 0x8
-	float rSizeY; // 0xC
-};
-
-// size: 0x14
-struct __anon_0x761FF
-{
-	int nSize; // 0x0
-	int nWidth; // 0x4
-	int nFormat; // 0x8
-	void *pData; // 0xC
-	int nAddress; // 0x10
-};
-
-// size: 0xC
-struct __anon_0x76340
-{
-	float x; // 0x0
-	float y; // 0x4
-	float z; // 0x8
-};
-
-// size: 0x3C
-struct __anon_0x763B0
-{
-	int bTransformed; // 0x0
-	__anon_0x76340 rVecOrigTowards; // 0x4
-	float rColorR; // 0x10
-	float rColorG; // 0x14
-	float rColorB; // 0x18
-	float rVectorX; // 0x1C
-	float rVectorY; // 0x20
-	float rVectorZ; // 0x24
-	float kc; // 0x28
-	float kl; // 0x2C
-	float kq; // 0x30
-	signed short coordX; // 0x34
-	signed short coordY; // 0x36
-	signed short coordZ; // 0x38
-};
-
-// size: 0x34
-struct __anon_0x765E0
-{
-	int bTransformed; // 0x0
-	__anon_0x76340 rS; // 0x4
-	__anon_0x76340 rT; // 0x10
-	__anon_0x76340 rSRaw; // 0x1C
-	__anon_0x76340 rTRaw; // 0x28
-};
-
-// size: 0x1C
-struct __anon_0x766C9
-{
-	float rSum; // 0x0
-	float rS; // 0x4
-	float rT; // 0x8
-	__anon_0x76340 vec; // 0xC
-	unsigned char anColor[4]; // 0x18
-};
-
-// size: 0x1000
-union __anon_0x76828
-{
-	unsigned char u8[4096]; // 0x0
-	unsigned short u16[2048]; // 0x0
-	unsigned int u32[1024]; // 0x0
-	unsigned long long u64[512]; // 0x0
-};
-
-// size: 0x1000
-struct __anon_0x768C5
-{
-	__anon_0x76828 data; // 0x0
-};
-
-// size: 0x4
-enum _GXTexFmt
-{
-	GX_TF_I4 = 0,
-	GX_TF_I8 = 1,
-	GX_TF_IA4 = 2,
-	GX_TF_IA8 = 3,
-	GX_TF_RGB565 = 4,
-	GX_TF_RGB5A3 = 5,
-	GX_TF_RGBA8 = 6,
-	GX_TF_CMPR = 14,
-	GX_CTF_R4 = 32,
-	GX_CTF_RA4 = 34,
-	GX_CTF_RA8 = 35,
-	GX_CTF_YUVA8 = 38,
-	GX_CTF_A8 = 39,
-	GX_CTF_R8 = 40,
-	GX_CTF_G8 = 41,
-	GX_CTF_B8 = 42,
-	GX_CTF_RG8 = 43,
-	GX_CTF_GB8 = 44,
-	GX_TF_Z8 = 17,
-	GX_TF_Z16 = 19,
-	GX_TF_Z24X8 = 22,
-	GX_CTF_Z4 = 48,
-	GX_CTF_Z8M = 57,
-	GX_CTF_Z8L = 58,
-	GX_CTF_Z16L = 60,
-	GX_TF_A8 = 39
-};
-
-// size: 0xC
-struct _GXTlutObj
-{
-	unsigned long dummy[3]; // 0x0
-};
-
-// size: 0x20
-struct _GXTexObj
-{
-	unsigned long dummy[8]; // 0x0
-};
-
-// size: 0x4
-enum _GXTexWrapMode
-{
-	GX_CLAMP = 0,
-	GX_REPEAT = 1,
-	GX_MIRROR = 2,
-	GX_MAX_TEXWRAPMODE = 3
-};
-
-// size: 0x6C
-struct _FRAME_TEXTURE
-{
-	int nMode; // 0x0
-	int iPackPixel; // 0x4
-	int iPackColor; // 0x8
-	int nFrameLast; // 0xC
-	signed short nSizeX; // 0x10
-	signed short nSizeY; // 0x12
-	unsigned int nAddress; // 0x14
-	unsigned int nCodePixel; // 0x18
-	unsigned int nCodeColor; // 0x1C
-	_FRAME_TEXTURE *pTextureNext; // 0x20
-	unsigned int nData0; // 0x24
-	unsigned int nData1; // 0x28
-	unsigned int nData2; // 0x2C
-	unsigned int nData3; // 0x30
-	_GXTexFmt eFormat; // 0x34
-	_GXTlutObj objectTLUT; // 0x38
-	_GXTexObj objectTexture; // 0x44
-	_GXTexWrapMode eWrapS; // 0x64
-	_GXTexWrapMode eWrapT; // 0x68
-};
-
-// size: 0x2C
-struct __anon_0x76F93
-{
-	int nSize; // 0x0
-	int nTMEM; // 0x4
-	int iTLUT; // 0x8
-	int nSizeX; // 0xC
-	int nFormat; // 0x10
-	signed short nMaskS; // 0x14
-	signed short nMaskT; // 0x16
-	signed short nModeS; // 0x18
-	signed short nModeT; // 0x1A
-	signed short nShiftS; // 0x1C
-	signed short nShiftT; // 0x1E
-	signed short nX0; // 0x20
-	signed short nY0; // 0x22
-	signed short nX1; // 0x24
-	signed short nY1; // 0x26
-	unsigned int nCodePixel; // 0x28
-};
-
-// size: 0x4
-enum __anon_0x77275
-{
-	FMP_NONE = 4294967295,
-	FMP_PERSPECTIVE = 0,
-	FMP_ORTHOGRAPHIC = 1
-};
-
-// size: 0x24
-struct __anon_0x772F8
-{
-	int nCount; // 0x0
-	float rScale; // 0x4
-	float rAspect; // 0x8
-	float rFieldOfViewY; // 0xC
-	float rClipNear; // 0x10
-	float rClipFar; // 0x14
-	unsigned int nAddressFloat; // 0x18
-	unsigned int nAddressFixed; // 0x1C
-	__anon_0x77275 eProjection; // 0x20
-};
-
-// size: 0x4
-struct _GXColor
-{
-	unsigned char r; // 0x0
-	unsigned char g; // 0x1
-	unsigned char b; // 0x2
-	unsigned char a; // 0x3
-};
-
-// size: 0x3D150
-struct __anon_0x77548
-{
-	unsigned int anCIMGAddresses[8]; // 0x0
-	unsigned short nNumCIMGAddresses; // 0x20
-	int bBlurOn; // 0x24
-	int bHackPause; // 0x28
-	int nHackCount; // 0x2C
-	int nFrameCounter; // 0x30
-	int bPauseThisFrame; // 0x34
-	int bCameFromBomberNotes; // 0x38
-	int bInBomberNotes; // 0x3C
-	int bShrinking; // 0x40
-	int bSnapShot; // 0x44
-	int bUsingLens; // 0x48
-	unsigned char cBlurAlpha; // 0x4C
-	int bBlurredThisFrame; // 0x50
-	int nFrameCIMGCalls; // 0x54
-	int bModifyZBuffer; // 0x58
-	int bOverrideDepth; // 0x5C
-	int nZBufferSets; // 0x60
-	int nLastFrameZSets; // 0x64
-	int bPauseBGDrawn; // 0x68
-	int bFrameOn; // 0x6C
-	int bBackBufferDrawn; // 0x70
-	int bGrabbedFrame; // 0x74
-	unsigned long long *pnGBI; // 0x78
-	unsigned int nFlag; // 0x7C
-	float rScaleX; // 0x80
-	float rScaleY; // 0x84
-	unsigned int nCountFrames; // 0x88
-	unsigned int nMode; // 0x8C
-	unsigned int aMode[10]; // 0x90
-	__anon_0x76165 viewport; // 0xB8
-	__anon_0x761FF aBuffer[4]; // 0xC8
-	unsigned int nOffsetDepth0; // 0x118
-	unsigned int nOffsetDepth1; // 0x11C
-	int nWidthLine; // 0x120
-	float rDepth; // 0x124
-	float rDelta; // 0x128
-	int (*aDraw[4])(void */* unknown0 */, void */* unknown1 */); // 0x12C
-	int nCountLight; // 0x13C
-	__anon_0x763B0 aLight[8]; // 0x140
-	__anon_0x765E0 lookAt; // 0x320
-	int nCountVertex; // 0x354
-	__anon_0x766C9 aVertex[80]; // 0x358
-	__anon_0x768C5 TMEM; // 0xC18
-	void *aPixelData; // 0x1C18
-	void *aColorData; // 0x1C1C
-	int nBlocksPixel; // 0x1C20
-	int nBlocksMaxPixel; // 0x1C24
-	int nBlocksColor; // 0x1C28
-	int nBlocksMaxColor; // 0x1C2C
-	int nBlocksTexture; // 0x1C30
-	int nBlocksMaxTexture; // 0x1C34
-	unsigned int anPackPixel[48]; // 0x1C38
-	unsigned int anPackColor[320]; // 0x1CF8
-	unsigned int nAddressLoad; // 0x21F8
-	unsigned int nCodePixel; // 0x21FC
-	unsigned int nTlutCode[16]; // 0x2200
-	_FRAME_TEXTURE aTexture[2048]; // 0x2240
-	unsigned int anTextureUsed[64]; // 0x38240
-	_FRAME_TEXTURE *apTextureCached[4096]; // 0x38340
-	int iTileLoad; // 0x3C340
-	unsigned int n2dLoadTexType; // 0x3C344
-	int nLastX0; // 0x3C348
-	int nLastY0; // 0x3C34C
-	int nLastX1; // 0x3C350
-	int nLastY1; // 0x3C354
-	__anon_0x76F93 aTile[8]; // 0x3C358
-	int anSizeX[2]; // 0x3C4B8
-	int anSizeY[2]; // 0x3C4C0
-	int iHintMatrix; // 0x3C4C8
-	int iMatrixModel; // 0x3C4CC
-	int iHintProjection; // 0x3C4D0
-	float matrixView[4][4]; // 0x3C4D4
-	int iHintLast; // 0x3C514
-	int iHintHack; // 0x3C518
-	__anon_0x77275 eTypeProjection; // 0x3C51C
-	float aMatrixModel[10][4][4]; // 0x3C520
-	float matrixProjection[4][4]; // 0x3C7A0
-	float matrixProjectionExtra[4][4]; // 0x3C7E0
-	__anon_0x772F8 aMatrixHint[64]; // 0x3C820
-	unsigned char primLODmin; // 0x3D120
-	unsigned char primLODfrac; // 0x3D121
-	unsigned char lastTile; // 0x3D122
-	unsigned char iTileDrawn; // 0x3D123
-	_GXColor aColor[5]; // 0x3D124
-	unsigned int nModeVtx; // 0x3D138
-	unsigned short *nTempBuffer; // 0x3D13C
-	unsigned short *nCopyBuffer; // 0x3D140
-	unsigned int *nLensBuffer; // 0x3D144
-	unsigned short *nCameraBuffer; // 0x3D148
-};
-
-int videoPut32(__anon_0x75B37 *pVideo, unsigned int nAddress, int *pData)
-{
-	void *pRAM;
-	__anon_0x77548 *pFrame;
-	__anon_0x761FF *pBuffer;
+    // Local variables
+    s32 nSizeX; // r1+0x8
+    s32 nSizeY; // r3
 }
 
-int videoPut16();
+// Range: 0x8008E9F4 -> 0x8008EA60
+s32 videoForceRetrace(struct __anon_0x75B37* pVideo) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r31
+}
 
-int videoPut8();
+// Erased
+static s32 videoTickScan() {}
 
+// Range: 0x8008EA60 -> 0x8008EA68
+s32 videoGet64() {}
+
+// Range: 0x8008EA68 -> 0x8008EB84
+s32 videoGet32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r31
+}
+
+// Range: 0x8008EB84 -> 0x8008EB8C
+s32 videoGet16() {}
+
+// Range: 0x8008EB8C -> 0x8008EB94
+s32 videoGet8() {}
+
+// Range: 0x8008EB94 -> 0x8008EB9C
+s32 videoPut64() {}
+
+struct __anon_0x76165 {
+    /* 0x0 */ float rX;
+    /* 0x4 */ float rY;
+    /* 0x8 */ float rSizeX;
+    /* 0xC */ float rSizeY;
+}; // size = 0x10
+
+struct __anon_0x761FF {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nWidth;
+    /* 0x08 */ s32 nFormat;
+    /* 0x0C */ void* pData;
+    /* 0x10 */ s32 nAddress;
+}; // size = 0x14
+
+struct __anon_0x76340 {
+    /* 0x0 */ float x;
+    /* 0x4 */ float y;
+    /* 0x8 */ float z;
+}; // size = 0xC
+
+struct __anon_0x763B0 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x76340 rVecOrigTowards;
+    /* 0x10 */ float rColorR;
+    /* 0x14 */ float rColorG;
+    /* 0x18 */ float rColorB;
+    /* 0x1C */ float rVectorX;
+    /* 0x20 */ float rVectorY;
+    /* 0x24 */ float rVectorZ;
+    /* 0x28 */ float kc;
+    /* 0x2C */ float kl;
+    /* 0x30 */ float kq;
+    /* 0x34 */ s16 coordX;
+    /* 0x36 */ s16 coordY;
+    /* 0x38 */ s16 coordZ;
+}; // size = 0x3C
+
+struct __anon_0x765E0 {
+    /* 0x00 */ s32 bTransformed;
+    /* 0x04 */ struct __anon_0x76340 rS;
+    /* 0x10 */ struct __anon_0x76340 rT;
+    /* 0x1C */ struct __anon_0x76340 rSRaw;
+    /* 0x28 */ struct __anon_0x76340 rTRaw;
+}; // size = 0x34
+
+struct __anon_0x766C9 {
+    /* 0x00 */ float rSum;
+    /* 0x04 */ float rS;
+    /* 0x08 */ float rT;
+    /* 0x0C */ struct __anon_0x76340 vec;
+    /* 0x18 */ u8 anColor[4];
+}; // size = 0x1C
+
+union __anon_0x76828 {
+    /* 0x0 */ u8 u8[4096];
+    /* 0x0 */ u16 u16[2048];
+    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ u64 u64[512];
+};
+
+struct __anon_0x768C5 {
+    /* 0x0 */ union __anon_0x76828 data;
+}; // size = 0x1000
+
+enum _GXTexFmt {
+    GX_TF_I4 = 0,
+    GX_TF_I8 = 1,
+    GX_TF_IA4 = 2,
+    GX_TF_IA8 = 3,
+    GX_TF_RGB565 = 4,
+    GX_TF_RGB5A3 = 5,
+    GX_TF_RGBA8 = 6,
+    GX_TF_CMPR = 14,
+    GX_CTF_R4 = 32,
+    GX_CTF_RA4 = 34,
+    GX_CTF_RA8 = 35,
+    GX_CTF_YUVA8 = 38,
+    GX_CTF_A8 = 39,
+    GX_CTF_R8 = 40,
+    GX_CTF_G8 = 41,
+    GX_CTF_B8 = 42,
+    GX_CTF_RG8 = 43,
+    GX_CTF_GB8 = 44,
+    GX_TF_Z8 = 17,
+    GX_TF_Z16 = 19,
+    GX_TF_Z24X8 = 22,
+    GX_CTF_Z4 = 48,
+    GX_CTF_Z8M = 57,
+    GX_CTF_Z8L = 58,
+    GX_CTF_Z16L = 60,
+    GX_TF_A8 = 39,
+};
+
+struct _GXTlutObj {
+    /* 0x0 */ u32 dummy[3];
+}; // size = 0xC
+
+struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+}; // size = 0x20
+
+enum _GXTexWrapMode {
+    GX_CLAMP = 0,
+    GX_REPEAT = 1,
+    GX_MIRROR = 2,
+    GX_MAX_TEXWRAPMODE = 3,
+};
+
+struct _FRAME_TEXTURE {
+    /* 0x00 */ s32 nMode;
+    /* 0x04 */ s32 iPackPixel;
+    /* 0x08 */ s32 iPackColor;
+    /* 0x0C */ s32 nFrameLast;
+    /* 0x10 */ s16 nSizeX;
+    /* 0x12 */ s16 nSizeY;
+    /* 0x14 */ u32 nAddress;
+    /* 0x18 */ u32 nCodePixel;
+    /* 0x1C */ u32 nCodeColor;
+    /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
+    /* 0x24 */ u32 nData0;
+    /* 0x28 */ u32 nData1;
+    /* 0x2C */ u32 nData2;
+    /* 0x30 */ u32 nData3;
+    /* 0x34 */ enum _GXTexFmt eFormat;
+    /* 0x38 */ struct _GXTlutObj objectTLUT;
+    /* 0x44 */ struct _GXTexObj objectTexture;
+    /* 0x64 */ enum _GXTexWrapMode eWrapS;
+    /* 0x68 */ enum _GXTexWrapMode eWrapT;
+}; // size = 0x6C
+
+struct __anon_0x76F93 {
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nTMEM;
+    /* 0x08 */ s32 iTLUT;
+    /* 0x0C */ s32 nSizeX;
+    /* 0x10 */ s32 nFormat;
+    /* 0x14 */ s16 nMaskS;
+    /* 0x16 */ s16 nMaskT;
+    /* 0x18 */ s16 nModeS;
+    /* 0x1A */ s16 nModeT;
+    /* 0x1C */ s16 nShiftS;
+    /* 0x1E */ s16 nShiftT;
+    /* 0x20 */ s16 nX0;
+    /* 0x22 */ s16 nY0;
+    /* 0x24 */ s16 nX1;
+    /* 0x26 */ s16 nY1;
+    /* 0x28 */ u32 nCodePixel;
+}; // size = 0x2C
+
+enum __anon_0x77275 {
+    FMP_NONE = -1,
+    FMP_PERSPECTIVE = 0,
+    FMP_ORTHOGRAPHIC = 1,
+};
+
+struct __anon_0x772F8 {
+    /* 0x00 */ s32 nCount;
+    /* 0x04 */ float rScale;
+    /* 0x08 */ float rAspect;
+    /* 0x0C */ float rFieldOfViewY;
+    /* 0x10 */ float rClipNear;
+    /* 0x14 */ float rClipFar;
+    /* 0x18 */ u32 nAddressFloat;
+    /* 0x1C */ u32 nAddressFixed;
+    /* 0x20 */ enum __anon_0x77275 eProjection;
+}; // size = 0x24
+
+struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+}; // size = 0x4
+
+struct __anon_0x77548 {
+    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00020 */ u16 nNumCIMGAddresses;
+    /* 0x00024 */ s32 bBlurOn;
+    /* 0x00028 */ s32 bHackPause;
+    /* 0x0002C */ s32 nHackCount;
+    /* 0x00030 */ s32 nFrameCounter;
+    /* 0x00034 */ s32 bPauseThisFrame;
+    /* 0x00038 */ s32 bCameFromBomberNotes;
+    /* 0x0003C */ s32 bInBomberNotes;
+    /* 0x00040 */ s32 bShrinking;
+    /* 0x00044 */ s32 bSnapShot;
+    /* 0x00048 */ s32 bUsingLens;
+    /* 0x0004C */ u8 cBlurAlpha;
+    /* 0x00050 */ s32 bBlurredThisFrame;
+    /* 0x00054 */ s32 nFrameCIMGCalls;
+    /* 0x00058 */ s32 bModifyZBuffer;
+    /* 0x0005C */ s32 bOverrideDepth;
+    /* 0x00060 */ s32 nZBufferSets;
+    /* 0x00064 */ s32 nLastFrameZSets;
+    /* 0x00068 */ s32 bPauseBGDrawn;
+    /* 0x0006C */ s32 bFrameOn;
+    /* 0x00070 */ s32 bBackBufferDrawn;
+    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00078 */ u64* pnGBI;
+    /* 0x0007C */ u32 nFlag;
+    /* 0x00080 */ float rScaleX;
+    /* 0x00084 */ float rScaleY;
+    /* 0x00088 */ u32 nCountFrames;
+    /* 0x0008C */ u32 nMode;
+    /* 0x00090 */ u32 aMode[10];
+    /* 0x000B8 */ struct __anon_0x76165 viewport;
+    /* 0x000C8 */ struct __anon_0x761FF aBuffer[4];
+    /* 0x00118 */ u32 nOffsetDepth0;
+    /* 0x0011C */ u32 nOffsetDepth1;
+    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00124 */ float rDepth;
+    /* 0x00128 */ float rDelta;
+    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
+    /* 0x0013C */ s32 nCountLight;
+    /* 0x00140 */ struct __anon_0x763B0 aLight[8];
+    /* 0x00320 */ struct __anon_0x765E0 lookAt;
+    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00358 */ struct __anon_0x766C9 aVertex[80];
+    /* 0x00C18 */ struct __anon_0x768C5 TMEM;
+    /* 0x01C18 */ void* aPixelData;
+    /* 0x01C1C */ void* aColorData;
+    /* 0x01C20 */ s32 nBlocksPixel;
+    /* 0x01C24 */ s32 nBlocksMaxPixel;
+    /* 0x01C28 */ s32 nBlocksColor;
+    /* 0x01C2C */ s32 nBlocksMaxColor;
+    /* 0x01C30 */ s32 nBlocksTexture;
+    /* 0x01C34 */ s32 nBlocksMaxTexture;
+    /* 0x01C38 */ u32 anPackPixel[48];
+    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x021F8 */ u32 nAddressLoad;
+    /* 0x021FC */ u32 nCodePixel;
+    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
+    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
+    /* 0x3C340 */ s32 iTileLoad;
+    /* 0x3C344 */ u32 n2dLoadTexType;
+    /* 0x3C348 */ s32 nLastX0;
+    /* 0x3C34C */ s32 nLastY0;
+    /* 0x3C350 */ s32 nLastX1;
+    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C358 */ struct __anon_0x76F93 aTile[8];
+    /* 0x3C4B8 */ s32 anSizeX[2];
+    /* 0x3C4C0 */ s32 anSizeY[2];
+    /* 0x3C4C8 */ s32 iHintMatrix;
+    /* 0x3C4CC */ s32 iMatrixModel;
+    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4D4 */ float matrixView[4][4];
+    /* 0x3C514 */ s32 iHintLast;
+    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C51C */ enum __anon_0x77275 eTypeProjection;
+    /* 0x3C520 */ float aMatrixModel[10][4][4];
+    /* 0x3C7A0 */ float matrixProjection[4][4];
+    /* 0x3C7E0 */ float matrixProjectionExtra[4][4];
+    /* 0x3C820 */ struct __anon_0x772F8 aMatrixHint[64];
+    /* 0x3D120 */ u8 primLODmin;
+    /* 0x3D121 */ u8 primLODfrac;
+    /* 0x3D122 */ u8 lastTile;
+    /* 0x3D123 */ u8 iTileDrawn;
+    /* 0x3D124 */ struct _GXColor aColor[5];
+    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D13C */ u16* nTempBuffer;
+    /* 0x3D140 */ u16* nCopyBuffer;
+    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D148 */ u16* nCameraBuffer;
+}; // size = 0x3D150
+
+// Range: 0x8008EB9C -> 0x8008EE10
+s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r31
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    void* pRAM; // r1+0x14
+    struct __anon_0x77548* pFrame; // r30
+    struct __anon_0x761FF* pBuffer; // r29
+}
+
+// Range: 0x8008EE10 -> 0x8008EE18
+s32 videoPut16() {}
+
+// Range: 0x8008EE18 -> 0x8008EE20
+s32 videoPut8() {}

--- a/debug/Fire/video.c
+++ b/debug/Fire/video.c
@@ -7,17 +7,17 @@
 
 #include "types.h"
 
-struct _XL_OBJECTTYPE {
+typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
     /* 0x4 */ s32 nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
     /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
-}; // size = 0x10
+} __anon_0x75A44; // size = 0x10
 
 // size = 0x10, address = 0x800EE870
 struct _XL_OBJECTTYPE gClassVideo;
 
-struct __anon_0x75B37 {
+typedef struct __anon_0x75B37 {
     /* 0x00 */ s32 nScan;
     /* 0x04 */ s32 bBlack;
     /* 0x08 */ s32 nBurst;
@@ -34,7 +34,7 @@ struct __anon_0x75B37 {
     /* 0x34 */ s32 nSyncH;
     /* 0x38 */ s32 nSyncV;
     /* 0x3C */ s32 nSyncLeap;
-}; // size = 0x40
+} __anon_0x75B37; // size = 0x40
 
 // Range: 0x8008E8A0 -> 0x8008E9F4
 s32 videoEvent(struct __anon_0x75B37* pVideo, s32 nEvent, void* pArgument) {
@@ -86,28 +86,28 @@ s32 videoGet8() {}
 // Range: 0x8008EB94 -> 0x8008EB9C
 s32 videoPut64() {}
 
-struct __anon_0x76165 {
+typedef struct __anon_0x76165 {
     /* 0x0 */ float rX;
     /* 0x4 */ float rY;
     /* 0x8 */ float rSizeX;
     /* 0xC */ float rSizeY;
-}; // size = 0x10
+} __anon_0x76165; // size = 0x10
 
-struct __anon_0x761FF {
+typedef struct __anon_0x761FF {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nWidth;
     /* 0x08 */ s32 nFormat;
     /* 0x0C */ void* pData;
     /* 0x10 */ s32 nAddress;
-}; // size = 0x14
+} __anon_0x761FF; // size = 0x14
 
-struct __anon_0x76340 {
+typedef struct __anon_0x76340 {
     /* 0x0 */ float x;
     /* 0x4 */ float y;
     /* 0x8 */ float z;
-}; // size = 0xC
+} __anon_0x76340; // size = 0xC
 
-struct __anon_0x763B0 {
+typedef struct __anon_0x763B0 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x76340 rVecOrigTowards;
     /* 0x10 */ float rColorR;
@@ -122,36 +122,36 @@ struct __anon_0x763B0 {
     /* 0x34 */ s16 coordX;
     /* 0x36 */ s16 coordY;
     /* 0x38 */ s16 coordZ;
-}; // size = 0x3C
+} __anon_0x763B0; // size = 0x3C
 
-struct __anon_0x765E0 {
+typedef struct __anon_0x765E0 {
     /* 0x00 */ s32 bTransformed;
     /* 0x04 */ struct __anon_0x76340 rS;
     /* 0x10 */ struct __anon_0x76340 rT;
     /* 0x1C */ struct __anon_0x76340 rSRaw;
     /* 0x28 */ struct __anon_0x76340 rTRaw;
-}; // size = 0x34
+} __anon_0x765E0; // size = 0x34
 
-struct __anon_0x766C9 {
+typedef struct __anon_0x766C9 {
     /* 0x00 */ float rSum;
     /* 0x04 */ float rS;
     /* 0x08 */ float rT;
     /* 0x0C */ struct __anon_0x76340 vec;
     /* 0x18 */ u8 anColor[4];
-}; // size = 0x1C
+} __anon_0x766C9; // size = 0x1C
 
-union __anon_0x76828 {
+typedef union __anon_0x76828 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
     /* 0x0 */ u32 u32[1024];
     /* 0x0 */ u64 u64[512];
-};
+} __anon_0x76828;
 
-struct __anon_0x768C5 {
+typedef struct __anon_0x768C5 {
     /* 0x0 */ union __anon_0x76828 data;
-}; // size = 0x1000
+} __anon_0x768C5; // size = 0x1000
 
-enum _GXTexFmt {
+typedef enum _GXTexFmt {
     GX_TF_I4 = 0,
     GX_TF_I8 = 1,
     GX_TF_IA4 = 2,
@@ -178,24 +178,24 @@ enum _GXTexFmt {
     GX_CTF_Z8L = 58,
     GX_CTF_Z16L = 60,
     GX_TF_A8 = 39,
-};
+} __anon_0x7695E;
 
-struct _GXTlutObj {
+typedef struct _GXTlutObj {
     /* 0x0 */ u32 dummy[3];
-}; // size = 0xC
+} __anon_0x76B20; // size = 0xC
 
-struct _GXTexObj {
+typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
-}; // size = 0x20
+} __anon_0x76B87; // size = 0x20
 
-enum _GXTexWrapMode {
+typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
     GX_REPEAT = 1,
     GX_MIRROR = 2,
     GX_MAX_TEXWRAPMODE = 3,
-};
+} __anon_0x76BCD;
 
-struct _FRAME_TEXTURE {
+typedef struct _FRAME_TEXTURE {
     /* 0x00 */ s32 nMode;
     /* 0x04 */ s32 iPackPixel;
     /* 0x08 */ s32 iPackColor;
@@ -215,9 +215,9 @@ struct _FRAME_TEXTURE {
     /* 0x44 */ struct _GXTexObj objectTexture;
     /* 0x64 */ enum _GXTexWrapMode eWrapS;
     /* 0x68 */ enum _GXTexWrapMode eWrapT;
-}; // size = 0x6C
+} __anon_0x76C36; // size = 0x6C
 
-struct __anon_0x76F93 {
+typedef struct __anon_0x76F93 {
     /* 0x00 */ s32 nSize;
     /* 0x04 */ s32 nTMEM;
     /* 0x08 */ s32 iTLUT;
@@ -234,15 +234,15 @@ struct __anon_0x76F93 {
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
     /* 0x28 */ u32 nCodePixel;
-}; // size = 0x2C
+} __anon_0x76F93; // size = 0x2C
 
-enum __anon_0x77275 {
+typedef enum __anon_0x77275 {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
-};
+} __anon_0x77275;
 
-struct __anon_0x772F8 {
+typedef struct __anon_0x772F8 {
     /* 0x00 */ s32 nCount;
     /* 0x04 */ float rScale;
     /* 0x08 */ float rAspect;
@@ -252,16 +252,16 @@ struct __anon_0x772F8 {
     /* 0x18 */ u32 nAddressFloat;
     /* 0x1C */ u32 nAddressFixed;
     /* 0x20 */ enum __anon_0x77275 eProjection;
-}; // size = 0x24
+} __anon_0x772F8; // size = 0x24
 
-struct _GXColor {
+typedef struct _GXColor {
     /* 0x0 */ u8 r;
     /* 0x1 */ u8 g;
     /* 0x2 */ u8 b;
     /* 0x3 */ u8 a;
-}; // size = 0x4
+} __anon_0x7748D; // size = 0x4
 
-struct __anon_0x77548 {
+typedef struct __anon_0x77548 {
     /* 0x00000 */ u32 anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
     /* 0x00024 */ s32 bBlurOn;
@@ -352,7 +352,7 @@ struct __anon_0x77548 {
     /* 0x3D140 */ u16* nCopyBuffer;
     /* 0x3D144 */ u32* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
-}; // size = 0x3D150
+} __anon_0x77548; // size = 0x3D150
 
 // Range: 0x8008EB9C -> 0x8008EE10
 s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {


### PR DESCRIPTION
Major changes:
* Add local variable register/stack locations
* Be explicit about which entries were "erased" (reconstructed via forensics, useful for functions that were inlined away)
* Remove erased global variables as they don't seem to be useful
* Use `s32` and friends (except `char`)
* Put offset comments in front of struct members and size comment to end of struct (matches OOT repo style)
* clang-format

A new file `debug/Fire/_buildtev.c` also appeared, I'm not sure why it wasn't in the original dump.

This was done using a modified version of dtk's dwarf dump tool (https://github.com/cadmic/decomp-toolkit/tree/oot-gc-debug-info) and then running clang-format on the output.