### PR TITLE
Import CPU types

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -3,17 +3,159 @@
 
 #include "types.h"
 
-typedef s32 (*Put8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
-typedef s32 (*Put16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
-typedef s32 (*Put32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
-typedef s32 (*Put64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
+//! TODO: Move to Dolphin SDK headers
+typedef struct OSContext {
+    /* 0x000 */ u32 gpr[32];
+    /* 0x080 */ u32 cr;
+    /* 0x084 */ u32 lr;
+    /* 0x088 */ u32 ctr;
+    /* 0x08C */ u32 xer;
+    /* 0x090 */ f64 fpr[32];
+    /* 0x190 */ u32 fpscr_pad;
+    /* 0x194 */ u32 fpscr;
+    /* 0x198 */ u32 srr0;
+    /* 0x19C */ u32 srr1;
+    /* 0x1A0 */ u16 mode;
+    /* 0x1A2 */ u16 state;
+    /* 0x1A4 */ u32 gqr[8];
+    /* 0x1C4 */ u32 psf_pad;
+    /* 0x1C8 */ f64 psf[32];
+} OSContext; // size = 0x2C8
 
-typedef s32 (*Get8Func)(struct Rom* pROM, u32 nAddress, s8* pData);
-typedef s32 (*Get16Func)(struct Rom* pROM, u32 nAddress, s16* pData);
-typedef s32 (*Get32Func)(struct Rom* pROM, u32 nAddress, s32* pData);
-typedef s32 (*Get64Func)(struct Rom* pROM, u32 nAddress, s64* pData);
+//! TODO: Move to Dolphin SDK headers
+typedef struct OSAlarm {
+    /* 0x00 */ void (*handler)(struct OSAlarm*, struct OSContext*);
+    /* 0x04 */ u32 tag;
+    /* 0x08 */ s64 fire;
+    /* 0x10 */ struct OSAlarm* prev;
+    /* 0x14 */ struct OSAlarm* next;
+    /* 0x18 */ s64 period;
+    /* 0x20 */ s64 start;
+} OSAlarm; // size = 0x28
 
-typedef struct __anon_0x3EB4F {
+typedef s32 (*Put8Func)(void* pObject, u32 nAddress, s8* pData);
+typedef s32 (*Put16Func)(void* pObject, u32 nAddress, s16* pData);
+typedef s32 (*Put32Func)(void* pObject, u32 nAddress, s32* pData);
+typedef s32 (*Put64Func)(void* pObject, u32 nAddress, s64* pData);
+
+typedef s32 (*Get8Func)(void* pObject, u32 nAddress, s8* pData);
+typedef s32 (*Get16Func)(void* pObject, u32 nAddress, s16* pData);
+typedef s32 (*Get32Func)(void* pObject, u32 nAddress, s32* pData);
+typedef s32 (*Get64Func)(void* pObject, u32 nAddress, s64* pData);
+
+// __anon_0x3DE78
+typedef struct CpuJump {
+    /* 0x0 */ s32 nOffsetHost;
+    /* 0x4 */ s32 nAddressN64;
+} CpuJump; // size = 0x8
+
+// cpu_callerID
+typedef struct CpuCallerID {
+    /* 0x0 */ s32 N64address;
+    /* 0x4 */ s32 GCNaddress;
+} CpuCallerID; // size = 0x8
+
+typedef struct CpuFunction CpuFunction;
+
+// cpu_function
+struct CpuFunction {
+    /* 0x00 */ void* pnBase;
+    /* 0x04 */ void* pfCode;
+    /* 0x08 */ s32 nCountJump;
+    /* 0x0C */ struct CpuJump* aJump;
+    /* 0x10 */ s32 nAddress0;
+    /* 0x14 */ s32 nAddress1;
+    /* 0x18 */ CpuCallerID* block;
+    /* 0x1C */ s32 callerID_total;
+    /* 0x20 */ s32 callerID_flag;
+    /* 0x24 */ u32 nChecksum;
+    /* 0x28 */ s32 timeToLive;
+    /* 0x2C */ s32 memory_size;
+    /* 0x30 */ s32 heapID;
+    /* 0x34 */ s32 heapWhere;
+    /* 0x38 */ s32 treeheapWhere;
+    /* 0x3C */ CpuFunction* prev;
+    /* 0x40 */ CpuFunction* left;
+    /* 0x44 */ CpuFunction* right;
+}; // size = 0x48
+
+// __anon_0x3E22D
+typedef union CpuGpr {
+    struct {
+        /* 0x0 */ s8 _0s8;
+        /* 0x1 */ s8 _1s8;
+        /* 0x2 */ s8 _2s8;
+        /* 0x3 */ s8 _3s8;
+        /* 0x4 */ s8 _4s8;
+        /* 0x5 */ s8 _5s8;
+        /* 0x6 */ s8 _6s8;
+        /* 0x7 */ s8 s8;
+    };
+    struct {
+        /* 0x0 */ s16 _0s16;
+        /* 0x2 */ s16 _1s16;
+        /* 0x4 */ s16 _2s16;
+        /* 0x6 */ s16 s16;
+    };
+    struct {
+        /* 0x0 */ s32 _0s32;
+        /* 0x4 */ s32 s32;
+    };
+    struct {
+        /* 0x0 */ s64 s64;
+    };
+    struct {
+        /* 0x0 */ u8 _0u8;
+        /* 0x1 */ u8 _1u8;
+        /* 0x2 */ u8 _2u8;
+        /* 0x3 */ u8 _3u8;
+        /* 0x4 */ u8 _4u8;
+        /* 0x5 */ u8 _5u8;
+        /* 0x6 */ u8 _6u8;
+        /* 0x7 */ u8 u8;
+    };
+    struct {
+        /* 0x0 */ u16 _0u16;
+        /* 0x2 */ u16 _1u16;
+        /* 0x4 */ u16 _2u16;
+        /* 0x6 */ u16 u16;
+    };
+    struct {
+        /* 0x0 */ u32 _0u32;
+        /* 0x4 */ u32 u32;
+    };
+    struct {
+        /* 0x0 */ u64 u64;
+    };
+} CpuGpr;
+
+// __anon_0x3E641
+typedef union CpuFpr {
+    struct {
+        /* 0x0 */ f32 _0f32;
+        /* 0x4 */ f32 f32;
+    };
+    struct {
+        /* 0x0 */ f64 f64;
+    };
+    struct {
+        /* 0x0 */ s32 _0s32;
+        /* 0x4 */ s32 s32;
+    };
+    struct {
+        /* 0x0 */ s64 s64;
+    };
+    struct {
+        /* 0x0 */ u32 _0u32;
+        /* 0x4 */ u32 u32;
+    };
+    struct {
+        /* 0x0 */ u64 u64;
+    };
+} CpuFpr;
+
+// __anon_0x3EB4F
+typedef struct CpuDevice {
     /* 0x00 */ s32 nType;
     /* 0x04 */ void* pObject;
     /* 0x08 */ s32 nOffsetAddress;
@@ -27,12 +169,106 @@ typedef struct __anon_0x3EB4F {
     /* 0x28 */ Put64Func pfPut64;
     /* 0x2C */ u32 nAddressPhysical0;
     /* 0x30 */ u32 nAddressPhysical1;
-} __anon_0x3EB4F; // size = 0x34
+} CpuDevice; // size = 0x34
 
-s32 cpuSetDevicePut(__anon_0x3EB4F* pDevice, void* pArgument, Put8Func pfPut8, Put16Func pfPut16, Put32Func pfPut32,
+// cpu_treeRoot
+typedef struct CpuTreeRoot {
+    /* 0x00 */ u16 total;
+    /* 0x04 */ s32 total_memory;
+    /* 0x08 */ s32 root_address;
+    /* 0x0C */ s32 start_range;
+    /* 0x10 */ s32 end_range;
+    /* 0x14 */ s32 cache_miss;
+    /* 0x18 */ s32 cache[20];
+    /* 0x68 */ CpuFunction* left;
+    /* 0x6C */ CpuFunction* right;
+    /* 0x70 */ s32 kill_limit;
+    /* 0x74 */ s32 kill_number;
+    /* 0x78 */ s32 side;
+    /* 0x7C */ CpuFunction* restore;
+    /* 0x80 */ s32 restore_side;
+} CpuTreeRoot; // size = 0x84
+
+// _CPU_ADDRESS
+typedef struct CpuAddress {
+    /* 0x0 */ s32 nN64;
+    /* 0x4 */ s32 nHost;
+    /* 0x8 */ CpuFunction* pFunction;
+} CpuAddress; // size = 0xC
+
+typedef struct __anon_0x3F080 {
+    /* 0x0 */ u32 nAddress;
+    /* 0x4 */ u32 nOpcodeOld;
+    /* 0x8 */ u32 nOpcodeNew;
+} __anon_0x3F080; // size = 0xC
+
+// cpu_optimize
+typedef struct CpuOptimize {
+    /* 0x00 */ u32 validCheck;
+    /* 0x04 */ u32 destGPR_check;
+    /* 0x08 */ s32 destGPR;
+    /* 0x0C */ s32 destGPR_mapping;
+    /* 0x10 */ u32 destFPR_check;
+    /* 0x14 */ s32 destFPR;
+    /* 0x18 */ u32 addr_check;
+    /* 0x1C */ s32 addr_last;
+    /* 0x20 */ u32 checkType;
+    /* 0x24 */ u32 checkNext;
+} CpuOptimize; // size = 0x28
+
+typedef struct Cpu Cpu;
+
+// _CPU
+struct Cpu {
+    /* 0x00000 */ s32 nMode;
+    /* 0x00004 */ s32 nTick;
+    /* 0x00008 */ void* pHost;
+    /* 0x00010 */ s64 nLo;
+    /* 0x00018 */ s64 nHi;
+    /* 0x00020 */ s32 nCountAddress;
+    /* 0x00024 */ s32 iDeviceDefault;
+    /* 0x00028 */ u32 nPC;
+    /* 0x0002C */ u32 nWaitPC;
+    /* 0x00030 */ u32 nCallLast;
+    /* 0x00034 */ CpuFunction* pFunctionLast;
+    /* 0x00038 */ s32 nReturnAddrLast;
+    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00040 */ CpuGpr aGPR[32];
+    /* 0x00140 */ CpuFpr aFPR[32];
+    /* 0x00240 */ u64 aTLB[48][5];
+    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x00A40 */ s64 anCP0[32];
+    /* 0x00B40 */ s32 (*pfStep)(Cpu*);
+    /* 0x00B44 */ s32 (*pfJump)(Cpu*);
+    /* 0x00B48 */ s32 (*pfCall)(Cpu*);
+    /* 0x00B4C */ s32 (*pfIdle)(Cpu*);
+    /* 0x00B50 */ s32 (*pfRam)(Cpu*);
+    /* 0x00B54 */ s32 (*pfRamF)(Cpu*);
+    /* 0x00B58 */ u32 nTickLast;
+    /* 0x00B5C */ u32 nRetrace;
+    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B64 */ CpuDevice* apDevice[256];
+    /* 0x00F64 */ u8 aiDevice[65536];
+    /* 0x10F64 */ void* gHeap1;
+    /* 0x10F68 */ void* gHeap2;
+    /* 0x10F6C */ u32 aHeap1Flag[192];
+    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x112A0 */ CpuTreeRoot* gTree;
+    /* 0x112A4 */ CpuAddress aAddressCache[256];
+    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA8 */ __anon_0x3F080 aCodeHack[32];
+    /* 0x12028 */ s64 nTimeRetrace;
+    /* 0x12030 */ OSAlarm alarmRetrace;
+    /* 0x12058 */ u32 nFlagRAM;
+    /* 0x1205C */ u32 nFlagCODE;
+    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12064 */ CpuOptimize nOptimize;
+}; // size = 0x12090
+
+s32 cpuSetDevicePut(Cpu* pCPU, CpuDevice* pDevice, Put8Func pfPut8, Put16Func pfPut16, Put32Func pfPut32,
                     Put64Func pfPut64);
 
-s32 cpuSetDeviceGet(__anon_0x3EB4F* pDevice, void* pArgument, Get8Func pfGet8, Get16Func pfGet16, Get32Func pfGet32,
+s32 cpuSetDeviceGet(Cpu* pCPU, CpuDevice* pDevice, Get8Func pfGet8, Get16Func pfGet16, Get32Func pfGet32,
                     Get64Func pfGet64);
 
 #endif

--- a/include/rom.h
+++ b/include/rom.h
@@ -54,12 +54,6 @@ typedef struct RomLoadState {
     /* 0x2C */ u32 nSizeRead;
 } RomLoadState; // size = 0x30
 
-typedef struct UnknownDeviceStruct {
-    /* 0x00 */ s32 unk;
-    /* 0x04 */ char unk2[0x20];
-    /* 0x24 */ struct __anon_0x3EB4F* pDevice;
-} UnknownDeviceStruct;
-
 // __anon_0x4D873
 typedef struct Rom {
     /* 0x00000 */ void* pHost;

--- a/src/ram.c
+++ b/src/ram.c
@@ -1,5 +1,7 @@
-#include "xlObject.h"
+#include "cpu.h"
 #include "ram.h"
+#include "system.h"
+#include "xlObject.h"
 
 s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument);
 
@@ -40,13 +42,6 @@ _XL_OBJECTTYPE gClassRAM = {
     (EventFunc)ramEvent,
 };
 
-//! TODO: proper fix
-typedef struct UnknownDeviceStruct {
-    /* 0x00 */ int unk;
-    /* 0x04 */ char unk2[0x20];
-    /* 0x24 */ struct __anon_0x3EB4F* pDevice;
-} UnknownDeviceStruct;
-
 s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument) {
     switch (nEvent) {
         case 2:
@@ -55,37 +50,39 @@ s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument) {
             pRAM->pHost = pArgument;
             break;
         case 0x1002:
-            switch (((UnknownDeviceStruct*)pArgument)->unk & 0xFF) {
+            switch (((CpuDevice*)pArgument)->nType & 0xFF) {
                 case 0:
-                    if (!cpuSetDevicePut(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramPut8, ramPut16,
-                                         ramPut32, ramPut64)) {
+                    if (!cpuSetDevicePut(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)ramPut8,
+                                         (Put16Func)ramPut16, (Put32Func)ramPut32, (Put64Func)ramPut64)) {
                         return 0;
                     }
 
-                    if (!cpuSetDeviceGet(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramGet8, ramGet16,
-                                         ramGet32, ramGet64)) {
+                    if (!cpuSetDeviceGet(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)ramGet8,
+                                         (Get16Func)ramGet16, (Get32Func)ramGet32, (Get64Func)ramGet64)) {
                         return 0;
                     }
                     break;
                 case 1:
-                    if (!cpuSetDevicePut(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramPutRI8, ramPutRI16,
-                                         ramPutRI32, ramPutRI64)) {
+                    if (!cpuSetDevicePut(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)ramPutRI8,
+                                         (Put16Func)ramPutRI16, (Put32Func)ramPutRI32, (Put64Func)ramPutRI64)) {
                         return 0;
                     }
 
-                    if (!cpuSetDeviceGet(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramGetRI8, ramGetRI16,
-                                         ramGetRI32, ramGetRI64)) {
+                    if (!cpuSetDeviceGet(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)ramGetRI8,
+                                         (Get16Func)ramGetRI16, (Get32Func)ramGetRI32, (Get64Func)ramGetRI64)) {
                         return 0;
                     }
                     break;
                 case 2:
-                    if (!cpuSetDevicePut(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramPutControl8,
-                                         ramPutControl16, ramPutControl32, ramPutControl64)) {
+                    if (!cpuSetDevicePut(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)ramPutControl8,
+                                         (Put16Func)ramPutControl16, (Put32Func)ramPutControl32,
+                                         (Put64Func)ramPutControl64)) {
                         return 0;
                     }
 
-                    if (!cpuSetDeviceGet(((UnknownDeviceStruct*)pRAM->pHost)->pDevice, pArgument, ramGetControl8,
-                                         ramGetControl16, ramGetControl32, ramGetControl64)) {
+                    if (!cpuSetDeviceGet(((System*)pRAM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)ramGetControl8,
+                                         (Get16Func)ramGetControl16, (Get32Func)ramGetControl32,
+                                         (Get64Func)ramGetControl64)) {
                         return 0;
                     }
                     break;

--- a/src/rom.c
+++ b/src/rom.c
@@ -158,24 +158,26 @@ s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument) {
             }
             break;
         case 0x1002:
-            switch (((UnknownDeviceStruct*)pArgument)->unk) {
+            switch (((CpuDevice*)pArgument)->nType) {
                 case 0:
-                    if (!cpuSetDevicePut(((UnknownDeviceStruct*)pROM->pHost)->pDevice, pArgument, romPut8, romPut16,
-                                         romPut32, romPut64)) {
+                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPut8,
+                                         (Put16Func)romPut16, (Put32Func)romPut32, (Put64Func)romPut64)) {
                         return 0;
                     }
-                    if (!cpuSetDeviceGet(((UnknownDeviceStruct*)pROM->pHost)->pDevice, pArgument, romGet8, romGet16,
-                                         romGet32, romGet64)) {
+                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGet8,
+                                         (Get16Func)romGet16, (Get32Func)romGet32, (Get64Func)romGet64)) {
                         return 0;
                     }
                     break;
                 case 1:
-                    if (!cpuSetDevicePut(((UnknownDeviceStruct*)pROM->pHost)->pDevice, pArgument, romPutDebug8,
-                                         romPutDebug16, romPutDebug32, romPutDebug64)) {
+                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPutDebug8,
+                                         (Put16Func)romPutDebug16, (Put32Func)romPutDebug32,
+                                         (Put64Func)romPutDebug64)) {
                         return 0;
                     }
-                    if (!cpuSetDeviceGet(((UnknownDeviceStruct*)pROM->pHost)->pDevice, pArgument, romGetDebug8,
-                                         romGetDebug16, romGetDebug32, romGetDebug64)) {
+                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGetDebug8,
+                                         (Get16Func)romGetDebug16, (Get32Func)romGetDebug32,
+                                         (Get64Func)romGetDebug64)) {
                         return 0;
                     }
                     break;


### PR DESCRIPTION
I really hate the naming scheme (both `_CPU_ADDRESS` and `cpu_function`) so I gave everything CamelCase names.

In addition, I fixed the signatures of `cpuSetDevicePut` and `cpuSetDeviceGet` and removed `UnknownDeviceStruct`. It seems like for all these "objects" (ROM, RAM, etc.) have a `void* pHost` which is actually a `System`, and when receiving event 0x1002 the object should register its get/set functions with a `CpuDevice` based on the device type.