### PR TITLE
Set -inline deferred and reverse function order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LDSCRIPT := $(BUILD_DIR)/ldscript.lcf
 
 # Outputs
 ELF := $(BUILD_DIR)/$(TARGET).elf
-MAP := $(ELF:.elf=.map)/
+MAP := $(ELF:.elf=.map)
 DOL := $(ELF:.elf=.dol)
 COMPARE_TO := $(ELF:.elf=_S.elf)
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ASFLAGS := -mgekko -I include
 LDFLAGS := -map $(MAP) -fp hard -nodefaults -w off
 
 # Compiler Flags
-CFLAGS := -Cpp_exceptions off -proc gekko -fp hard -enum int -O4,p -sym on -nodefaults -msgstyle gcc $(INCLUDES)
+CFLAGS := -Cpp_exceptions off -proc gekko -fp hard -enum int -O4,p -inline deferred -sym on -nodefaults -msgstyle gcc $(INCLUDES)
 
 # postprocess
 PROCFLAGS := -fprologue-fixup=old_stack

--- a/include/rom.h
+++ b/include/rom.h
@@ -79,19 +79,19 @@ typedef struct Rom {
     /* 0x10EF4 */ s32 offsetToRom;
 } Rom; // size = 0x10EF8
 
-s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument);
-s32 romGetImage(Rom* pROM, char* acNameFile);
-s32 romSetImage(Rom* pROM, char* szNameFile);
-s32 romSetCacheSize(Rom* pROM, s32 nSize);
-s32 romUpdate(Rom* pROM);
+s32 romGetPC(Rom* pROM, u64* pnPC);
+s32 romGetCode(Rom* pROM, char* acCode);
+s32 romTestCode(Rom* pROM, char* acCode);
 
 //! NOTE: The debug informations indicates that `nSize` is unsigned, but the
 //! generated code seems to treat it as signed.
 s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize);
 s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback);
 
-s32 romTestCode(Rom* pROM, char* acCode);
-s32 romGetCode(Rom* pROM, char* acCode);
-s32 romGetPC(Rom* pROM, u64* pnPC);
+s32 romUpdate(Rom* pROM);
+s32 romSetCacheSize(Rom* pROM, s32 nSize);
+s32 romSetImage(Rom* pROM, char* szNameFile);
+s32 romGetImage(Rom* pROM, char* acNameFile);
+s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument);
 
 #endif

--- a/include/rom.h
+++ b/include/rom.h
@@ -85,8 +85,8 @@ s32 romTestCode(Rom* pROM, char* acCode);
 
 //! NOTE: The debug informations indicates that `nSize` is unsigned, but the
 //! generated code seems to treat it as signed.
-s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize);
 s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback);
+s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize);
 
 s32 romUpdate(Rom* pROM);
 s32 romSetCacheSize(Rom* pROM, s32 nSize);

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -4,7 +4,7 @@ O_FILES :=                                  \
     $(BUILD_DIR)/asm/xlCoreGCN.o            \
     $(BUILD_DIR)/asm/xlPostGCN.o            \
     $(BUILD_DIR)/asm/xlFileGCN.o            \
-    $(BUILD_DIR)/asm/xlList.o               \
+    $(BUILD_DIR)/src/xlList.o               \
     $(BUILD_DIR)/asm/xlHeap.o               \
     $(BUILD_DIR)/asm/xlObject.o             \
     $(BUILD_DIR)/asm/simGCN.o               \

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -18,7 +18,7 @@ O_FILES :=                                  \
     $(BUILD_DIR)/asm/codeGCN.o              \
     $(BUILD_DIR)/asm/soundGCN.o             \
     $(BUILD_DIR)/asm/frame.o                \
-    $(BUILD_DIR)/asm/system.o               \
+    $(BUILD_DIR)/src/system.o               \
     $(BUILD_DIR)/asm/cpu.o                  \
     $(BUILD_DIR)/asm/pif.o                  \
     $(BUILD_DIR)/asm/ram.o                  \

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -4,7 +4,7 @@ O_FILES :=                                  \
     $(BUILD_DIR)/asm/xlCoreGCN.o            \
     $(BUILD_DIR)/asm/xlPostGCN.o            \
     $(BUILD_DIR)/asm/xlFileGCN.o            \
-    $(BUILD_DIR)/src/xlList.o               \
+    $(BUILD_DIR)/asm/xlList.o               \
     $(BUILD_DIR)/asm/xlHeap.o               \
     $(BUILD_DIR)/asm/xlObject.o             \
     $(BUILD_DIR)/asm/simGCN.o               \
@@ -18,10 +18,10 @@ O_FILES :=                                  \
     $(BUILD_DIR)/asm/codeGCN.o              \
     $(BUILD_DIR)/asm/soundGCN.o             \
     $(BUILD_DIR)/asm/frame.o                \
-    $(BUILD_DIR)/src/system.o               \
+    $(BUILD_DIR)/asm/system.o               \
     $(BUILD_DIR)/asm/cpu.o                  \
     $(BUILD_DIR)/asm/pif.o                  \
-    $(BUILD_DIR)/src/ram.o                  \
+    $(BUILD_DIR)/asm/ram.o                  \
     $(BUILD_DIR)/src/rom.o                  \
     $(BUILD_DIR)/asm/rdp.o                  \
     $(BUILD_DIR)/asm/rdb.o                  \

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -21,7 +21,7 @@ O_FILES :=                                  \
     $(BUILD_DIR)/src/system.o               \
     $(BUILD_DIR)/asm/cpu.o                  \
     $(BUILD_DIR)/asm/pif.o                  \
-    $(BUILD_DIR)/asm/ram.o                  \
+    $(BUILD_DIR)/src/ram.o                  \
     $(BUILD_DIR)/src/rom.o                  \
     $(BUILD_DIR)/asm/rdp.o                  \
     $(BUILD_DIR)/asm/rdb.o                  \

--- a/src/ram.c
+++ b/src/ram.c
@@ -5,42 +5,256 @@
 
 s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument);
 
