### PR TITLE
Clean up style: integer types and struct/enum/union comments

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -3,20 +3,20 @@
 
 #include "types.h"
 
-typedef int (*Put8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
-typedef int (*Put16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
-typedef int (*Put32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
-typedef int (*Put64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
+typedef s32 (*Put8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
+typedef s32 (*Put16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
+typedef s32 (*Put32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
+typedef s32 (*Put64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
 
-typedef int (*Get8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
-typedef int (*Get16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
-typedef int (*Get32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
-typedef int (*Get64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
+typedef s32 (*Get8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
+typedef s32 (*Get16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
+typedef s32 (*Get32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
+typedef s32 (*Get64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
 
 typedef struct __anon_0x3EB4F {
-    /* 0x00 */ int nType;
+    /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ int nOffsetAddress;
+    /* 0x08 */ s32 nOffsetAddress;
     /* 0x0C */ Get8Func pfGet8;
     /* 0x10 */ Get16Func pfGet16;
     /* 0x14 */ Get32Func pfGet32;
@@ -29,10 +29,10 @@ typedef struct __anon_0x3EB4F {
     /* 0x30 */ u32 nAddressPhysical1;
 } __anon_0x3EB4F; // size = 0x34
 
-int cpuSetDevicePut(__anon_0x3EB4F* pDevice, void* pArgument, Put8Func pfPut8, Put16Func pfPut16, Put32Func pfPut32,
+s32 cpuSetDevicePut(__anon_0x3EB4F* pDevice, void* pArgument, Put8Func pfPut8, Put16Func pfPut16, Put32Func pfPut32,
                     Put64Func pfPut64);
 
-int cpuSetDeviceGet(__anon_0x3EB4F* pDevice, void* pArgument, Get8Func pfGet8, Get16Func pfGet16, Get32Func pfGet32,
+s32 cpuSetDeviceGet(__anon_0x3EB4F* pDevice, void* pArgument, Get8Func pfGet8, Get16Func pfGet16, Get32Func pfGet32,
                     Get64Func pfGet64);
 
 #endif

--- a/include/rom.h
+++ b/include/rom.h
@@ -8,44 +8,46 @@ typedef s32 ProgressCallbackFunc(f32 progressPercent);
 
 // __anon_0x4CF87
 typedef enum RomModeLoad {
-    /* -1 */ RLM_NONE = -1,
-    /*  0 */ RLM_PART,
-    /*  1 */ RLM_FULL,
-    /*  2 */ RLM_COUNT
+    RLM_NONE = -1,
+    RLM_PART = 0,
+    RLM_FULL = 1,
+    RLM_COUNT = 2,
 } RomModeLoad;
 
 // __anon_0x5219D
 typedef enum RomCacheType {
-    /* -1 */ RCT_NONE = -1,
-    /*  0 */ RCT_RAM,
-    /*  1 */ RCT_ARAM
+    RCT_NONE = -1,
+    RCT_RAM = 0,
+    RCT_ARAM = 1,
 } RomCacheType;
 
 // __anon_0x4CFE6
 typedef struct RomBlock {
-    /* 0x00 */ int iCache; // Stores cache index `i` if the block is in RAM, or `-(i + 1)` if the block is in ARAM
+    /* 0x00 */ s32 iCache; // Stores cache index `i` if the block is in RAM, or `-(i + 1)` if the block is in ARAM
     /* 0x04 */ u32 nSize;
     /* 0x08 */ u32 nTickUsed;
     /* 0x0C */ s8 keep;
 } RomBlock; // size = 0x10
 
+// __anon_0x4D0FA
 typedef struct RomCopyState {
-    /* 0x00 */ int bWait;
+    /* 0x00 */ s32 bWait;
     /* 0x04 */ UnknownCallbackFunc* pCallback;
     /* 0x08 */ u8* pTarget;
     /* 0x0C */ u32 nSize;
     /* 0x10 */ u32 nOffset;
 } RomCopyState; // size = 0x14
 
+// __anon_0x4D1DA
 typedef struct RomLoadState {
-    /* 0x00 */ int bWait;
-    /* 0x04 */ int bDone;
-    /* 0x08 */ int nResult;
+    /* 0x00 */ s32 bWait;
+    /* 0x04 */ s32 bDone;
+    /* 0x08 */ s32 nResult;
     /* 0x0C */ u8* anData;
     /* 0x10 */ UnknownCallbackFunc* pCallback;
-    /* 0x14 */ int iCache;
-    /* 0x18 */ int iBlock;
-    /* 0x1C */ int nOffset;
+    /* 0x14 */ s32 iCache;
+    /* 0x18 */ s32 iBlock;
+    /* 0x1C */ s32 nOffset;
     /* 0x20 */ u32 nOffset0;
     /* 0x24 */ u32 nOffset1;
     /* 0x28 */ u32 nSize;
@@ -53,7 +55,7 @@ typedef struct RomLoadState {
 } RomLoadState; // size = 0x30
 
 typedef struct UnknownDeviceStruct {
-    /* 0x00 */ int unk;
+    /* 0x00 */ s32 unk;
     /* 0x04 */ char unk2[0x20];
     /* 0x24 */ __anon_0x3EB4F* pDevice;
 } UnknownDeviceStruct;
@@ -62,8 +64,8 @@ typedef struct UnknownDeviceStruct {
 typedef struct Rom {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
-    /* 0x00008 */ int bFlip;
-    /* 0x0000C */ int bLoad;
+    /* 0x00008 */ s32 bFlip;
+    /* 0x0000C */ s32 bLoad;
     /* 0x00010 */ char acNameFile[513];
     /* 0x00214 */ u32 nSize;
     /* 0x00218 */ RomModeLoad eModeLoad;
@@ -74,27 +76,28 @@ typedef struct Rom {
     /* 0x10624 */ u8 anBlockCachedARAM[2046]; // Bitfield, one bit per block
     /* 0x10E24 */ RomCopyState copy;
     /* 0x10E38 */ RomLoadState load;
-    /* 0x10E68 */ int nCountBlockRAM;
-    /* 0x10E6C */ int nSizeCacheRAM;
+    /* 0x10E68 */ s32 nCountBlockRAM;
+    /* 0x10E6C */ s32 nSizeCacheRAM;
     /* 0x10E70 */ u8 acHeader[64];
     /* 0x10EB0 */ u32* anOffsetBlock;
-    /* 0x10EB4 */ int nCountOffsetBlocks;
+    /* 0x10EB4 */ s32 nCountOffsetBlocks;
     /* 0x10EB8 */ DVDFileInfo fileInfo;
-    /* 0x10EF4 */ int offsetToRom;
+    /* 0x10EF4 */ s32 offsetToRom;
 } Rom; // size = 0x10EF8
 
-int romEvent(Rom* pROM, s32 nEvent, void* pArgument);
-int romGetImage(Rom* pROM, char* acNameFile);
-int romSetImage(Rom* pROM, char* szNameFile);
-int romSetCacheSize(Rom* pROM, int nSize);
-int romUpdate(Rom* pROM);
+s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument);
+s32 romGetImage(Rom* pROM, char* acNameFile);
+s32 romSetImage(Rom* pROM, char* szNameFile);
+s32 romSetCacheSize(Rom* pROM, s32 nSize);
+s32 romUpdate(Rom* pROM);
 
-//! NOTE: The debug informations indicates that ``nSize`` is an unsigned int
-int romCopyImmediate(Rom* pROM, void* pTarget, int nOffsetROM, int nSize);
-int romCopy(Rom* pROM, void* pTarget, int nOffset, int nSize, UnknownCallbackFunc* pCallback);
+//! NOTE: The debug informations indicates that `nSize` is unsigned, but the
+//! generated code seems to treat it as signed.
+s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize);
+s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback);
 
-int romTestCode(Rom* pROM, char* acCode);
-int romGetCode(Rom* pROM, char* acCode);
-int romGetPC(Rom* pROM, u64* pnPC);
+s32 romTestCode(Rom* pROM, char* acCode);
+s32 romGetCode(Rom* pROM, char* acCode);
+s32 romGetPC(Rom* pROM, u64* pnPC);
 
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -3,61 +3,66 @@
 
 #include "types.h"
 
+// __anon_0x394CD
 typedef enum SystemMode {
-    /* -1 */ SM_NONE = -1,
-    /*  0 */ SM_RUNNING,
-    /*  1 */ SM_STOPPED
+    SM_NONE = -1,
+    SM_RUNNING = 0,
+    SM_STOPPED = 1,
 } SystemMode;
 
+// __anon_0x370F1
 typedef enum SystemRomType {
-    /* -1 */ SRT_NONE = -1,
-    /*  0 */ SRT_MARIO,
-    /*  1 */ SRT_WAVERACE,
-    /*  2 */ SRT_MARIOKART,
-    /*  3 */ SRT_STARFOX,
-    /*  4 */ SRT_ZELDA1,
-    /*  5 */ SRT_ZELDA2,
-    /*  6 */ SRT_1080,
-    /*  7 */ SRT_PANEL,
-    /*  8 */ SRT_MARIOPARTY1,
-    /*  9 */ SRT_MARIOPARTY2,
-    /* 10 */ SRT_MARIOPARTY3,
-    /* 11 */ SRT_DRMARIO,
-    /* 12 */ SRT_UNKNOWN
+    SRT_NONE = -1,
+    SRT_MARIO = 0,
+    SRT_WAVERACE = 1,
+    SRT_MARIOKART = 2,
+    SRT_STARFOX = 3,
+    SRT_ZELDA1 = 4,
+    SRT_ZELDA2 = 5,
+    SRT_1080 = 6,
+    SRT_PANEL = 7,
+    SRT_MARIOPARTY1 = 8,
+    SRT_MARIOPARTY2 = 9,
+    SRT_MARIOPARTY3 = 10,
+    SRT_DRMARIO = 11,
+    SRT_UNKNOWN = 12,
 } SystemRomType;
 
+// __anon_0x370F1
 typedef enum SystemObjectType {
-    /* -1 */ SOT_NONE = -1,
-    /*  0 */ SOT_CPU,
-    /*  1 */ SOT_PIF,
-    /*  2 */ SOT_RAM,
-    /*  3 */ SOT_ROM,
-    /*  4 */ SOT_RSP,
-    /*  5 */ SOT_RDP,
-    /*  6 */ SOT_MIPS,
-    /*  7 */ SOT_DISK,
-    /*  8 */ SOT_FLASH,
-    /*  9 */ SOT_SRAM,
-    /* 10 */ SOT_AUDIO,
-    /* 11 */ SOT_VIDEO,
-    /* 12 */ SOT_SERIAL,
-    /* 13 */ SOT_LIBRARY,
-    /* 14 */ SOT_PERIPHERAL,
-    /* 15 */ SOT_RDB,
-    /* 16 */ SOT_COUNT
+    SOT_NONE = -1,
+    SOT_CPU = 0,
+    SOT_PIF = 1,
+    SOT_RAM = 2,
+    SOT_ROM = 3,
+    SOT_RSP = 4,
+    SOT_RDP = 5,
+    SOT_MIPS = 6,
+    SOT_DISK = 7,
+    SOT_FLASH = 8,
+    SOT_SRAM = 9,
+    SOT_AUDIO = 10,
+    SOT_VIDEO = 11,
+    SOT_SERIAL = 12,
+    SOT_LIBRARY = 13,
+    SOT_PERIPHERAL = 14,
+    SOT_RDB = 15,
+    SOT_COUNT = 16,
 } SystemObjectType;
 
+// __anon_0x37040
 typedef struct RomCopy {
-    /* 0x00 */ int nSize;
-    /* 0x04 */ int nOffsetRAM;
-    /* 0x08 */ int nOffsetROM;
-    /* 0x0C */ int (*pCallback)();
+    /* 0x00 */ s32 nSize;
+    /* 0x04 */ s32 nOffsetRAM;
+    /* 0x08 */ s32 nOffsetROM;
+    /* 0x0C */ s32 (*pCallback)();
 } RomCopy; // size = 0x10
 
+// __anon_0x37240
 typedef struct System {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ int bException;
+    /* 0x08 */ s32 bException;
     /* 0x0C */ SystemMode eMode;
     /* 0x10 */ RomCopy romCopy;
     /* 0x20 */ SystemRomType eTypeROM;
@@ -65,16 +70,17 @@ typedef struct System {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ SystemObjectType storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ int bJapaneseVersion;
+    /* 0x84 */ s32 bJapaneseVersion;
 } System; // size = 0x88
 
+// __anon_0x3459E
 typedef struct SystemRomConfig {
     /* 0x0000 */ char rom[36];
-    /* 0x0024 */ int controllerConfiguration[4][20];
-    /* 0x0164 */ int rumbleConfiguration;
+    /* 0x0024 */ s32 controllerConfiguration[4][20];
+    /* 0x0164 */ s32 rumbleConfiguration;
     /* 0x0168 */ SystemObjectType storageDevice;
-    /* 0x016C */ int normalControllerConfig;
-    /* 0x0170 */ int currentControllerConfig;
+    /* 0x016C */ s32 normalControllerConfig;
+    /* 0x0170 */ s32 currentControllerConfig;
 } SystemRomConfig; // size = 0x174
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -14,6 +14,7 @@ typedef unsigned char u8;
 typedef float f32;
 typedef double f64;
 
-typedef unsigned int size_t;
+typedef unsigned long size_t;
+typedef unsigned long uintptr_t;
 
 #endif

--- a/include/xlCoreGCN.h
+++ b/include/xlCoreGCN.h
@@ -1,10 +1,12 @@
 #ifndef _XL_CORE_GCN_H
 #define _XL_CORE_GCN_H
 
+#include "types.h"
+
 void xlCoreBeforeRender(void);
-int xlCoreHiResolution(void);
-int xlCoreGetArgument(int iArgument, char** pszArgument);
-int xlCoreGetArgumentCount(void);
-int xlCoreReset(void);
+s32 xlCoreHiResolution(void);
+s32 xlCoreGetArgument(s32 iArgument, char** pszArgument);
+s32 xlCoreGetArgumentCount(void);
+s32 xlCoreReset(void);
 
 #endif

--- a/include/xlFileGCN.h
+++ b/include/xlFileGCN.h
@@ -1,72 +1,72 @@
 #ifndef _XL_FILE_GCN_H
 #define _XL_FILE_GCN_H
 
-// size: 0x20
+#include "types.h"
+
+//! TODO: Move DVDDiskID etc. to Dolphin SDK headers
+
 typedef struct DVDDiskID {
-    char gameName[4]; // 0x0
-    char company[2]; // 0x4
-    unsigned char diskNumber; // 0x6
-    unsigned char gameVersion; // 0x7
-    unsigned char streaming; // 0x8
-    unsigned char streamingBufSize; // 0x9
-    unsigned char padding[22]; // 0xA
-} DVDDiskID;
+    /* 0x0 */ char gameName[4];
+    /* 0x4 */ char company[2];
+    /* 0x6 */ u8 diskNumber;
+    /* 0x7 */ u8 gameVersion;
+    /* 0x8 */ u8 streaming;
+    /* 0x9 */ u8 streamingBufSize;
+    /* 0xA */ u8 padding[22];
+} DVDDiskID; // size = 0x20
 
 typedef struct DVDCommandBlock DVDCommandBlock;
 
-// size: 0x30
 struct DVDCommandBlock {
-    DVDCommandBlock* next; // 0x0
-    DVDCommandBlock* prev; // 0x4
-    unsigned long command; // 0x8
-    long state; // 0xC
-    unsigned long offset; // 0x10
-    unsigned long length; // 0x14
-    void* addr; // 0x18
-    unsigned long currTransferSize; // 0x1C
-    unsigned long transferredSize; // 0x20
-    DVDDiskID* id; // 0x24
-    void (*callback)(long /* unknown0 */, DVDCommandBlock* /* unknown1 */); // 0x28
-    void* userData; // 0x2C
-};
+    /* 0x00 */ DVDCommandBlock* next;
+    /* 0x04 */ DVDCommandBlock* prev;
+    /* 0x08 */ u32 command;
+    /* 0x0C */ long state;
+    /* 0x10 */ u32 offset;
+    /* 0x14 */ u32 length;
+    /* 0x18 */ void* addr;
+    /* 0x1C */ u32 currTransferSize;
+    /* 0x20 */ u32 transferredSize;
+    /* 0x24 */ DVDDiskID* id;
+    /* 0x28 */ void (*callback)(long /* unknown0 */, DVDCommandBlock* /* unknown1 */);
+    /* 0x2C */ void* userData;
+}; // size = 0x30
 
 typedef struct DVDFileInfo DVDFileInfo;
 
-// size: 0x3C
 struct DVDFileInfo {
-    DVDCommandBlock cb; // 0x0
-    unsigned long startAddr; // 0x30
-    unsigned long length; // 0x34
-    void (*callback)(long /* unknown0 */, DVDFileInfo* /* unknown1 */); // 0x38
-};
+    /* 0x00 */ DVDCommandBlock cb;
+    /* 0x30 */ u32 startAddr;
+    /* 0x34 */ u32 length;
+    /* 0x38 */ void (*callback)(long /* unknown0 */, DVDFileInfo* /* unknown1 */);
+}; // size = 0x3C
 
 typedef enum __anon_0x2757 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
-    XLFT_BINARY = 1
+    XLFT_BINARY = 1,
 } __anon_0x2757;
 
-// size: 0x58
 typedef struct tXL_FILE {
-    int iBuffer; // 0x0
-    void* pData; // 0x4
-    void* pBuffer; // 0x8
-    int nAttributes; // 0xC
-    int nSize; // 0x10
-    int nOffset; // 0x14
-    __anon_0x2757 eType; // 0x18
-    DVDFileInfo info; // 0x1C
-} tXL_FILE;
+    /* 0x00 */ s32 iBuffer;
+    /* 0x04 */ void* pData;
+    /* 0x08 */ void* pBuffer;
+    /* 0x0C */ s32 nAttributes;
+    /* 0x10 */ s32 nSize;
+    /* 0x14 */ s32 nOffset;
+    /* 0x18 */ __anon_0x2757 eType;
+    /* 0x1C */ DVDFileInfo info;
+} tXL_FILE; // size = 0x58
 
-int xlFileEvent(tXL_FILE* pFile, int nEvent);
-int xlFileSetPosition(tXL_FILE* pFile, int nOffset);
-int xlFileGet(tXL_FILE* pFile, void* pTarget, int nSizeBytes);
-int xlFileClose(tXL_FILE** ppFile);
-int xlFileOpen(tXL_FILE** ppFile, __anon_0x2757 eType, char* szFileName);
-int xlFileGetSize(int* pnSize, char* szFileName);
-int xlFileSetRead(int (*pfRead)(DVDFileInfo* /* unknown0 */, void* /* unknown1 */, int /* unknown2 */,
-                                int /* unknown3 */,
+s32 xlFileEvent(tXL_FILE* pFile, s32 nEvent);
+s32 xlFileSetPosition(tXL_FILE* pFile, s32 nOffset);
+s32 xlFileGet(tXL_FILE* pFile, void* pTarget, s32 nSizeBytes);
+s32 xlFileClose(tXL_FILE** ppFile);
+s32 xlFileOpen(tXL_FILE** ppFile, __anon_0x2757 eType, char* szFileName);
+s32 xlFileGetSize(s32* pnSize, char* szFileName);
+s32 xlFileSetRead(s32 (*pfRead)(DVDFileInfo* /* unknown0 */, void* /* unknown1 */, s32 /* unknown2 */,
+                                s32 /* unknown3 */,
                                 void (* /* unknown4 */)(long /* unknown0 */, DVDFileInfo* /* unknown1 */)));
-int xlFileSetOpen(int (*pfOpen)(char* /* unknown0 */, DVDFileInfo* /* unknown1 */));
+s32 xlFileSetOpen(s32 (*pfOpen)(char* /* unknown0 */, DVDFileInfo* /* unknown1 */));
 
 #endif

--- a/include/xlHeap.h
+++ b/include/xlHeap.h
@@ -1,13 +1,13 @@
 #ifndef _XL_HEAP_H
 #define _XL_HEAP_H
 
-int xlHeapReset(void);
-int xlHeapSetup(void* pHeap, int nSizeBytes);
-int xlHeapGetFree(int* pnFreeBytes);
-int xlHeapFill32(void* pHeap, int nByteCount, unsigned int nData);
-int xlHeapCopy(void* pHeapTarget, void* pHeapSource, int nByteCount);
-int xlHeapCompact(void);
-int xlHeapFree(void** ppHeap);
-int xlHeapTake(void** ppHeap, int nByteCount);
+s32 xlHeapReset(void);
+s32 xlHeapSetup(void* pHeap, s32 nSizeBytes);
+s32 xlHeapGetFree(s32* pnFreeBytes);
+s32 xlHeapFill32(void* pHeap, s32 nByteCount, u32 nData);
+s32 xlHeapCopy(void* pHeapTarget, void* pHeapSource, s32 nByteCount);
+s32 xlHeapCompact(void);
+s32 xlHeapFree(void** ppHeap);
+s32 xlHeapTake(void** ppHeap, s32 nByteCount);
 
 #endif

--- a/include/xlList.h
+++ b/include/xlList.h
@@ -6,24 +6,23 @@
 typedef struct tXL_NODE tXL_NODE;
 
 struct tXL_NODE {
-    tXL_NODE* next;
-    u8 data[];
-};
+    /* 0x0 */ tXL_NODE* next;
+    /* 0x4 */ u8 data[];
+}; // size = 0x4
 
-// size: 0x10
 typedef struct tXL_LIST {
-    int nItemSize; // 0x0
-    int nItemCount; // 0x4
-    void* pNodeHead; // 0x8
-    void* pNodeNext; // 0xC
-} tXL_LIST;
+    /* 0x0 */ s32 nItemSize;
+    /* 0x4 */ s32 nItemCount;
+    /* 0x8 */ void* pNodeHead;
+    /* 0xC */ void* pNodeNext;
+} tXL_LIST; // size = 0x10
 
-int xlListReset(void);
-int xlListSetup(void);
-int xlListTestItem(tXL_LIST* pList, void* pItem);
-int xlListFreeItem(tXL_LIST* pList, void** ppItem);
-int xlListMakeItem(tXL_LIST* pList, void** ppItem);
-int xlListFree(tXL_LIST** ppList);
-int xlListMake(tXL_LIST** ppList);
+s32 xlListReset(void);
+s32 xlListSetup(void);
+s32 xlListTestItem(tXL_LIST* pList, void* pItem);
+s32 xlListFreeItem(tXL_LIST* pList, void** ppItem);
+s32 xlListMakeItem(tXL_LIST* pList, void** ppItem);
+s32 xlListFree(tXL_LIST** ppList);
+s32 xlListMake(tXL_LIST** ppList);
 
 #endif

--- a/include/xlObject.h
+++ b/include/xlObject.h
@@ -1,23 +1,24 @@
 #ifndef _XL_OBJECT_H
 #define _XL_OBJECT_H
 
+#include "types.h"
+
 typedef struct _XL_OBJECTTYPE _XL_OBJECTTYPE;
 
-typedef int (*EventFunc)(void* pObject, int nEvent, void* pArgument);
+typedef s32 (*EventFunc)(void* pObject, s32 nEvent, void* pArgument);
 
-// size: 0x10
 struct _XL_OBJECTTYPE {
-    char* szName; // 0x0
-    int nSizeObject; // 0x4
-    _XL_OBJECTTYPE* pClassBase; // 0x8
-    EventFunc pfEvent; // 0xC
-};
+    /* 0x0 */ char* szName;
+    /* 0x4 */ s32 nSizeObject;
+    /* 0x8 */ _XL_OBJECTTYPE* pClassBase;
+    /* 0xC */ EventFunc pfEvent;
+}; // size: 0x10
 
-int xlObjectReset(void);
-int xlObjectSetup(void);
-int xlObjectEvent(void* pObject, int nEvent, void* pArgument);
-int xlObjectTest(void* pObject, _XL_OBJECTTYPE* pType);
-int xlObjectFree(void** ppObject);
-int xlObjectMake(void** ppObject, void* pArgument, _XL_OBJECTTYPE* pType);
+s32 xlObjectReset(void);
+s32 xlObjectSetup(void);
+s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument);
+s32 xlObjectTest(void* pObject, _XL_OBJECTTYPE* pType);
+s32 xlObjectFree(void** ppObject);
+s32 xlObjectMake(void** ppObject, void* pArgument, _XL_OBJECTTYPE* pType);
 
 #endif

--- a/include/xlPostGCN.h
+++ b/include/xlPostGCN.h
@@ -1,8 +1,10 @@
 #ifndef _XL_POST_GCN_H
 #define _XL_POST_GCN_H
 
-int xlPostReset(void);
-int xlPostSetup(void);
-int xlPostText(void);
+#include "types.h"
+
+s32 xlPostReset(void);
+s32 xlPostSetup(void);
+s32 xlPostText(void);
 
 #endif

--- a/src/rom.c
+++ b/src/rom.c
@@ -73,9 +73,9 @@ char D_8013529C[1] = "";
 char D_801352A0[5] = "NZSJ";
 char D_801352A8[5] = "NZSE";
 
-static int gbProgress;
+static s32 gbProgress;
 static void* gpImageBack;
-static int iImage;
+static s32 iImage;
 
 const f32 D_80135FD0 = 1.0;
 const f64 D_80135FD8 = 4503601774854144.0;
@@ -90,31 +90,31 @@ const f32 D_80136000 = 400.0f;
 
 extern System* gpSystem;
 
-static int romPut8(Rom* pROM, u32 nAddress, s8* pData);
-static int romPut16(Rom* pROM, u32 nAddress, s16* pData);
-static int romPut32(Rom* pROM, u32 nAddress, s32* pData);
-static int romPut64(Rom* pROM, u32 nAddress, s64* pData);
+static s32 romPut8(Rom* pROM, u32 nAddress, s8* pData);
+static s32 romPut16(Rom* pROM, u32 nAddress, s16* pData);
+static s32 romPut32(Rom* pROM, u32 nAddress, s32* pData);
+static s32 romPut64(Rom* pROM, u32 nAddress, s64* pData);
 
-static int romGet8(Rom* pROM, u32 nAddress, s8* pData);
-static int romGet16(Rom* pROM, u32 nAddress, s16* pData);
-static int romGet32(Rom* pROM, u32 nAddress, s32* pData);
-static int romGet64(Rom* pROM, u32 nAddress, s64* pData);
+static s32 romGet8(Rom* pROM, u32 nAddress, s8* pData);
+static s32 romGet16(Rom* pROM, u32 nAddress, s16* pData);
+static s32 romGet32(Rom* pROM, u32 nAddress, s32* pData);
+static s32 romGet64(Rom* pROM, u32 nAddress, s64* pData);
 
-static int romPutDebug8(Rom* pROM, u32 nAddress, s8* pData);
-static int romPutDebug16(Rom* pROM, u32 nAddress, s16* pData);
-static int romPutDebug32(Rom* pROM, u32 nAddress, s32* pData);
-static int romPutDebug64(Rom* pROM, u32 nAddress, s64* pData);
+static s32 romPutDebug8(Rom* pROM, u32 nAddress, s8* pData);
+static s32 romPutDebug16(Rom* pROM, u32 nAddress, s16* pData);
+static s32 romPutDebug32(Rom* pROM, u32 nAddress, s32* pData);
+static s32 romPutDebug64(Rom* pROM, u32 nAddress, s64* pData);
 
-static int romGetDebug8(Rom* pROM, u32 nAddress, s8* pData);
-static int romGetDebug16(Rom* pROM, u32 nAddress, s16* pData);
-static int romGetDebug32(Rom* pROM, u32 nAddress, s32* pData);
-static int romGetDebug64(Rom* pROM, u32 nAddress, s64* pData);
+static s32 romGetDebug8(Rom* pROM, u32 nAddress, s8* pData);
+static s32 romGetDebug16(Rom* pROM, u32 nAddress, s16* pData);
+static s32 romGetDebug32(Rom* pROM, u32 nAddress, s32* pData);
+static s32 romGetDebug64(Rom* pROM, u32 nAddress, s64* pData);
 
 s32 __romCopyUpdate_Complete(void);
 s32 __romLoadUpdate_Complete(void);
 void __romLoadBlock_CompleteGCN(long nResult, DVDFileInfo* fileInfo);
-int romMakeFreeCache(Rom* pROM, int* piCache, RomCacheType eType);
-int romFindOldestBlock(Rom* pROM, int* piBlock, RomCacheType eTypeCache, int whichBlock);
+s32 romMakeFreeCache(Rom* pROM, s32* piCache, RomCacheType eType);
+s32 romFindOldestBlock(Rom* pROM, s32* piBlock, RomCacheType eTypeCache, s32 whichBlock);
 
 //! TODO: remove this when the SDK files are present
 u32 ARGetDMAStatus(void);
@@ -210,7 +210,7 @@ s32 romGetImage(Rom* pROM, char* acNameFile) {
 
 inline void romOpen(Rom* pROM, char* szNameFile) {
     s32 var_r30 = 0;
-    int bFlip;
+    s32 bFlip;
 
     if ((pROM->acHeader[0] == 0x37) && (pROM->acHeader[1] == 0x80)) {
         var_r30 = 1;
@@ -337,19 +337,19 @@ inline s32 romCopyLoad(Rom* pROM) {
     return 1;
 }
 
-int romCopyImmediate(Rom* pROM, void* pTarget, int nOffsetROM, int nSize) {
+s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize) {
     void* pSource;
     RomBlock* pBlock;
-    int nOffsetARAM;
-    int nSizeCopy;
-    int nOffsetBlock;
-    int nSizeCopyARAM;
-    int nSizeDMA;
-    int nOffset;
-    int nOffsetTarget;
+    s32 nOffsetARAM;
+    s32 nSizeCopy;
+    s32 nOffsetBlock;
+    s32 nSizeCopyARAM;
+    s32 nSizeDMA;
+    s32 nOffset;
+    s32 nOffsetTarget;
     s32 pad;
-    unsigned char* pBuffer;
-    unsigned char anBuffer[608];
+    u8* pBuffer;
+    u8 anBuffer[608];
 
     if (pROM->nSizeCacheRAM == 0) {
         return 0;
@@ -447,7 +447,7 @@ inline s32 romCopyLoop(Rom* pROM, u8* pTarget, u32 nOffset, u32 nSize, UnknownCa
     return 0;
 }
 
-int romCopy(Rom* pROM, void* pTarget, int nOffset, int nSize, UnknownCallbackFunc* pCallback) {
+s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback) {
     tXL_FILE* pFile;
 
     nOffset &= 0x07FFFFFF;
@@ -511,32 +511,32 @@ int romCopy(Rom* pROM, void* pTarget, int nOffset, int nSize, UnknownCallbackFun
     return 0;
 }
 
-static int romGetDebug64(Rom* pROM, u32 nAddress, s64* pData) {
+static s32 romGetDebug64(Rom* pROM, u32 nAddress, s64* pData) {
     *pData = 0;
     return 1;
 }
 
-static int romGetDebug32(Rom* pROM, u32 nAddress, s32* pData) {
+static s32 romGetDebug32(Rom* pROM, u32 nAddress, s32* pData) {
     *pData = 0;
     return 1;
 }
 
-static int romGetDebug16(Rom* pROM, u32 nAddress, s16* pData) {
+static s32 romGetDebug16(Rom* pROM, u32 nAddress, s16* pData) {
     *pData = 0;
     return 1;
 }
 
-static int romGetDebug8(Rom* pROM, u32 nAddress, s8* pData) {
+static s32 romGetDebug8(Rom* pROM, u32 nAddress, s8* pData) {
     *pData = 0;
     return 1;
 }
 
-static int romPutDebug64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
-static int romPutDebug32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
-static int romPutDebug16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
-static int romPutDebug8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
+static s32 romPutDebug64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
+static s32 romPutDebug32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
+static s32 romPutDebug16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
+static s32 romPutDebug8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
 
-static int romGet64(Rom* pROM, u32 nAddress, s64* pData) {
+static s32 romGet64(Rom* pROM, u32 nAddress, s64* pData) {
     u64 nData;
 
     nAddress = nAddress & 0x07ffffff;
@@ -549,7 +549,7 @@ static int romGet64(Rom* pROM, u32 nAddress, s64* pData) {
     }
 }
 
-static int romGet32(Rom* pROM, u32 nAddress, s32* pData) {
+static s32 romGet32(Rom* pROM, u32 nAddress, s32* pData) {
     u32 nData;
 
     nAddress = nAddress & 0x07ffffff;
@@ -562,7 +562,7 @@ static int romGet32(Rom* pROM, u32 nAddress, s32* pData) {
     }
 }
 
-static int romGet16(Rom* pROM, u32 nAddress, s16* pData) {
+static s32 romGet16(Rom* pROM, u32 nAddress, s16* pData) {
     u16 nData;
 
     nAddress = nAddress & 0x07ffffff;
@@ -575,7 +575,7 @@ static int romGet16(Rom* pROM, u32 nAddress, s16* pData) {
     }
 }
 
-static int romGet8(Rom* pROM, u32 nAddress, s8* pData) {
+static s32 romGet8(Rom* pROM, u32 nAddress, s8* pData) {
     u8 nData;
 
     nAddress = nAddress & 0x07ffffff;
@@ -588,15 +588,15 @@ static int romGet8(Rom* pROM, u32 nAddress, s8* pData) {
     }
 }
 
-static int romPut64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
-static int romPut32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
-static int romPut16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
-static int romPut8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
+static s32 romPut64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
+static s32 romPut32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
+static s32 romPut16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
+static s32 romPut8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
 
-int romTestCode(Rom* pROM, char* acCode) {
-    int iCode;
+s32 romTestCode(Rom* pROM, char* acCode) {
+    s32 iCode;
     char acCodeCurrent[5];
-    int iOffset = 0x3B;
+    s32 iOffset = 0x3B;
 
     for (iCode = 0; iCode < 4; iCode++) {
         acCodeCurrent[iCode] = pROM->acHeader[iOffset + iCode];
@@ -611,7 +611,7 @@ int romTestCode(Rom* pROM, char* acCode) {
     return 1;
 }
 
-int romGetCode(Rom* pROM, char* acCode) {
+s32 romGetCode(Rom* pROM, char* acCode) {
     acCode[0] = pROM->acHeader[0x3B];
     acCode[1] = pROM->acHeader[0x3C];
     acCode[2] = pROM->acHeader[0x3D];
@@ -620,8 +620,8 @@ int romGetCode(Rom* pROM, char* acCode) {
     return 1;
 }
 
-int romGetPC(Rom* pROM, u64* pnPC) {
-    int nOffset;
+s32 romGetPC(Rom* pROM, u64* pnPC) {
+    s32 nOffset;
     u32 nData;
     u32 iData;
     u32 anData[0x400];
@@ -662,7 +662,7 @@ int romGetPC(Rom* pROM, u64* pnPC) {
 #pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadFullOrPart.s")
 #else
 // weird float issue at ``simulatorShowLoad(1, pROM->acNameFile, D_80135FD0);``
-inline int romLoadFullOrPartLoop(Rom* pROM) {
+inline s32 romLoadFullOrPartLoop(Rom* pROM) {
     s32 i;
     s32 iCache;
     u32 temp_r27;
@@ -823,9 +823,9 @@ s32 romLoadRange(Rom* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
 }
 #endif
 
-static int romLoadBlock(Rom* pROM, int iBlock, int iCache, UnknownCallbackFunc pCallback) {
+static s32 romLoadBlock(Rom* pROM, s32 iBlock, s32 iCache, UnknownCallbackFunc pCallback) {
     u8* anData;
-    int nSizeRead;
+    s32 nSizeRead;
     u32 nSize;
     u32 nOffset;
 
@@ -896,12 +896,12 @@ s32 __romLoadBlock_Complete(Rom* pROM) {
     return 1;
 }
 
-static int romSetBlockCache(Rom* pROM, int iBlock, RomCacheType eType) {
+static s32 romSetBlockCache(Rom* pROM, s32 iBlock, RomCacheType eType) {
     RomBlock* pBlock;
-    int iCacheRAM;
-    int iCacheARAM;
-    int nOffsetRAM;
-    int nOffsetARAM;
+    s32 iCacheRAM;
+    s32 iCacheARAM;
+    s32 nOffsetRAM;
+    s32 nOffsetARAM;
 
     pBlock = &pROM->aBlock[iBlock];
     if ((eType == RCT_RAM && pBlock->iCache >= 0) || (eType == RCT_ARAM && pBlock->iCache < 0)) {
@@ -955,9 +955,9 @@ static int romSetBlockCache(Rom* pROM, int iBlock, RomCacheType eType) {
     return 1;
 }
 
-inline void romMarkBlockAsFree(Rom* pROM, int iBlock) {
+inline void romMarkBlockAsFree(Rom* pROM, s32 iBlock) {
     RomBlock* pBlock;
-    int iCache;
+    s32 iCache;
 
     pBlock = &pROM->aBlock[iBlock];
     iCache = pBlock->iCache;
@@ -970,9 +970,9 @@ inline void romMarkBlockAsFree(Rom* pROM, int iBlock) {
     pBlock->nSize = 0;
 }
 
-static int romMakeFreeCache(Rom* pROM, int* piCache, RomCacheType eType) {
-    int iCache;
-    int iBlockOldest;
+static s32 romMakeFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
+    s32 iCache;
+    s32 iBlockOldest;
 
     if (eType == RCT_RAM) {
         if (!romFindFreeCache(pROM, &iCache, RCT_RAM)) {
@@ -1002,13 +1002,13 @@ static int romMakeFreeCache(Rom* pROM, int* piCache, RomCacheType eType) {
     return 1;
 }
 
-static int romFindOldestBlock(Rom* pROM, int* piBlock, RomCacheType eTypeCache, int whichBlock) {
+static s32 romFindOldestBlock(Rom* pROM, s32* piBlock, RomCacheType eTypeCache, s32 whichBlock) {
     RomBlock* pBlock;
-    int iBlock;
-    int iBlockOldest;
-    unsigned int nTick;
-    unsigned int nTickDelta;
-    unsigned int nTickDeltaOldest;
+    s32 iBlock;
+    s32 iBlockOldest;
+    u32 nTick;
+    u32 nTickDelta;
+    u32 nTickDeltaOldest;
 
     nTick = pROM->nTick;
     nTickDeltaOldest = 0;
@@ -1047,8 +1047,8 @@ static int romFindOldestBlock(Rom* pROM, int* piBlock, RomCacheType eTypeCache, 
     return 0;
 }
 
-static int romFindFreeCache(Rom* pROM, int* piCache, RomCacheType eType) {
-    int iBlock;
+static s32 romFindFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
+    s32 iBlock;
 
     if (eType == RCT_RAM) {
         for (iBlock = 0; iBlock < pROM->nCountBlockRAM; iBlock++) {

--- a/src/system.c
+++ b/src/system.c
@@ -1,7 +1,7 @@
 #include "xlObject.h"
 #include "system.h"
 
-int systemEvent(System* pSystem, int nEvent, void* pArgument);
+s32 systemEvent(System* pSystem, s32 nEvent, void* pArgument);
 
 char D_800EB300[] = "SYSTEM (N64)";
 

--- a/src/xlList.c
+++ b/src/xlList.c
@@ -4,9 +4,9 @@
 
 static tXL_LIST gListList;
 
-int xlListReset(void) { return 1; }
+s32 xlListReset(void) { return 1; }
 
-int xlListSetup(void) {
+s32 xlListSetup(void) {
     gListList.nItemCount = 0;
     gListList.nItemSize = sizeof(tXL_LIST);
     gListList.pNodeNext = NULL;
@@ -14,7 +14,7 @@ int xlListSetup(void) {
     return 1;
 }
 
-static inline int xlListTest(tXL_LIST* pList) {
+static inline s32 xlListTest(tXL_LIST* pList) {
     tXL_NODE* pNode;
 
     if (pList == &gListList) {
@@ -32,7 +32,7 @@ static inline int xlListTest(tXL_LIST* pList) {
     return 0;
 }
 
-int xlListTestItem(tXL_LIST* pList, void* pItem) {
+s32 xlListTestItem(tXL_LIST* pList, void* pItem) {
     tXL_NODE* pListNode;
 
     if (!xlListTest(pList) || pItem == NULL) {
@@ -50,7 +50,7 @@ int xlListTestItem(tXL_LIST* pList, void* pItem) {
     return 0;
 }
 
-int xlListFreeItem(tXL_LIST* pList, void** ppItem) {
+s32 xlListFreeItem(tXL_LIST* pList, void** ppItem) {
     tXL_NODE* pNode;
     tXL_NODE* pNodeNext;
 
@@ -76,8 +76,8 @@ int xlListFreeItem(tXL_LIST* pList, void** ppItem) {
     return 0;
 }
 
-int xlListMakeItem(tXL_LIST* pList, void** ppItem) {
-    int nSize;
+s32 xlListMakeItem(tXL_LIST* pList, void** ppItem) {
+    s32 nSize;
     tXL_NODE* pListNode;
     tXL_NODE* pNode;
     tXL_NODE* pNodeNext;
@@ -103,7 +103,7 @@ int xlListMakeItem(tXL_LIST* pList, void** ppItem) {
     return 0;
 }
 
-static inline int xlListWipe(tXL_LIST* pList) {
+static inline s32 xlListWipe(tXL_LIST* pList) {
     tXL_NODE* pNode;
     tXL_NODE* pNodeNext;
 
@@ -122,7 +122,7 @@ static inline int xlListWipe(tXL_LIST* pList) {
     return 1;
 }
 
-int xlListFree(tXL_LIST** ppList) {
+s32 xlListFree(tXL_LIST** ppList) {
     if (!xlListWipe(*ppList)) {
         return 0;
     }


### PR DESCRIPTION
Changes:
* Use `s32` and friends instead of `int` and friends (except for `char` for strings)
* Put struct offset comments in front, and size comment at the end
* Remove enum value comments in favor of explicit values in code
* Put a comment with the original __anon_0xABCD for renamed types, for easy reference from debug info

I defined `size_t` and `uintptr_t` as `long` instead of `int`, just as a guess. I'm totally sure yet when `long` vs `int` matters. Probably we should have bool/true/false too someday.