-static s32 ramGet64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramGet32(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramGet16(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramGet8(Ram* pRAM, u32 nAddress, s8* pData);
-
-static s32 ramPut64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramPut32(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramPut16(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramPut8(Ram* pRAM, u32 nAddress, s8* pData);
-
-static s32 ramGetRI64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramGetRI16(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramGetRI32(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramGetRI8(Ram* pRAM, u32 nAddress, s8* pData);
-
-static s32 ramPutRI64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramPutRI16(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramPutRI32(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramPutRI8(Ram* pRAM, u32 nAddress, s8* pData);
-
-static s32 ramGetControl64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramGetControl16(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramGetControl32(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramGetControl8(Ram* pRAM, u32 nAddress, s8* pData);
-
-static s32 ramPutControl64(Ram* pRAM, u32 nAddress, s64* pData);
-static s32 ramPutControl16(Ram* pRAM, u32 nAddress, s32* pData);
-static s32 ramPutControl32(Ram* pRAM, u32 nAddress, s16* pData);
-static s32 ramPutControl8(Ram* pRAM, u32 nAddress, s8* pData);
-
 _XL_OBJECTTYPE gClassRAM = {
     "RAM",
     sizeof(Ram),
     NULL,
     (EventFunc)ramEvent,
 };
+
+static s32 ramPutControl8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
+
+static s32 ramPutControl16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
+
+static s32 ramPutControl32(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x3F;
+
+    switch (nAddress) {
+        default:
+            return 0;
+        case 0x00:
+        case 0x04:
+        case 0x08:
+        case 0x0C:
+        case 0x10:
+        case 0x14:
+        case 0x18:
+        case 0x1C:
+        case 0x20:
+        case 0x24:
+            return 1;
+    }
+}
+
+static s32 ramPutControl64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
+
+static s32 ramGetControl8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
+
+static s32 ramGetControl16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
+
+static s32 ramGetControl32(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x3F;
+
+    switch (nAddress) {
+        default:
+            return 0;
+        case 0x00:
+        case 0x04:
+        case 0x08:
+        case 0x0C:
+        case 0x10:
+        case 0x14:
+        case 0x18:
+        case 0x1C:
+        case 0x20:
+        case 0x24:
+            return 1;
+    }
+}
+
+static s32 ramGetControl64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
+
+static s32 ramPutRI8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
+
+static s32 ramPutRI16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
+
+static s32 ramPutRI32(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x1F;
+
+    switch (nAddress) {
+        default:
+            return 0;
+        case 0x00:
+        case 0x04:
+        case 0x08:
+        case 0x0C:
+        case 0x10:
+        case 0x14:
+        case 0x18:
+        case 0x1C:
+            return 1;
+    }
+}
+
+static s32 ramPutRI64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
+
+static s32 ramGetRI8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
+
+static s32 ramGetRI16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
+
+static s32 ramGetRI32(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x1F;
+
+    switch (nAddress) {
+        default:
+            return 0;
+        case 0x00:
+        case 0x04:
+        case 0x08:
+        case 0x0C:
+        case 0x10:
+        case 0x14:
+        case 0x18:
+        case 0x1C:
+            return 1;
+    }
+}
+
+static s32 ramGetRI64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
+
+static s32 ramPut8(Ram* pRAM, u32 nAddress, s8* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *((s8*)pRAM->pBuffer + nAddress) = *pData;
+    }
+
+    return 1;
+}
+
+static s32 ramPut16(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *((u16*)pRAM->pBuffer + (nAddress >> 1)) = *pData;
+    }
+
+    return 1;
+}
+
+static s32 ramPut32(Ram* pRAM, u32 nAddress, s32* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *((s32*)pRAM->pBuffer + (nAddress >> 2)) = *pData;
+    }
+
+    return 1;
+}
+
+static s32 ramPut64(Ram* pRAM, u32 nAddress, s64* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *((s64*)pRAM->pBuffer + (nAddress >> 3)) = *pData;
+    }
+
+    return 1;
+}
+
+static s32 ramGet8(Ram* pRAM, u32 nAddress, s8* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *pData = *((s8*)pRAM->pBuffer + nAddress);
+    } else {
+        *pData = 0;
+    }
+
+    return 1;
+}
+
+static s32 ramGet16(Ram* pRAM, u32 nAddress, s16* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *pData = *((s16*)pRAM->pBuffer + (nAddress >> 1));
+    } else {
+        *pData = 0;
+    }
+
+    return 1;
+}
+
+static s32 ramGet32(Ram* pRAM, u32 nAddress, s32* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *pData = *((s32*)pRAM->pBuffer + (nAddress >> 2));
+    } else {
+        *pData = 0;
+    }
+
+    return 1;
+}
+
+static s32 ramGet64(Ram* pRAM, u32 nAddress, s64* pData) {
+    nAddress &= 0x03FFFFFF;
+
+    if (nAddress < pRAM->nSize) {
+        *pData = *((s64*)pRAM->pBuffer + (nAddress >> 3));
+    } else {
+        *pData = 0;
+    }
+
+    return 1;
+}
+
+s32 ramGetBuffer(Ram* pRAM, void** ppRAM, u32 nOffset, u32* pnSize) {
+    s32 nSize;
+
+    nOffset &= 0x03FFFFFF;
+
+    if (pRAM->nSize == 0) {
+        return 0;
+    }
+
+    if ((pnSize != NULL) && ((u32)(nOffset + *pnSize) >= pRAM->nSize)) {
+        nSize = pRAM->nSize - nOffset;
+        *pnSize = nSize;
+
+        if (nSize < 0) {
+            *pnSize = 0;
+        }
+    }
+
+    *((u8**)ppRAM) = (u8*)pRAM->pBuffer + nOffset;
+    return 1;
+}
+
+s32 ramWipe(Ram* pRAM) {
+    if (pRAM->nSize != 0 && !xlHeapFill32(pRAM->pBuffer, pRAM->nSize, 0)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+s32 ramSetSize(Ram* pRAM, s32 nSize) {
+    s32 nSizeRAM;
+
+    if (pRAM->pBuffer != NULL) {
+        return 0;
+    }
+
+    nSizeRAM = (nSize + 0x3FF) & 0xFFFFFC00;
+
+    if (!xlHeapTake(&pRAM->pBuffer, nSizeRAM | 0x30000000)) {
+        return 0;
+    }
+
+    pRAM->nSize = nSizeRAM;
+
+    return 1;
+}
+
+s32 ramGetSize(Ram* pRAM, s32* nSize) {
+    if (nSize != NULL) {
+        *nSize = pRAM->nSize;
+    }
+
+    return 1;
+}
 
 s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument) {
     switch (nEvent) {
@@ -99,247 +313,3 @@ s32 ramEvent(Ram* pRAM, s32 nEvent, void* pArgument) {
 
     return 1;
 }
-
-s32 ramGetSize(Ram* pRAM, s32* nSize) {
-    if (nSize != NULL) {
-        *nSize = pRAM->nSize;
-    }
-
-    return 1;
-}
-
-s32 ramSetSize(Ram* pRAM, s32 nSize) {
-    s32 nSizeRAM;
-
-    if (pRAM->pBuffer != NULL) {
-        return 0;
-    }
-
-    nSizeRAM = (nSize + 0x3FF) & 0xFFFFFC00;
-
-    if (!xlHeapTake(&pRAM->pBuffer, nSizeRAM | 0x30000000)) {
-        return 0;
-    }
-
-    pRAM->nSize = nSizeRAM;
-
-    return 1;
-}
-
-s32 ramWipe(Ram* pRAM) {
-    if (pRAM->nSize != 0 && !xlHeapFill32(pRAM->pBuffer, pRAM->nSize, 0)) {
-        return 0;
-    }
-
-    return 1;
-}
-
-s32 ramGetBuffer(Ram* pRAM, void** ppRAM, u32 nOffset, u32* pnSize) {
-    s32 nSize;
-
-    nOffset &= 0x03FFFFFF;
-
-    if (pRAM->nSize == 0) {
-        return 0;
-    }
-
-    if ((pnSize != NULL) && ((u32)(nOffset + *pnSize) >= pRAM->nSize)) {
-        nSize = pRAM->nSize - nOffset;
-        *pnSize = nSize;
-
-        if (nSize < 0) {
-            *pnSize = 0;
-        }
-    }
-
-    *((u8**)ppRAM) = (u8*)pRAM->pBuffer + nOffset;
-    return 1;
-}
-
-static s32 ramGet64(Ram* pRAM, u32 nAddress, s64* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *pData = *((s64*)pRAM->pBuffer + (nAddress >> 3));
-    } else {
-        *pData = 0;
-    }
-
-    return 1;
-}
-
-static s32 ramGet32(Ram* pRAM, u32 nAddress, s32* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *pData = *((s32*)pRAM->pBuffer + (nAddress >> 2));
-    } else {
-        *pData = 0;
-    }
-
-    return 1;
-}
-
-static s32 ramGet16(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *pData = *((s16*)pRAM->pBuffer + (nAddress >> 1));
-    } else {
-        *pData = 0;
-    }
-
-    return 1;
-}
-
-static s32 ramGet8(Ram* pRAM, u32 nAddress, s8* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *pData = *((s8*)pRAM->pBuffer + nAddress);
-    } else {
-        *pData = 0;
-    }
-
-    return 1;
-}
-
-static s32 ramPut64(Ram* pRAM, u32 nAddress, s64* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *((s64*)pRAM->pBuffer + (nAddress >> 3)) = *pData;
-    }
-
-    return 1;
-}
-
-static s32 ramPut32(Ram* pRAM, u32 nAddress, s32* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *((s32*)pRAM->pBuffer + (nAddress >> 2)) = *pData;
-    }
-
-    return 1;
-}
-
-static s32 ramPut16(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *((u16*)pRAM->pBuffer + (nAddress >> 1)) = *pData;
-    }
-
-    return 1;
-}
-
-static s32 ramPut8(Ram* pRAM, u32 nAddress, s8* pData) {
-    nAddress &= 0x03FFFFFF;
-
-    if (nAddress < pRAM->nSize) {
-        *((s8*)pRAM->pBuffer + nAddress) = *pData;
-    }
-
-    return 1;
-}
-
-static s32 ramGetRI64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
-
-static s32 ramGetRI32(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x1F;
-
-    switch (nAddress) {
-        default:
-            return 0;
-        case 0x00:
-        case 0x04:
-        case 0x08:
-        case 0x0C:
-        case 0x10:
-        case 0x14:
-        case 0x18:
-        case 0x1C:
-            return 1;
-    }
-}
-
-static s32 ramGetRI16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
-
-static s32 ramGetRI8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
-
-static s32 ramPutRI64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
-
-static s32 ramPutRI32(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x1F;
-
-    switch (nAddress) {
-        default:
-            return 0;
-        case 0x00:
-        case 0x04:
-        case 0x08:
-        case 0x0C:
-        case 0x10:
-        case 0x14:
-        case 0x18:
-        case 0x1C:
-            return 1;
-    }
-}
-
-static s32 ramPutRI16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
-
-static s32 ramPutRI8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
-
-static s32 ramGetControl64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
-
-static s32 ramGetControl32(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x3F;
-
-    switch (nAddress) {
-        default:
-            return 0;
-        case 0x00:
-        case 0x04:
-        case 0x08:
-        case 0x0C:
-        case 0x10:
-        case 0x14:
-        case 0x18:
-        case 0x1C:
-        case 0x20:
-        case 0x24:
-            return 1;
-    }
-}
-
-static s32 ramGetControl16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
-
-static s32 ramGetControl8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }
-
-static s32 ramPutControl64(Ram* pRAM, u32 nAddress, s64* pData) { return 0; }
-
-static s32 ramPutControl32(Ram* pRAM, u32 nAddress, s16* pData) {
-    nAddress &= 0x3F;
-
-    switch (nAddress) {
-        default:
-            return 0;
-        case 0x00:
-        case 0x04:
-        case 0x08:
-        case 0x0C:
-        case 0x10:
-        case 0x14:
-        case 0x18:
-        case 0x1C:
-        case 0x20:
-        case 0x24:
-            return 1;
-    }
-}
-
-static s32 ramPutControl16(Ram* pRAM, u32 nAddress, s32* pData) { return 0; }
-
-static s32 ramPutControl8(Ram* pRAM, u32 nAddress, s8* pData) { return 0; }

--- a/src/rom.c
+++ b/src/rom.c
@@ -90,32 +90,6 @@ const f32 D_80136000 = 400.0f;
 
 extern System* gpSystem;
 
-static s32 romPut8(Rom* pROM, u32 nAddress, s8* pData);
-static s32 romPut16(Rom* pROM, u32 nAddress, s16* pData);
-static s32 romPut32(Rom* pROM, u32 nAddress, s32* pData);
-static s32 romPut64(Rom* pROM, u32 nAddress, s64* pData);
-
-static s32 romGet8(Rom* pROM, u32 nAddress, s8* pData);
-static s32 romGet16(Rom* pROM, u32 nAddress, s16* pData);
-static s32 romGet32(Rom* pROM, u32 nAddress, s32* pData);
-static s32 romGet64(Rom* pROM, u32 nAddress, s64* pData);
-
-static s32 romPutDebug8(Rom* pROM, u32 nAddress, s8* pData);
-static s32 romPutDebug16(Rom* pROM, u32 nAddress, s16* pData);
-static s32 romPutDebug32(Rom* pROM, u32 nAddress, s32* pData);
-static s32 romPutDebug64(Rom* pROM, u32 nAddress, s64* pData);
-
-static s32 romGetDebug8(Rom* pROM, u32 nAddress, s8* pData);
-static s32 romGetDebug16(Rom* pROM, u32 nAddress, s16* pData);
-static s32 romGetDebug32(Rom* pROM, u32 nAddress, s32* pData);
-static s32 romGetDebug64(Rom* pROM, u32 nAddress, s64* pData);
-
-s32 __romCopyUpdate_Complete(void);
-s32 __romLoadUpdate_Complete(void);
-void __romLoadBlock_CompleteGCN(long nResult, DVDFileInfo* fileInfo);
-s32 romMakeFreeCache(Rom* pROM, s32* piCache, RomCacheType eType);
-s32 romFindOldestBlock(Rom* pROM, s32* piBlock, RomCacheType eTypeCache, s32 whichBlock);
-
 //! TODO: remove this when the SDK files are present
 u32 ARGetDMAStatus(void);
 void ARStartDMA(u32 type, u32 mainmem_addr, u32 aram_addr, u32 length);
@@ -128,537 +102,313 @@ void DCInvalidateRange(void* addr, u32 nBytes);
 #define ARStartDMARead(mmem, aram, len) ARStartDMA(ARAM_DIR_ARAM_TO_MRAM, mmem, aram, len)
 #define ARStartDMAWrite(mmem, aram, len) ARStartDMA(ARAM_DIR_MRAM_TO_ARAM, mmem, aram, len)
 
-s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument) {
-    switch (nEvent) {
-        case 2:
-            pROM->nSize = 0;
-            pROM->nTick = 0;
-            pROM->bLoad = 1;
-            pROM->bFlip = 0;
-            pROM->pHost = pArgument;
-            pROM->acNameFile[0] = '\0';
-            pROM->eModeLoad = RLM_NONE;
-            pROM->pBuffer = NULL;
-            pROM->offsetToRom = 0;
-            pROM->anOffsetBlock = NULL;
-            pROM->nCountOffsetBlocks = 0;
-            pROM->copy.nSize = 0;
-            pROM->copy.bWait = 0;
-            pROM->load.bWait = 0;
-            pROM->load.nOffset1 = 0;
-            pROM->load.nOffset0 = 0;
-            pROM->load.bDone = 0;
-            pROM->nSizeCacheRAM = 0;
-            pROM->nCountBlockRAM = 0;
-            pROM->pCacheRAM = NULL;
-            break;
-        case 3:
-            if ((pROM->pBuffer != NULL) && (pROM->pBuffer != pROM->pCacheRAM) && (!xlHeapFree(&pROM->pBuffer))) {
-                return 0;
+static s32 romFindFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
+    s32 iBlock;
+
+    if (eType == RCT_RAM) {
+        for (iBlock = 0; iBlock < pROM->nCountBlockRAM; iBlock++) {
+            if (!(pROM->anBlockCachedRAM[iBlock >> 3] & (1 << (iBlock & 7)))) {
+                *piCache = iBlock;
+                return 1;
             }
-            break;
-        case 0x1002:
-            switch (((CpuDevice*)pArgument)->nType) {
-                case 0:
-                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPut8,
-                                         (Put16Func)romPut16, (Put32Func)romPut32, (Put64Func)romPut64)) {
-                        return 0;
-                    }
-                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGet8,
-                                         (Get16Func)romGet16, (Get32Func)romGet32, (Get64Func)romGet64)) {
-                        return 0;
-                    }
-                    break;
-                case 1:
-                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPutDebug8,
-                                         (Put16Func)romPutDebug16, (Put32Func)romPutDebug32,
-                                         (Put64Func)romPutDebug64)) {
-                        return 0;
-                    }
-                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGetDebug8,
-                                         (Get16Func)romGetDebug16, (Get32Func)romGetDebug32,
-                                         (Get64Func)romGetDebug64)) {
-                        return 0;
-                    }
-                    break;
-            }
-            break;
-        case 0:
-        case 1:
-        case 0x1003:
-            break;
-        default:
-            return 0;
-    }
-
-    return 1;
-}
-
-s32 romGetImage(Rom* pROM, char* acNameFile) {
-    if (pROM->acNameFile[0] == '\0') {
-        return 0;
-    }
-
-    if (acNameFile != NULL) {
-        s32 iName;
-
-        for (iName = 0; pROM->acNameFile[iName] != '\0'; iName++) {
-            acNameFile[iName] = pROM->acNameFile[iName];
         }
-    }
-
-    return 1;
-}
-
-inline void romOpen(Rom* pROM, char* szNameFile) {
-    s32 var_r30 = 0;
-    s32 bFlip;
-
-    if ((pROM->acHeader[0] == 0x37) && (pROM->acHeader[1] == 0x80)) {
-        var_r30 = 1;
-    }
-
-    if (var_r30 != 0) {
-        bFlip = 1;
-    } else {
-        bFlip = 0;
-    }
-
-    pROM->bFlip = bFlip;
-    simulatorDVDOpen(szNameFile, &pROM->fileInfo);
-}
-
-s32 romSetImage(Rom* pROM, char* szNameFile) {
-    tXL_FILE* pFile;
-    s32 iName;
-    s32 nSize;
-
-    for (iName = 0; (szNameFile[iName] != '\0') && (iName < 0x200); iName++) {
-        pROM->acNameFile[iName] = szNameFile[iName];
-    }
-    pROM->acNameFile[iName] = '\0';
-
-    if (xlFileGetSize(&nSize, pROM->acNameFile)) {
-        pROM->nSize = (u32)(nSize - pROM->offsetToRom);
+    } else if (eType == RCT_ARAM) {
+        for (iBlock = 0; iBlock < ARRAY_COUNT(pROM->anBlockCachedARAM); iBlock++) {
+            if (!(pROM->anBlockCachedARAM[iBlock >> 3] & (1 << (iBlock & 7)))) {
+                *piCache = -(iBlock + 1);
+                return 1;
+            }
+        }
     } else {
         return 0;
     }
 
-    if (!xlFileOpen(&pFile, XLFT_BINARY, szNameFile)) {
-        return 0;
-    }
-
-    if (!xlFileSetPosition(pFile, pROM->offsetToRom)) {
-        return 0;
-    }
-
-    if (!xlFileGet(pFile, pROM->acHeader, sizeof(pROM->acHeader))) {
-        return 0;
-    }
-
-    if (!xlFileClose(&pFile)) {
-        return 0;
-    }
-
-    romOpen(pROM, szNameFile);
-    return 1;
+    return 0;
 }
 
-s32 romSetCacheSize(Rom* pROM, s32 nSize) {
-    s32 nSizeCacheRAM;
-
-    if (nSize < 0x100000) {
-        nSizeCacheRAM = 0x100000;
-    } else if (nSize > 0x800000) {
-        nSizeCacheRAM = 0x800000;
-    } else {
-        nSizeCacheRAM = (nSize + 0x1FFF) & 0xFFFFE000;
-    }
-
-    pROM->nSizeCacheRAM = nSizeCacheRAM;
-    pROM->nCountBlockRAM = nSizeCacheRAM / 0x2000;
-
-    if (!xlHeapTake(&pROM->pBuffer, nSizeCacheRAM | 0x30000000)) {
-        return 0;
-    }
-
-    pROM->pCacheRAM = (u8*)pROM->pBuffer;
-
-    return 1;
-}
-
-s32 romUpdate(Rom* pROM) {
-    s32 nStatus;
-
-    if ((pROM->copy.bWait != 0) || (pROM->load.bWait != 0)) {
-        if ((pROM->load.bDone != 0) && (pROM->load.nResult == pROM->load.nSizeRead)) {
-            pROM->load.bDone = 0;
-            if (!__romLoadBlock_Complete(pROM)) {
-                return 0;
-            }
-        }
-
-        nStatus = DVDGetCommandBlockStatus(&pROM->fileInfo);
-        if (nStatus != 1) {
-            if (!simulatorDVDShowError(nStatus, pROM->load.anData, pROM->load.nSizeRead,
-                                       pROM->offsetToRom + pROM->load.nOffset)) {
-                return 0;
-            }
-
-            if ((nStatus == 0xB) || (nStatus == -1)) {
-                DVDCancel(&pROM->fileInfo);
-                if (!simulatorDVDRead(&pROM->fileInfo, pROM->load.anData, pROM->load.nSizeRead,
-                                      pROM->offsetToRom + pROM->load.nOffset, &__romLoadBlock_CompleteGCN)) {
-                    return 0;
-                }
-            }
-        }
-    }
-
-    if (!romLoadUpdate(pROM)) {
-        return 0;
-    }
-
-    if (!romCopyUpdate(pROM)) {
-        return 0;
-    }
-
-    return 1;
-}
-
-inline s32 romCopyLoad(Rom* pROM) {
-    if (!romLoadFullOrPart(pROM)) {
-        return 0;
-    }
-
-    if (!romCacheGame(pROM)) {
-        return 0;
-    }
-
-    pROM->bLoad = 0;
-    return 1;
-}
-
-s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize) {
-    void* pSource;
+static s32 romFindOldestBlock(Rom* pROM, s32* piBlock, RomCacheType eTypeCache, s32 whichBlock) {
     RomBlock* pBlock;
-    s32 nOffsetARAM;
-    s32 nSizeCopy;
-    s32 nOffsetBlock;
-    s32 nSizeCopyARAM;
-    s32 nSizeDMA;
-    s32 nOffset;
-    s32 nOffsetTarget;
-    s32 pad;
-    u8* pBuffer;
-    u8 anBuffer[608];
+    s32 iBlock;
+    s32 iBlockOldest;
+    u32 nTick;
+    u32 nTickDelta;
+    u32 nTickDeltaOldest;
 
-    if (pROM->nSizeCacheRAM == 0) {
-        return 0;
+    nTick = pROM->nTick;
+    nTickDeltaOldest = 0;
+
+    for (iBlock = 0; iBlock < ARRAY_COUNT(pROM->aBlock); iBlock++) {
+        pBlock = &pROM->aBlock[iBlock];
+        if (pBlock->nSize != 0 &&
+            ((eTypeCache == RCT_RAM && pBlock->iCache >= 0) || (eTypeCache == RCT_ARAM && pBlock->iCache < 0))) {
+            if (pBlock->nTickUsed > nTick) {
+                nTickDelta = -1 - (pBlock->nTickUsed - nTick);
+            } else {
+                nTickDelta = nTick - pBlock->nTickUsed;
+            }
+            if (whichBlock == 0) {
+                if (nTickDelta > nTickDeltaOldest && pBlock->keep == 0) {
+                    iBlockOldest = iBlock;
+                    nTickDeltaOldest = nTickDelta;
+                }
+            } else if (whichBlock == 1) {
+                if (nTickDelta > nTickDeltaOldest && pBlock->keep == 1) {
+                    iBlockOldest = iBlock;
+                    nTickDeltaOldest = nTickDelta;
+                }
+            } else if (nTickDelta > nTickDeltaOldest) {
+                iBlockOldest = iBlock;
+                nTickDeltaOldest = nTickDelta;
+            }
+        }
     }
 
-    if (pROM->bLoad && !romCopyLoad(pROM)) {
-        return 0;
-    }
-
-    nOffsetROM = nOffsetROM & 0x07FFFFFF;
-    pBuffer = (u8*)(((s32)anBuffer + 0x1F) & 0xFFFFFFE0);
-
-    if (nOffsetROM + nSize > pROM->nSize && (nSize = pROM->nSize - nOffsetROM) < 0) {
+    if (nTickDeltaOldest != 0) {
+        *piBlock = iBlockOldest;
         return 1;
     }
 
-    if (pROM->eModeLoad == RLM_PART) {
-        while (nSize != 0U) {
-            pBlock = &pROM->aBlock[nOffsetROM / 0x2000];
-            if (pBlock->nSize == 0) {
-                return 0;
-            }
+    return 0;
+}
 
-            nOffsetBlock = nOffsetROM % 0x2000;
-            if ((nSizeCopy = pBlock->nSize - nOffsetBlock) > nSize) {
-                nSizeCopy = nSize;
-            }
+inline void romMarkBlockAsFree(Rom* pROM, s32 iBlock) {
+    RomBlock* pBlock;
+    s32 iCache;
 
-            if (pBlock->iCache >= 0) {
-                pSource = &pROM->pCacheRAM[(pBlock->iCache * 0x2000)] + nOffsetBlock;
-                if (!xlHeapCopy(pTarget, pSource, nSizeCopy)) {
-                    return 0;
+    pBlock = &pROM->aBlock[iBlock];
+    iCache = pBlock->iCache;
+    if (iCache < 0) {
+        iCache = -(iCache + 1);
+        pROM->anBlockCachedARAM[iCache >> 3] &= ~(1 << (iCache & 7));
+    } else {
+        pROM->anBlockCachedRAM[iCache >> 3] &= ~(1 << (iCache & 7));
+    }
+    pBlock->nSize = 0;
+}
+
+static s32 romMakeFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
+    s32 iCache;
+    s32 iBlockOldest;
+
+    if (eType == RCT_RAM) {
+        if (!romFindFreeCache(pROM, &iCache, RCT_RAM)) {
+            if (romFindOldestBlock(pROM, &iBlockOldest, RCT_RAM, 2)) {
+                iCache = pROM->aBlock[iBlockOldest].iCache;
+                if (!romSetBlockCache(pROM, iBlockOldest, RCT_ARAM) &&
+                    romFindOldestBlock(pROM, &iBlockOldest, RCT_RAM, 0)) {
+                    iCache = pROM->aBlock[iBlockOldest].iCache;
+                    romMarkBlockAsFree(pROM, iBlockOldest);
                 }
             } else {
-                nSizeCopyARAM = nSizeCopy;
-                nOffsetTarget = 0;
-                nOffsetARAM = nOffsetBlock + (-(pBlock->iCache + 1) * 0x2000);
-                nOffsetARAM += ARGetBaseAddress();
+                return 0;
+            }
+        }
+    } else {
+        if (!romFindFreeCache(pROM, &iCache, RCT_ARAM)) {
+            if (romFindOldestBlock(pROM, &iBlockOldest, RCT_ARAM, 0)) {
+                iCache = pROM->aBlock[iBlockOldest].iCache;
+                romMarkBlockAsFree(pROM, iBlockOldest);
+            } else {
+                return 0;
+            }
+        }
+    }
 
-                while (nSizeCopyARAM > 0) {
-                    if ((nSizeDMA = nSizeCopyARAM) > 0x200) {
-                        nSizeDMA = 0x200;
-                    }
+    *piCache = iCache;
+    return 1;
+}
 
-                    while (ARGetDMAStatus()) {}
+static s32 romSetBlockCache(Rom* pROM, s32 iBlock, RomCacheType eType) {
+    RomBlock* pBlock;
+    s32 iCacheRAM;
+    s32 iCacheARAM;
+    s32 nOffsetRAM;
+    s32 nOffsetARAM;
 
-                    nOffset = nOffsetARAM & 0x1F;
-                    ARStartDMARead((u32)pBuffer, nOffsetARAM & 0xFFFFFFE0, (nSizeDMA + nOffset + 0x1F) & 0xFFFFFFE0);
-                    DCInvalidateRange(pBuffer, nSizeDMA + nOffset);
+    pBlock = &pROM->aBlock[iBlock];
+    if ((eType == RCT_RAM && pBlock->iCache >= 0) || (eType == RCT_ARAM && pBlock->iCache < 0)) {
+        return 1;
+    }
 
-                    while (ARGetDMAStatus()) {}
+    if (eType == RCT_RAM) {
+        iCacheARAM = -(pBlock->iCache + 1);
+        if (!romMakeFreeCache(pROM, &iCacheRAM, RCT_RAM)) {
+            return 0;
+        }
 
-                    if (!xlHeapCopy((u8*)pTarget + nOffsetTarget, pBuffer + nOffset, nSizeDMA)) {
-                        return 0;
-                    }
+        nOffsetRAM = iCacheRAM * 0x2000;
+        nOffsetARAM = iCacheARAM * 0x2000;
+        nOffsetARAM += ARGetBaseAddress();
 
-                    nOffsetARAM += nSizeDMA;
-                    nOffsetTarget += nSizeDMA;
-                    nSizeCopyARAM -= nSizeDMA;
-                }
+        while (ARGetDMAStatus()) {}
+
+        ARStartDMARead((u32)&pROM->pCacheRAM[nOffsetRAM], nOffsetARAM, 0x2000);
+        DCInvalidateRange(&pROM->pCacheRAM[nOffsetRAM], 0x2000);
+
+        pROM->anBlockCachedARAM[iCacheARAM >> 3] &= ~(1 << (iCacheARAM & 7));
+        pROM->anBlockCachedRAM[iCacheRAM >> 3] |= (1 << (iCacheRAM & 7));
+        pBlock->iCache = iCacheRAM;
+    } else if (eType == RCT_ARAM) {
+        iCacheRAM = pBlock->iCache;
+        if (!romMakeFreeCache(pROM, &iCacheARAM, RCT_ARAM)) {
+            return 0;
+        }
+        iCacheARAM = -(iCacheARAM + 1);
+
+        nOffsetRAM = iCacheRAM * 0x2000;
+        nOffsetARAM = iCacheARAM * 0x2000;
+        nOffsetARAM += ARGetBaseAddress();
+
+        DCStoreRange(&pROM->pCacheRAM[nOffsetRAM], 0x2000);
+
+        while (ARGetDMAStatus()) {}
+
+        ARStartDMAWrite((u32)&pROM->pCacheRAM[nOffsetRAM], nOffsetARAM, 0x2000);
+
+        pROM->anBlockCachedRAM[iCacheRAM >> 3] &= ~(1 << (iCacheRAM & 7));
+        pROM->anBlockCachedARAM[iCacheARAM >> 3] |= (1 << (iCacheARAM & 7));
+        pBlock->iCache = -(iCacheARAM + 1);
+    } else {
+        return 0;
+    }
+
+    while (ARGetDMAStatus()) {}
+
+    return 1;
+}
+
+s32 __romLoadBlock_Complete(Rom* pROM) {
+    s32 iBlock;
+
+    if (pROM->bFlip) {
+        //! TODO: this might be an inline function, see ``romLoadFullOrPart``
+        u32* anData = (u32*)pROM->load.anData;
+        u32 i;
+
+        for (i = 0; i < ((pROM->load.nSize + 3) >> 2); i++) {
+            *anData++ = ((*anData >> 8) & 0x00FF00FF) | ((*anData << 8) & 0xFF00FF00);
+        }
+    }
+
+    iBlock = pROM->load.iBlock;
+    pROM->aBlock[iBlock].nSize = pROM->load.nSize;
+    pROM->aBlock[iBlock].iCache = pROM->load.iCache;
+    pROM->aBlock[iBlock].keep = 0;
+
+    pROM->anBlockCachedRAM[pROM->load.iCache >> 3] |= (1 << (pROM->load.iCache & 7));
+
+    if ((pROM->load.pCallback != NULL) && !pROM->load.pCallback()) {
+        return 0;
+    }
+
+    return 1;
+}
+
+void __romLoadBlock_CompleteGCN(long nResult, DVDFileInfo* fileInfo) {
+    Rom* pROM = gpSystem->apObject[SOT_ROM];
+
+    pROM->load.nResult = nResult;
+    pROM->load.bDone = 1;
+}
+
+static s32 romLoadBlock(Rom* pROM, s32 iBlock, s32 iCache, UnknownCallbackFunc pCallback) {
+    u8* anData;
+    s32 nSizeRead;
+    u32 nSize;
+    u32 nOffset;
+
+    nOffset = iBlock * 0x2000;
+    if ((nSize = pROM->nSize - nOffset) > 0x2000) {
+        nSize = 0x2000;
+    }
+    anData = &pROM->pCacheRAM[iCache * 0x2000];
+    nSizeRead = (nSize + 0x1F) & 0xFFFFFFE0;
+
+    pROM->load.nSize = nSize;
+    pROM->load.iBlock = iBlock;
+    pROM->load.iCache = iCache;
+    pROM->load.anData = anData;
+    pROM->load.pCallback = pCallback;
+
+    if (pCallback == NULL) {
+        if (!simulatorDVDRead(&pROM->fileInfo, anData, nSizeRead, nOffset + pROM->offsetToRom, NULL)) {
+            return 0;
+        }
+    } else {
+        pROM->load.nOffset = nOffset;
+        pROM->load.nSizeRead = nSizeRead;
+        if (!simulatorDVDRead(&pROM->fileInfo, anData, nSizeRead, nOffset + pROM->offsetToRom,
+                              &__romLoadBlock_CompleteGCN)) {
+            return 0;
+        }
+        return 1;
+    }
+
+    if (!__romLoadBlock_Complete(pROM)) {
+        return 0;
+    }
+    return 1;
+}
+
+//! TODO: remove this when ``romLoadFullOrPart`` is matched
+#ifndef NON_MATCHING
+#pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadRange.s")
+#else
+s32 romLoadRange(Rom* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
+                 ProgressCallbackFunc* pProgressCallback) {
+    s32 iCache;
+    u32 iBlock;
+    u32 iBlockLast;
+
+    iBlockLast = end / 0x2000;
+    for (iBlock = begin / 0x2000; iBlock <= iBlockLast; iBlock++) {
+        if (pProgressCallback != NULL) {
+            pProgressCallback((f32)(iBlock - (begin / 0x2000)) / (f32)((end - begin) / 0x2000));
+        }
+
+        if (pROM->aBlock[iBlock].nSize == 0) {
+            if (!romMakeFreeCache(pROM, &iCache, RCT_RAM)) {
+                return 0;
             }
 
-            pTarget = (u8*)pTarget + nSizeCopy;
-            nOffsetROM += nSizeCopy;
-            nSize -= nSizeCopy;
+            if (!romLoadBlock(pROM, iBlock, iCache, NULL)) {
+                return 0;
+            }
         }
-        return 1;
-    } else if (pROM->eModeLoad == RLM_FULL) {
-        if (!xlHeapCopy(pTarget, (u8*)pROM->pBuffer + nOffsetROM, nSize)) {
-            return 0;
+
+        pROM->aBlock[iBlock].keep = whichBlock;
+        pROM->aBlock[iBlock].nTickUsed = ++pROM->nTick;
+
+        if (blockCount != NULL) {
+            *blockCount += 1;
         }
-        return 1;
     }
 
-    return 0;
+    return 1;
+}
+#endif
+
+#pragma GLOBAL_ASM("asm/non_matchings/rom/romCacheGame_ZELDA.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/rom/romCacheGame.s")
+
+s32 __romLoadUpdate_Complete(void) {
+    Rom* pROM = gpSystem->apObject[SOT_ROM];
+
+    pROM->load.bWait = 0;
+    return 1;
 }
 
-inline s32 romCopyLoop(Rom* pROM, u8* pTarget, u32 nOffset, u32 nSize, UnknownCallbackFunc* pCallback) {
-    s32 i;
+#pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadUpdate.s")
+
+s32 __romCopyUpdate_Complete(void) {
+    Rom* pROM = gpSystem->apObject[SOT_ROM];
 
     pROM->copy.bWait = 0;
-    pROM->copy.nSize = nSize;
-    pROM->copy.pTarget = pTarget;
-    pROM->copy.nOffset = nOffset;
-    pROM->copy.pCallback = pCallback;
-
-    for (i = 0; i < pROM->nCountOffsetBlocks; i += 2) {
-        if ((pROM->anOffsetBlock[i] <= nOffset) && (nOffset <= pROM->anOffsetBlock[i + 1])) {
-            pROM->load.nOffset0 = pROM->anOffsetBlock[i];
-            pROM->load.nOffset1 = pROM->anOffsetBlock[i + 1];
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback) {
-    tXL_FILE* pFile;
-
-    nOffset &= 0x07FFFFFF;
-
-    if (!pROM->nSizeCacheRAM) {
-        if (!xlFileOpen(&pFile, XLFT_BINARY, pROM->acNameFile)) {
-            return 0;
-        }
-
-        if (!xlFileSetPosition(pFile, nOffset + pROM->offsetToRom)) {
-            return 0;
-        }
-
-        if (!xlFileGet(pFile, pTarget, (s32)nSize)) {
-            return 0;
-        }
-
-        if (!xlFileClose(&pFile)) {
-            return 0;
-        }
-
-        if ((pCallback != NULL) && !pCallback()) {
-            return 0;
-        }
-
-        return 1;
-    }
-
-    if (pROM->bLoad && !romCopyLoad(pROM)) {
-        return 0;
-    }
-
-    if (((nOffset + nSize) > pROM->nSize) && ((nSize = pROM->nSize - nOffset) < 0)) {
-        return 1;
-    }
-
-    if (pROM->eModeLoad == RLM_PART) {
-        if (romCopyLoop(pROM, pTarget, nOffset, nSize, pCallback) && !romLoadUpdate(pROM)) {
-            return 0;
-        }
-
-        if (!romCopyUpdate(pROM)) {
-            return 0;
-        }
-
-        return 1;
-    }
-
-    if (pROM->eModeLoad == RLM_FULL) {
-        if (!xlHeapCopy(pTarget, (void*)((u32)pROM->pBuffer + nOffset), nSize)) {
-            return 0;
-        }
-
-        if ((pCallback != NULL) && !pCallback()) {
-            return 0;
-        }
-
-        return 1;
-    }
-
-    return 0;
-}
-
-static s32 romGetDebug64(Rom* pROM, u32 nAddress, s64* pData) {
-    *pData = 0;
     return 1;
 }
 
-static s32 romGetDebug32(Rom* pROM, u32 nAddress, s32* pData) {
-    *pData = 0;
-    return 1;
-}
-
-static s32 romGetDebug16(Rom* pROM, u32 nAddress, s16* pData) {
-    *pData = 0;
-    return 1;
-}
-
-static s32 romGetDebug8(Rom* pROM, u32 nAddress, s8* pData) {
-    *pData = 0;
-    return 1;
-}
-
-static s32 romPutDebug64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
-static s32 romPutDebug32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
-static s32 romPutDebug16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
-static s32 romPutDebug8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
-
-static s32 romGet64(Rom* pROM, u32 nAddress, s64* pData) {
-    u64 nData;
-
-    nAddress = nAddress & 0x07ffffff;
-    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 8, 0)) {
-        *pData = nData;
-        return 1;
-    } else {
-        *pData = 0;
-        return 1;
-    }
-}
-
-static s32 romGet32(Rom* pROM, u32 nAddress, s32* pData) {
-    u32 nData;
-
-    nAddress = nAddress & 0x07ffffff;
-    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 4, 0)) {
-        *pData = nData;
-        return 1;
-    } else {
-        *pData = 0;
-        return 1;
-    }
-}
-
-static s32 romGet16(Rom* pROM, u32 nAddress, s16* pData) {
-    u16 nData;
-
-    nAddress = nAddress & 0x07ffffff;
-    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 2, 0)) {
-        *pData = nData;
-        return 1;
-    } else {
-        *pData = 0;
-        return 1;
-    }
-}
-
-static s32 romGet8(Rom* pROM, u32 nAddress, s8* pData) {
-    u8 nData;
-
-    nAddress = nAddress & 0x07ffffff;
-    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 1, 0)) {
-        *pData = nData;
-        return 1;
-    } else {
-        *pData = 0;
-        return 1;
-    }
-}
-
-static s32 romPut64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
-static s32 romPut32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
-static s32 romPut16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
-static s32 romPut8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
-
-s32 romTestCode(Rom* pROM, char* acCode) {
-    s32 iCode;
-    char acCodeCurrent[5];
-    s32 iOffset = 0x3B;
-
-    for (iCode = 0; iCode < 4; iCode++) {
-        acCodeCurrent[iCode] = pROM->acHeader[iOffset + iCode];
-    }
-    acCodeCurrent[4] = '\0';
-
-    for (iCode = 0; iCode < 4; iCode++) {
-        if (acCode[iCode] != acCodeCurrent[iCode]) {
-            return 0;
-        }
-    }
-    return 1;
-}
-
-s32 romGetCode(Rom* pROM, char* acCode) {
-    acCode[0] = pROM->acHeader[0x3B];
-    acCode[1] = pROM->acHeader[0x3C];
-    acCode[2] = pROM->acHeader[0x3D];
-    acCode[3] = pROM->acHeader[0x3E];
-    acCode[4] = '\0';
-    return 1;
-}
-
-s32 romGetPC(Rom* pROM, u64* pnPC) {
-    s32 nOffset;
-    u32 nData;
-    u32 iData;
-    u32 anData[0x400];
-
-    if (romCopy(pROM, &anData, 0, sizeof(anData), 0)) {
-        nData = 0;
-        for (iData = 0; iData < 0x400 - 0x10; iData++) {
-            nData += anData[iData + 0x10];
-        }
-
-        switch (nData) {
-            case 0x49F60E96:
-            case 0xFB631223:
-            case 0x2ADFE50A:
-            case 0x57C85244:
-                nOffset = 0;
-                break;
-            case 0x497E414B:
-            case 0xE6DECB4B:
-            case 0x27C4ED44:
-                nOffset = 0x100000;
-                break;
-            case 0xD5BE5580:
-                nOffset = 0x200000;
-                break;
-            default:
-                return 0;
-        }
-
-        *pnPC = anData[2] - nOffset;
-        return 1;
-    } else {
-        return 0;
-    }
-}
+#pragma GLOBAL_ASM("asm/non_matchings/rom/romCopyUpdate.s")
 
 #ifndef NON_MATCHING
 #pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadFullOrPart.s")
@@ -765,310 +515,534 @@ s32 romLoadFullOrPart(Rom* pROM) {
 }
 #endif
 
-#pragma GLOBAL_ASM("asm/non_matchings/rom/romCopyUpdate.s")
+s32 romGetPC(Rom* pROM, u64* pnPC) {
+    s32 nOffset;
+    u32 nData;
+    u32 iData;
+    u32 anData[0x400];
 
-s32 __romCopyUpdate_Complete(void) {
-    Rom* pROM = gpSystem->apObject[SOT_ROM];
+    if (romCopy(pROM, &anData, 0, sizeof(anData), 0)) {
+        nData = 0;
+        for (iData = 0; iData < 0x400 - 0x10; iData++) {
+            nData += anData[iData + 0x10];
+        }
+
+        switch (nData) {
+            case 0x49F60E96:
+            case 0xFB631223:
+            case 0x2ADFE50A:
+            case 0x57C85244:
+                nOffset = 0;
+                break;
+            case 0x497E414B:
+            case 0xE6DECB4B:
+            case 0x27C4ED44:
+                nOffset = 0x100000;
+                break;
+            case 0xD5BE5580:
+                nOffset = 0x200000;
+                break;
+            default:
+                return 0;
+        }
+
+        *pnPC = anData[2] - nOffset;
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+s32 romGetCode(Rom* pROM, char* acCode) {
+    acCode[0] = pROM->acHeader[0x3B];
+    acCode[1] = pROM->acHeader[0x3C];
+    acCode[2] = pROM->acHeader[0x3D];
+    acCode[3] = pROM->acHeader[0x3E];
+    acCode[4] = '\0';
+    return 1;
+}
+
+s32 romTestCode(Rom* pROM, char* acCode) {
+    s32 iCode;
+    char acCodeCurrent[5];
+    s32 iOffset = 0x3B;
+
+    for (iCode = 0; iCode < 4; iCode++) {
+        acCodeCurrent[iCode] = pROM->acHeader[iOffset + iCode];
+    }
+    acCodeCurrent[4] = '\0';
+
+    for (iCode = 0; iCode < 4; iCode++) {
+        if (acCode[iCode] != acCodeCurrent[iCode]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static s32 romPut8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
+static s32 romPut16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
+static s32 romPut32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
+static s32 romPut64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
+
+static s32 romGet8(Rom* pROM, u32 nAddress, s8* pData) {
+    u8 nData;
+
+    nAddress = nAddress & 0x07ffffff;
+    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 1, 0)) {
+        *pData = nData;
+        return 1;
+    } else {
+        *pData = 0;
+        return 1;
+    }
+}
+
+static s32 romGet16(Rom* pROM, u32 nAddress, s16* pData) {
+    u16 nData;
+
+    nAddress = nAddress & 0x07ffffff;
+    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 2, 0)) {
+        *pData = nData;
+        return 1;
+    } else {
+        *pData = 0;
+        return 1;
+    }
+}
+
+static s32 romGet32(Rom* pROM, u32 nAddress, s32* pData) {
+    u32 nData;
+
+    nAddress = nAddress & 0x07ffffff;
+    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 4, 0)) {
+        *pData = nData;
+        return 1;
+    } else {
+        *pData = 0;
+        return 1;
+    }
+}
+
+static s32 romGet64(Rom* pROM, u32 nAddress, s64* pData) {
+    u64 nData;
+
+    nAddress = nAddress & 0x07ffffff;
+    if (nAddress < pROM->nSize && romCopy(pROM, &nData, nAddress, 8, 0)) {
+        *pData = nData;
+        return 1;
+    } else {
+        *pData = 0;
+        return 1;
+    }
+}
+
+static s32 romPutDebug8(Rom* pROM, u32 nAddress, s8* pData) { return 1; }
+static s32 romPutDebug16(Rom* pROM, u32 nAddress, s16* pData) { return 1; }
+static s32 romPutDebug32(Rom* pROM, u32 nAddress, s32* pData) { return 1; }
+static s32 romPutDebug64(Rom* pROM, u32 nAddress, s64* pData) { return 1; }
+
+static s32 romGetDebug8(Rom* pROM, u32 nAddress, s8* pData) {
+    *pData = 0;
+    return 1;
+}
+
+static s32 romGetDebug16(Rom* pROM, u32 nAddress, s16* pData) {
+    *pData = 0;
+    return 1;
+}
+
+static s32 romGetDebug32(Rom* pROM, u32 nAddress, s32* pData) {
+    *pData = 0;
+    return 1;
+}
+
+static s32 romGetDebug64(Rom* pROM, u32 nAddress, s64* pData) {
+    *pData = 0;
+    return 1;
+}
+
+inline s32 romCopyLoad(Rom* pROM) {
+    if (!romLoadFullOrPart(pROM)) {
+        return 0;
+    }
+
+    if (!romCacheGame(pROM)) {
+        return 0;
+    }
+
+    pROM->bLoad = 0;
+    return 1;
+}
+
+inline s32 romCopyLoop(Rom* pROM, u8* pTarget, u32 nOffset, u32 nSize, UnknownCallbackFunc* pCallback) {
+    s32 i;
 
     pROM->copy.bWait = 0;
-    return 1;
-}
+    pROM->copy.nSize = nSize;
+    pROM->copy.pTarget = pTarget;
+    pROM->copy.nOffset = nOffset;
+    pROM->copy.pCallback = pCallback;
 
-#pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadUpdate.s")
-
-s32 __romLoadUpdate_Complete(void) {
-    Rom* pROM = gpSystem->apObject[SOT_ROM];
-
-    pROM->load.bWait = 0;
-    return 1;
-}
-
-#pragma GLOBAL_ASM("asm/non_matchings/rom/romCacheGame.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/rom/romCacheGame_ZELDA.s")
-
-//! TODO: remove this when ``romLoadFullOrPart`` is matched
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/non_matchings/rom/romLoadRange.s")
-#else
-s32 romLoadRange(Rom* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
-                 ProgressCallbackFunc* pProgressCallback) {
-    s32 iCache;
-    u32 iBlock;
-    u32 iBlockLast;
-
-    iBlockLast = end / 0x2000;
-    for (iBlock = begin / 0x2000; iBlock <= iBlockLast; iBlock++) {
-        if (pProgressCallback != NULL) {
-            pProgressCallback((f32)(iBlock - (begin / 0x2000)) / (f32)((end - begin) / 0x2000));
-        }
-
-        if (pROM->aBlock[iBlock].nSize == 0) {
-            if (!romMakeFreeCache(pROM, &iCache, RCT_RAM)) {
-                return 0;
-            }
-
-            if (!romLoadBlock(pROM, iBlock, iCache, NULL)) {
-                return 0;
-            }
-        }
-
-        pROM->aBlock[iBlock].keep = whichBlock;
-        pROM->aBlock[iBlock].nTickUsed = ++pROM->nTick;
-
-        if (blockCount != NULL) {
-            *blockCount += 1;
+    for (i = 0; i < pROM->nCountOffsetBlocks; i += 2) {
+        if ((pROM->anOffsetBlock[i] <= nOffset) && (nOffset <= pROM->anOffsetBlock[i + 1])) {
+            pROM->load.nOffset0 = pROM->anOffsetBlock[i];
+            pROM->load.nOffset1 = pROM->anOffsetBlock[i + 1];
+            return 1;
         }
     }
 
-    return 1;
+    return 0;
 }
-#endif
 
-static s32 romLoadBlock(Rom* pROM, s32 iBlock, s32 iCache, UnknownCallbackFunc pCallback) {
-    u8* anData;
-    s32 nSizeRead;
-    u32 nSize;
-    u32 nOffset;
+s32 romCopy(Rom* pROM, void* pTarget, s32 nOffset, s32 nSize, UnknownCallbackFunc* pCallback) {
+    tXL_FILE* pFile;
 
-    nOffset = iBlock * 0x2000;
-    if ((nSize = pROM->nSize - nOffset) > 0x2000) {
-        nSize = 0x2000;
-    }
-    anData = &pROM->pCacheRAM[iCache * 0x2000];
-    nSizeRead = (nSize + 0x1F) & 0xFFFFFFE0;
+    nOffset &= 0x07FFFFFF;
 
-    pROM->load.nSize = nSize;
-    pROM->load.iBlock = iBlock;
-    pROM->load.iCache = iCache;
-    pROM->load.anData = anData;
-    pROM->load.pCallback = pCallback;
-
-    if (pCallback == NULL) {
-        if (!simulatorDVDRead(&pROM->fileInfo, anData, nSizeRead, nOffset + pROM->offsetToRom, NULL)) {
+    if (!pROM->nSizeCacheRAM) {
+        if (!xlFileOpen(&pFile, XLFT_BINARY, pROM->acNameFile)) {
             return 0;
         }
-    } else {
-        pROM->load.nOffset = nOffset;
-        pROM->load.nSizeRead = nSizeRead;
-        if (!simulatorDVDRead(&pROM->fileInfo, anData, nSizeRead, nOffset + pROM->offsetToRom,
-                              &__romLoadBlock_CompleteGCN)) {
+
+        if (!xlFileSetPosition(pFile, nOffset + pROM->offsetToRom)) {
             return 0;
         }
+
+        if (!xlFileGet(pFile, pTarget, (s32)nSize)) {
+            return 0;
+        }
+
+        if (!xlFileClose(&pFile)) {
+            return 0;
+        }
+
+        if ((pCallback != NULL) && !pCallback()) {
+            return 0;
+        }
+
         return 1;
     }
 
-    if (!__romLoadBlock_Complete(pROM)) {
+    if (pROM->bLoad && !romCopyLoad(pROM)) {
         return 0;
     }
-    return 1;
-}
 
-void __romLoadBlock_CompleteGCN(long nResult, DVDFileInfo* fileInfo) {
-    Rom* pROM = gpSystem->apObject[SOT_ROM];
+    if (((nOffset + nSize) > pROM->nSize) && ((nSize = pROM->nSize - nOffset) < 0)) {
+        return 1;
+    }
 
-    pROM->load.nResult = nResult;
-    pROM->load.bDone = 1;
-}
-
-s32 __romLoadBlock_Complete(Rom* pROM) {
-    s32 iBlock;
-
-    if (pROM->bFlip) {
-        //! TODO: this might be an inline function, see ``romLoadFullOrPart``
-        u32* anData = (u32*)pROM->load.anData;
-        u32 i;
-
-        for (i = 0; i < ((pROM->load.nSize + 3) >> 2); i++) {
-            *anData++ = ((*anData >> 8) & 0x00FF00FF) | ((*anData << 8) & 0xFF00FF00);
+    if (pROM->eModeLoad == RLM_PART) {
+        if (romCopyLoop(pROM, pTarget, nOffset, nSize, pCallback) && !romLoadUpdate(pROM)) {
+            return 0;
         }
+
+        if (!romCopyUpdate(pROM)) {
+            return 0;
+        }
+
+        return 1;
     }
 
-    iBlock = pROM->load.iBlock;
-    pROM->aBlock[iBlock].nSize = pROM->load.nSize;
-    pROM->aBlock[iBlock].iCache = pROM->load.iCache;
-    pROM->aBlock[iBlock].keep = 0;
+    if (pROM->eModeLoad == RLM_FULL) {
+        if (!xlHeapCopy(pTarget, (void*)((u32)pROM->pBuffer + nOffset), nSize)) {
+            return 0;
+        }
 
-    pROM->anBlockCachedRAM[pROM->load.iCache >> 3] |= (1 << (pROM->load.iCache & 7));
+        if ((pCallback != NULL) && !pCallback()) {
+            return 0;
+        }
 
-    if ((pROM->load.pCallback != NULL) && !pROM->load.pCallback()) {
-        return 0;
+        return 1;
     }
 
-    return 1;
+    return 0;
 }
 
-static s32 romSetBlockCache(Rom* pROM, s32 iBlock, RomCacheType eType) {
+s32 romCopyImmediate(Rom* pROM, void* pTarget, s32 nOffsetROM, s32 nSize) {
+    void* pSource;
     RomBlock* pBlock;
-    s32 iCacheRAM;
-    s32 iCacheARAM;
-    s32 nOffsetRAM;
     s32 nOffsetARAM;
+    s32 nSizeCopy;
+    s32 nOffsetBlock;
+    s32 nSizeCopyARAM;
+    s32 nSizeDMA;
+    s32 nOffset;
+    s32 nOffsetTarget;
+    s32 pad;
+    u8* pBuffer;
+    u8 anBuffer[608];
 
-    pBlock = &pROM->aBlock[iBlock];
-    if ((eType == RCT_RAM && pBlock->iCache >= 0) || (eType == RCT_ARAM && pBlock->iCache < 0)) {
-        return 1;
-    }
-
-    if (eType == RCT_RAM) {
-        iCacheARAM = -(pBlock->iCache + 1);
-        if (!romMakeFreeCache(pROM, &iCacheRAM, RCT_RAM)) {
-            return 0;
-        }
-
-        nOffsetRAM = iCacheRAM * 0x2000;
-        nOffsetARAM = iCacheARAM * 0x2000;
-        nOffsetARAM += ARGetBaseAddress();
-
-        while (ARGetDMAStatus()) {}
-
-        ARStartDMARead((u32)&pROM->pCacheRAM[nOffsetRAM], nOffsetARAM, 0x2000);
-        DCInvalidateRange(&pROM->pCacheRAM[nOffsetRAM], 0x2000);
-
-        pROM->anBlockCachedARAM[iCacheARAM >> 3] &= ~(1 << (iCacheARAM & 7));
-        pROM->anBlockCachedRAM[iCacheRAM >> 3] |= (1 << (iCacheRAM & 7));
-        pBlock->iCache = iCacheRAM;
-    } else if (eType == RCT_ARAM) {
-        iCacheRAM = pBlock->iCache;
-        if (!romMakeFreeCache(pROM, &iCacheARAM, RCT_ARAM)) {
-            return 0;
-        }
-        iCacheARAM = -(iCacheARAM + 1);
-
-        nOffsetRAM = iCacheRAM * 0x2000;
-        nOffsetARAM = iCacheARAM * 0x2000;
-        nOffsetARAM += ARGetBaseAddress();
-
-        DCStoreRange(&pROM->pCacheRAM[nOffsetRAM], 0x2000);
-
-        while (ARGetDMAStatus()) {}
-
-        ARStartDMAWrite((u32)&pROM->pCacheRAM[nOffsetRAM], nOffsetARAM, 0x2000);
-
-        pROM->anBlockCachedRAM[iCacheRAM >> 3] &= ~(1 << (iCacheRAM & 7));
-        pROM->anBlockCachedARAM[iCacheARAM >> 3] |= (1 << (iCacheARAM & 7));
-        pBlock->iCache = -(iCacheARAM + 1);
-    } else {
+    if (pROM->nSizeCacheRAM == 0) {
         return 0;
     }
 
-    while (ARGetDMAStatus()) {}
-
-    return 1;
-}
-
-inline void romMarkBlockAsFree(Rom* pROM, s32 iBlock) {
-    RomBlock* pBlock;
-    s32 iCache;
-
-    pBlock = &pROM->aBlock[iBlock];
-    iCache = pBlock->iCache;
-    if (iCache < 0) {
-        iCache = -(iCache + 1);
-        pROM->anBlockCachedARAM[iCache >> 3] &= ~(1 << (iCache & 7));
-    } else {
-        pROM->anBlockCachedRAM[iCache >> 3] &= ~(1 << (iCache & 7));
+    if (pROM->bLoad && !romCopyLoad(pROM)) {
+        return 0;
     }
-    pBlock->nSize = 0;
-}
 
-static s32 romMakeFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
-    s32 iCache;
-    s32 iBlockOldest;
+    nOffsetROM = nOffsetROM & 0x07FFFFFF;
+    pBuffer = (u8*)(((s32)anBuffer + 0x1F) & 0xFFFFFFE0);
 
-    if (eType == RCT_RAM) {
-        if (!romFindFreeCache(pROM, &iCache, RCT_RAM)) {
-            if (romFindOldestBlock(pROM, &iBlockOldest, RCT_RAM, 2)) {
-                iCache = pROM->aBlock[iBlockOldest].iCache;
-                if (!romSetBlockCache(pROM, iBlockOldest, RCT_ARAM) &&
-                    romFindOldestBlock(pROM, &iBlockOldest, RCT_RAM, 0)) {
-                    iCache = pROM->aBlock[iBlockOldest].iCache;
-                    romMarkBlockAsFree(pROM, iBlockOldest);
-                }
-            } else {
+    if (nOffsetROM + nSize > pROM->nSize && (nSize = pROM->nSize - nOffsetROM) < 0) {
+        return 1;
+    }
+
+    if (pROM->eModeLoad == RLM_PART) {
+        while (nSize != 0U) {
+            pBlock = &pROM->aBlock[nOffsetROM / 0x2000];
+            if (pBlock->nSize == 0) {
                 return 0;
             }
-        }
-    } else {
-        if (!romFindFreeCache(pROM, &iCache, RCT_ARAM)) {
-            if (romFindOldestBlock(pROM, &iBlockOldest, RCT_ARAM, 0)) {
-                iCache = pROM->aBlock[iBlockOldest].iCache;
-                romMarkBlockAsFree(pROM, iBlockOldest);
-            } else {
-                return 0;
+
+            nOffsetBlock = nOffsetROM % 0x2000;
+            if ((nSizeCopy = pBlock->nSize - nOffsetBlock) > nSize) {
+                nSizeCopy = nSize;
             }
-        }
-    }
 
-    *piCache = iCache;
-    return 1;
-}
-
-static s32 romFindOldestBlock(Rom* pROM, s32* piBlock, RomCacheType eTypeCache, s32 whichBlock) {
-    RomBlock* pBlock;
-    s32 iBlock;
-    s32 iBlockOldest;
-    u32 nTick;
-    u32 nTickDelta;
-    u32 nTickDeltaOldest;
-
-    nTick = pROM->nTick;
-    nTickDeltaOldest = 0;
-
-    for (iBlock = 0; iBlock < ARRAY_COUNT(pROM->aBlock); iBlock++) {
-        pBlock = &pROM->aBlock[iBlock];
-        if (pBlock->nSize != 0 &&
-            ((eTypeCache == RCT_RAM && pBlock->iCache >= 0) || (eTypeCache == RCT_ARAM && pBlock->iCache < 0))) {
-            if (pBlock->nTickUsed > nTick) {
-                nTickDelta = -1 - (pBlock->nTickUsed - nTick);
-            } else {
-                nTickDelta = nTick - pBlock->nTickUsed;
-            }
-            if (whichBlock == 0) {
-                if (nTickDelta > nTickDeltaOldest && pBlock->keep == 0) {
-                    iBlockOldest = iBlock;
-                    nTickDeltaOldest = nTickDelta;
+            if (pBlock->iCache >= 0) {
+                pSource = &pROM->pCacheRAM[(pBlock->iCache * 0x2000)] + nOffsetBlock;
+                if (!xlHeapCopy(pTarget, pSource, nSizeCopy)) {
+                    return 0;
                 }
-            } else if (whichBlock == 1) {
-                if (nTickDelta > nTickDeltaOldest && pBlock->keep == 1) {
-                    iBlockOldest = iBlock;
-                    nTickDeltaOldest = nTickDelta;
-                }
-            } else if (nTickDelta > nTickDeltaOldest) {
-                iBlockOldest = iBlock;
-                nTickDeltaOldest = nTickDelta;
-            }
-        }
-    }
+            } else {
+                nSizeCopyARAM = nSizeCopy;
+                nOffsetTarget = 0;
+                nOffsetARAM = nOffsetBlock + (-(pBlock->iCache + 1) * 0x2000);
+                nOffsetARAM += ARGetBaseAddress();
 
-    if (nTickDeltaOldest != 0) {
-        *piBlock = iBlockOldest;
+                while (nSizeCopyARAM > 0) {
+                    if ((nSizeDMA = nSizeCopyARAM) > 0x200) {
+                        nSizeDMA = 0x200;
+                    }
+
+                    while (ARGetDMAStatus()) {}
+
+                    nOffset = nOffsetARAM & 0x1F;
+                    ARStartDMARead((u32)pBuffer, nOffsetARAM & 0xFFFFFFE0, (nSizeDMA + nOffset + 0x1F) & 0xFFFFFFE0);
+                    DCInvalidateRange(pBuffer, nSizeDMA + nOffset);
+
+                    while (ARGetDMAStatus()) {}
+
+                    if (!xlHeapCopy((u8*)pTarget + nOffsetTarget, pBuffer + nOffset, nSizeDMA)) {
+                        return 0;
+                    }
+
+                    nOffsetARAM += nSizeDMA;
+                    nOffsetTarget += nSizeDMA;
+                    nSizeCopyARAM -= nSizeDMA;
+                }
+            }
+
+            pTarget = (u8*)pTarget + nSizeCopy;
+            nOffsetROM += nSizeCopy;
+            nSize -= nSizeCopy;
+        }
+        return 1;
+    } else if (pROM->eModeLoad == RLM_FULL) {
+        if (!xlHeapCopy(pTarget, (u8*)pROM->pBuffer + nOffsetROM, nSize)) {
+            return 0;
+        }
         return 1;
     }
 
     return 0;
 }
 
-static s32 romFindFreeCache(Rom* pROM, s32* piCache, RomCacheType eType) {
-    s32 iBlock;
+s32 romUpdate(Rom* pROM) {
+    s32 nStatus;
 
-    if (eType == RCT_RAM) {
-        for (iBlock = 0; iBlock < pROM->nCountBlockRAM; iBlock++) {
-            if (!(pROM->anBlockCachedRAM[iBlock >> 3] & (1 << (iBlock & 7)))) {
-                *piCache = iBlock;
-                return 1;
+    if ((pROM->copy.bWait != 0) || (pROM->load.bWait != 0)) {
+        if ((pROM->load.bDone != 0) && (pROM->load.nResult == pROM->load.nSizeRead)) {
+            pROM->load.bDone = 0;
+            if (!__romLoadBlock_Complete(pROM)) {
+                return 0;
             }
         }
-    } else if (eType == RCT_ARAM) {
-        for (iBlock = 0; iBlock < ARRAY_COUNT(pROM->anBlockCachedARAM); iBlock++) {
-            if (!(pROM->anBlockCachedARAM[iBlock >> 3] & (1 << (iBlock & 7)))) {
-                *piCache = -(iBlock + 1);
-                return 1;
+
+        nStatus = DVDGetCommandBlockStatus(&pROM->fileInfo);
+        if (nStatus != 1) {
+            if (!simulatorDVDShowError(nStatus, pROM->load.anData, pROM->load.nSizeRead,
+                                       pROM->offsetToRom + pROM->load.nOffset)) {
+                return 0;
+            }
+
+            if ((nStatus == 0xB) || (nStatus == -1)) {
+                DVDCancel(&pROM->fileInfo);
+                if (!simulatorDVDRead(&pROM->fileInfo, pROM->load.anData, pROM->load.nSizeRead,
+                                      pROM->offsetToRom + pROM->load.nOffset, &__romLoadBlock_CompleteGCN)) {
+                    return 0;
+                }
             }
         }
+    }
+
+    if (!romLoadUpdate(pROM)) {
+        return 0;
+    }
+
+    if (!romCopyUpdate(pROM)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+s32 romSetCacheSize(Rom* pROM, s32 nSize) {
+    s32 nSizeCacheRAM;
+
+    if (nSize < 0x100000) {
+        nSizeCacheRAM = 0x100000;
+    } else if (nSize > 0x800000) {
+        nSizeCacheRAM = 0x800000;
+    } else {
+        nSizeCacheRAM = (nSize + 0x1FFF) & 0xFFFFE000;
+    }
+
+    pROM->nSizeCacheRAM = nSizeCacheRAM;
+    pROM->nCountBlockRAM = nSizeCacheRAM / 0x2000;
+
+    if (!xlHeapTake(&pROM->pBuffer, nSizeCacheRAM | 0x30000000)) {
+        return 0;
+    }
+
+    pROM->pCacheRAM = (u8*)pROM->pBuffer;
+
+    return 1;
+}
+
+inline void romOpen(Rom* pROM, char* szNameFile) {
+    s32 var_r30 = 0;
+    s32 bFlip;
+
+    if ((pROM->acHeader[0] == 0x37) && (pROM->acHeader[1] == 0x80)) {
+        var_r30 = 1;
+    }
+
+    if (var_r30 != 0) {
+        bFlip = 1;
+    } else {
+        bFlip = 0;
+    }
+
+    pROM->bFlip = bFlip;
+    simulatorDVDOpen(szNameFile, &pROM->fileInfo);
+}
+
+s32 romSetImage(Rom* pROM, char* szNameFile) {
+    tXL_FILE* pFile;
+    s32 iName;
+    s32 nSize;
+
+    for (iName = 0; (szNameFile[iName] != '\0') && (iName < 0x200); iName++) {
+        pROM->acNameFile[iName] = szNameFile[iName];
+    }
+    pROM->acNameFile[iName] = '\0';
+
+    if (xlFileGetSize(&nSize, pROM->acNameFile)) {
+        pROM->nSize = (u32)(nSize - pROM->offsetToRom);
     } else {
         return 0;
     }
 
-    return 0;
+    if (!xlFileOpen(&pFile, XLFT_BINARY, szNameFile)) {
+        return 0;
+    }
+
+    if (!xlFileSetPosition(pFile, pROM->offsetToRom)) {
+        return 0;
+    }
+
+    if (!xlFileGet(pFile, pROM->acHeader, sizeof(pROM->acHeader))) {
+        return 0;
+    }
+
+    if (!xlFileClose(&pFile)) {
+        return 0;
+    }
+
+    romOpen(pROM, szNameFile);
+    return 1;
+}
+
+s32 romGetImage(Rom* pROM, char* acNameFile) {
+    if (pROM->acNameFile[0] == '\0') {
+        return 0;
+    }
+
+    if (acNameFile != NULL) {
+        s32 iName;
+
+        for (iName = 0; pROM->acNameFile[iName] != '\0'; iName++) {
+            acNameFile[iName] = pROM->acNameFile[iName];
+        }
+    }
+
+    return 1;
+}
+
+s32 romEvent(Rom* pROM, s32 nEvent, void* pArgument) {
+    switch (nEvent) {
+        case 2:
+            pROM->nSize = 0;
+            pROM->nTick = 0;
+            pROM->bLoad = 1;
+            pROM->bFlip = 0;
+            pROM->pHost = pArgument;
+            pROM->acNameFile[0] = '\0';
+            pROM->eModeLoad = RLM_NONE;
+            pROM->pBuffer = NULL;
+            pROM->offsetToRom = 0;
+            pROM->anOffsetBlock = NULL;
+            pROM->nCountOffsetBlocks = 0;
+            pROM->copy.nSize = 0;
+            pROM->copy.bWait = 0;
+            pROM->load.bWait = 0;
+            pROM->load.nOffset1 = 0;
+            pROM->load.nOffset0 = 0;
+            pROM->load.bDone = 0;
+            pROM->nSizeCacheRAM = 0;
+            pROM->nCountBlockRAM = 0;
+            pROM->pCacheRAM = NULL;
+            break;
+        case 3:
+            if ((pROM->pBuffer != NULL) && (pROM->pBuffer != pROM->pCacheRAM) && (!xlHeapFree(&pROM->pBuffer))) {
+                return 0;
+            }
+            break;
+        case 0x1002:
+            switch (((CpuDevice*)pArgument)->nType) {
+                case 0:
+                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPut8,
+                                         (Put16Func)romPut16, (Put32Func)romPut32, (Put64Func)romPut64)) {
+                        return 0;
+                    }
+                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGet8,
+                                         (Get16Func)romGet16, (Get32Func)romGet32, (Get64Func)romGet64)) {
+                        return 0;
+                    }
+                    break;
+                case 1:
+                    if (!cpuSetDevicePut(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Put8Func)romPutDebug8,
+                                         (Put16Func)romPutDebug16, (Put32Func)romPutDebug32,
+                                         (Put64Func)romPutDebug64)) {
+                        return 0;
+                    }
+                    if (!cpuSetDeviceGet(((System*)pROM->pHost)->apObject[SOT_CPU], pArgument, (Get8Func)romGetDebug8,
+                                         (Get16Func)romGetDebug16, (Get32Func)romGetDebug32,
+                                         (Get64Func)romGetDebug64)) {
+                        return 0;
+                    }
+                    break;
+            }
+            break;
+        case 0:
+        case 1:
+        case 0x1003:
+            break;
+        default:
+            return 0;
+    }
+
+    return 1;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -155,48 +155,48 @@ const f32 D_80135F90 = 0.01666666753590107;
 const f32 D_80135F94 = 1.100000023841858;
 const f64 D_80135F98 = 4503599627370496.0;
 
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemEvent.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemExceptionPending.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemCheckInterrupts.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemExecute.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemReset.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetStorageDevice.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetStorageDevice.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetMode.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetMode.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemCopyROM.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/__systemCopyROM_Complete.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut64.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut32.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut16.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut8.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet64.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet32.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet16.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet8.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetException.s")
-
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetupGameALL.s")
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetupGameRAM.s")
 
 #pragma GLOBAL_ASM("asm/non_matchings/system/systemGetInitialConfiguration.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetupGameRAM.s")
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetupGameALL.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetException.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet8.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet16.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet32.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGet64.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut8.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut16.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut32.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemPut64.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/__systemCopyROM_Complete.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemCopyROM.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetMode.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetMode.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemSetStorageDevice.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemGetStorageDevice.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemReset.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemExecute.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemCheckInterrupts.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemExceptionPending.s")
+
+#pragma GLOBAL_ASM("asm/non_matchings/system/systemEvent.s")

--- a/src/xlList.c
+++ b/src/xlList.c
@@ -4,14 +4,90 @@
 
 static tXL_LIST gListList;
 
-s32 xlListReset(void) { return 1; }
+#pragma GLOBAL_ASM("asm/non_matchings/xlList/xlListMake.s")
 
-s32 xlListSetup(void) {
-    gListList.nItemCount = 0;
-    gListList.nItemSize = sizeof(tXL_LIST);
-    gListList.pNodeNext = NULL;
-    gListList.pNodeHead = NULL;
+static inline s32 xlListWipe(tXL_LIST* pList) {
+    tXL_NODE* pNode;
+    tXL_NODE* pNodeNext;
+
+    pNode = pList->pNodeHead;
+    while (pNode != NULL) {
+        pNodeNext = pNode->next;
+        if (!xlHeapFree((void**)&pNode)) {
+            return 0;
+        }
+        pNode = pNodeNext;
+    }
+
+    pList->nItemCount = 0;
+    pList->pNodeNext = NULL;
+    pList->pNodeHead = NULL;
     return 1;
+}
+
+s32 xlListFree(tXL_LIST** ppList) {
+    if (!xlListWipe(*ppList)) {
+        return 0;
+    }
+
+    if (!xlListFreeItem(&gListList, (void**)ppList)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+s32 xlListMakeItem(tXL_LIST* pList, void** ppItem) {
+    s32 nSize;
+    tXL_NODE* pListNode;
+    tXL_NODE* pNode;
+    tXL_NODE* pNodeNext;
+
+    nSize = pList->nItemSize + 4;
+    if (!xlHeapTake((void**)&pListNode, nSize)) {
+        return 0;
+    }
+
+    pListNode->next = NULL;
+    *ppItem = (void*)pListNode->data;
+    pNode = (tXL_NODE*)&pList->pNodeHead;
+    while (pNode != NULL) {
+        pNodeNext = pNode->next;
+        if (pNodeNext == NULL) {
+            pNode->next = pListNode;
+            pList->nItemCount++;
+            return 1;
+        }
+        pNode = pNodeNext;
+    }
+
+    return 0;
+}
+
+s32 xlListFreeItem(tXL_LIST* pList, void** ppItem) {
+    tXL_NODE* pNode;
+    tXL_NODE* pNodeNext;
+
+    if (pList->pNodeHead == NULL) {
+        return 0;
+    }
+
+    pNode = (tXL_NODE*)&pList->pNodeHead;
+    while (pNode != NULL) {
+        pNodeNext = pNode->next;
+        if (*ppItem == (void*)pNodeNext->data) {
+            pNode->next = pNodeNext->next;
+            *ppItem = NULL;
+            if (!xlHeapFree((void**)&pNodeNext)) {
+                return 0;
+            }
+            pList->nItemCount--;
+            return 1;
+        }
+        pNode = pNodeNext;
+    }
+
+    return 0;
 }
 
 static inline s32 xlListTest(tXL_LIST* pList) {
@@ -50,88 +126,12 @@ s32 xlListTestItem(tXL_LIST* pList, void* pItem) {
     return 0;
 }
 
-s32 xlListFreeItem(tXL_LIST* pList, void** ppItem) {
-    tXL_NODE* pNode;
-    tXL_NODE* pNodeNext;
-
-    if (pList->pNodeHead == NULL) {
-        return 0;
-    }
-
-    pNode = (tXL_NODE*)&pList->pNodeHead;
-    while (pNode != NULL) {
-        pNodeNext = pNode->next;
-        if (*ppItem == (void*)pNodeNext->data) {
-            pNode->next = pNodeNext->next;
-            *ppItem = NULL;
-            if (!xlHeapFree((void**)&pNodeNext)) {
-                return 0;
-            }
-            pList->nItemCount--;
-            return 1;
-        }
-        pNode = pNodeNext;
-    }
-
-    return 0;
-}
-
-s32 xlListMakeItem(tXL_LIST* pList, void** ppItem) {
-    s32 nSize;
-    tXL_NODE* pListNode;
-    tXL_NODE* pNode;
-    tXL_NODE* pNodeNext;
-
-    nSize = pList->nItemSize + 4;
-    if (!xlHeapTake((void**)&pListNode, nSize)) {
-        return 0;
-    }
-
-    pListNode->next = NULL;
-    *ppItem = (void*)pListNode->data;
-    pNode = (tXL_NODE*)&pList->pNodeHead;
-    while (pNode != NULL) {
-        pNodeNext = pNode->next;
-        if (pNodeNext == NULL) {
-            pNode->next = pListNode;
-            pList->nItemCount++;
-            return 1;
-        }
-        pNode = pNodeNext;
-    }
-
-    return 0;
-}
-
-static inline s32 xlListWipe(tXL_LIST* pList) {
-    tXL_NODE* pNode;
-    tXL_NODE* pNodeNext;
-
-    pNode = pList->pNodeHead;
-    while (pNode != NULL) {
-        pNodeNext = pNode->next;
-        if (!xlHeapFree((void**)&pNode)) {
-            return 0;
-        }
-        pNode = pNodeNext;
-    }
-
-    pList->nItemCount = 0;
-    pList->pNodeNext = NULL;
-    pList->pNodeHead = NULL;
+s32 xlListSetup(void) {
+    gListList.nItemCount = 0;
+    gListList.nItemSize = sizeof(tXL_LIST);
+    gListList.pNodeNext = NULL;
+    gListList.pNodeHead = NULL;
     return 1;
 }
 
-s32 xlListFree(tXL_LIST** ppList) {
-    if (!xlListWipe(*ppList)) {
-        return 0;
-    }
-
-    if (!xlListFreeItem(&gListList, (void**)ppList)) {
-        return 0;
-    }
-
-    return 1;
-}
-
-#pragma GLOBAL_ASM("asm/non_matchings/xlList/xlListMake.s")
+s32 xlListReset(void) { return 1; }

--- a/tools/asm_processor/asm_processor.py
+++ b/tools/asm_processor/asm_processor.py
@@ -658,9 +658,12 @@ class GlobalAsmBlock:
                         # Don't let functions become too large. When a function reaches 284
                         # instructions, and -O2 -framepointer flags are passed, the IRIX
                         # compiler decides it is a great idea to start optimizing more.
+
+                        # Keep last function name for reversed function order due to -inline deferred
+                        text_name = state.make_name('large_func')  
                         fn_emitted = 0
                         fn_skipped = 0
-                        src[line] += '((volatile void *) 0); }} int {}(void) {{ return '.format(state.make_name('large_func'))
+                        src[line] += '((volatile void *) 0); }} int {}(void) {{ return '.format(text_name)
                     if fn_skipped < state.skip_instr_count:
                         fn_skipped += 1
                         tot_skipped += 1
@@ -699,9 +702,12 @@ class GlobalAsmBlock:
                         # Don't let functions become too large. When a function reaches 284
                         # instructions, and -O2 -framepointer flags are passed, the IRIX
                         # compiler decides it is a great idea to start optimizing more.
+                        
+                        # Keep last function name for reversed function order due to -inline deferred
+                        text_name = state.make_name('large_func')  
                         fn_emitted = 0
                         fn_skipped = 0
-                        src[line] += '((volatile void *) 0); }} int {}(void) {{ return '.format(state.make_name('large_func'))
+                        src[line] += '((volatile void *) 0); }} int {}(void) {{ return '.format(text_name)
                     if fn_skipped < state.skip_instr_count:
                         fn_skipped += 1
                         tot_skipped += 1
@@ -916,7 +922,8 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc):
     # simplicity we pad with nops/.space so that addresses match exactly, so we
     # don't have to fix up relocations/symbol references.
     all_text_glabels = set()
-    for function in functions:
+    # -inline deferred will reverse function order
+    for function in reversed(functions):
         ifdefed = False
         for sectype, (temp_name, size) in function.data.items():
             if temp_name is None:

--- a/tools/func_splitter.py
+++ b/tools/func_splitter.py
@@ -64,6 +64,9 @@ def splitAsm(inputFile: str):
         # create the folders if necessary
         os.makedirs(os.path.dirname(f"asm/non_matchings/{inputFile}/"), exist_ok=True)
 
+        # reverse function order for -inline deferred
+        parsedFunctions.reverse()
+
         # write the files
         for i, (functionName, functionData) in enumerate(parsedFunctions):
             cPath = f"src/{inputFile}.c"


### PR DESCRIPTION
I'm fairly sure `-inline deferrred` was used, because I don't see how the inlining can work out for `romCacheGame` otherwise. This has the side-effect of reversing the function order between the source code and the compiled object, which makes a lot of sense logically and it's consistent with the line numbers in the debug info.

I've also updated func_splitter.py to split the functions in reverse order now. Probably we should try to update the debug info too, but I'll do that in another PR.