### PR TITLE
Reverse function order in debug info

### DIFF
--- a/debug/Core/xlCoreGCN.c
+++ b/debug/Core/xlCoreGCN.c
@@ -84,12 +84,6 @@ struct _GXTexObj g_texMap[4];
 // size = 0x4, address = 0x8013559C
 struct _GXRenderModeObj* rmode;
 
-// Range: 0x800055A0 -> 0x80005674
-void xlCoreBeforeRender() {
-    // References
-    // -> struct _GXRenderModeObj* rmode;
-}
-
 // size = 0x4, address = 0x80135420
 s32 __OSCurrHeap;
 
@@ -161,6 +155,135 @@ typedef struct _GXColor {
     /* 0x3 */ u8 a;
 } __anon_0xD8F; // size = 0x4
 
+typedef union DoubleLongLong {
+    /* 0x0 */ f64 f;
+    /* 0x0 */ s64 i;
+} __anon_0x1026;
+
+// size = 0x3C, address = 0x800F1E60
+struct _GXRenderModeObj GXNtsc480IntDf;
+
+// size = 0x3C, address = 0x800F1E9C
+struct _GXRenderModeObj GXNtsc480Prog;
+
+// size = 0x3C, address = 0x800F1F14
+struct _GXRenderModeObj GXPal528IntDf;
+
+// size = 0x3C, address = 0x800F1ED8
+struct _GXRenderModeObj GXMpal480IntDf;
+
+// Erased
+static void xlCoreInit(struct _GXRenderModeObj* mode) {
+    // Parameters
+    // struct _GXRenderModeObj* mode; // r31
+
+    // References
+    // -> struct _GXRenderModeObj* rmode;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+    // -> static void* DefaultFifo;
+    // -> static struct __anon_0x238* DefaultFifoObj;
+    // -> s32 __OSCurrHeap;
+}
+
+// Range: 0x80005DC8 -> 0x80005E04
+s32 xlCoreReset() {
+    // References
+    // -> static void* gArenaHi;
+    // -> static void* gArenaLo;
+    // -> static void* gpHeap;
+    // -> s32 __OSCurrHeap;
+}
+
+// Range: 0x80005C54 -> 0x80005DC8
+static void xlCoreInitRenderMode(struct _GXRenderModeObj* mode) {
+    // Parameters
+    // struct _GXRenderModeObj* mode; // r1+0x8
+
+    // Local variables
+    char* szText; // r31
+    s32 iArgument; // r5
+
+    // References
+    // -> static struct _GXRenderModeObj rmodeobj;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> struct _GXRenderModeObj GXMpal480IntDf;
+    // -> struct _GXRenderModeObj GXPal528IntDf;
+    // -> struct _GXRenderModeObj GXNtsc480Prog;
+    // -> static s32 gnCountArgument;
+    // -> static char** gaszArgument;
+    // -> struct _GXRenderModeObj GXNtsc480IntDf;
+}
+
+// Range: 0x80005B7C -> 0x80005C54
+static void xlCoreInitMem() {
+    // Local variables
+    void* arenaLo; // r1+0x8
+    void* arenaHi; // r1+0x8
+    u32 fbSize; // r3
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> static void* gArenaHi;
+    // -> static void* gArenaLo;
+}
+
+// Range: 0x80005920 -> 0x80005B7C
+static void xlCoreInitGX() {
+    // Local variables
+    u8 newFilter[7]; // r1+0x18
+
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> struct _GXRenderModeObj* rmode;
+}
+
+// Erased
+static void xlCoreInitVI() {
+    // References
+    // -> struct _GXRenderModeObj* rmode;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer1;
+}
+
+// Range: 0x80005918 -> 0x80005920
+s32 xlCoreGetArgumentCount() {
+    // References
+    // -> static s32 gnCountArgument;
+}
+
+// Range: 0x800058E4 -> 0x80005918
+s32 xlCoreGetArgument(s32 iArgument, char** pszArgument) {
+    // Parameters
+    // s32 iArgument; // r1+0x0
+    // char** pszArgument; // r1+0x4
+
+    // References
+    // -> static char** gaszArgument;
+    // -> static s32 gnCountArgument;
+}
+
+// Range: 0x800058DC -> 0x800058E4
+s32 xlCoreHiResolution() {}
+
+// Erased
+static s32 xlCoreEnableFPExceptions() {
+    // Local variables
+    f64 control; // r1+0x8
+    union DoubleLongLong d; // r1+0x8
+}
+
+// Erased
+static s32 xlCoreGetUpper24MB(void* ppBuffer) {
+    // Parameters
+    // void* ppBuffer; // r1+0x0
+}
+
 // Range: 0x80005674 -> 0x800058DC
 s32 main(s32 nCount, char** aszArgument) {
     // Parameters
@@ -190,131 +313,8 @@ s32 main(s32 nCount, char** aszArgument) {
     // -> static s32 gnCountArgument;
 }
 
-// Erased
-static s32 xlCoreGetUpper24MB(void* ppBuffer) {
-    // Parameters
-    // void* ppBuffer; // r1+0x0
-}
-
-typedef union DoubleLongLong {
-    /* 0x0 */ f64 f;
-    /* 0x0 */ s64 i;
-} __anon_0x1026;
-
-// Erased
-static s32 xlCoreEnableFPExceptions() {
-    // Local variables
-    f64 control; // r1+0x8
-    union DoubleLongLong d; // r1+0x8
-}
-
-// Range: 0x800058DC -> 0x800058E4
-s32 xlCoreHiResolution() {}
-
-// Range: 0x800058E4 -> 0x80005918
-s32 xlCoreGetArgument(s32 iArgument, char** pszArgument) {
-    // Parameters
-    // s32 iArgument; // r1+0x0
-    // char** pszArgument; // r1+0x4
-
-    // References
-    // -> static char** gaszArgument;
-    // -> static s32 gnCountArgument;
-}
-
-// Range: 0x80005918 -> 0x80005920
-s32 xlCoreGetArgumentCount() {
-    // References
-    // -> static s32 gnCountArgument;
-}
-
-// Erased
-static void xlCoreInitVI() {
+// Range: 0x800055A0 -> 0x80005674
+void xlCoreBeforeRender() {
     // References
     // -> struct _GXRenderModeObj* rmode;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer1;
-}
-
-// Range: 0x80005920 -> 0x80005B7C
-static void xlCoreInitGX() {
-    // Local variables
-    u8 newFilter[7]; // r1+0x18
-
-    // References
-    // -> void* DemoCurrentBuffer;
-    // -> struct _GXRenderModeObj* rmode;
-}
-
-// Range: 0x80005B7C -> 0x80005C54
-static void xlCoreInitMem() {
-    // Local variables
-    void* arenaLo; // r1+0x8
-    void* arenaHi; // r1+0x8
-    u32 fbSize; // r3
-
-    // References
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer1;
-    // -> struct _GXRenderModeObj* rmode;
-    // -> static void* gArenaHi;
-    // -> static void* gArenaLo;
-}
-
-// size = 0x3C, address = 0x800F1E60
-struct _GXRenderModeObj GXNtsc480IntDf;
-
-// size = 0x3C, address = 0x800F1E9C
-struct _GXRenderModeObj GXNtsc480Prog;
-
-// size = 0x3C, address = 0x800F1F14
-struct _GXRenderModeObj GXPal528IntDf;
-
-// size = 0x3C, address = 0x800F1ED8
-struct _GXRenderModeObj GXMpal480IntDf;
-
-// Range: 0x80005C54 -> 0x80005DC8
-static void xlCoreInitRenderMode(struct _GXRenderModeObj* mode) {
-    // Parameters
-    // struct _GXRenderModeObj* mode; // r1+0x8
-
-    // Local variables
-    char* szText; // r31
-    s32 iArgument; // r5
-
-    // References
-    // -> static struct _GXRenderModeObj rmodeobj;
-    // -> struct _GXRenderModeObj* rmode;
-    // -> struct _GXRenderModeObj GXMpal480IntDf;
-    // -> struct _GXRenderModeObj GXPal528IntDf;
-    // -> struct _GXRenderModeObj GXNtsc480Prog;
-    // -> static s32 gnCountArgument;
-    // -> static char** gaszArgument;
-    // -> struct _GXRenderModeObj GXNtsc480IntDf;
-}
-
-// Range: 0x80005DC8 -> 0x80005E04
-s32 xlCoreReset() {
-    // References
-    // -> static void* gArenaHi;
-    // -> static void* gArenaLo;
-    // -> static void* gpHeap;
-    // -> s32 __OSCurrHeap;
-}
-
-// Erased
-static void xlCoreInit(struct _GXRenderModeObj* mode) {
-    // Parameters
-    // struct _GXRenderModeObj* mode; // r31
-
-    // References
-    // -> struct _GXRenderModeObj* rmode;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer1;
-    // -> static void* DefaultFifo;
-    // -> static struct __anon_0x238* DefaultFifoObj;
-    // -> s32 __OSCurrHeap;
 }

--- a/debug/Core/xlFileGCN.c
+++ b/debug/Core/xlFileGCN.c
@@ -66,100 +66,38 @@ typedef struct tXL_FILE {
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x2085; // size = 0x58
 
-// Range: 0x80005E68 -> 0x80005F18
-s32 xlFileEvent(struct tXL_FILE* pFile, s32 nEvent) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r31
-    // s32 nEvent; // r1+0xC
-}
-
-// Erased
-static s32 xlFileGetPosition(struct tXL_FILE* pFile, s32* pnOffset) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r1+0x0
-    // s32* pnOffset; // r1+0x4
-}
-
-// Range: 0x80005F18 -> 0x80005F40
-s32 xlFileSetPosition(struct tXL_FILE* pFile, s32 nOffset) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r1+0x0
-    // s32 nOffset; // r1+0x4
-}
-
-// Erased
-static s32 xlFilePutLine() {}
-
-// Erased
-static s32 xlFilePutFlip(s32 nSizeBytes) {
-    // Parameters
-    // s32 nSizeBytes; // r1+0x8
-}
-
-// Erased
-static s32 xlFilePut() {}
-
-// Erased
-static s32 xlFileGetLine(struct tXL_FILE* pFile, char* acLine, s32 nSizeLine) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r28
-    // char* acLine; // r29
-    // s32 nSizeLine; // r30
-
-    // Local variables
-    s32 iCharacter; // r31
-    char nCharacter; // r1+0x14
-}
-
-// Erased
-static s32 xlFileGetFlip(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r30
-    // void* pTarget; // r31
-    // s32 nSizeBytes; // r1+0x10
-}
-
-// Range: 0x80005F40 -> 0x80006044
-s32 xlFileGet(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
-    // Parameters
-    // struct tXL_FILE* pFile; // r27
-    // void* pTarget; // r28
-    // s32 nSizeBytes; // r29
-
-    // Local variables
-    s32 nOffset; // r6
-    s32 nOffsetExtra; // r1+0x8
-    s32 nSize; // r5
-    s32 nSizeUsed; // r30
-
-    // References
-    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
-}
-
-// Range: 0x80006044 -> 0x80006078
-s32 xlFileClose(struct tXL_FILE** ppFile) {
-    // Parameters
-    // struct tXL_FILE** ppFile; // r3
-}
-
-// Erased
-static s32 xlFileCreate() {}
-
 typedef enum __anon_0x2757 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
     XLFT_BINARY = 1,
 } __anon_0x2757;
 
-// Range: 0x80006078 -> 0x8000614C
-s32 xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {
+// Range: 0x80006274 -> 0x80006280
+s32 xlFileSetOpen(s32 (*pfOpen)(char*, struct DVDFileInfo*)) {
     // Parameters
-    // struct tXL_FILE** ppFile; // r29
-    // enum __anon_0x2757 eType; // r30
-    // char* szFileName; // r31
+    // s32 (* pfOpen)(char*, struct DVDFileInfo*); // r1+0x0
+
+    // References
+    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+}
+
+// Range: 0x80006268 -> 0x80006274
+s32 xlFileSetRead(s32 (*pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*))) {
+    // Parameters
+    // s32 (* pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*)); // r1+0x0
+
+    // References
+    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+}
+
+// Range: 0x8000614C -> 0x80006268
+s32 xlFileGetSize(s32* pnSize, char* szFileName) {
+    // Parameters
+    // s32* pnSize; // r31
+    // char* szFileName; // r30
 
     // Local variables
-    s32 nStatus; // r3
+    struct tXL_FILE* pFile; // r1+0x10
 
     // References
     // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
@@ -181,34 +119,96 @@ static s32 xlFileLoad(char* szFileName, void* ppBuffer) {
     // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
-// Range: 0x8000614C -> 0x80006268
-s32 xlFileGetSize(s32* pnSize, char* szFileName) {
+// Range: 0x80006078 -> 0x8000614C
+s32 xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {
     // Parameters
-    // s32* pnSize; // r31
-    // char* szFileName; // r30
+    // struct tXL_FILE** ppFile; // r29
+    // enum __anon_0x2757 eType; // r30
+    // char* szFileName; // r31
 
     // Local variables
-    struct tXL_FILE* pFile; // r1+0x10
+    s32 nStatus; // r3
 
     // References
     // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
     // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
-// Range: 0x80006268 -> 0x80006274
-s32 xlFileSetRead(s32 (*pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*))) {
+// Erased
+static s32 xlFileCreate() {}
+
+// Range: 0x80006044 -> 0x80006078
+s32 xlFileClose(struct tXL_FILE** ppFile) {
     // Parameters
-    // s32 (* pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*)); // r1+0x0
+    // struct tXL_FILE** ppFile; // r3
+}
+
+// Range: 0x80005F40 -> 0x80006044
+s32 xlFileGet(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r27
+    // void* pTarget; // r28
+    // s32 nSizeBytes; // r29
+
+    // Local variables
+    s32 nOffset; // r6
+    s32 nOffsetExtra; // r1+0x8
+    s32 nSize; // r5
+    s32 nSizeUsed; // r30
 
     // References
     // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
 }
 
-// Range: 0x80006274 -> 0x80006280
-s32 xlFileSetOpen(s32 (*pfOpen)(char*, struct DVDFileInfo*)) {
+// Erased
+static s32 xlFileGetFlip(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
     // Parameters
-    // s32 (* pfOpen)(char*, struct DVDFileInfo*); // r1+0x0
+    // struct tXL_FILE* pFile; // r30
+    // void* pTarget; // r31
+    // s32 nSizeBytes; // r1+0x10
+}
 
-    // References
-    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+// Erased
+static s32 xlFileGetLine(struct tXL_FILE* pFile, char* acLine, s32 nSizeLine) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r28
+    // char* acLine; // r29
+    // s32 nSizeLine; // r30
+
+    // Local variables
+    s32 iCharacter; // r31
+    char nCharacter; // r1+0x14
+}
+
+// Erased
+static s32 xlFilePut() {}
+
+// Erased
+static s32 xlFilePutFlip(s32 nSizeBytes) {
+    // Parameters
+    // s32 nSizeBytes; // r1+0x8
+}
+
+// Erased
+static s32 xlFilePutLine() {}
+
+// Range: 0x80005F18 -> 0x80005F40
+s32 xlFileSetPosition(struct tXL_FILE* pFile, s32 nOffset) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r1+0x0
+    // s32 nOffset; // r1+0x4
+}
+
+// Erased
+static s32 xlFileGetPosition(struct tXL_FILE* pFile, s32* pnOffset) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r1+0x0
+    // s32* pnOffset; // r1+0x4
+}
+
+// Range: 0x80005E68 -> 0x80005F18
+s32 xlFileEvent(struct tXL_FILE* pFile, s32 nEvent) {
+    // Parameters
+    // struct tXL_FILE* pFile; // r31
+    // s32 nEvent; // r1+0xC
 }

--- a/debug/Core/xlHeap.c
+++ b/debug/Core/xlHeap.c
@@ -31,138 +31,103 @@ static u32* gapHeapBlockCache[11][32];
 // size = 0x4, address = 0x801355C0
 s32 gnSizeHeap;
 
-// Range: 0x80006648 -> 0x800066B0
-s32 xlHeapReset() {
-    // Local variables
-    s32 nBlockSize; // r6
-
-    // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gpHeap;
-    // -> s32 gnSizeHeap;
+// Erased
+static s32 xlHeapTestBlock(u32 nBlock) {
+    // Parameters
+    // u32 nBlock; // r1+0x0
 }
 
-// Range: 0x800066B0 -> 0x80006870
-s32 xlHeapSetup(void* pHeap, s32 nSizeBytes) {
-    // Parameters
-    // void* pHeap; // r6
-    // s32 nSizeBytes; // r1+0xC
+// Erased
+static void xlHeapShowStatistics() {}
 
-    // Local variables
-    s32 nSizeWords; // r5
-
+// Erased
+static void xlHeapStatisticsReset() {
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gpHeap;
-    // -> s32 gnSizeHeap;
+    // -> static s32 gnHeapFreeCount;
+    // -> static s32 gnHeapTakeCount;
+    // -> static s32 gnHeapTakeCacheCount;
 }
 
-// Range: 0x80006870 -> 0x80006908
-s32 xlHeapGetFree(s32* pnFreeBytes) {
+// Range: 0x800079C0 -> 0x80007BC0
+static s32 xlHeapBlockCacheGet(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
     // Parameters
-    // s32* pnFreeBytes; // r31
+    // s32 nSize; // r1+0x0
+    // u32** ppBlock; // r1+0x4
+    // s32* pnBlockSize; // r1+0x8
+
+    // Local variables
+    s32 nBlockCachedSize; // r1+0x0
+    s32 nBlock; // r8
+    s32 nBlockSize; // r9
+    s32 nBlockBest; // r10
+    s32 nBlockBestSize; // r11
+    u32* pBlock; // r12
+
+    // References
+    // -> static s32 gnHeapTakeCacheCount;
+    // -> static u32* gapHeapBlockCache[11][32];
+}
+
+// Range: 0x80007758 -> 0x800079C0
+static s32 xlHeapBlockCacheAdd(u32* pBlock) {
+    // Parameters
+    // u32* pBlock; // r1+0x0
+
+    // Local variables
+    s32 nSize; // r6
+    s32 nBlock; // r7
+    s32 nBlockSize; // r1+0x0
+    s32 nBlockCachedSize; // r1+0x0
+    u32* pBlockCached; // r8
+
+    // References
+    // -> static u32* gapHeapBlockCache[11][32];
+}
+
+// Range: 0x8000764C -> 0x80007758
+static s32 xlHeapBlockCacheClear(u32* pBlock) {
+    // Parameters
+    // u32* pBlock; // r1+0x0
+
+    // Local variables
+    s32 nSize; // r1+0x0
+    s32 nBlock; // r6
+    s32 nBlockSize; // r1+0x0
+
+    // References
+    // -> static u32* gapHeapBlockCache[11][32];
+}
+
+// Range: 0x80007540 -> 0x8000764C
+static s32 xlHeapBlockCacheReset() {
+    // Local variables
+    s32 nBlockSize; // r1+0x8
+    u32* pBlock; // r30
+    u32 nBlock; // r1+0x8
+
+    // References
+    // -> static u32* gpHeapBlockFirst;
+    // -> static u32* gapHeapBlockCache[11][32];
+    // -> static s32 gnHeapFreeCount;
+    // -> static s32 gnHeapTakeCount;
+    // -> static s32 gnHeapTakeCacheCount;
+}
+
+// Range: 0x8000743C -> 0x80007540
+static s32 xlHeapFindUpperBlock(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+    // Parameters
+    // s32 nSize; // r28
+    // u32** ppBlock; // r29
+    // s32* pnBlockSize; // r30
 
     // Local variables
     s32 nBlockSize; // r3
-    s32 nFree; // r5
-    s32 nCount; // r1+0x8
-    u32* pBlock; // r6
-    u32 nBlock; // r7
+    u32 nBlock; // r4
+    u32* pBlock; // r7
+    u32* pBlockBest; // r31
+    u32* pBlockNext; // r27
 
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
-}
-
-// Range: 0x80006908 -> 0x80006AF0
-s32 xlHeapFill32(void* pHeap, s32 nByteCount, u32 nData) {
-    // Parameters
-    // void* pHeap; // r3
-    // s32 nByteCount; // r6
-    // u32 nData; // r1+0x8
-
-    // Local variables
-    u32* pnTarget; // r3
-}
-
-// Erased
-static s32 xlHeapFill16(void* pHeap, s32 nByteCount, u16 nData) {
-    // Parameters
-    // void* pHeap; // r3
-    // s32 nByteCount; // r6
-    // u16 nData; // r1+0x8
-
-    // Local variables
-    u16* pnTarget; // r3
-}
-
-// Erased
-static s32 xlHeapFill8(void* pHeap, s32 nByteCount, u8 nData) {
-    // Parameters
-    // void* pHeap; // r3
-    // s32 nByteCount; // r4
-    // u8 nData; // r1+0x8
-
-    // Local variables
-    u8* pnTarget; // r3
-}
-
-// Range: 0x80006AF0 -> 0x80006F68
-s32 xlHeapCopy(void* pHeapTarget, void* pHeapSource, s32 nByteCount) {
-    // Parameters
-    // void* pHeapTarget; // r3
-    // void* pHeapSource; // r4
-    // s32 nByteCount; // r5
-
-    // Local variables
-    u8* pSource8; // r4
-    u8* pTarget8; // r3
-    u32* pSource32; // r4
-    u32* pTarget32; // r3
-}
-
-// Range: 0x80006F68 -> 0x80007098
-s32 xlHeapCompact() {
-    // Local variables
-    s32 nCount; // r1+0x8
-    s32 nBlockLarge; // r1+0x8
-    s32 nBlockSize; // r4
-    s32 nBlockNextSize; // r3
-    s32 anBlockLarge[6]; // r1+0x8
-    u32 nBlock; // r1+0x8
-    u32* pBlock; // r5
-    u32* pBlockPrevious; // r6
-    u32 nBlockNext; // r7
-    u32* pBlockNext; // r8
-
-    // References
-    // -> static u32* gpHeapBlockFirst;
-}
-
-// Erased
-static s32 xlHeapTest(void* pHeap) {
-    // Parameters
-    // void* pHeap; // r1+0x0
-
-    // Local variables
-    u32* pBlock; // r3
-}
-
-// Range: 0x80007098 -> 0x800071B4
-s32 xlHeapFree(void* ppHeap) {
-    // Parameters
-    // void* ppHeap; // r31
-
-    // Local variables
-    s32 nBlockSize; // r30
-    s32 nBlockNextSize; // r29
-    u32* pBlock; // r28
-    u32* pBlockNext; // r3
-
-    // References
-    // -> static s32 gnHeapFreeCount;
     // -> static u32* gpHeapBlockLast;
     // -> static u32* gpHeapBlockFirst;
 }
@@ -192,103 +157,138 @@ s32 xlHeapTake(void* ppHeap, s32 nByteCount) {
     // -> static u32* gpHeapBlockFirst;
 }
 
-// Range: 0x8000743C -> 0x80007540
-static s32 xlHeapFindUpperBlock(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+// Range: 0x80007098 -> 0x800071B4
+s32 xlHeapFree(void* ppHeap) {
     // Parameters
-    // s32 nSize; // r28
-    // u32** ppBlock; // r29
-    // s32* pnBlockSize; // r30
+    // void* ppHeap; // r31
+
+    // Local variables
+    s32 nBlockSize; // r30
+    s32 nBlockNextSize; // r29
+    u32* pBlock; // r28
+    u32* pBlockNext; // r3
+
+    // References
+    // -> static s32 gnHeapFreeCount;
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
+}
+
+// Erased
+static s32 xlHeapTest(void* pHeap) {
+    // Parameters
+    // void* pHeap; // r1+0x0
+
+    // Local variables
+    u32* pBlock; // r3
+}
+
+// Range: 0x80006F68 -> 0x80007098
+s32 xlHeapCompact() {
+    // Local variables
+    s32 nCount; // r1+0x8
+    s32 nBlockLarge; // r1+0x8
+    s32 nBlockSize; // r4
+    s32 nBlockNextSize; // r3
+    s32 anBlockLarge[6]; // r1+0x8
+    u32 nBlock; // r1+0x8
+    u32* pBlock; // r5
+    u32* pBlockPrevious; // r6
+    u32 nBlockNext; // r7
+    u32* pBlockNext; // r8
+
+    // References
+    // -> static u32* gpHeapBlockFirst;
+}
+
+// Range: 0x80006AF0 -> 0x80006F68
+s32 xlHeapCopy(void* pHeapTarget, void* pHeapSource, s32 nByteCount) {
+    // Parameters
+    // void* pHeapTarget; // r3
+    // void* pHeapSource; // r4
+    // s32 nByteCount; // r5
+
+    // Local variables
+    u8* pSource8; // r4
+    u8* pTarget8; // r3
+    u32* pSource32; // r4
+    u32* pTarget32; // r3
+}
+
+// Erased
+static s32 xlHeapFill8(void* pHeap, s32 nByteCount, u8 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r4
+    // u8 nData; // r1+0x8
+
+    // Local variables
+    u8* pnTarget; // r3
+}
+
+// Erased
+static s32 xlHeapFill16(void* pHeap, s32 nByteCount, u16 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r6
+    // u16 nData; // r1+0x8
+
+    // Local variables
+    u16* pnTarget; // r3
+}
+
+// Range: 0x80006908 -> 0x80006AF0
+s32 xlHeapFill32(void* pHeap, s32 nByteCount, u32 nData) {
+    // Parameters
+    // void* pHeap; // r3
+    // s32 nByteCount; // r6
+    // u32 nData; // r1+0x8
+
+    // Local variables
+    u32* pnTarget; // r3
+}
+
+// Range: 0x80006870 -> 0x80006908
+s32 xlHeapGetFree(s32* pnFreeBytes) {
+    // Parameters
+    // s32* pnFreeBytes; // r31
 
     // Local variables
     s32 nBlockSize; // r3
-    u32 nBlock; // r4
-    u32* pBlock; // r7
-    u32* pBlockBest; // r31
-    u32* pBlockNext; // r27
+    s32 nFree; // r5
+    s32 nCount; // r1+0x8
+    u32* pBlock; // r6
+    u32 nBlock; // r7
 
     // References
     // -> static u32* gpHeapBlockLast;
     // -> static u32* gpHeapBlockFirst;
 }
 
-// Range: 0x80007540 -> 0x8000764C
-static s32 xlHeapBlockCacheReset() {
+// Range: 0x800066B0 -> 0x80006870
+s32 xlHeapSetup(void* pHeap, s32 nSizeBytes) {
+    // Parameters
+    // void* pHeap; // r6
+    // s32 nSizeBytes; // r1+0xC
+
     // Local variables
-    s32 nBlockSize; // r1+0x8
-    u32* pBlock; // r30
-    u32 nBlock; // r1+0x8
+    s32 nSizeWords; // r5
 
     // References
+    // -> static u32* gpHeapBlockLast;
     // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gapHeapBlockCache[11][32];
-    // -> static s32 gnHeapFreeCount;
-    // -> static s32 gnHeapTakeCount;
-    // -> static s32 gnHeapTakeCacheCount;
+    // -> static u32* gpHeap;
+    // -> s32 gnSizeHeap;
 }
 
-// Range: 0x8000764C -> 0x80007758
-static s32 xlHeapBlockCacheClear(u32* pBlock) {
-    // Parameters
-    // u32* pBlock; // r1+0x0
-
+// Range: 0x80006648 -> 0x800066B0
+s32 xlHeapReset() {
     // Local variables
-    s32 nSize; // r1+0x0
-    s32 nBlock; // r6
-    s32 nBlockSize; // r1+0x0
+    s32 nBlockSize; // r6
 
     // References
-    // -> static u32* gapHeapBlockCache[11][32];
-}
-
-// Range: 0x80007758 -> 0x800079C0
-static s32 xlHeapBlockCacheAdd(u32* pBlock) {
-    // Parameters
-    // u32* pBlock; // r1+0x0
-
-    // Local variables
-    s32 nSize; // r6
-    s32 nBlock; // r7
-    s32 nBlockSize; // r1+0x0
-    s32 nBlockCachedSize; // r1+0x0
-    u32* pBlockCached; // r8
-
-    // References
-    // -> static u32* gapHeapBlockCache[11][32];
-}
-
-// Range: 0x800079C0 -> 0x80007BC0
-static s32 xlHeapBlockCacheGet(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
-    // Parameters
-    // s32 nSize; // r1+0x0
-    // u32** ppBlock; // r1+0x4
-    // s32* pnBlockSize; // r1+0x8
-
-    // Local variables
-    s32 nBlockCachedSize; // r1+0x0
-    s32 nBlock; // r8
-    s32 nBlockSize; // r9
-    s32 nBlockBest; // r10
-    s32 nBlockBestSize; // r11
-    u32* pBlock; // r12
-
-    // References
-    // -> static s32 gnHeapTakeCacheCount;
-    // -> static u32* gapHeapBlockCache[11][32];
-}
-
-// Erased
-static void xlHeapStatisticsReset() {
-    // References
-    // -> static s32 gnHeapFreeCount;
-    // -> static s32 gnHeapTakeCount;
-    // -> static s32 gnHeapTakeCacheCount;
-}
-
-// Erased
-static void xlHeapShowStatistics() {}
-
-// Erased
-static s32 xlHeapTestBlock(u32 nBlock) {
-    // Parameters
-    // u32 nBlock; // r1+0x0
+    // -> static u32* gpHeapBlockLast;
+    // -> static u32* gpHeapBlockFirst;
+    // -> static u32* gpHeap;
+    // -> s32 gnSizeHeap;
 }

--- a/debug/Core/xlList.c
+++ b/debug/Core/xlList.c
@@ -17,115 +17,45 @@ typedef struct tXL_LIST {
 // size = 0x10, address = 0x800F3FA0
 static struct tXL_LIST gListList;
 
-// Range: 0x80006280 -> 0x80006288
-s32 xlListReset() {}
+// Erased
+static s32 xlListWipe(struct tXL_LIST* pList) {
+    // Parameters
+    // struct tXL_LIST* pList; // r30
 
-// Range: 0x80006288 -> 0x800062B0
-s32 xlListSetup() {
+    // Local variables
+    void* pNode; // r1+0xC
+    void* pNodeNext; // r31
+}
+
+// Range: 0x80006550 -> 0x80006648
+s32 xlListMake(struct tXL_LIST** ppList, s32 nItemSize) {
+    // Parameters
+    // struct tXL_LIST** ppList; // r31
+    // s32 nItemSize; // r29
+
     // References
     // -> static struct tXL_LIST gListList;
 }
 
-// Erased
-static s32 xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
+// Range: 0x80006494 -> 0x80006550
+s32 xlListFree(struct tXL_LIST** ppList) {
     // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // void* pItem; // r1+0x4
-
-    // Local variables
-    void* pNode; // r5
-    void* pNodeLast; // r6
-    void* pNodeItem; // r7
-    void* pNodeItemLast; // r8
-}
-
-// Erased
-static s32 xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // void* pItem; // r1+0x4
-
-    // Local variables
-    void* pNode; // r5
-    void* pNodeLast; // r6
-}
-
-// Erased
-static s32 xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // void* ppListNode; // r1+0x4
+    // struct tXL_LIST** ppList; // r29
 
     // References
     // -> static struct tXL_LIST gListList;
 }
 
 // Erased
-static s32 xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
+static s32 xlListTest(struct tXL_LIST* pList) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
-    // void* ppListNode; // r1+0x4
+
+    // Local variables
+    void* pNode; // r4
 
     // References
     // -> static struct tXL_LIST gListList;
-}
-
-// Erased
-static s32 xlListEnumerate(struct tXL_LIST* pList, s32 (*pfCallback)(void*)) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x8
-    // s32 (* pfCallback)(void*); // r30
-
-    // Local variables
-    void* pNode; // r31
-}
-
-// Erased
-static s32 xlListFindItemIndex(struct tXL_LIST* pList, s32* piItem, void* pItem) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // s32* piItem; // r1+0x4
-    // void* pItem; // r1+0x8
-
-    // Local variables
-    s32 iItem; // r3
-    void* pListNode; // r6
-}
-
-// Erased
-static s32 xlListFindItem(struct tXL_LIST* pList, s32 iItem, void* ppItem) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // s32 iItem; // r1+0x4
-    // void* ppItem; // r1+0x8
-
-    // Local variables
-    s32 nItemCount; // r3
-    void* pListNode; // r6
-}
-
-// Range: 0x800062B0 -> 0x8000633C
-s32 xlListTestItem(struct tXL_LIST* pList, void* pItem) {
-    // Parameters
-    // struct tXL_LIST* pList; // r1+0x0
-    // void* pItem; // r1+0x4
-
-    // Local variables
-    void* pListNode; // r3
-
-    // References
-    // -> static struct tXL_LIST gListList;
-}
-
-// Range: 0x8000633C -> 0x800063E8
-s32 xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
-    // Parameters
-    // struct tXL_LIST* pList; // r31
-    // void* ppItem; // r1+0xC
-
-    // Local variables
-    void* pNode; // r6
-    void* pNodeNext; // r1+0x10
 }
 
 // Range: 0x800063E8 -> 0x80006494
@@ -141,43 +71,113 @@ s32 xlListMakeItem(struct tXL_LIST* pList, void* ppItem) {
     void* pNodeNext; // r1+0x8
 }
 
-// Erased
-static s32 xlListTest(struct tXL_LIST* pList) {
+// Range: 0x8000633C -> 0x800063E8
+s32 xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r31
+    // void* ppItem; // r1+0xC
+
+    // Local variables
+    void* pNode; // r6
+    void* pNodeNext; // r1+0x10
+}
+
+// Range: 0x800062B0 -> 0x8000633C
+s32 xlListTestItem(struct tXL_LIST* pList, void* pItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
 
     // Local variables
-    void* pNode; // r4
-
-    // References
-    // -> static struct tXL_LIST gListList;
-}
-
-// Range: 0x80006494 -> 0x80006550
-s32 xlListFree(struct tXL_LIST** ppList) {
-    // Parameters
-    // struct tXL_LIST** ppList; // r29
-
-    // References
-    // -> static struct tXL_LIST gListList;
-}
-
-// Range: 0x80006550 -> 0x80006648
-s32 xlListMake(struct tXL_LIST** ppList, s32 nItemSize) {
-    // Parameters
-    // struct tXL_LIST** ppList; // r31
-    // s32 nItemSize; // r29
+    void* pListNode; // r3
 
     // References
     // -> static struct tXL_LIST gListList;
 }
 
 // Erased
-static s32 xlListWipe(struct tXL_LIST* pList) {
+static s32 xlListFindItem(struct tXL_LIST* pList, s32 iItem, void* ppItem) {
     // Parameters
-    // struct tXL_LIST* pList; // r30
+    // struct tXL_LIST* pList; // r1+0x0
+    // s32 iItem; // r1+0x4
+    // void* ppItem; // r1+0x8
 
     // Local variables
-    void* pNode; // r1+0xC
-    void* pNodeNext; // r31
+    s32 nItemCount; // r3
+    void* pListNode; // r6
 }
+
+// Erased
+static s32 xlListFindItemIndex(struct tXL_LIST* pList, s32* piItem, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // s32* piItem; // r1+0x4
+    // void* pItem; // r1+0x8
+
+    // Local variables
+    s32 iItem; // r3
+    void* pListNode; // r6
+}
+
+// Erased
+static s32 xlListEnumerate(struct tXL_LIST* pList, s32 (*pfCallback)(void*)) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x8
+    // s32 (* pfCallback)(void*); // r30
+
+    // Local variables
+    void* pNode; // r31
+}
+
+// Erased
+static s32 xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* ppListNode; // r1+0x4
+
+    // References
+    // -> static struct tXL_LIST gListList;
+}
+
+// Erased
+static s32 xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* ppListNode; // r1+0x4
+
+    // References
+    // -> static struct tXL_LIST gListList;
+}
+
+// Erased
+static s32 xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
+
+    // Local variables
+    void* pNode; // r5
+    void* pNodeLast; // r6
+}
+
+// Erased
+static s32 xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
+    // Parameters
+    // struct tXL_LIST* pList; // r1+0x0
+    // void* pItem; // r1+0x4
+
+    // Local variables
+    void* pNode; // r5
+    void* pNodeLast; // r6
+    void* pNodeItem; // r7
+    void* pNodeItemLast; // r8
+}
+
+// Range: 0x80006288 -> 0x800062B0
+s32 xlListSetup() {
+    // References
+    // -> static struct tXL_LIST gListList;
+}
+
+// Range: 0x80006280 -> 0x80006288
+s32 xlListReset() {}

--- a/debug/Core/xlObject.c
+++ b/debug/Core/xlObject.c
@@ -29,31 +29,61 @@ typedef struct __anon_0x5062 {
     /* 0x4 */ struct _XL_OBJECTTYPE* pType;
 } __anon_0x5062; // size = 0x8
 
-// Range: 0x80007BC0 -> 0x80007C30
-s32 xlObjectReset() {
-    // Local variables
-    struct __anon_0x5062* pData; // r3
-    void* pListNode; // r31
-
-    // References
-    // -> static struct tXL_LIST* gpListData;
-}
-
-// Range: 0x80007C30 -> 0x80007C6C
-s32 xlObjectSetup() {
-    // References
-    // -> static struct tXL_LIST* gpListData;
-}
-
-// Range: 0x80007C6C -> 0x80007D24
-s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument) {
+// Erased
+static s32 xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
     // Parameters
-    // void* pObject; // r26
-    // s32 nEvent; // r27
-    // void* pArgument; // r28
+    // struct __anon_0x5062** ppData; // r1+0x0
+    // struct _XL_OBJECTTYPE* pType; // r1+0x4
 
     // Local variables
-    struct __anon_0x5062* pData; // r29
+    void* pListNode; // r6
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
+}
+
+// Erased
+static s32 xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // struct __anon_0x5062** ppData; // r30
+    // struct _XL_OBJECTTYPE* pType; // r31
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
+}
+
+// Range: 0x80007E24 -> 0x80007F80
+s32 xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // void* ppObject; // r28
+    // void* pArgument; // r29
+    // struct _XL_OBJECTTYPE* pType; // r30
+
+    // Local variables
+    s32 bFlag; // r31
+    struct __anon_0x5062* pData; // r1+0x14
+
+    // References
+    // -> static struct tXL_LIST* gpListData;
+}
+
+// Range: 0x80007D8C -> 0x80007E24
+s32 xlObjectFree(void* ppObject) {
+    // Parameters
+    // void* ppObject; // r30
+
+    // Local variables
+    struct __anon_0x5062* pData; // r31
+}
+
+// Range: 0x80007D24 -> 0x80007D8C
+s32 xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
+    // Parameters
+    // void* pObject; // r1+0x8
+    // struct _XL_OBJECTTYPE* pType; // r30
+
+    // Local variables
+    struct __anon_0x5062* pData; // r31
 
     // References
     // -> static struct tXL_LIST* gpListData;
@@ -72,61 +102,31 @@ static s32 xlObjectFindType(void* pObject, struct _XL_OBJECTTYPE** ppType) {
     // -> static struct tXL_LIST* gpListData;
 }
 
-// Range: 0x80007D24 -> 0x80007D8C
-s32 xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
+// Range: 0x80007C6C -> 0x80007D24
+s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument) {
     // Parameters
-    // void* pObject; // r1+0x8
-    // struct _XL_OBJECTTYPE* pType; // r30
+    // void* pObject; // r26
+    // s32 nEvent; // r27
+    // void* pArgument; // r28
 
     // Local variables
-    struct __anon_0x5062* pData; // r31
+    struct __anon_0x5062* pData; // r29
 
     // References
     // -> static struct tXL_LIST* gpListData;
 }
 
-// Range: 0x80007D8C -> 0x80007E24
-s32 xlObjectFree(void* ppObject) {
-    // Parameters
-    // void* ppObject; // r30
-
-    // Local variables
-    struct __anon_0x5062* pData; // r31
-}
-
-// Range: 0x80007E24 -> 0x80007F80
-s32 xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) {
-    // Parameters
-    // void* ppObject; // r28
-    // void* pArgument; // r29
-    // struct _XL_OBJECTTYPE* pType; // r30
-
-    // Local variables
-    s32 bFlag; // r31
-    struct __anon_0x5062* pData; // r1+0x14
-
+// Range: 0x80007C30 -> 0x80007C6C
+s32 xlObjectSetup() {
     // References
     // -> static struct tXL_LIST* gpListData;
 }
 
-// Erased
-static s32 xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
-    // Parameters
-    // struct __anon_0x5062** ppData; // r30
-    // struct _XL_OBJECTTYPE* pType; // r31
-
-    // References
-    // -> static struct tXL_LIST* gpListData;
-}
-
-// Erased
-static s32 xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
-    // Parameters
-    // struct __anon_0x5062** ppData; // r1+0x0
-    // struct _XL_OBJECTTYPE* pType; // r1+0x4
-
+// Range: 0x80007BC0 -> 0x80007C30
+s32 xlObjectReset() {
     // Local variables
-    void* pListNode; // r6
+    struct __anon_0x5062* pData; // r3
+    void* pListNode; // r31
 
     // References
     // -> static struct tXL_LIST* gpListData;

--- a/debug/Core/xlPostGCN.c
+++ b/debug/Core/xlPostGCN.c
@@ -7,11 +7,11 @@
 
 #include "types.h"
 
-// Range: 0x80005E04 -> 0x80005E0C
-s32 xlPostReset() {}
+// Range: 0x80005E14 -> 0x80005E68
+s32 xlPostText() {}
 
 // Range: 0x80005E0C -> 0x80005E14
 s32 xlPostSetup() {}
 
-// Range: 0x80005E14 -> 0x80005E68
-s32 xlPostText() {}
+// Range: 0x80005E04 -> 0x80005E0C
+s32 xlPostReset() {}

--- a/debug/Fire/THPAudioDecode.c
+++ b/debug/Fire/THPAudioDecode.c
@@ -102,42 +102,6 @@ static void* FreeAudioBufferMessage[3];
 // size = 0xC, address = 0x800FB1B4
 static void* DecodedAudioBufferMessage[3];
 
-// Range: 0x80010D9C -> 0x80010E7C
-s32 CreateAudioDecodeThread(s32 priority, u8* ptr) {
-    // Parameters
-    // s32 priority; // r8
-    // u8* ptr; // r5
-
-    // References
-    // -> static s32 AudioDecodeThreadCreated;
-    // -> static void* DecodedAudioBufferMessage[3];
-    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
-    // -> static void* FreeAudioBufferMessage[3];
-    // -> static struct OSMessageQueue FreeAudioBufferQueue;
-    // -> static u8 AudioDecodeThreadStack[4096];
-    // -> static struct OSThread AudioDecodeThread;
-}
-
-// Range: 0x80010E7C -> 0x80010EB0
-void AudioDecodeThreadStart() {
-    // References
-    // -> static struct OSThread AudioDecodeThread;
-    // -> static s32 AudioDecodeThreadCreated;
-}
-
-// Erased
-static void AudioDecodeThreadCancel() {
-    // References
-    // -> static s32 AudioDecodeThreadCreated;
-    // -> static struct OSThread AudioDecodeThread;
-}
-
-// Range: 0x80010EB0 -> 0x80010ED8
-static void* AudioDecoder() {
-    // Local variables
-    struct __anon_0x14130* readBuffer; // r31
-}
-
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
@@ -262,20 +226,43 @@ typedef struct __anon_0x14130 {
     /* 0x8 */ s32 isValid;
 } __anon_0x14130; // size = 0xC
 
-// Range: 0x80010ED8 -> 0x80010F88
-static void* AudioDecoderForOnMemory(void* ptr) {
+// Range: 0x80011108 -> 0x80011138
+void PushDecodedAudioBuffer(void* buffer) {
     // Parameters
-    // void* ptr; // r1+0x8
-
-    // Local variables
-    struct __anon_0x14130 readBuffer; // r1+0x10
-    s32 tmp; // r4
-    s32 size; // r28
-    s32 readFrame; // r31
+    // void* buffer; // r4
 
     // References
-    // -> static struct OSThread AudioDecodeThread;
-    // -> struct __anon_0x13BA7 ActivePlayer;
+    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+}
+
+// Range: 0x800110C4 -> 0x80011108
+void* PopDecodedAudioBuffer(s32 flag) {
+    // Parameters
+    // s32 flag; // r5
+
+    // Local variables
+    void* msg; // r1+0xC
+
+    // References
+    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+}
+
+// Range: 0x80011094 -> 0x800110C4
+void PushFreeAudioBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
+}
+
+// Range: 0x80011060 -> 0x80011094
+void* PopFreeAudioBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
 }
 
 // Range: 0x80010F88 -> 0x80011060
@@ -294,41 +281,54 @@ static void AudioDecode(struct __anon_0x14130* readBuffer) {
     // -> struct __anon_0x13BA7 ActivePlayer;
 }
 
-// Range: 0x80011060 -> 0x80011094
-void* PopFreeAudioBuffer() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue FreeAudioBufferQueue;
-}
-
-// Range: 0x80011094 -> 0x800110C4
-void PushFreeAudioBuffer(void* buffer) {
+// Range: 0x80010ED8 -> 0x80010F88
+static void* AudioDecoderForOnMemory(void* ptr) {
     // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue FreeAudioBufferQueue;
-}
-
-// Range: 0x800110C4 -> 0x80011108
-void* PopDecodedAudioBuffer(s32 flag) {
-    // Parameters
-    // s32 flag; // r5
+    // void* ptr; // r1+0x8
 
     // Local variables
-    void* msg; // r1+0xC
+    struct __anon_0x14130 readBuffer; // r1+0x10
+    s32 tmp; // r4
+    s32 size; // r28
+    s32 readFrame; // r31
 
     // References
-    // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+    // -> static struct OSThread AudioDecodeThread;
+    // -> struct __anon_0x13BA7 ActivePlayer;
 }
 
-// Range: 0x80011108 -> 0x80011138
-void PushDecodedAudioBuffer(void* buffer) {
+// Range: 0x80010EB0 -> 0x80010ED8
+static void* AudioDecoder() {
+    // Local variables
+    struct __anon_0x14130* readBuffer; // r31
+}
+
+// Erased
+static void AudioDecodeThreadCancel() {
+    // References
+    // -> static s32 AudioDecodeThreadCreated;
+    // -> static struct OSThread AudioDecodeThread;
+}
+
+// Range: 0x80010E7C -> 0x80010EB0
+void AudioDecodeThreadStart() {
+    // References
+    // -> static struct OSThread AudioDecodeThread;
+    // -> static s32 AudioDecodeThreadCreated;
+}
+
+// Range: 0x80010D9C -> 0x80010E7C
+s32 CreateAudioDecodeThread(s32 priority, u8* ptr) {
     // Parameters
-    // void* buffer; // r4
+    // s32 priority; // r8
+    // u8* ptr; // r5
 
     // References
+    // -> static s32 AudioDecodeThreadCreated;
+    // -> static void* DecodedAudioBufferMessage[3];
     // -> static struct OSMessageQueue DecodedAudioBufferQueue;
+    // -> static void* FreeAudioBufferMessage[3];
+    // -> static struct OSMessageQueue FreeAudioBufferQueue;
+    // -> static u8 AudioDecodeThreadStack[4096];
+    // -> static struct OSThread AudioDecodeThread;
 }

--- a/debug/Fire/THPDraw.c
+++ b/debug/Fire/THPDraw.c
@@ -7,9 +7,6 @@
 
 #include "types.h"
 
-// Range: 0x80011138 -> 0x80011250
-void THPGXRestore() {}
-
 typedef enum __anon_0x14611 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
@@ -46,18 +43,6 @@ typedef struct _GXRenderModeObj {
     /* 0x32 */ u8 vfilter[7];
 } __anon_0x1480C; // size = 0x3C
 
-// Range: 0x80011250 -> 0x80011754
-void THPGXYuv2RgbSetup(struct _GXRenderModeObj* rmode) {
-    // Parameters
-    // struct _GXRenderModeObj* rmode; // r1+0x8
-
-    // Local variables
-    s32 scrWidth; // r28
-    s32 scrHeight; // r27
-    f32 pMtx[4][4]; // r1+0x74
-    f32 mMtx[3][4]; // r1+0x44
-}
-
 typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
 } __anon_0x14BBE; // size = 0x20
@@ -81,3 +66,18 @@ void THPGXYuv2RgbDraw(u8* y_data, u8* u_data, u8* v_data, s16 x, s16 y, s16 text
     struct _GXTexObj tobj1; // r1+0x40
     struct _GXTexObj tobj2; // r1+0x20
 }
+
+// Range: 0x80011250 -> 0x80011754
+void THPGXYuv2RgbSetup(struct _GXRenderModeObj* rmode) {
+    // Parameters
+    // struct _GXRenderModeObj* rmode; // r1+0x8
+
+    // Local variables
+    s32 scrWidth; // r28
+    s32 scrHeight; // r27
+    f32 pMtx[4][4]; // r1+0x74
+    f32 mMtx[3][4]; // r1+0x44
+}
+
+// Range: 0x80011138 -> 0x80011250
+void THPGXRestore() {}

--- a/debug/Fire/THPPlayer.c
+++ b/debug/Fire/THPPlayer.c
@@ -247,197 +247,6 @@ typedef struct __anon_0x10B6F {
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x10B6F ActivePlayer;
 
-// Range: 0x8000F890 -> 0x8000F9C8
-s32 THPPlayerInit(s32 audioSystem) {
-    // Parameters
-    // s32 audioSystem; // r30
-
-    // Local variables
-    s32 old; // r30
-
-    // References
-    // -> static s32 Initialized;
-    // -> static s32 SoundBufferIndex;
-    // -> static s16 SoundBuffer[2][320];
-    // -> static s32 AudioSystem;
-    // -> static void (* OldAIDCallback)();
-    // -> static s16* CurAudioBuffer;
-    // -> static s16* LastAudioBuffer;
-    // -> static void* UsedTextureSetMessage[3];
-    // -> static struct OSMessageQueue UsedTextureSetQueue;
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static void THPPlayerQuit() {
-    // Local variables
-    s32 old; // r31
-
-    // References
-    // -> static s32 Initialized;
-    // -> static void (* OldAIDCallback)();
-}
-
-// Range: 0x8000F9C8 -> 0x8000FC40
-s32 THPPlayerOpen(char* fileName, s32 onMemory) {
-    // Parameters
-    // char* fileName; // r21
-    // s32 onMemory; // r30
-
-    // Local variables
-    s32 offset; // r22
-    s32 i; // r21
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-    // -> static s32 WorkBuffer[16];
-    // -> static s32 Initialized;
-}
-
-// Erased
-static s32 THPPlayerClose() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x8000FC40 -> 0x8000FCE8
-u32 THPPlayerCalcNeedMemory() {
-    // Local variables
-    u32 size; // r6
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x8000FCE8 -> 0x8000FF24
-s32 THPPlayerSetBuffer(u8* buffer) {
-    // Parameters
-    // u8* buffer; // r1+0x8
-
-    // Local variables
-    u32 i; // r1+0x8
-    u8* ptr; // r30
-    u32 ysize; // r27
-    u32 uvsize; // r26
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x8000FF24 -> 0x8000FFF0
-static void InitAllMessageQueue() {
-    // Local variables
-    s32 i; // r28
-    struct __anon_0x10A84* readBuffer; // r3
-    struct __anon_0x10944* textureSet; // r3
-    struct __anon_0x109FA* audioBuffer; // r3
-
-    // References
-    // -> static void* PrepareReadyMessage;
-    // -> static struct OSMessageQueue PrepareReadyQueue;
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static s32 WaitUntilPrepare() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue PrepareReadyQueue;
-}
-
-// Range: 0x8000FFF0 -> 0x80010020
-void PrepareReady(s32 flag) {
-    // Parameters
-    // s32 flag; // r4
-
-    // References
-    // -> static struct OSMessageQueue PrepareReadyQueue;
-}
-
-// Range: 0x80010020 -> 0x80010294
-s32 THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
-    // Parameters
-    // s32 frameNum; // r29
-    // s32 playFlag; // r26
-    // s32 audioTrack; // r27
-
-    // Local variables
-    s32 offset; // r6
-    u8* ptr; // r26
-
-    // References
-    // -> static void (* OldVIPostCallback)(u32);
-    // -> struct __anon_0x10B6F ActivePlayer;
-    // -> static struct OSMessageQueue PrepareReadyQueue;
-    // -> static s32 WorkBuffer[16];
-}
-
-// Range: 0x80010294 -> 0x800102F0
-s32 THPPlayerPlay() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static void THPPlayerStop() {
-    // Local variables
-    void* texture; // r1+0x8
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-    // -> static void (* OldVIPostCallback)(u32);
-}
-
-// Erased
-static s32 THPPlayerPause() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static s32 THPPlayerSkip() {
-    // Local variables
-    s32 old; // r3
-    s32 frameNumber; // r3
-    s32 audioGet; // r29
-    s32 videoGet; // r1+0x8
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x800102F0 -> 0x8001058C
-static void PlayControl(u32 retraceCount) {
-    // Parameters
-    // u32 retraceCount; // r3
-
-    // Local variables
-    s32 diff; // r1+0x8
-    s32 frameNumber; // r4
-    struct __anon_0x10944* textureSet; // r29
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-    // -> static void (* OldVIPostCallback)(u32);
-}
-
-// Range: 0x8001058C -> 0x800105F8
-static s32 ProperTimingForStart() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x800105F8 -> 0x8001071C
-static s32 ProperTimingForGettingNextFrame() {
-    // Local variables
-    s32 frameRate; // r30
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
 typedef enum __anon_0x119E9 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
@@ -474,95 +283,24 @@ typedef struct _GXRenderModeObj {
     /* 0x32 */ u8 vfilter[7];
 } __anon_0x11BE8; // size = 0x3C
 
-// Range: 0x8001071C -> 0x800107E8
-s32 THPPlayerDrawCurrentFrame(struct _GXRenderModeObj* rmode, u32 x, u32 y, u32 polygonW, u32 polygonH) {
+// Erased
+static s32 THPPlayerGetVolume() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 THPPlayerSetVolume(s32 vol, s32 time) {
     // Parameters
-    // struct _GXRenderModeObj* rmode; // r3
-    // u32 x; // r26
-    // u32 y; // r27
-    // u32 polygonW; // r28
-    // u32 polygonH; // r29
+    // s32 vol; // r28
+    // s32 time; // r29
 
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static s32 THPPlayerGetVideoInfo(struct __anon_0x1080A* videoInfo) {
-    // Parameters
-    // struct __anon_0x1080A* videoInfo; // r3
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static s32 THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
-    // Parameters
-    // struct __anon_0x1088A* audioInfo; // r3
-
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static f32 THPPlayerGetFrameRate() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static u32 THPPlayerGetTotalFrame() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Erased
-static s32 THPPlayerGetState() {
-    // References
-    // -> struct __anon_0x10B6F ActivePlayer;
-}
-
-// Range: 0x800107E8 -> 0x80010818
-static void PushUsedTextureSet(void* buffer) {
-    // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue UsedTextureSetQueue;
-}
-
-// Erased
-static void* PopUsedTextureSet() {
     // Local variables
-    void* msg; // r1+0x8
+    s32 old; // r3
+    s32 samplePerMs; // r30
 
     // References
-    // -> static struct OSMessageQueue UsedTextureSetQueue;
-}
-
-// Range: 0x80010818 -> 0x80010888
-void THPPlayerDrawDone() {
-    // Local variables
-    void* textureSet; // r3
-
-    // References
-    // -> static struct OSMessageQueue UsedTextureSetQueue;
-    // -> static s32 Initialized;
-}
-
-// Range: 0x80010888 -> 0x80010A00
-static void THPAudioMixCallback() {
-    // Local variables
-    s32 old; // r30
-
-    // References
-    // -> static s32 SoundBufferIndex;
-    // -> static s16 SoundBuffer[2][320];
-    // -> static s16* CurAudioBuffer;
-    // -> static void (* OldAIDCallback)();
-    // -> static s16* LastAudioBuffer;
-    // -> static s32 AudioSystem;
+    // -> struct __anon_0x10B6F ActivePlayer;
 }
 
 // Range: 0x80010A00 -> 0x80010D9C
@@ -587,22 +325,284 @@ static void MixAudio(s16* destination, s16* source, u32 sample) {
     // -> static u16 VolumeTable[128];
 }
 
-// Erased
-static s32 THPPlayerSetVolume(s32 vol, s32 time) {
-    // Parameters
-    // s32 vol; // r28
-    // s32 time; // r29
-
+// Range: 0x80010888 -> 0x80010A00
+static void THPAudioMixCallback() {
     // Local variables
-    s32 old; // r3
-    s32 samplePerMs; // r30
+    s32 old; // r30
+
+    // References
+    // -> static s32 SoundBufferIndex;
+    // -> static s16 SoundBuffer[2][320];
+    // -> static s16* CurAudioBuffer;
+    // -> static void (* OldAIDCallback)();
+    // -> static s16* LastAudioBuffer;
+    // -> static s32 AudioSystem;
+}
+
+// Range: 0x80010818 -> 0x80010888
+void THPPlayerDrawDone() {
+    // Local variables
+    void* textureSet; // r3
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
+    // -> static s32 Initialized;
+}
+
+// Erased
+static void* PopUsedTextureSet() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
+}
+
+// Range: 0x800107E8 -> 0x80010818
+static void PushUsedTextureSet(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
+}
+
+// Erased
+static s32 THPPlayerGetState() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static u32 THPPlayerGetTotalFrame() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static f32 THPPlayerGetFrameRate() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
+    // Parameters
+    // struct __anon_0x1088A* audioInfo; // r3
 
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
 }
 
 // Erased
-static s32 THPPlayerGetVolume() {
+static s32 THPPlayerGetVideoInfo(struct __anon_0x1080A* videoInfo) {
+    // Parameters
+    // struct __anon_0x1080A* videoInfo; // r3
+
     // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8001071C -> 0x800107E8
+s32 THPPlayerDrawCurrentFrame(struct _GXRenderModeObj* rmode, u32 x, u32 y, u32 polygonW, u32 polygonH) {
+    // Parameters
+    // struct _GXRenderModeObj* rmode; // r3
+    // u32 x; // r26
+    // u32 y; // r27
+    // u32 polygonW; // r28
+    // u32 polygonH; // r29
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x800105F8 -> 0x8001071C
+static s32 ProperTimingForGettingNextFrame() {
+    // Local variables
+    s32 frameRate; // r30
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8001058C -> 0x800105F8
+static s32 ProperTimingForStart() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x800102F0 -> 0x8001058C
+static void PlayControl(u32 retraceCount) {
+    // Parameters
+    // u32 retraceCount; // r3
+
+    // Local variables
+    s32 diff; // r1+0x8
+    s32 frameNumber; // r4
+    struct __anon_0x10944* textureSet; // r29
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static void (* OldVIPostCallback)(u32);
+}
+
+// Erased
+static s32 THPPlayerSkip() {
+    // Local variables
+    s32 old; // r3
+    s32 frameNumber; // r3
+    s32 audioGet; // r29
+    s32 videoGet; // r1+0x8
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 THPPlayerPause() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static void THPPlayerStop() {
+    // Local variables
+    void* texture; // r1+0x8
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static void (* OldVIPostCallback)(u32);
+}
+
+// Range: 0x80010294 -> 0x800102F0
+s32 THPPlayerPlay() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x80010020 -> 0x80010294
+s32 THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
+    // Parameters
+    // s32 frameNum; // r29
+    // s32 playFlag; // r26
+    // s32 audioTrack; // r27
+
+    // Local variables
+    s32 offset; // r6
+    u8* ptr; // r26
+
+    // References
+    // -> static void (* OldVIPostCallback)(u32);
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+    // -> static s32 WorkBuffer[16];
+}
+
+// Range: 0x8000FFF0 -> 0x80010020
+void PrepareReady(s32 flag) {
+    // Parameters
+    // s32 flag; // r4
+
+    // References
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+}
+
+// Erased
+static s32 WaitUntilPrepare() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+}
+
+// Range: 0x8000FF24 -> 0x8000FFF0
+static void InitAllMessageQueue() {
+    // Local variables
+    s32 i; // r28
+    struct __anon_0x10A84* readBuffer; // r3
+    struct __anon_0x10944* textureSet; // r3
+    struct __anon_0x109FA* audioBuffer; // r3
+
+    // References
+    // -> static void* PrepareReadyMessage;
+    // -> static struct OSMessageQueue PrepareReadyQueue;
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000FCE8 -> 0x8000FF24
+s32 THPPlayerSetBuffer(u8* buffer) {
+    // Parameters
+    // u8* buffer; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x8
+    u8* ptr; // r30
+    u32 ysize; // r27
+    u32 uvsize; // r26
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000FC40 -> 0x8000FCE8
+u32 THPPlayerCalcNeedMemory() {
+    // Local variables
+    u32 size; // r6
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Erased
+static s32 THPPlayerClose() {
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+}
+
+// Range: 0x8000F9C8 -> 0x8000FC40
+s32 THPPlayerOpen(char* fileName, s32 onMemory) {
+    // Parameters
+    // char* fileName; // r21
+    // s32 onMemory; // r30
+
+    // Local variables
+    s32 offset; // r22
+    s32 i; // r21
+
+    // References
+    // -> struct __anon_0x10B6F ActivePlayer;
+    // -> static s32 WorkBuffer[16];
+    // -> static s32 Initialized;
+}
+
+// Erased
+static void THPPlayerQuit() {
+    // Local variables
+    s32 old; // r31
+
+    // References
+    // -> static s32 Initialized;
+    // -> static void (* OldAIDCallback)();
+}
+
+// Range: 0x8000F890 -> 0x8000F9C8
+s32 THPPlayerInit(s32 audioSystem) {
+    // Parameters
+    // s32 audioSystem; // r30
+
+    // Local variables
+    s32 old; // r30
+
+    // References
+    // -> static s32 Initialized;
+    // -> static s32 SoundBufferIndex;
+    // -> static s16 SoundBuffer[2][320];
+    // -> static s32 AudioSystem;
+    // -> static void (* OldAIDCallback)();
+    // -> static s16* CurAudioBuffer;
+    // -> static s16* LastAudioBuffer;
+    // -> static void* UsedTextureSetMessage[3];
+    // -> static struct OSMessageQueue UsedTextureSetQueue;
     // -> struct __anon_0x10B6F ActivePlayer;
 }

--- a/debug/Fire/THPRead.c
+++ b/debug/Fire/THPRead.c
@@ -123,60 +123,6 @@ static s32 gbReset;
 // size = 0x4, address = 0x80135650
 static u32 gnTickReset;
 
-// Range: 0x80011938 -> 0x80011968
-void PushReadedBuffer2(void* buffer) {
-    // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue ReadedBufferQueue2;
-}
-
-// Range: 0x80011968 -> 0x8001199C
-void* PopReadedBuffer2() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue ReadedBufferQueue2;
-}
-
-// Range: 0x8001199C -> 0x800119CC
-void PushFreeReadBuffer(void* buffer) {
-    // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue FreeReadBufferQueue;
-}
-
-// Erased
-static void* PopFreeReadBuffer() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue FreeReadBufferQueue;
-}
-
-// Erased
-static void PushReadedBuffer(void* buffer) {
-    // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue ReadedBufferQueue;
-}
-
-// Range: 0x800119CC -> 0x80011A00
-void* PopReadedBuffer() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue ReadedBufferQueue;
-}
-
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
@@ -301,60 +247,6 @@ typedef struct __anon_0x16849 {
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x16849 ActivePlayer;
 
-// Range: 0x80011A00 -> 0x80011B2C
-static void* Reader() {
-    // Local variables
-    struct __anon_0x1675E* readBuffer; // r27
-    s32 offset; // r26
-    s32 size; // r25
-    s32 readFrame; // r24
-
-    // References
-    // -> static struct OSThread ReadThread;
-    // -> struct __anon_0x16849 ActivePlayer;
-    // -> static struct OSMessageQueue ReadedBufferQueue;
-    // -> s32 gMovieErrorToggle;
-    // -> static struct OSMessageQueue FreeReadBufferQueue;
-}
-
-// Erased
-static void ReadThreadCancel() {
-    // References
-    // -> static s32 ReadThreadCreated;
-    // -> static struct OSThread ReadThread;
-}
-
-// Range: 0x80011B2C -> 0x80011B60
-void ReadThreadStart() {
-    // References
-    // -> static struct OSThread ReadThread;
-    // -> static s32 ReadThreadCreated;
-}
-
-// Range: 0x80011B60 -> 0x80011C0C
-s32 CreateReadThread(s32 priority) {
-    // Parameters
-    // s32 priority; // r3
-
-    // References
-    // -> static s32 ReadThreadCreated;
-    // -> static void* ReadedBufferMessage2[10];
-    // -> static struct OSMessageQueue ReadedBufferQueue2;
-    // -> static void* ReadedBufferMessage[10];
-    // -> static struct OSMessageQueue ReadedBufferQueue;
-    // -> static void* FreeReadBufferMessage[10];
-    // -> static struct OSMessageQueue FreeReadBufferQueue;
-    // -> static u8 ReadThreadStack[4096];
-    // -> static struct OSThread ReadThread;
-}
-
-// Range: 0x80011C0C -> 0x80011CAC
-void movieReset(s32 IPL, s32 forceMenu) {
-    // Parameters
-    // s32 IPL; // r30
-    // s32 forceMenu; // r31
-}
-
 typedef struct PADStatus {
     /* 0x0 */ u16 button;
     /* 0x2 */ s8 stickX;
@@ -384,38 +276,6 @@ typedef struct __anon_0x171A2 {
 // size = 0x78, address = 0x80132758
 struct __anon_0x171A2 DemoPad[4];
 
-// Range: 0x80011CAC -> 0x80011E60
-s32 movieTestReset(s32 IPL, s32 forceMenu) {
-    // Parameters
-    // s32 IPL; // r29
-    // s32 forceMenu; // r30
-
-    // Local variables
-    u32 bFlag; // r1+0x8
-    u32 nTick; // r1+0x8
-
-    // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
-    // -> struct __anon_0x171A2 DemoPad[4];
-}
-
-// Range: 0x80011E60 -> 0x80011F10
-s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset) {
-    // Parameters
-    // struct DVDFileInfo* pFileInfo; // r26
-    // void* anData; // r27
-    // s32 nSizeRead; // r28
-    // s32 nOffset; // r29
-
-    // Local variables
-    s32 nStatus; // r31
-    s32 bRetry; // r30
-
-    // References
-    // -> s32 gMovieErrorToggle;
-}
-
 typedef enum __anon_0x17564 {
     M_M_NONE = -1,
     M_M_DISK_COVER_OPEN = 0,
@@ -426,22 +286,6 @@ typedef enum __anon_0x17564 {
     M_M_DISK_NO_DISK = 5,
     M_M_DISK_DEFAULT_ERROR = 6,
 } __anon_0x17564;
-
-// Range: 0x80011F10 -> 0x80012170
-s32 movieDVDShowError(s32 nStatus) {
-    // Parameters
-    // s32 nStatus; // r1+0x8
-
-    // Local variables
-    enum __anon_0x17564 nMessage; // r31
-
-    // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
-    // -> struct __anon_0x171A2 DemoPad[4];
-    // -> static s32 toggle$184;
-    // -> s32 gMovieErrorToggle;
-}
 
 // size = 0x0, address = 0x800DB800
 u8 gcoverOpen[];
@@ -460,20 +304,6 @@ u8 gfatalErr[];
 
 // size = 0x0, address = 0x800DE0E0
 u8 gnoDisk[];
-
-// Range: 0x80012170 -> 0x80012334
-s32 movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
-    // Parameters
-    // enum __anon_0x17564 movieMessage; // r1+0x8
-
-    // References
-    // -> u8 gfatalErr[];
-    // -> u8 gnoDisk[];
-    // -> u8 gretryErr[];
-    // -> u8 greadingDisk[];
-    // -> u8 gwrongDisk[];
-    // -> u8 gcoverOpen[];
-}
 
 // size = 0x0, address = 0x800E9960
 s16 Vert_s16[];
@@ -553,6 +383,16 @@ typedef struct _GXColor {
     /* 0x3 */ u8 a;
 } __anon_0x17F8F; // size = 0x4
 
+// Range: 0x80012850 -> 0x80012F20
+s32 movieGXInit() {
+    // Local variables
+    s32 i; // r31
+    struct _GXColor GX_DEFAULT_BG; // r1+0x58
+    struct _GXColor BLACK; // r1+0x54
+    struct _GXColor WHITE; // r1+0x50
+    f32 identity_mtx[3][4]; // r1+0x20
+}
+
 // Range: 0x80012334 -> 0x80012850
 s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
     // Parameters
@@ -574,12 +414,172 @@ s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
     // -> static f32 gOrthoMtx[4][4];
 }
 
-// Range: 0x80012850 -> 0x80012F20
-s32 movieGXInit() {
+// Range: 0x80012170 -> 0x80012334
+s32 movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
+    // Parameters
+    // enum __anon_0x17564 movieMessage; // r1+0x8
+
+    // References
+    // -> u8 gfatalErr[];
+    // -> u8 gnoDisk[];
+    // -> u8 gretryErr[];
+    // -> u8 greadingDisk[];
+    // -> u8 gwrongDisk[];
+    // -> u8 gcoverOpen[];
+}
+
+// Range: 0x80011F10 -> 0x80012170
+s32 movieDVDShowError(s32 nStatus) {
+    // Parameters
+    // s32 nStatus; // r1+0x8
+
     // Local variables
-    s32 i; // r31
-    struct _GXColor GX_DEFAULT_BG; // r1+0x58
-    struct _GXColor BLACK; // r1+0x54
-    struct _GXColor WHITE; // r1+0x50
-    f32 identity_mtx[3][4]; // r1+0x20
+    enum __anon_0x17564 nMessage; // r31
+
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0x171A2 DemoPad[4];
+    // -> static s32 toggle$184;
+    // -> s32 gMovieErrorToggle;
+}
+
+// Range: 0x80011E60 -> 0x80011F10
+s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset) {
+    // Parameters
+    // struct DVDFileInfo* pFileInfo; // r26
+    // void* anData; // r27
+    // s32 nSizeRead; // r28
+    // s32 nOffset; // r29
+
+    // Local variables
+    s32 nStatus; // r31
+    s32 bRetry; // r30
+
+    // References
+    // -> s32 gMovieErrorToggle;
+}
+
+// Range: 0x80011CAC -> 0x80011E60
+s32 movieTestReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r29
+    // s32 forceMenu; // r30
+
+    // Local variables
+    u32 bFlag; // r1+0x8
+    u32 nTick; // r1+0x8
+
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0x171A2 DemoPad[4];
+}
+
+// Range: 0x80011C0C -> 0x80011CAC
+void movieReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r30
+    // s32 forceMenu; // r31
+}
+
+// Range: 0x80011B60 -> 0x80011C0C
+s32 CreateReadThread(s32 priority) {
+    // Parameters
+    // s32 priority; // r3
+
+    // References
+    // -> static s32 ReadThreadCreated;
+    // -> static void* ReadedBufferMessage2[10];
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
+    // -> static void* ReadedBufferMessage[10];
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+    // -> static void* FreeReadBufferMessage[10];
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
+    // -> static u8 ReadThreadStack[4096];
+    // -> static struct OSThread ReadThread;
+}
+
+// Range: 0x80011B2C -> 0x80011B60
+void ReadThreadStart() {
+    // References
+    // -> static struct OSThread ReadThread;
+    // -> static s32 ReadThreadCreated;
+}
+
+// Erased
+static void ReadThreadCancel() {
+    // References
+    // -> static s32 ReadThreadCreated;
+    // -> static struct OSThread ReadThread;
+}
+
+// Range: 0x80011A00 -> 0x80011B2C
+static void* Reader() {
+    // Local variables
+    struct __anon_0x1675E* readBuffer; // r27
+    s32 offset; // r26
+    s32 size; // r25
+    s32 readFrame; // r24
+
+    // References
+    // -> static struct OSThread ReadThread;
+    // -> struct __anon_0x16849 ActivePlayer;
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+    // -> s32 gMovieErrorToggle;
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
+}
+
+// Range: 0x800119CC -> 0x80011A00
+void* PopReadedBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+}
+
+// Erased
+static void PushReadedBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue;
+}
+
+// Erased
+static void* PopFreeReadBuffer() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
+}
+
+// Range: 0x8001199C -> 0x800119CC
+void PushFreeReadBuffer(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeReadBufferQueue;
+}
+
+// Range: 0x80011968 -> 0x8001199C
+void* PopReadedBuffer2() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
+}
+
+// Range: 0x80011938 -> 0x80011968
+void PushReadedBuffer2(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue ReadedBufferQueue2;
 }

--- a/debug/Fire/THPVideoDecode.c
+++ b/debug/Fire/THPVideoDecode.c
@@ -105,37 +105,6 @@ static void* DecodedTextureSetMessage[3];
 // size = 0x4, address = 0x8013565C
 static s32 First;
 
-// Range: 0x80012F20 -> 0x80013004
-s32 CreateVideoDecodeThread(s32 priority, u8* ptr) {
-    // Parameters
-    // s32 priority; // r8
-    // u8* ptr; // r5
-
-    // References
-    // -> static s32 First;
-    // -> static s32 VideoDecodeThreadCreated;
-    // -> static void* DecodedTextureSetMessage[3];
-    // -> static struct OSMessageQueue DecodedTextureSetQueue;
-    // -> static void* FreeTextureSetMessage[3];
-    // -> static struct OSMessageQueue FreeTextureSetQueue;
-    // -> static u8 VideoDecodeThreadStack[4096];
-    // -> static struct OSThread VideoDecodeThread;
-}
-
-// Range: 0x80013004 -> 0x80013038
-void VideoDecodeThreadStart() {
-    // References
-    // -> static struct OSThread VideoDecodeThread;
-    // -> static s32 VideoDecodeThreadCreated;
-}
-
-// Erased
-static void VideoDecodeThreadCancel() {
-    // References
-    // -> static s32 VideoDecodeThreadCreated;
-    // -> static struct OSThread VideoDecodeThread;
-}
-
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
@@ -254,37 +223,49 @@ typedef struct __anon_0x1999C {
 // size = 0x1D0, address = 0x800F9C80
 struct __anon_0x1999C ActivePlayer;
 
-// Range: 0x80013038 -> 0x80013114
-static void* VideoDecoder() {
-    // Local variables
-    struct __anon_0x19FA4* readBuffer; // r28
-    s32 old; // r3
-
-    // References
-    // -> struct __anon_0x1999C ActivePlayer;
-}
-
 typedef struct __anon_0x19FA4 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
     /* 0x8 */ s32 isValid;
 } __anon_0x19FA4; // size = 0xC
 
-// Range: 0x80013114 -> 0x80013248
-static void* VideoDecoderForOnMemory(void* ptr) {
+// Range: 0x80013410 -> 0x80013440
+void PushDecodedTextureSet(void* buffer) {
     // Parameters
-    // void* ptr; // r1+0x8
-
-    // Local variables
-    struct __anon_0x19FA4 readBuffer; // r1+0x10
-    s32 old; // r3
-    s32 tmp; // r4
-    s32 size; // r29
-    s32 readFrame; // r28
+    // void* buffer; // r4
 
     // References
-    // -> static struct OSThread VideoDecodeThread;
-    // -> struct __anon_0x1999C ActivePlayer;
+    // -> static struct OSMessageQueue DecodedTextureSetQueue;
+}
+
+// Range: 0x800133CC -> 0x80013410
+void* PopDecodedTextureSet(s32 flag) {
+    // Parameters
+    // s32 flag; // r5
+
+    // Local variables
+    void* msg; // r1+0xC
+
+    // References
+    // -> static struct OSMessageQueue DecodedTextureSetQueue;
+}
+
+// Range: 0x8001339C -> 0x800133CC
+void PushFreeTextureSet(void* buffer) {
+    // Parameters
+    // void* buffer; // r4
+
+    // References
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
+}
+
+// Range: 0x80013368 -> 0x8001339C
+void* PopFreeTextureSet() {
+    // Local variables
+    void* msg; // r1+0x8
+
+    // References
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
 }
 
 // Range: 0x80013248 -> 0x80013368
@@ -305,41 +286,60 @@ static void VideoDecode(struct __anon_0x19FA4* readBuffer) {
     // -> static struct OSThread VideoDecodeThread;
 }
 
-// Range: 0x80013368 -> 0x8001339C
-void* PopFreeTextureSet() {
-    // Local variables
-    void* msg; // r1+0x8
-
-    // References
-    // -> static struct OSMessageQueue FreeTextureSetQueue;
-}
-
-// Range: 0x8001339C -> 0x800133CC
-void PushFreeTextureSet(void* buffer) {
+// Range: 0x80013114 -> 0x80013248
+static void* VideoDecoderForOnMemory(void* ptr) {
     // Parameters
-    // void* buffer; // r4
-
-    // References
-    // -> static struct OSMessageQueue FreeTextureSetQueue;
-}
-
-// Range: 0x800133CC -> 0x80013410
-void* PopDecodedTextureSet(s32 flag) {
-    // Parameters
-    // s32 flag; // r5
+    // void* ptr; // r1+0x8
 
     // Local variables
-    void* msg; // r1+0xC
+    struct __anon_0x19FA4 readBuffer; // r1+0x10
+    s32 old; // r3
+    s32 tmp; // r4
+    s32 size; // r29
+    s32 readFrame; // r28
 
     // References
-    // -> static struct OSMessageQueue DecodedTextureSetQueue;
+    // -> static struct OSThread VideoDecodeThread;
+    // -> struct __anon_0x1999C ActivePlayer;
 }
 
-// Range: 0x80013410 -> 0x80013440
-void PushDecodedTextureSet(void* buffer) {
-    // Parameters
-    // void* buffer; // r4
+// Range: 0x80013038 -> 0x80013114
+static void* VideoDecoder() {
+    // Local variables
+    struct __anon_0x19FA4* readBuffer; // r28
+    s32 old; // r3
 
     // References
+    // -> struct __anon_0x1999C ActivePlayer;
+}
+
+// Erased
+static void VideoDecodeThreadCancel() {
+    // References
+    // -> static s32 VideoDecodeThreadCreated;
+    // -> static struct OSThread VideoDecodeThread;
+}
+
+// Range: 0x80013004 -> 0x80013038
+void VideoDecodeThreadStart() {
+    // References
+    // -> static struct OSThread VideoDecodeThread;
+    // -> static s32 VideoDecodeThreadCreated;
+}
+
+// Range: 0x80012F20 -> 0x80013004
+s32 CreateVideoDecodeThread(s32 priority, u8* ptr) {
+    // Parameters
+    // s32 priority; // r8
+    // u8* ptr; // r5
+
+    // References
+    // -> static s32 First;
+    // -> static s32 VideoDecodeThreadCreated;
+    // -> static void* DecodedTextureSetMessage[3];
     // -> static struct OSMessageQueue DecodedTextureSetQueue;
+    // -> static void* FreeTextureSetMessage[3];
+    // -> static struct OSMessageQueue FreeTextureSetQueue;
+    // -> static u8 VideoDecodeThreadStack[4096];
+    // -> static struct OSThread VideoDecodeThread;
 }

--- a/debug/Fire/_aspMain.c
+++ b/debug/Fire/_aspMain.c
@@ -7,726 +7,246 @@
 
 #include "types.h"
 
-// Range: 0x80080AA4 -> 0x800811C0
-static s32 rspParseABI4(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+// Range: 0x8008BBDC -> 0x8008CF0C
+static s32 rspInitAudioDMEM1(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+}
+
+// Range: 0x8008B768 -> 0x8008BBDC
+s32 rspDotProduct8x15MatrixBy15x1Vector(s16* matrix, s16* vectorIn, s16* vectorOut) {
+    // Parameters
+    // s16* matrix; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+
+    // Local variables
+    s32 sum; // r12
+    s32 vec1; // r1+0x8
+    s32 vec2; // r1+0x8
+    s32 vec3; // r1+0x8
+    s32 vec4; // r1+0x8
+    s32 vec5; // r1+0x8
+    s32 vec6; // r1+0x8
+    s32 vec7; // r1+0x8
+    s32 vec8; // r31
+    s32 vec9; // r30
+    s32 vec10; // r29
+    s32 vec11; // r28
+    s32 vec12; // r27
+    s32 vec13; // r26
+    s32 vec14; // r5
+}
+
+// Erased
+static s32 rspMultADPCMCoef1(struct __anon_0x5845E* pRSP, s32* matrix, s16* vectorIn, s16* vectorOut, s32 nOptPred) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32* matrix; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+    // s32 nOptPred; // r1+0x18
+
+    // Local variables
+    s32 sum; // r12
+    s32 vec0; // r1+0x8
+    s32 vec1; // r1+0x8
+    s32 vec2; // r26
+    s32 vec3; // r25
+    s32 vec4; // r24
+    s32 vec5; // r23
+    s32 vec6; // r22
+    s32 vec7; // r21
+    s32 vec8; // r20
+}
+
+// Range: 0x8008B378 -> 0x8008B768
+s32 rspMultPolef(s16 (*matrix)[8], s16* vectorIn, s16* vectorOut) {
+    // Parameters
+    // s16 (* matrix)[8]; // r1+0xC
+    // s16* vectorIn; // r1+0x10
+    // s16* vectorOut; // r1+0x14
+
+    // Local variables
+    s32 sum; // r22
+    s32 vec0; // r1+0x8
+    s32 vec1; // r1+0x8
+    s32 vec2; // r8
+    s32 vec3; // r9
+    s32 vec4; // r10
+    s32 vec5; // r11
+    s32 vec6; // r12
+    s32 vec7; // r31
+    s32 vec8; // r5
+    s32 vec9; // r1+0x8
+}
+
+// Erased
+static s32 rspDumpDMEMToFile(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x40
-    u32* pABILast32; // r29
-    u32 nSize; // r23
-
-    // References
-    // -> static s32 nFirstTime$2796;
+    struct tXL_FILE* fp; // r1+0x50
+    s32 i; // r30
+    u32 nStartAddress; // r29
+    u32 nSize; // r1+0x4C
+    char acDMEMLine[64]; // r1+0xC
 }
 
 // Erased
-static s32 rspADMEMMove4(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspDumpMotorolaSDMEMTOFile(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+
+    // Local variables
+    struct tXL_FILE* fp; // r1+0x220
+    s32 i; // r29
+    u32 nStartAddress; // r28
+    u32 nSize; // r1+0x21C
+    char acDMEMLine[512]; // r1+0x1C
+}
+
+// Erased
+static s32 rspDumpBinaryDMEMToFile(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+
+    // Local variables
+    struct tXL_FILE* fp; // r1+0x10
+    s32 i; // r30
+    u32 nSize; // r1+0xC
+}
+
+// Erased
+static s32 rspLoadADPCMCoefRow(struct __anon_0x5845E* pRSP, u32 nCoefIndex, u32 nOptPred) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // u32 nCoefIndex; // r6
+    // u32 nOptPred; // r1+0x10
+}
+
+// Range: 0x8008B1FC -> 0x8008B378
+static s32 rspLoadADPCMCoefTable1(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
 
     // Local variables
-    u16 nDMEMOut; // r1+0x8
-    u16 nCount; // r4
-    u32 nDMEMIn; // r1+0x8
+    u32 j; // r1+0x8
+    u32 nCoefIndex; // r5
+}
+
+// Range: 0x8008B080 -> 0x8008B1FC
+static s32 rspLoadADPCMCoefTable2(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+
+    // Local variables
+    u32 j; // r1+0x8
+    u32 nCoefIndex; // r5
 }
 
 // Erased
-static s32 rspAInterleave4(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-
-    // Local variables
-    u32 iIndex; // r1+0x0
-    u32 iIndex2; // r9
-}
-
-// Erased
-static s32 rspARingFilter4() {}
-
-// Range: 0x800811C0 -> 0x80082624
-static s32 rspInitAudioDMEM4(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-}
-
-// Range: 0x80082624 -> 0x80082B94
-static s32 rspParseABI3(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x575BD* pTask; // r5
-
-    // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x38
-    u32* pABILast32; // r29
-    u32 nSize; // r23
-
-    // References
-    // -> static s32 nFirstTime$2757;
-}
-
-// Erased
-static s32 rspADMEMCopy(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-}
-
-// Range: 0x80082B94 -> 0x80082C2C
-static s32 rspAMix3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r8
-    s16* srcP; // r4
-    s32 outData32; // r6
-}
-
-// Erased
-static s32 rspAHalfCut3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s32 count; // r1+0x8
-    s32 outp; // r1+0x8
-    s32 inpp; // r7
-    s32 i; // r8
-}
-
-// Range: 0x80082C2C -> 0x80082E60
-static s32 rspAEnvMixer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    u16 vParams[8]; // r1+0x20
-    s32 i; // r27
-    s32 j; // r1+0x8
-    s32 inpp; // r26
-    s32 outL; // r25
-    s32 outR; // r24
-    s32 outFL; // r23
-    s32 outFR; // r22
-    s32 count; // r21
-    s32 id; // r1+0x8
-    s32 waveL; // r20
-    s32 waveR; // r19
-    s32 waveI; // r19
-    s32 srcL; // r18
-    s32 srcR; // r17
-    s32 srcFXL; // r16
-    s32 srcFXR; // r12
-}
-
-// Erased
-static s32 rspASaveBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
-
-    // Local variables
-    void* pData; // r1+0x14
-}
-
-// Erased
-static s32 rspALoadBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
-
-    // Local variables
-    void* pData; // r1+0x14
-}
-
-// Erased
-static s32 rspASetEnvParam32(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-}
-
-// Erased
-static s32 rspASetEnvParam3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-}
-
-// Range: 0x80082E60 -> 0x8008429C
-static s32 rspInitAudioDMEM3(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-}
-
-// Range: 0x8008429C -> 0x80084984
-static s32 rspParseABI2(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x575BD* pTask; // r5
-
-    // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x40
-    u32* pABILast32; // r29
-    u32 nSize; // r23
-
-    // References
-    // -> static s32 nFirstTime$2648;
-}
-
-// Range: 0x80084984 -> 0x80085218
-static s32 rspAPCM8Dec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r25
-
-    // Local variables
-    s32 inpp; // r31
-    s32 outp; // r30
-    s32 count; // r26
-    s16 flags; // r1+0x8
-    s16 vtmp0[8]; // r1+0x60
-    s16 vtmp1[8]; // r1+0x50
-    s32 i; // r1+0x8
-    s32 j; // r1+0x8
-    s32 stateAddr; // r5
-    s32 s; // r1+0x8
-    void* pData; // r1+0x4C
-    s16* pStateAddress; // r29
-    s16* pTempStateAddr; // r7
-}
-
-// Erased
-static s32 rspASaveBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
-
-    // Local variables
-    void* pData; // r1+0x14
-}
-
-// Erased
-static s32 rspALoadBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
-
-    // Local variables
-    void* pData; // r1+0x14
-}
-
-// Range: 0x80085218 -> 0x800854F0
-static s32 rspAEnvMixer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s16 vStep[8]; // r1+0x3C
-    u16 vParams[8]; // r1+0x2C
-    s32 i; // r28
-    s32 j; // r27
-    s32 inpp; // r26
-    s32 outL; // r25
-    s32 outR; // r24
-    s32 outFL; // r23
-    s32 outFR; // r22
-    s32 count; // r21
-    s32 temp; // r1+0x8
-    s32 id; // r1+0x8
-    s32 waveL; // r20
-    s32 waveR; // r19
-    s32 waveI; // r15
-    s32 srcL; // r18
-    s32 srcR; // r17
-    s32 srcFXL; // r16
-    s32 srcFXR; // r10
-}
-
-// Erased
-static s32 rspASetEnvParam22(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-
-    // Local variables
-    s16 tmp; // r6
-}
-
-// Erased
-static s32 rspASetEnvParam2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    s16 temp; // r7
-}
-
-// Erased
-static s32 rspAHalfCut2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s32 count; // r1+0x8
-    s32 outp; // r1+0x8
-    s32 inpp; // r7
-    s32 i; // r8
-}
-
-// Erased
-static s32 rspADMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-}
-
-// Erased
-static s32 rspASetLoop2(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-}
-
-// Range: 0x800854F0 -> 0x800855FC
-static s32 rspADistFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r26
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s16 dpow; // r7
-    s32 i; // r27
-    s64 mult; // r3
-}
-
-// Range: 0x800855FC -> 0x80085848
-static s32 rspAInterleave2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s32 outp; // r6
-    s32 inpr; // r1+0x8
-    s32 inpl; // r1+0x8
-    s32 count; // r7
-    s32 i; // r1+0x8
-}
-
-// Range: 0x80085848 -> 0x800858D0
-static s32 rspAMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r7
-    s16* srcP; // r8
-    s32 outData32; // r6
-}
-
-// Erased
-static s32 rspALoadADPCM2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r25
-
-    // Local variables
-    void* pData; // r1+0x20
-}
-
-// Erased
-static s32 rspADMEMMove2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r1+0x10
-}
-
-// Erased
-static s32 rspAWMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-}
-
-// Erased
-static s32 rspASetBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u16 nDMEMIn; // r1+0x0
-    u16 nDMEMOut; // r5
-    u16 nCount; // r1+0x0
-}
-
-// Range: 0x800858D0 -> 0x80086680
-static s32 rspAFirFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspALoadBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
     // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r16
 
     // Local variables
-    s32 filterState; // r1+0x8
-    s32 filterTable; // r27
-    s32 i; // r1+0x8
-    s32 pointer; // r19
-    void* pData; // r1+0x114
-    s16* pStateAddress; // r29
-    s16 flag; // r1+0x8
-    s16 vANS[8]; // r1+0x104
-    s16 vOLD[8]; // r1+0xF4
-    s16 vTP1[8]; // r1+0xE4
-    s16 vT0[8]; // r1+0xD4
-    s32 accumulator[8]; // r1+0xB4
-    s32 temp32[8]; // r1+0x94
-    s32 stateAddr; // r1+0x8
-    s16 anMatrix[8]; // r1+0x84
-    s16 anInputVec[15]; // r1+0x64
-
-    // References
-    // -> static s32 counter$2409;
+    void* pData; // r1+0x14
+    s32 nAddress; // r5
 }
 
-// Erased
-static s32 rspASResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    s32 outp; // r7
-    s32 outCount; // r6
-    s32 pitchSpeed; // r8
-    s32 i; // r9
-    s32 mainCounter; // r10
-}
-
-// Range: 0x80086680 -> 0x800868B0
-static s32 rspAResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s16* srcP; // r30
-    s16* dstP; // r29
-    s16 lastValue; // r6
-    u16 nCount; // r28
-    u16 i; // r7
-    s32 nSrcStep; // r1+0x8
-    s32 nCursorPos; // r8
-    u32 scratch; // r1+0x8
-    u8 flags; // r27
-    s16* pData; // r1+0x30
-}
-
-// Range: 0x800868B0 -> 0x8008691C
-static s32 rspANMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u32 nCount; // r5
-    u32 i; // r1+0x0
-    s16* inP; // r6
-    s32 out; // r5
-}
-
-// Range: 0x8008691C -> 0x80086BE8
-static s32 rspANoise2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r23
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    u32 nDest; // r26
-    u32 nSource; // r25
-    u32 nCount; // r24
-    u32 i; // r12
-    u32 j; // r5
-    s16 vIn[16]; // r1+0x78
-    s16 vOut[16]; // r1+0x58
-    s64 accumulator[8]; // r1+0x18
-}
-
-// Erased
-static s32 rspAClearBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r1+0x10
-}
-
-// Erased
-static s32 rspAADPCMDec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    u8 nFlags; // r23
-    char* pDMEM8; // r1+0x110
-    s32 anCoef[8]; // r1+0xF0
-    s16 anIData1[8]; // r1+0xC0
-    s16 anOData0[8]; // r1+0xB0
-    s16* pStateAddress; // r1+0xAC
-    s16* pDMEM16; // r3
-    s16 anOData1[8]; // r1+0x9C
-    s16 anIData0[8]; // r1+0x8C
-    s16 anInputVec[10]; // r1+0x78
-    s32 nDMEMIn8; // r18
-    s32 nDMEMOut; // r30
-    s32 nCount; // r19
-    s32 nSrcAddress; // r1+0x8
-    s32 nOptPred; // r23
-    s32 nHeaderBase8; // r1+0x8
-    s32 nVScale; // r29
-    s32 nScaleI; // r22
-    s32 i; // r1+0x8
-    s32 nHeader; // r25
-    s32 nTIndex; // r1+0x8
-    s16* pTempStateAddr; // r1+0x74
-}
-
-// Range: 0x80086BE8 -> 0x80087520
-static s32 rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+// Range: 0x8008A7E0 -> 0x8008B080
+static s32 rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // u32 nCommandLo; // r1+0xC
     // u32 nCommandHi; // r1+0x10
 
     // Local variables
-    u8 nFlags; // r19
+    u8 nFlags; // r21
     u8 ucControl; // r6
     char* pHeader; // r31
     s16* pStateAddress; // r1+0x60
-    s16 anIData0; // r19
+    s16 anIData0; // r23
     s32 nDMEMOut; // r30
     s32 nCount; // r29
     s32 nSrcAddress; // r5
     s32 nOptPred; // r7
-    s32 nVScale; // r19
+    s32 nVScale; // r1+0x8
     s32 i; // r1+0x8
     u32 dwDecodeSelect; // r1+0x8
-    u32 n; // r10
-    s32 nA; // r11
-    s32 nB; // r12
-    s16 nSamp1; // r27
-    s16 nSamp2; // r26
-    s16* pTempStateAddr; // r1+0x50
-    s16 nibble[4]; // r1+0x48
-    s32 nOutput; // r19
-}
-
-// Range: 0x80087520 -> 0x800887E8
-static s32 rspInitAudioDMEM2(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-}
-
-// Range: 0x800887E8 -> 0x80088B48
-static s32 rspParseABI1(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // struct __anon_0x575BD* pTask; // r5
-
-    // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r5
-    u32* pABI32; // r1+0x28
-    u32* pABILast32; // r30
-    u32 nSize; // r28
-
-    // References
-    // -> static s32 nFirstTime$2148;
-}
-
-// Range: 0x80088B48 -> 0x80088D74
-static s32 rspParseABI(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // struct __anon_0x575BD* pTask; // r31
-
-    // Local variables
-    u8* pFUCode; // r1+0x1C
-    u32 nCheckSum; // r4
+    u32 n; // r1+0x8
+    s32 nA; // r8
+    s32 nB; // r9
+    s16 nSamp1; // r10
+    s16 nSamp2; // r1+0x8
+    s16* pTempStateAddr; // r1+0x4C
+    s32 nOutput; // r10
 }
 
 // Erased
-static s32 rspALoadADPCM1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspAADPCMDec1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
     // u32 nCommandLo; // r1+0xC
     // u32 nCommandHi; // r1+0x10
 
     // Local variables
-    void* pData; // r1+0x20
-    u32 nCount; // r25
-    s32 nAddress; // r5
+    u8 nFlags; // r20
+    char* pDMEM8; // r27
+    char* pHeader; // r1+0xD8
+    s32 anCoef[8]; // r1+0xAC
+    s16 anIData0[8]; // r1+0x8C
+    s16 anOData0[8]; // r1+0x7C
+    s16* pStateAddress; // r1+0x78
+    s16* pDMEM16; // r4
+    s16 anInputVec[10]; // r1+0x64
+    s32 nDMEMOut; // r30
+    s32 nCount; // r14
+    s32 nSrcAddress; // r1+0x8
+    s32 nOptPred; // r1+0x8
+    s32 nVScale; // r1+0x8
+    s32 nScaleI; // r4
+    s32 i; // r1+0x8
+    s32 nHeader; // r23
+    s32 nToggle; // r1+0xD4
+    s32 nTIndex; // r1+0x8
+    s16* pTempStateAddr; // r1+0x60
+}
+
+// Range: 0x80089E7C -> 0x8008A7E0
+static s32 rspAPoleFilter1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r25
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r24
+    u16 nScale; // r30
+    s16 anCoef[10][8]; // r1+0xC0
+    s16 anEntries[8]; // r1+0xB0
+    s16 nVTemp[8]; // r1+0xA0
+    s16 nTempScale; // r4
+    s16 anIData0[8]; // r1+0x90
+    s16 anOData0[8]; // r1+0x80
+    s16 anInputVec[10]; // r1+0x6C
+    s16* pStateAddress; // r1+0x68
+    s16* pDMEM16; // r29
+    s32 nDMEMIn; // r28
+    s32 nDMEMOut; // r27
+    s32 nCount; // r26
+    s32 nSrcAddress; // r5
 }
 
 // Erased
-static s32 rspADMEMMove1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspAClearBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandLo; // r4
     // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    u16 nDMEMOut; // r1+0x8
-    u16 nCount; // r5
-    u32 nDMEMIn; // r1+0x8
-}
-
-// Erased
-static s32 rspASetLoop1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-}
-
-// Range: 0x80088D74 -> 0x80088E0C
-static s32 rspASetVolume1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u16 nFlags; // r1+0x0
-    u16 v; // r5
-    u16 t; // r7
-    u16 r; // r8
-}
-
-// Range: 0x80088E0C -> 0x80088F14
-static s32 rspASetBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u16 nDMEMIn; // r5
-    u16 nDMEMOut; // r6
-    u16 nCount; // r4
-}
-
-// Erased
-static s32 rspASegment1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-}
-
-// Erased
-static s32 rspASaveBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-
-    // Local variables
-    u32 nSize; // r1+0x18
-    u32* pData; // r1+0x14
-    s32 nAddress; // r5
-}
-
-// Range: 0x80088F14 -> 0x8008920C
-static s32 rspAResample1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r26
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    s16* srcP; // r30
-    s16* dstP; // r29
-    s16 lastValue; // r7
-    u16 nCount; // r28
-    u16 i; // r10
-    s32 nSrcStep; // r1+0x8
-    s32 nCursorPos; // r8
-    s32 nExtra; // r3
-    u32 scratch; // r1+0x8
-    u8 flags; // r27
-    s16* pData; // r1+0x34
-}
-
-// Range: 0x8008920C -> 0x800892A4
-static s32 rspAMix1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
-
-    // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r8
-    s16* srcP; // r4
-    s32 outData32; // r6
-}
-
-// Erased
-static s32 rspAInterleave1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-
-    // Local variables
-    u16 nLeft; // r1+0x0
-    u32 iIndex; // r1+0x0
-    u32 iIndex2; // r9
 }
 
 // Range: 0x800892A4 -> 0x80089E7C
@@ -777,243 +297,723 @@ static s32 rspAEnvMixer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComma
 }
 
 // Erased
-static s32 rspAClearBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspAInterleave1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    u16 nLeft; // r1+0x0
+    u32 iIndex; // r1+0x0
+    u32 iIndex2; // r9
+}
+
+// Range: 0x8008920C -> 0x800892A4
+static s32 rspAMix1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r8
+    s16* srcP; // r4
+    s32 outData32; // r6
+}
+
+// Range: 0x80088F14 -> 0x8008920C
+static s32 rspAResample1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r26
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16* srcP; // r30
+    s16* dstP; // r29
+    s16 lastValue; // r7
+    u16 nCount; // r28
+    u16 i; // r10
+    s32 nSrcStep; // r1+0x8
+    s32 nCursorPos; // r8
+    s32 nExtra; // r3
+    u32 scratch; // r1+0x8
+    u8 flags; // r27
+    s16* pData; // r1+0x34
+}
+
+// Erased
+static s32 rspASaveBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+
+    // Local variables
+    u32 nSize; // r1+0x18
+    u32* pData; // r1+0x14
+    s32 nAddress; // r5
+}
+
+// Erased
+static s32 rspASegment1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+}
+
+// Range: 0x80088E0C -> 0x80088F14
+static s32 rspASetBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u16 nDMEMIn; // r5
+    u16 nDMEMOut; // r6
+    u16 nCount; // r4
+}
+
+// Range: 0x80088D74 -> 0x80088E0C
+static s32 rspASetVolume1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u16 nFlags; // r1+0x0
+    u16 v; // r5
+    u16 t; // r7
+    u16 r; // r8
+}
+
+// Erased
+static s32 rspASetLoop1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+}
+
+// Erased
+static s32 rspADMEMMove1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 nDMEMOut; // r1+0x8
+    u16 nCount; // r5
+    u32 nDMEMIn; // r1+0x8
+}
+
+// Erased
+static s32 rspALoadADPCM1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    void* pData; // r1+0x20
+    u32 nCount; // r25
+    s32 nAddress; // r5
+}
+
+// Range: 0x80088B48 -> 0x80088D74
+static s32 rspParseABI(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r31
+
+    // Local variables
+    u8* pFUCode; // r1+0x1C
+    u32 nCheckSum; // r4
+}
+
+// Range: 0x800887E8 -> 0x80088B48
+static s32 rspParseABI1(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x575BD* pTask; // r5
+
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r5
+    u32* pABI32; // r1+0x28
+    u32* pABILast32; // r30
+    u32 nSize; // r28
+
+    // References
+    // -> static s32 nFirstTime$2148;
+}
+
+// Range: 0x80087520 -> 0x800887E8
+static s32 rspInitAudioDMEM2(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+}
+
+// Range: 0x80086BE8 -> 0x80087520
+static s32 rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r19
+    u8 ucControl; // r6
+    char* pHeader; // r31
+    s16* pStateAddress; // r1+0x60
+    s16 anIData0; // r19
+    s32 nDMEMOut; // r30
+    s32 nCount; // r29
+    s32 nSrcAddress; // r5
+    s32 nOptPred; // r7
+    s32 nVScale; // r19
+    s32 i; // r1+0x8
+    u32 dwDecodeSelect; // r1+0x8
+    u32 n; // r10
+    s32 nA; // r11
+    s32 nB; // r12
+    s16 nSamp1; // r27
+    s16 nSamp2; // r26
+    s16* pTempStateAddr; // r1+0x50
+    s16 nibble[4]; // r1+0x48
+    s32 nOutput; // r19
+}
+
+// Erased
+static s32 rspAADPCMDec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u8 nFlags; // r23
+    char* pDMEM8; // r1+0x110
+    s32 anCoef[8]; // r1+0xF0
+    s16 anIData1[8]; // r1+0xC0
+    s16 anOData0[8]; // r1+0xB0
+    s16* pStateAddress; // r1+0xAC
+    s16* pDMEM16; // r3
+    s16 anOData1[8]; // r1+0x9C
+    s16 anIData0[8]; // r1+0x8C
+    s16 anInputVec[10]; // r1+0x78
+    s32 nDMEMIn8; // r18
+    s32 nDMEMOut; // r30
+    s32 nCount; // r19
+    s32 nSrcAddress; // r1+0x8
+    s32 nOptPred; // r23
+    s32 nHeaderBase8; // r1+0x8
+    s32 nVScale; // r29
+    s32 nScaleI; // r22
+    s32 i; // r1+0x8
+    s32 nHeader; // r25
+    s32 nTIndex; // r1+0x8
+    s16* pTempStateAddr; // r1+0x74
+}
+
+// Erased
+static s32 rspAClearBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
     // u32 nCommandLo; // r4
     // u32 nCommandHi; // r1+0x10
 }
 
-// Range: 0x80089E7C -> 0x8008A7E0
-static s32 rspAPoleFilter1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+// Range: 0x8008691C -> 0x80086BE8
+static s32 rspANoise2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r25
+    // struct __anon_0x5845E* pRSP; // r23
     // u32 nCommandLo; // r1+0xC
     // u32 nCommandHi; // r1+0x10
 
     // Local variables
-    u8 nFlags; // r24
-    u16 nScale; // r30
-    s16 anCoef[10][8]; // r1+0xC0
-    s16 anEntries[8]; // r1+0xB0
-    s16 nVTemp[8]; // r1+0xA0
-    s16 nTempScale; // r4
-    s16 anIData0[8]; // r1+0x90
-    s16 anOData0[8]; // r1+0x80
-    s16 anInputVec[10]; // r1+0x6C
-    s16* pStateAddress; // r1+0x68
-    s16* pDMEM16; // r29
-    s32 nDMEMIn; // r28
-    s32 nDMEMOut; // r27
-    s32 nCount; // r26
-    s32 nSrcAddress; // r5
+    u32 nDest; // r26
+    u32 nSource; // r25
+    u32 nCount; // r24
+    u32 i; // r12
+    u32 j; // r5
+    s16 vIn[16]; // r1+0x78
+    s16 vOut[16]; // r1+0x58
+    s64 accumulator[8]; // r1+0x18
+}
+
+// Range: 0x800868B0 -> 0x8008691C
+static s32 rspANMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 nCount; // r5
+    u32 i; // r1+0x0
+    s16* inP; // r6
+    s32 out; // r5
+}
+
+// Range: 0x80086680 -> 0x800868B0
+static s32 rspAResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16* srcP; // r30
+    s16* dstP; // r29
+    s16 lastValue; // r6
+    u16 nCount; // r28
+    u16 i; // r7
+    s32 nSrcStep; // r1+0x8
+    s32 nCursorPos; // r8
+    u32 scratch; // r1+0x8
+    u8 flags; // r27
+    s16* pData; // r1+0x30
 }
 
 // Erased
-static s32 rspAADPCMDec1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static s32 rspASResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    s32 outp; // r7
+    s32 outCount; // r6
+    s32 pitchSpeed; // r8
+    s32 i; // r9
+    s32 mainCounter; // r10
+}
+
+// Range: 0x800858D0 -> 0x80086680
+static s32 rspAFirFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
     // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // u32 nCommandHi; // r16
 
     // Local variables
-    u8 nFlags; // r20
-    char* pDMEM8; // r27
-    char* pHeader; // r1+0xD8
-    s32 anCoef[8]; // r1+0xAC
-    s16 anIData0[8]; // r1+0x8C
-    s16 anOData0[8]; // r1+0x7C
-    s16* pStateAddress; // r1+0x78
-    s16* pDMEM16; // r4
-    s16 anInputVec[10]; // r1+0x64
-    s32 nDMEMOut; // r30
-    s32 nCount; // r14
-    s32 nSrcAddress; // r1+0x8
-    s32 nOptPred; // r1+0x8
-    s32 nVScale; // r1+0x8
-    s32 nScaleI; // r4
+    s32 filterState; // r1+0x8
+    s32 filterTable; // r27
     s32 i; // r1+0x8
-    s32 nHeader; // r23
-    s32 nToggle; // r1+0xD4
-    s32 nTIndex; // r1+0x8
-    s16* pTempStateAddr; // r1+0x60
-}
+    s32 pointer; // r19
+    void* pData; // r1+0x114
+    s16* pStateAddress; // r29
+    s16 flag; // r1+0x8
+    s16 vANS[8]; // r1+0x104
+    s16 vOLD[8]; // r1+0xF4
+    s16 vTP1[8]; // r1+0xE4
+    s16 vT0[8]; // r1+0xD4
+    s32 accumulator[8]; // r1+0xB4
+    s32 temp32[8]; // r1+0x94
+    s32 stateAddr; // r1+0x8
+    s16 anMatrix[8]; // r1+0x84
+    s16 anInputVec[15]; // r1+0x64
 
-// Range: 0x8008A7E0 -> 0x8008B080
-static s32 rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-
-    // Local variables
-    u8 nFlags; // r21
-    u8 ucControl; // r6
-    char* pHeader; // r31
-    s16* pStateAddress; // r1+0x60
-    s16 anIData0; // r23
-    s32 nDMEMOut; // r30
-    s32 nCount; // r29
-    s32 nSrcAddress; // r5
-    s32 nOptPred; // r7
-    s32 nVScale; // r1+0x8
-    s32 i; // r1+0x8
-    u32 dwDecodeSelect; // r1+0x8
-    u32 n; // r1+0x8
-    s32 nA; // r8
-    s32 nB; // r9
-    s16 nSamp1; // r10
-    s16 nSamp2; // r1+0x8
-    s16* pTempStateAddr; // r1+0x4C
-    s32 nOutput; // r10
+    // References
+    // -> static s32 counter$2409;
 }
 
 // Erased
-static s32 rspALoadBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static s32 rspASetBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u16 nDMEMIn; // r1+0x0
+    u16 nDMEMOut; // r5
+    u16 nCount; // r1+0x0
+}
+
+// Erased
+static s32 rspAWMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+}
+
+// Erased
+static s32 rspADMEMMove2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r1+0x10
+}
+
+// Erased
+static s32 rspALoadADPCM2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r25
+
+    // Local variables
+    void* pData; // r1+0x20
+}
+
+// Range: 0x80085848 -> 0x800858D0
+static s32 rspAMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r7
+    s16* srcP; // r8
+    s32 outData32; // r6
+}
+
+// Range: 0x800855FC -> 0x80085848
+static s32 rspAInterleave2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
     // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s32 outp; // r6
+    s32 inpr; // r1+0x8
+    s32 inpl; // r1+0x8
+    s32 count; // r7
+    s32 i; // r1+0x8
+}
+
+// Range: 0x800854F0 -> 0x800855FC
+static s32 rspADistFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r26
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16 dpow; // r7
+    s32 i; // r27
+    s64 mult; // r3
+}
+
+// Erased
+static s32 rspASetLoop2(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+}
+
+// Erased
+static s32 rspADMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+}
+
+// Erased
+static s32 rspAHalfCut2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s32 count; // r1+0x8
+    s32 outp; // r1+0x8
+    s32 inpp; // r7
+    s32 i; // r8
+}
+
+// Erased
+static s32 rspASetEnvParam2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    s16 temp; // r7
+}
+
+// Erased
+static s32 rspASetEnvParam22(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    s16 tmp; // r6
+}
+
+// Range: 0x80085218 -> 0x800854F0
+static s32 rspAEnvMixer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s16 vStep[8]; // r1+0x3C
+    u16 vParams[8]; // r1+0x2C
+    s32 i; // r28
+    s32 j; // r27
+    s32 inpp; // r26
+    s32 outL; // r25
+    s32 outR; // r24
+    s32 outFL; // r23
+    s32 outFR; // r22
+    s32 count; // r21
+    s32 temp; // r1+0x8
+    s32 id; // r1+0x8
+    s32 waveL; // r20
+    s32 waveR; // r19
+    s32 waveI; // r15
+    s32 srcL; // r18
+    s32 srcR; // r17
+    s32 srcFXL; // r16
+    s32 srcFXR; // r10
+}
+
+// Erased
+static s32 rspALoadBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
 
     // Local variables
     void* pData; // r1+0x14
-    s32 nAddress; // r5
-}
-
-// Range: 0x8008B080 -> 0x8008B1FC
-static s32 rspLoadADPCMCoefTable2(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-
-    // Local variables
-    u32 j; // r1+0x8
-    u32 nCoefIndex; // r5
-}
-
-// Range: 0x8008B1FC -> 0x8008B378
-static s32 rspLoadADPCMCoefTable1(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-
-    // Local variables
-    u32 j; // r1+0x8
-    u32 nCoefIndex; // r5
 }
 
 // Erased
-static s32 rspLoadADPCMCoefRow(struct __anon_0x5845E* pRSP, u32 nCoefIndex, u32 nOptPred) {
+static s32 rspASaveBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCoefIndex; // r6
-    // u32 nOptPred; // r1+0x10
-}
-
-// Erased
-static s32 rspDumpBinaryDMEMToFile(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
 
     // Local variables
-    struct tXL_FILE* fp; // r1+0x10
-    s32 i; // r30
-    u32 nSize; // r1+0xC
+    void* pData; // r1+0x14
 }
 
-// Erased
-static s32 rspDumpMotorolaSDMEMTOFile(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r27
-
-    // Local variables
-    struct tXL_FILE* fp; // r1+0x220
-    s32 i; // r29
-    u32 nStartAddress; // r28
-    u32 nSize; // r1+0x21C
-    char acDMEMLine[512]; // r1+0x1C
-}
-
-// Erased
-static s32 rspDumpDMEMToFile(struct __anon_0x5845E* pRSP) {
+// Range: 0x80084984 -> 0x80085218
+static s32 rspAPCM8Dec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r25
 
     // Local variables
-    struct tXL_FILE* fp; // r1+0x50
-    s32 i; // r30
-    u32 nStartAddress; // r29
-    u32 nSize; // r1+0x4C
-    char acDMEMLine[64]; // r1+0xC
+    s32 inpp; // r31
+    s32 outp; // r30
+    s32 count; // r26
+    s16 flags; // r1+0x8
+    s16 vtmp0[8]; // r1+0x60
+    s16 vtmp1[8]; // r1+0x50
+    s32 i; // r1+0x8
+    s32 j; // r1+0x8
+    s32 stateAddr; // r5
+    s32 s; // r1+0x8
+    void* pData; // r1+0x4C
+    s16* pStateAddress; // r29
+    s16* pTempStateAddr; // r7
 }
 
-// Range: 0x8008B378 -> 0x8008B768
-s32 rspMultPolef(s16 (*matrix)[8], s16* vectorIn, s16* vectorOut) {
+// Range: 0x8008429C -> 0x80084984
+static s32 rspParseABI2(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
-    // s16 (* matrix)[8]; // r1+0xC
-    // s16* vectorIn; // r1+0x10
-    // s16* vectorOut; // r1+0x14
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    s32 sum; // r22
-    s32 vec0; // r1+0x8
-    s32 vec1; // r1+0x8
-    s32 vec2; // r8
-    s32 vec3; // r9
-    s32 vec4; // r10
-    s32 vec5; // r11
-    s32 vec6; // r12
-    s32 vec7; // r31
-    s32 vec8; // r5
-    s32 vec9; // r1+0x8
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x40
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2648;
+}
+
+// Range: 0x80082E60 -> 0x8008429C
+static s32 rspInitAudioDMEM3(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Erased
-static s32 rspMultADPCMCoef1(struct __anon_0x5845E* pRSP, s32* matrix, s16* vectorIn, s16* vectorOut, s32 nOptPred) {
+static s32 rspASetEnvParam3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32* matrix; // r1+0xC
-    // s16* vectorIn; // r1+0x10
-    // s16* vectorOut; // r1+0x14
-    // s32 nOptPred; // r1+0x18
-
-    // Local variables
-    s32 sum; // r12
-    s32 vec0; // r1+0x8
-    s32 vec1; // r1+0x8
-    s32 vec2; // r26
-    s32 vec3; // r25
-    s32 vec4; // r24
-    s32 vec5; // r23
-    s32 vec6; // r22
-    s32 vec7; // r21
-    s32 vec8; // r20
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
 }
 
-// Range: 0x8008B768 -> 0x8008BBDC
-s32 rspDotProduct8x15MatrixBy15x1Vector(s16* matrix, s16* vectorIn, s16* vectorOut) {
+// Erased
+static s32 rspASetEnvParam32(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
     // Parameters
-    // s16* matrix; // r1+0xC
-    // s16* vectorIn; // r1+0x10
-    // s16* vectorOut; // r1+0x14
-
-    // Local variables
-    s32 sum; // r12
-    s32 vec1; // r1+0x8
-    s32 vec2; // r1+0x8
-    s32 vec3; // r1+0x8
-    s32 vec4; // r1+0x8
-    s32 vec5; // r1+0x8
-    s32 vec6; // r1+0x8
-    s32 vec7; // r1+0x8
-    s32 vec8; // r31
-    s32 vec9; // r30
-    s32 vec10; // r29
-    s32 vec11; // r28
-    s32 vec12; // r27
-    s32 vec13; // r26
-    s32 vec14; // r5
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
 }
 
-// Range: 0x8008BBDC -> 0x8008CF0C
-static s32 rspInitAudioDMEM1(struct __anon_0x5845E* pRSP) {
+// Erased
+static s32 rspALoadBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
+
+    // Local variables
+    void* pData; // r1+0x14
+}
+
+// Erased
+static s32 rspASaveBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nCommandLo; // r4
+    // u32 nCommandHi; // r31
+
+    // Local variables
+    void* pData; // r1+0x14
+}
+
+// Range: 0x80082C2C -> 0x80082E60
+static s32 rspAEnvMixer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 vParams[8]; // r1+0x20
+    s32 i; // r27
+    s32 j; // r1+0x8
+    s32 inpp; // r26
+    s32 outL; // r25
+    s32 outR; // r24
+    s32 outFL; // r23
+    s32 outFR; // r22
+    s32 count; // r21
+    s32 id; // r1+0x8
+    s32 waveL; // r20
+    s32 waveR; // r19
+    s32 waveI; // r19
+    s32 srcL; // r18
+    s32 srcR; // r17
+    s32 srcFXL; // r16
+    s32 srcFXR; // r12
+}
+
+// Erased
+static s32 rspAHalfCut3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    s32 count; // r1+0x8
+    s32 outp; // r1+0x8
+    s32 inpp; // r7
+    s32 i; // r8
+}
+
+// Range: 0x80082B94 -> 0x80082C2C
+static s32 rspAMix3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+    // u32 nCommandHi; // r1+0x8
+
+    // Local variables
+    u32 i; // r1+0x0
+    u32 nCount; // r8
+    s16* srcP; // r4
+    s32 outData32; // r6
+}
+
+// Erased
+static s32 rspADMEMCopy(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+}
+
+// Range: 0x80082624 -> 0x80082B94
+static s32 rspParseABI3(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
+
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x38
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2757;
+}
+
+// Range: 0x800811C0 -> 0x80082624
+static s32 rspInitAudioDMEM4(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+}
+
+// Erased
+static s32 rspARingFilter4() {}
+
+// Erased
+static s32 rspAInterleave4(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nCommandLo; // r1+0x4
+
+    // Local variables
+    u32 iIndex; // r1+0x0
+    u32 iIndex2; // r9
+}
+
+// Erased
+static s32 rspADMEMMove4(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u32 nCommandLo; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+
+    // Local variables
+    u16 nDMEMOut; // r1+0x8
+    u16 nCount; // r4
+    u32 nDMEMIn; // r1+0x8
+}
+
+// Range: 0x80080AA4 -> 0x800811C0
+static s32 rspParseABI4(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r5
+
+    // Local variables
+    u32 nCommandLo; // r4
+    u32 nCommandHi; // r30
+    u32* pABI32; // r1+0x40
+    u32* pABILast32; // r29
+    u32 nSize; // r23
+
+    // References
+    // -> static s32 nFirstTime$2796;
 }

--- a/debug/Fire/_buildtev.c
+++ b/debug/Fire/_buildtev.c
@@ -174,109 +174,6 @@ typedef struct CombineModeTev {
 // size = 0x2B8, address = 0x80130C50
 static struct CombineModeTev tevStages$519;
 
-// Range: 0x800986A4 -> 0x80098AE0
-struct CombineModeTev* BuildCombineModeTev(u32 color1, u32 alpha1, u32 color2, u32 alpha2, u32 numCycles) {
-    // Parameters
-    // u32 color1; // r26
-    // u32 alpha1; // r27
-    // u32 color2; // r28
-    // u32 alpha2; // r29
-    // u32 numCycles; // r30
-
-    // Local variables
-    u8 stageValues[2][2][4]; // r1+0x28
-    s32 i; // r1+0x8
-    s32 j; // r6
-    u8* tempPtr; // r1+0x8
-
-    // References
-    // -> static struct CombineModeTev tevStages$519;
-    // -> static enum _GXTevAlphaArg sUsualAArgs[4];
-    // -> static enum _GXTevColorArg sUsualCArgs[4];
-}
-
-// Range: 0x80098AE0 -> 0x80098BCC
-void BuildCycle(struct CombineModeTev* tvP, u8 (*stageValues)[4]) {
-    // Parameters
-    // struct CombineModeTev* tvP; // r31
-    // u8 (* stageValues)[4]; // r29
-
-    // Local variables
-    s32 numCParts; // r1+0x8
-    s32 numAParts; // r1+0x8
-    s32 i; // r5
-}
-
-// Range: 0x80098BCC -> 0x8009B6BC
-s32 SetupStage(struct CombineModeTev* tvP, u8* stageValues, s32 type) {
-    // Parameters
-    // struct CombineModeTev* tvP; // r26
-    // u8* stageValues; // r27
-    // s32 type; // r22
-
-    // Local variables
-    s32 zero; // r1+0x8
-    s32 curStage; // r31
-    s32 textureFoundPos; // r30
-    s32 numFound[2]; // r1+0x18
-    s32 retStages; // r29
-    s32 ret; // r1+0x8
-    s32 i; // r21
-    s32 num; // r6
-    s32 j; // r7
-    s32 foundTypes; // r28
-    s32 texelNum; // r10
-    s32 mask; // r5
-    s32 mask; // r21
-    s32 index1; // r1+0x8
-    s32 index2; // r23
-    s32 index1; // r1+0x8
-    s32 index2; // r23
-    s32 flag; // r7
-    s32 mask; // r4
-
-    // References
-    // -> enum _GXTevAlphaArg gAlphaArgs[10];
-    // -> static struct TevColorOp sUsualOps[4];
-    // -> enum _GXTevColorArg gColorArgs[16];
-    // -> static s32 lightType$184[2][2];
-    // -> static s32 texelType$183[2][4];
-    // -> static s32 zeroType$182[2];
-}
-
-// Erased
-static void AddColorTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
-    // Parameters
-    // struct CombineModeTev* tvP; // r1+0x0
-    // s32 foundTypes; // r1+0x4
-    // s32 curStage; // r1+0x8
-}
-
-// Range: 0x8009B6BC -> 0x8009B7DC
-static s32 AddAlphaTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
-    // Parameters
-    // struct CombineModeTev* tvP; // r1+0x0
-    // s32 foundTypes; // r1+0x4
-    // s32 curStage; // r5
-
-    // Local variables
-    s32 ret; // r6
-
-    // References
-    // -> static struct TevColorOp sUsualOps[4];
-}
-
-// Range: 0x8009B7DC -> 0x8009B914
-void SetAlpha(u8* stageValues, u32 alphaVal, u8 cycle) {
-    // Parameters
-    // u8* stageValues; // r1+0x0
-    // u32 alphaVal; // r1+0x4
-    // u8 cycle; // r1+0x8
-
-    // Local variables
-    s32 i; // r8
-}
-
 typedef enum __anon_0x8A896 {
     SM_NONE = -1,
     SM_RUNNING = 0,
@@ -357,4 +254,107 @@ void SetColor(u8* stageValues, u32 colorVal, u8 cycle) {
 
     // References
     // -> struct __anon_0x8AC22* gpSystem;
+}
+
+// Range: 0x8009B7DC -> 0x8009B914
+void SetAlpha(u8* stageValues, u32 alphaVal, u8 cycle) {
+    // Parameters
+    // u8* stageValues; // r1+0x0
+    // u32 alphaVal; // r1+0x4
+    // u8 cycle; // r1+0x8
+
+    // Local variables
+    s32 i; // r8
+}
+
+// Range: 0x8009B6BC -> 0x8009B7DC
+static s32 AddAlphaTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r1+0x0
+    // s32 foundTypes; // r1+0x4
+    // s32 curStage; // r5
+
+    // Local variables
+    s32 ret; // r6
+
+    // References
+    // -> static struct TevColorOp sUsualOps[4];
+}
+
+// Erased
+static void AddColorTevOrder(struct CombineModeTev* tvP, s32 foundTypes, s32 curStage) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r1+0x0
+    // s32 foundTypes; // r1+0x4
+    // s32 curStage; // r1+0x8
+}
+
+// Range: 0x80098BCC -> 0x8009B6BC
+s32 SetupStage(struct CombineModeTev* tvP, u8* stageValues, s32 type) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r26
+    // u8* stageValues; // r27
+    // s32 type; // r22
+
+    // Local variables
+    s32 zero; // r1+0x8
+    s32 curStage; // r31
+    s32 textureFoundPos; // r30
+    s32 numFound[2]; // r1+0x18
+    s32 retStages; // r29
+    s32 ret; // r1+0x8
+    s32 i; // r21
+    s32 num; // r6
+    s32 j; // r7
+    s32 foundTypes; // r28
+    s32 texelNum; // r10
+    s32 mask; // r5
+    s32 mask; // r21
+    s32 index1; // r1+0x8
+    s32 index2; // r23
+    s32 index1; // r1+0x8
+    s32 index2; // r23
+    s32 flag; // r7
+    s32 mask; // r4
+
+    // References
+    // -> enum _GXTevAlphaArg gAlphaArgs[10];
+    // -> static struct TevColorOp sUsualOps[4];
+    // -> enum _GXTevColorArg gColorArgs[16];
+    // -> static s32 lightType$184[2][2];
+    // -> static s32 texelType$183[2][4];
+    // -> static s32 zeroType$182[2];
+}
+
+// Range: 0x80098AE0 -> 0x80098BCC
+void BuildCycle(struct CombineModeTev* tvP, u8 (*stageValues)[4]) {
+    // Parameters
+    // struct CombineModeTev* tvP; // r31
+    // u8 (* stageValues)[4]; // r29
+
+    // Local variables
+    s32 numCParts; // r1+0x8
+    s32 numAParts; // r1+0x8
+    s32 i; // r5
+}
+
+// Range: 0x800986A4 -> 0x80098AE0
+struct CombineModeTev* BuildCombineModeTev(u32 color1, u32 alpha1, u32 color2, u32 alpha2, u32 numCycles) {
+    // Parameters
+    // u32 color1; // r26
+    // u32 alpha1; // r27
+    // u32 color2; // r28
+    // u32 alpha2; // r29
+    // u32 numCycles; // r30
+
+    // Local variables
+    u8 stageValues[2][2][4]; // r1+0x28
+    s32 i; // r1+0x8
+    s32 j; // r6
+    u8* tempPtr; // r1+0x8
+
+    // References
+    // -> static struct CombineModeTev tevStages$519;
+    // -> static enum _GXTevAlphaArg sUsualAArgs[4];
+    // -> static enum _GXTevColorArg sUsualCArgs[4];
 }

--- a/debug/Fire/_cpuDecodePPC2.c
+++ b/debug/Fire/_cpuDecodePPC2.c
@@ -7,8 +7,89 @@
 
 #include "types.h"
 
-// Range: 0x80068368 -> 0x800684F4
-static s32 cpuCompile_LWR(s32* addressGCN) {
+// Range: 0x8006BC80 -> 0x8006BE68
+static s32 cpuCompile_DSLLV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r11
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006BA98 -> 0x8006BC80
+static s32 cpuCompile_DSRLV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r11
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006B894 -> 0x8006BA98
+static s32 cpuCompile_DSRAV(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r1+0x8
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006B390 -> 0x8006B894
+static s32 cpuCompile_DMULT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r27
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006B07C -> 0x8006B390
+static s32 cpuCompile_DMULTU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r30
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006AAC0 -> 0x8006B07C
+static s32 cpuCompile_DDIV(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r16
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r23
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006A6A4 -> 0x8006AAC0
+static s32 cpuCompile_DDIVU(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r24
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r9
+    s32 nSize; // r1+0x8
+}
+
+// Erased
+static s32 cpuCompile_DADD(s32* addressGCN) {
     // Parameters
     // s32* addressGCN; // r31
 
@@ -18,9 +99,136 @@ static s32 cpuCompile_LWR(s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x800684F4 -> 0x80068684
-static s32 cpuCompile_LWL(s32* addressGCN) {
+// Erased
+static s32 cpuCompile_DADDU(s32* addressGCN) {
     // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Erased
+static s32 cpuCompile_DSUB(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Erased
+static s32 cpuCompile_DSUBU(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006A364 -> 0x8006A6A4
+static s32 cpuCompile_S_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r19
+    // s32* addressGCN; // r18
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r29
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x80069F30 -> 0x8006A364
+static s32 cpuCompile_D_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r22
+    // s32* addressGCN; // r21
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r21
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x80069D80 -> 0x80069F30
+static s32 cpuCompile_W_CVT_SD(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32* addressGCN; // r30
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r30
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x80069800 -> 0x80069D80
+static s32 cpuCompile_L_CVT_SD(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r5
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x80069644 -> 0x80069800
+static s32 cpuCompile_CEIL_W(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x80069488 -> 0x80069644
+static s32 cpuCompile_FLOOR_W(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Erased
+static s32 cpuCompile_ROUND_W(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Erased
+static s32 cpuCompile_TRUNC_W(s32* addressGCN) {
+    // Parameters
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006931C -> 0x80069488
+static s32 cpuCompile_LB(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
 
     // Local variables
@@ -29,68 +237,20 @@ static s32 cpuCompile_LWL(s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x80068684 -> 0x8006880C
-static s32 cpuCompile_SDC(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x800691B0 -> 0x8006931C
+static s32 cpuCompile_LH(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
 
     // Local variables
     s32* compile; // r1+0x10
-    s32 count; // r5
+    s32 count; // r9
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x8006880C -> 0x80068994
-static s32 cpuCompile_LDC(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80068994 -> 0x80068AF0
-static s32 cpuCompile_SW(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80068AF0 -> 0x80068C4C
-static s32 cpuCompile_SH(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80068C4C -> 0x80068DA8
-static s32 cpuCompile_SB(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80068DA8 -> 0x80068F00
-static s32 cpuCompile_LHU(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x80069058 -> 0x800691B0
+static s32 cpuCompile_LW(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
@@ -113,8 +273,8 @@ static s32 cpuCompile_LBU(struct _CPU* pCPU, s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x80069058 -> 0x800691B0
-static s32 cpuCompile_LW(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x80068DA8 -> 0x80068F00
+static s32 cpuCompile_LHU(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
@@ -125,54 +285,8 @@ static s32 cpuCompile_LW(struct _CPU* pCPU, s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x800691B0 -> 0x8006931C
-static s32 cpuCompile_LH(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006931C -> 0x80069488
-static s32 cpuCompile_LB(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_TRUNC_W(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_ROUND_W(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80069488 -> 0x80069644
-static s32 cpuCompile_FLOOR_W(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x80068C4C -> 0x80068DA8
+static s32 cpuCompile_SB(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
@@ -183,8 +297,8 @@ static s32 cpuCompile_FLOOR_W(struct _CPU* pCPU, s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x80069644 -> 0x80069800
-static s32 cpuCompile_CEIL_W(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x80068AF0 -> 0x80068C4C
+static s32 cpuCompile_SH(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
@@ -195,9 +309,22 @@ static s32 cpuCompile_CEIL_W(struct _CPU* pCPU, s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x80069800 -> 0x80069D80
-static s32 cpuCompile_L_CVT_SD(s32* addressGCN) {
+// Range: 0x80068994 -> 0x80068AF0
+static s32 cpuCompile_SW(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* addressGCN; // r31
+
+    // Local variables
+    s32* compile; // r1+0x10
+    s32 count; // r7
+    s32 nSize; // r1+0x8
+}
+
+// Range: 0x8006880C -> 0x80068994
+static s32 cpuCompile_LDC(struct _CPU* pCPU, s32* addressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
     // s32* addressGCN; // r31
 
     // Local variables
@@ -206,127 +333,11 @@ static s32 cpuCompile_L_CVT_SD(s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x80069D80 -> 0x80069F30
-static s32 cpuCompile_W_CVT_SD(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r30
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r30
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x80069F30 -> 0x8006A364
-static s32 cpuCompile_D_SQRT(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r22
-    // s32* addressGCN; // r21
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r21
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006A364 -> 0x8006A6A4
-static s32 cpuCompile_S_SQRT(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r19
-    // s32* addressGCN; // r18
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r29
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_DSUBU(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_DSUB(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_DADDU(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Erased
-static s32 cpuCompile_DADD(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006A6A4 -> 0x8006AAC0
-static s32 cpuCompile_DDIVU(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r24
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006AAC0 -> 0x8006B07C
-static s32 cpuCompile_DDIV(struct _CPU* pCPU, s32* addressGCN) {
+// Range: 0x80068684 -> 0x8006880C
+static s32 cpuCompile_SDC(struct _CPU* pCPU, s32* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r16
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r23
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006B07C -> 0x8006B390
-static s32 cpuCompile_DMULTU(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r30
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006B390 -> 0x8006B894
-static s32 cpuCompile_DMULT(struct _CPU* pCPU, s32* addressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r27
+    // s32* addressGCN; // r31
 
     // Local variables
     s32* compile; // r1+0x10
@@ -334,35 +345,24 @@ static s32 cpuCompile_DMULT(struct _CPU* pCPU, s32* addressGCN) {
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x8006B894 -> 0x8006BA98
-static s32 cpuCompile_DSRAV(s32* addressGCN) {
+// Range: 0x800684F4 -> 0x80068684
+static s32 cpuCompile_LWL(s32* addressGCN) {
     // Parameters
     // s32* addressGCN; // r31
 
     // Local variables
     s32* compile; // r1+0x10
-    s32 count; // r1+0x8
+    s32 count; // r9
     s32 nSize; // r1+0x8
 }
 
-// Range: 0x8006BA98 -> 0x8006BC80
-static s32 cpuCompile_DSRLV(s32* addressGCN) {
+// Range: 0x80068368 -> 0x800684F4
+static s32 cpuCompile_LWR(s32* addressGCN) {
     // Parameters
     // s32* addressGCN; // r31
 
     // Local variables
     s32* compile; // r1+0x10
-    s32 count; // r11
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8006BC80 -> 0x8006BE68
-static s32 cpuCompile_DSLLV(s32* addressGCN) {
-    // Parameters
-    // s32* addressGCN; // r31
-
-    // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r11
+    s32 count; // r7
     s32 nSize; // r1+0x8
 }

--- a/debug/Fire/_cpuGCN.c
+++ b/debug/Fire/_cpuGCN.c
@@ -7,342 +7,41 @@
 
 #include "types.h"
 
-// Range: 0x80036870 -> 0x800374DC
-s32 cpuExecute(struct _CPU* pCPU) {
+// Erased
+static s32 cpuFindBranchOffset(struct cpu_function* pFunction, s32* pnOffset, s32 nAddress, s32* anCode) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x4
+    // s32* pnOffset; // r1+0x8
+    // s32 nAddress; // r1+0xC
+    // s32* anCode; // r1+0x10
+
+    // Local variables
+    s32 iJump; // r8
+}
+
+// Range: 0x80068238 -> 0x80068368
+static s32 cpuCheckDelaySlot(u32 opcode) {
+    // Parameters
+    // u32 opcode; // r1+0x0
+
+    // Local variables
+    s32 flag; // r5
+}
+
+// Erased
+static void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
+    // Parameters
+    // s32* anCode; // r1+0x0
+    // s32* iCode; // r1+0x4
+    // s32 number; // r5
+}
+
+// Erased
+static s32 cpuRecompileFunction(struct _CPU* pCPU, struct cpu_function* pFunction, s32 nAddressN64) {
     // Parameters
     // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32 iGPR; // r8
-    s32* pnCode; // r1+0x54
-    s32 nData; // r1+0x8
-    struct cpu_function* pFunction; // r1+0x4C
-    void (*pfCode)(); // r1+0x48
-
-    // References
-    // -> static s32 cpuCompile_LWR_function;
-    // -> static s32 cpuCompile_LWL_function;
-    // -> static s32 cpuCompile_SDC_function;
-    // -> static s32 cpuCompile_LDC_function;
-    // -> static s32 cpuCompile_SW_function;
-    // -> static s32 cpuCompile_SH_function;
-    // -> static s32 cpuCompile_SB_function;
-    // -> static s32 cpuCompile_LHU_function;
-    // -> static s32 cpuCompile_LBU_function;
-    // -> static s32 cpuCompile_LW_function;
-    // -> static s32 cpuCompile_LH_function;
-    // -> static s32 cpuCompile_LB_function;
-    // -> static s32 cpuCompile_ROUND_W_function;
-    // -> static s32 cpuCompile_TRUNC_W_function;
-    // -> static s32 cpuCompile_FLOOR_W_function;
-    // -> static s32 cpuCompile_CEIL_W_function;
-    // -> static s32 cpuCompile_L_CVT_SD_function;
-    // -> static s32 cpuCompile_W_CVT_SD_function;
-    // -> static s32 cpuCompile_D_SQRT_function;
-    // -> static s32 cpuCompile_S_SQRT_function;
-    // -> static s32 cpuCompile_DSUBU_function;
-    // -> static s32 cpuCompile_DSUB_function;
-    // -> static s32 cpuCompile_DADDU_function;
-    // -> static s32 cpuCompile_DADD_function;
-    // -> static s32 cpuCompile_DDIVU_function;
-    // -> static s32 cpuCompile_DDIV_function;
-    // -> static s32 cpuCompile_DMULTU_function;
-    // -> static s32 cpuCompile_DMULT_function;
-    // -> static s32 cpuCompile_DSRAV_function;
-    // -> static s32 cpuCompile_DSRLV_function;
-    // -> static s32 cpuCompile_DSLLV_function;
-    // -> s32 ganMapGPR[32];
-}
-
-// Erased
-static void __cpuTest() {}
-
-// Erased
-static s32 cpuFreeLink(void (**ppfLink)()) {
-    // Parameters
-    // void (** ppfLink)(); // r1+0xC
-}
-
-// Range: 0x800374DC -> 0x8003779C
-static s32 cpuMakeLink(struct _CPU* pCPU, void (**ppfLink)(), void (*pfFunction)()) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // void (** ppfLink)(); // r30
-    // void (* pfFunction)(); // r31
-
-    // Local variables
-    s32 iGPR; // r1+0x8
-    s32* pnCode; // r1+0x18
-    s32 nData; // r1+0x8
-
-    // References
-    // -> s32 ganMapGPR[32];
-}
-
-// Range: 0x8003779C -> 0x800382F8
-static s32 cpuExecuteLoadStoreF(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r25
-
-    // Local variables
-    u32* opcode; // r1+0x1C
-    s32 address; // r1+0x8
-    s32 iRegisterA; // r6
-    s32 iRegisterB; // r1+0x8
-    u8 device; // r5
-    s32 total; // r30
-    s32 count; // r29
-    s32 save; // r28
-    s32 interpret; // r27
-    s32* before; // r26
-    s32* after; // r25
-    s32 check2; // r24
-    s32* anCode; // r23
-
-    // References
-    // -> s32 ganMapGPR[32];
-}
-
-// Range: 0x800382F8 -> 0x80039158
-static s32 cpuExecuteLoadStore(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r24
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r27
-
-    // Local variables
-    u32* opcode; // r1+0x1C
-    s32 address; // r1+0x8
-    s32 iRegisterA; // r5
-    s32 iRegisterB; // r1+0x8
-    u8 device; // r5
-    s32 total; // r23
-    s32 count; // r31
-    s32 save; // r30
-    s32 interpret; // r29
-    s32* before; // r28
-    s32* after; // r27
-    s32 check2; // r26
-    s32* anCode; // r25
-
-    // References
-    // -> s32 ganMapGPR[32];
-}
-
-// Range: 0x80039158 -> 0x800393B8
-static s32 cpuExecuteCall(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32 nCount; // r29
-    // s32 nAddressN64; // r30
-    // s32 nAddressGCN; // r1+0x14
-
-    // Local variables
-    s32 count; // r4
-    s32* anCode; // r30
-    s32 saveGCN; // r31
-    struct cpu_function* node; // r1+0x18
-    struct cpu_callerID* block; // r5
-    s32 nDeltaAddress; // r1+0x8
-
-    // References
-    // -> s32 ganMapGPR[32];
-}
-
-// Range: 0x800393B8 -> 0x80039488
-static s32 cpuExecuteJump(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 nCount; // r30
-    // s32 nAddressN64; // r31
-    // s32 nAddressGCN; // r1+0x14
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-}
-
-// Range: 0x80039488 -> 0x80039594
-static s32 cpuExecuteIdle(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32 nCount; // r28
-    // s32 nAddressN64; // r29
-    // s32 nAddressGCN; // r1+0x14
-
-    // Local variables
-    struct __anon_0x443F6* pROM; // r30
-}
-
-// Range: 0x80039594 -> 0x8003DF08
-static s32 cpuExecuteOpcode(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // s32 nCount; // r1+0xC
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r1+0x14
-
-    // Local variables
-    u64 save; // r25
-    s32 restore; // r27
-    u32 nOpcode; // r30
-    u32* opcode; // r1+0x6C
-    struct __anon_0x3EB4F** apDevice; // r28
-    u8* aiDevice; // r29
-    s32 iEntry; // r4
-    s32 nCount; // r22
-    char nData8; // r1+0x66
-    s16 nData16; // r1+0x64
-    s32 nData32; // r1+0x60
-    s64 nData64; // r1+0x58
-    s32 nAddress; // r23
-    struct cpu_function* pFunction; // r1+0x50
-
-    // References
-    // -> s32 __float_huge[];
-    // -> s32 __float_nan[];
-}
-
-// Range: 0x8003DF08 -> 0x8003E204
-static s32 cpuExecuteUpdate(struct _CPU* pCPU, s32* pnAddressGCN, u32 nCount) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32* pnAddressGCN; // r29
-    // u32 nCount; // r30
-
-    // Local variables
-    enum __anon_0x44829 eModeUpdate; // r4
-    struct __anon_0x3DB14* pSystem; // r31
-    s32 nDelta; // r1+0x8
-    u32 nCounter; // r1+0x8
-    u32 nCompare; // r1+0x8
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-    // -> u32 nTickMultiplier;
-    // -> f32 fTickScale;
-}
-
-// Erased
-static s32 cpuRetraceReset() {}
-
-// Erased
-static s32 cpuRetraceSetup(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-}
-
-// Range: 0x8003E204 -> 0x8003E214
-static void cpuRetraceCallback(u32 nCount) {
-    // Parameters
-    // u32 nCount; // r1+0x0
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-}
-
-// Erased
-static void cpuAlarmCallback(struct OSAlarm* pAlarm) {
-    // Parameters
-    // struct OSAlarm* pAlarm; // r3
-
-    // Local variables
-    struct _CPU* pCPU; // r31
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-}
-
-// Range: 0x8003E214 -> 0x8003E4D8
-static s32 cpuNextInstruction(struct _CPU* pCPU, s32 addressN64, s32 opcode, s32* anCode, s32* iCode) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // s32 addressN64; // r10
-    // s32 opcode; // r5
-    // s32* anCode; // r1+0x14
-    // s32* iCode; // r1+0x18
-}
-
-// Erased
-static s32 cpuStackOffset(struct _CPU* pCPU, s32 currentAddress, s32* anCode, s32 source, s32 target) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32* anCode; // r1+0x8
-    // s32 source; // r1+0xC
-    // s32 target; // r1+0x10
-}
-
-// Erased
-static s32 cpuCutStoreLoadF(struct _CPU* pCPU, s32 currentAddress, s32 source) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32 source; // r1+0x8
-}
-
-// Erased
-static s32 cpuCutStoreLoad(struct _CPU* pCPU, s32 currentAddress, s32 source) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32 source; // r1+0x8
-}
-
-// Erased
-static s32 cpuNoBranchTo(struct cpu_function* pFunction, s32 currentAddress) {
-    // Parameters
-    // struct cpu_function* pFunction; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-
-    // Local variables
-    s32 i; // r1+0x0
-}
-
-// Range: 0x8003E4D8 -> 0x8003E974
-static s32 cpuFindAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressGCN) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 nAddressN64; // r30
-    // s32* pnAddressGCN; // r31
-
-    // Local variables
-    s32 iJump; // r6
-    s32 iCode; // r1+0x20
-    s32 nAddress; // r1+0x1C
-    struct cpu_function* pFunction; // r1+0x18
-}
-
-// Erased
-static s32 cpuFreeFunction(struct _CPU* pCPU, struct cpu_function* pFunction) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // struct cpu_function* pFunction; // r4
-}
-
-// Range: 0x8003E974 -> 0x8003EE04
-s32 cpuMakeFunction(struct _CPU* pCPU, struct cpu_function** ppFunction, s32 nAddressN64) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // struct cpu_function** ppFunction; // r31
+    // struct cpu_function* pFunction; // r1+0xC
     // s32 nAddressN64; // r5
-
-    // Local variables
-    s32 iCode; // r1+0x2028
-    s32 iCode0; // r1+0x8
-    s32 iJump; // r7
-    s32 iCheck; // r1+0x8
-    s32 firstTime; // r24
-    s32 kill_value; // r23
-    s32 memory_used; // r22
-    s32 codeMemory; // r1+0x8
-    s32 blockMemory; // r21
-    s32* chunkMemory; // r1+0x2020
-    s32* anCode; // r23
-    s32 nAddress; // r1+0x201C
-    struct cpu_function* pFunction; // r1+0x2018
-    struct __anon_0x3DE78 aJump[1024]; // r1+0x18
 }
 
 // Range: 0x8003EE04 -> 0x80068238
@@ -418,39 +117,340 @@ static s32 cpuGetPPC(struct _CPU* pCPU, s32* pnAddress, struct cpu_function* pFu
     // -> static s32 cpuCompile_DSLLV_function;
 }
 
+// Range: 0x8003E974 -> 0x8003EE04
+s32 cpuMakeFunction(struct _CPU* pCPU, struct cpu_function** ppFunction, s32 nAddressN64) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // struct cpu_function** ppFunction; // r31
+    // s32 nAddressN64; // r5
+
+    // Local variables
+    s32 iCode; // r1+0x2028
+    s32 iCode0; // r1+0x8
+    s32 iJump; // r7
+    s32 iCheck; // r1+0x8
+    s32 firstTime; // r24
+    s32 kill_value; // r23
+    s32 memory_used; // r22
+    s32 codeMemory; // r1+0x8
+    s32 blockMemory; // r21
+    s32* chunkMemory; // r1+0x2020
+    s32* anCode; // r23
+    s32 nAddress; // r1+0x201C
+    struct cpu_function* pFunction; // r1+0x2018
+    struct __anon_0x3DE78 aJump[1024]; // r1+0x18
+}
+
 // Erased
-static s32 cpuRecompileFunction(struct _CPU* pCPU, struct cpu_function* pFunction, s32 nAddressN64) {
+static s32 cpuFreeFunction(struct _CPU* pCPU, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // struct cpu_function* pFunction; // r4
+}
+
+// Range: 0x8003E4D8 -> 0x8003E974
+static s32 cpuFindAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nAddressN64; // r30
+    // s32* pnAddressGCN; // r31
+
+    // Local variables
+    s32 iJump; // r6
+    s32 iCode; // r1+0x20
+    s32 nAddress; // r1+0x1C
+    struct cpu_function* pFunction; // r1+0x18
+}
+
+// Erased
+static s32 cpuNoBranchTo(struct cpu_function* pFunction, s32 currentAddress) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Erased
+static s32 cpuCutStoreLoad(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32 source; // r1+0x8
+}
+
+// Erased
+static s32 cpuCutStoreLoadF(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32 source; // r1+0x8
+}
+
+// Erased
+static s32 cpuStackOffset(struct _CPU* pCPU, s32 currentAddress, s32* anCode, s32 source, s32 target) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 currentAddress; // r1+0x4
+    // s32* anCode; // r1+0x8
+    // s32 source; // r1+0xC
+    // s32 target; // r1+0x10
+}
+
+// Range: 0x8003E214 -> 0x8003E4D8
+static s32 cpuNextInstruction(struct _CPU* pCPU, s32 addressN64, s32 opcode, s32* anCode, s32* iCode) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 addressN64; // r10
+    // s32 opcode; // r5
+    // s32* anCode; // r1+0x14
+    // s32* iCode; // r1+0x18
+}
+
+// Erased
+static void cpuAlarmCallback(struct OSAlarm* pAlarm) {
+    // Parameters
+    // struct OSAlarm* pAlarm; // r3
+
+    // Local variables
+    struct _CPU* pCPU; // r31
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+// Range: 0x8003E204 -> 0x8003E214
+static void cpuRetraceCallback(u32 nCount) {
+    // Parameters
+    // u32 nCount; // r1+0x0
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+// Erased
+static s32 cpuRetraceSetup(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+}
+
+// Erased
+static s32 cpuRetraceReset() {}
+
+// Range: 0x8003DF08 -> 0x8003E204
+static s32 cpuExecuteUpdate(struct _CPU* pCPU, s32* pnAddressGCN, u32 nCount) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32* pnAddressGCN; // r29
+    // u32 nCount; // r30
+
+    // Local variables
+    enum __anon_0x44829 eModeUpdate; // r4
+    struct __anon_0x3DB14* pSystem; // r31
+    s32 nDelta; // r1+0x8
+    u32 nCounter; // r1+0x8
+    u32 nCompare; // r1+0x8
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+    // -> u32 nTickMultiplier;
+    // -> f32 fTickScale;
+}
+
+// Range: 0x80039594 -> 0x8003DF08
+static s32 cpuExecuteOpcode(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // struct cpu_function* pFunction; // r1+0xC
-    // s32 nAddressN64; // r5
+    // s32 nCount; // r1+0xC
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    u64 save; // r25
+    s32 restore; // r27
+    u32 nOpcode; // r30
+    u32* opcode; // r1+0x6C
+    struct __anon_0x3EB4F** apDevice; // r28
+    u8* aiDevice; // r29
+    s32 iEntry; // r4
+    s32 nCount; // r22
+    char nData8; // r1+0x66
+    s16 nData16; // r1+0x64
+    s32 nData32; // r1+0x60
+    s64 nData64; // r1+0x58
+    s32 nAddress; // r23
+    struct cpu_function* pFunction; // r1+0x50
+
+    // References
+    // -> s32 __float_huge[];
+    // -> s32 __float_nan[];
+}
+
+// Range: 0x80039488 -> 0x80039594
+static s32 cpuExecuteIdle(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32 nCount; // r28
+    // s32 nAddressN64; // r29
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    struct __anon_0x443F6* pROM; // r30
+}
+
+// Range: 0x800393B8 -> 0x80039488
+static s32 cpuExecuteJump(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nCount; // r30
+    // s32 nAddressN64; // r31
+    // s32 nAddressGCN; // r1+0x14
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+// Range: 0x80039158 -> 0x800393B8
+static s32 cpuExecuteCall(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 nCount; // r29
+    // s32 nAddressN64; // r30
+    // s32 nAddressGCN; // r1+0x14
+
+    // Local variables
+    s32 count; // r4
+    s32* anCode; // r30
+    s32 saveGCN; // r31
+    struct cpu_function* node; // r1+0x18
+    struct cpu_callerID* block; // r5
+    s32 nDeltaAddress; // r1+0x8
+
+    // References
+    // -> s32 ganMapGPR[32];
+}
+
+// Range: 0x800382F8 -> 0x80039158
+static s32 cpuExecuteLoadStore(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r27
+
+    // Local variables
+    u32* opcode; // r1+0x1C
+    s32 address; // r1+0x8
+    s32 iRegisterA; // r5
+    s32 iRegisterB; // r1+0x8
+    u8 device; // r5
+    s32 total; // r23
+    s32 count; // r31
+    s32 save; // r30
+    s32 interpret; // r29
+    s32* before; // r28
+    s32* after; // r27
+    s32 check2; // r26
+    s32* anCode; // r25
+
+    // References
+    // -> s32 ganMapGPR[32];
+}
+
+// Range: 0x8003779C -> 0x800382F8
+static s32 cpuExecuteLoadStoreF(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // s32 nAddressN64; // r22
+    // s32 nAddressGCN; // r25
+
+    // Local variables
+    u32* opcode; // r1+0x1C
+    s32 address; // r1+0x8
+    s32 iRegisterA; // r6
+    s32 iRegisterB; // r1+0x8
+    u8 device; // r5
+    s32 total; // r30
+    s32 count; // r29
+    s32 save; // r28
+    s32 interpret; // r27
+    s32* before; // r26
+    s32* after; // r25
+    s32 check2; // r24
+    s32* anCode; // r23
+
+    // References
+    // -> s32 ganMapGPR[32];
+}
+
+// Range: 0x800374DC -> 0x8003779C
+static s32 cpuMakeLink(struct _CPU* pCPU, void (**ppfLink)(), void (*pfFunction)()) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // void (** ppfLink)(); // r30
+    // void (* pfFunction)(); // r31
+
+    // Local variables
+    s32 iGPR; // r1+0x8
+    s32* pnCode; // r1+0x18
+    s32 nData; // r1+0x8
+
+    // References
+    // -> s32 ganMapGPR[32];
 }
 
 // Erased
-static void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
+static s32 cpuFreeLink(void (**ppfLink)()) {
     // Parameters
-    // s32* anCode; // r1+0x0
-    // s32* iCode; // r1+0x4
-    // s32 number; // r5
-}
-
-// Range: 0x80068238 -> 0x80068368
-static s32 cpuCheckDelaySlot(u32 opcode) {
-    // Parameters
-    // u32 opcode; // r1+0x0
-
-    // Local variables
-    s32 flag; // r5
+    // void (** ppfLink)(); // r1+0xC
 }
 
 // Erased
-static s32 cpuFindBranchOffset(struct cpu_function* pFunction, s32* pnOffset, s32 nAddress, s32* anCode) {
+static void __cpuTest() {}
+
+// Range: 0x80036870 -> 0x800374DC
+s32 cpuExecute(struct _CPU* pCPU) {
     // Parameters
-    // struct cpu_function* pFunction; // r1+0x4
-    // s32* pnOffset; // r1+0x8
-    // s32 nAddress; // r1+0xC
-    // s32* anCode; // r1+0x10
+    // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 iJump; // r8
+    s32 iGPR; // r8
+    s32* pnCode; // r1+0x54
+    s32 nData; // r1+0x8
+    struct cpu_function* pFunction; // r1+0x4C
+    void (*pfCode)(); // r1+0x48
+
+    // References
+    // -> static s32 cpuCompile_LWR_function;
+    // -> static s32 cpuCompile_LWL_function;
+    // -> static s32 cpuCompile_SDC_function;
+    // -> static s32 cpuCompile_LDC_function;
+    // -> static s32 cpuCompile_SW_function;
+    // -> static s32 cpuCompile_SH_function;
+    // -> static s32 cpuCompile_SB_function;
+    // -> static s32 cpuCompile_LHU_function;
+    // -> static s32 cpuCompile_LBU_function;
+    // -> static s32 cpuCompile_LW_function;
+    // -> static s32 cpuCompile_LH_function;
+    // -> static s32 cpuCompile_LB_function;
+    // -> static s32 cpuCompile_ROUND_W_function;
+    // -> static s32 cpuCompile_TRUNC_W_function;
+    // -> static s32 cpuCompile_FLOOR_W_function;
+    // -> static s32 cpuCompile_CEIL_W_function;
+    // -> static s32 cpuCompile_L_CVT_SD_function;
+    // -> static s32 cpuCompile_W_CVT_SD_function;
+    // -> static s32 cpuCompile_D_SQRT_function;
+    // -> static s32 cpuCompile_S_SQRT_function;
+    // -> static s32 cpuCompile_DSUBU_function;
+    // -> static s32 cpuCompile_DSUB_function;
+    // -> static s32 cpuCompile_DADDU_function;
+    // -> static s32 cpuCompile_DADD_function;
+    // -> static s32 cpuCompile_DDIVU_function;
+    // -> static s32 cpuCompile_DDIV_function;
+    // -> static s32 cpuCompile_DMULTU_function;
+    // -> static s32 cpuCompile_DMULT_function;
+    // -> static s32 cpuCompile_DSRAV_function;
+    // -> static s32 cpuCompile_DSRLV_function;
+    // -> static s32 cpuCompile_DSLLV_function;
+    // -> s32 ganMapGPR[32];
 }

--- a/debug/Fire/_frameGCN.c
+++ b/debug/Fire/_frameGCN.c
@@ -7,988 +7,131 @@
 
 #include "types.h"
 
-// Range: 0x80021204 -> 0x80021588
-static s32 frameEvent(struct __anon_0x24C38* pFrame, s32 nEvent) {
+// Erased
+static s32 frameSetProjection(struct __anon_0x24C38* pFrame, s32 iHint) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // s32 nEvent; // r1+0xC
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 iHint; // r1+0xC
 
-    // References
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> static s32 gnCountMapHack;
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
+    // Local variables
+    struct __anon_0x24A81* pHint; // r1+0x8
 }
 
-// Range: 0x80021588 -> 0x800217F8
-s32 frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, s32 nAddress) {
+// Range: 0x8002C67C -> 0x8002CA14
+static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
-    // u16* pnData; // r1+0xC
-    // s32 nAddress; // r1+0x10
 
     // Local variables
-    u32 nX; // r7
-    u32 nY; // r8
-    u32 nOffset; // r1+0x8
-    s32 n64CalcValue; // r6
-    s32 exp; // r7
-    s32 mantissa; // r1+0x8
-    s32 compare; // r3
-    s32 val; // r7
-    struct __anon_0x285E5 z_format[8]; // r1+0x14
-
-    // References
-    // -> static u16 sTempZBuf[4800][4][4];
-}
-
-// Range: 0x800217F8 -> 0x8002303C
-s32 frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer,
-                        u64** ppnGBI) {
-    // Parameters
-    // struct __anon_0x2865F* pRDP; // r29
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x23B9E* pBuffer; // r17
-    // u64** ppnGBI; // r14
-
-    // Local variables
-    struct __anon_0x297E0* pRSP; // r17
-    u64* pnGBI; // r20
-    s32 count; // r8
-    s32 nAddress; // r5
-    s32 sizeX; // r6
-    u32 nCommandLo; // r7
-    u32 nCommandHi; // r3
-    u16* BG; // r18
-    u16* FR; // r28
-    u16* pLUT; // r16
-    u16* pBitmap16; // r4
-    u8* pBitmap8; // r5
-    s32 iTile; // r5
-    s32 nCount; // r4
-    struct __anon_0x247BF* pTile; // r5
-    s32 iTile; // r1+0x8
-    s32 nCount; // r4
-    s32 iTile; // r5
-    s32 nCount; // r4
-    union __anon_0x2ACA3 bg; // r1+0x50
-    union __anon_0x2B091 objTxtr; // r1+0x38
-    u32 nLoadType; // r1+0x34
-    struct __anon_0x23B9E* pBG; // r18
-
-    // References
-    // -> static u32 GBIcode2D2$1906[7];
-    // -> static u32 GBIcode3D2$1908[6];
-    // -> static u32 GBIcode3D1$1907[5];
-}
-
-// Range: 0x8002303C -> 0x800230E0
-s32 frameHackTIMG_Panel(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // struct __anon_0x23B9E* pBuffer; // r1+0x4
-}
-
-// Range: 0x800230E0 -> 0x80023194
-void PanelDrawFR3D(u16* FR, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 first) {
-    // Parameters
-    // u16* FR; // r1+0x8
-    // u16* LUT; // r1+0xC
-    // u8* bitmap; // r1+0x10
-    // s32 sizeX; // r1+0x14
-    // s32 sizeY; // r1+0x18
-    // s32 posX; // r1+0x1C
-    // s32 posY; // r1+0x20
-    // s32 first; // r1+0x24
-
-    // Local variables
-    s32 i; // r30
-    s32 j; // r1+0x8
-    u16 color; // r29
-}
-
-// Range: 0x80023194 -> 0x80023250
-void PanelDrawBG16(u16* BG, u16* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
-    // Parameters
-    // u16* BG; // r1+0x8
-    // u16* bitmap; // r1+0xC
-    // s32 sizeX; // r1+0x10
-    // s32 sizeY; // r1+0x14
-    // s32 posX; // r1+0x18
-    // s32 posY; // r1+0x1C
-    // s32 flip; // r1+0x20
-
-    // Local variables
-    s32 i; // r29
-    s32 j; // r28
-    u16 color; // r1+0x8
-}
-
-// Range: 0x80023250 -> 0x800232FC
-void PanelDrawBG8(u16* BG, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
-    // Parameters
-    // u16* BG; // r1+0x8
-    // u16* LUT; // r1+0xC
-    // u8* bitmap; // r1+0x10
-    // s32 sizeX; // r1+0x14
-    // s32 sizeY; // r1+0x18
-    // s32 posX; // r1+0x1C
-    // s32 posY; // r1+0x20
-    // s32 flip; // r1+0x24
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r27
-    u16 color; // r1+0x8
-}
-
-// Range: 0x800232FC -> 0x80023430
-s32 frameHackCIMG_Zelda2_Camera(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u32 nCommandHi,
-                                u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // struct __anon_0x23B9E* pBuffer; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-    // u32 nCommandLo; // r1+0x14
-}
-
-// Range: 0x80023430 -> 0x800235A4
-s32 frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, u64** ppnGBI) {
-    // Parameters
-    // struct __anon_0x2865F* pRDP; // r1+0x8
-    // struct __anon_0x24C38* pFrame; // r27
-    // u64** ppnGBI; // r28
-
-    // Local variables
-    u64* pnGBI; // r30
-    s32 count; // r8
-    s32 nAddress; // r4
-    u32 nCommandLo; // r6
-    u32 nCommandHi; // r1+0x8
-    struct __anon_0x297E0* pRSP; // r29
-    s32 done; // r3
-    union __anon_0x2ACA3 bg; // r1+0x18
-
-    // References
-    // -> static u32 GBIcode$1816[3];
-}
-
-// Range: 0x800235A4 -> 0x800239E4
-s32 frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI, u32 nCommandLo) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // struct __anon_0x23B9E* pBuffer; // r28
-    // u64* pnGBI; // r1+0x10
-    // u32 nCommandLo; // r29
-
-    // Local variables
-    u32 i; // r30
-    u32 low2; // r1+0x8
-    u32 high2; // r1+0x8
-    u16* srcP; // r1+0x20
-    u16* val; // r27
-    u16* valEnd; // r29
-    s32 tile; // r6
-    s32 y; // r7
-    s32 x; // r1+0x8
-    u8* val; // r3
-    u8* valEnd; // r4
-
-    // References
-    // -> static u16 tempLine$1785[16][4][4];
-    // -> static s32 sCopyFrameSyncReceived;
-    // -> s32 gNoSwapBuffer;
-    // -> static u32 sNumAddr;
-    // -> static u32 sConstantBufAddr[6];
-    // -> static s32 gnCountMapHack;
-    // -> static u32 sSrcBuffer;
-    // -> static u32 sDestinationBuffer;
-    // -> struct __anon_0x26A4E* gpSystem;
-}
-
-// Range: 0x800239E4 -> 0x8002403C
-s32 frameHackCIMG_Zelda2(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x23B9E* pBuffer; // r31
-    // u64* pnGBI; // r1+0x10
-
-    // Local variables
-    u32 i; // r7
-    u32* pGBI; // r8
-
-    // References
-    // -> static s32 sCopyFrameSyncReceived;
-    // -> s32 gNoSwapBuffer;
-    // -> static s32 nLastFrame$1695;
-    // -> static s32 nCopyFrame$1697;
-    // -> static u32 sCommandCodes2$1722[10];
-    // -> static u32 sCommandCodes$1702[10];
-}
-
-// Range: 0x8002403C -> 0x80024204
-s32 frameHackTIMG_Zelda(struct __anon_0x24C38* pFrame, u64** pnGBI, u32* pnCommandLo, u32* pnCommandHi) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // u64** pnGBI; // r30
-    // u32* pnCommandLo; // r31
-    // u32* pnCommandHi; // r1+0x14
-
-    // Local variables
-    u32 i; // r7
-
-    // References
-    // -> static u32 sDestinationBuffer;
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> static u32 sSrcBuffer;
-    // -> static u8 sSpecialZeldaHackON;
-    // -> static u32 sCommandCodes$1679[8];
-}
-
-// Range: 0x80024204 -> 0x800244F8
-void ZeldaDrawFrameCamera(struct __anon_0x24C38* pFrame, void* buffer) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // void* buffer; // r29
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x30
-    struct _GXColor color; // r1+0x2C
-
-    // References
-    // -> static struct _GXTexObj frameObj$1673;
-}
-
-// Erased
-static void ZeldaCopyCamera(u16* buffer) {
-    // Parameters
-    // u16* buffer; // r31
-}
-
-// Range: 0x800244F8 -> 0x80024A04
-void ZeldaDrawFrameShrink(struct __anon_0x24C38* pFrame, s32 posX, s32 posY, s32 size) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // s32 posX; // r1+0xC
-    // s32 posY; // r1+0x10
-    // s32 size; // r1+0x14
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x28
-    f32 nX0; // f31
-    f32 nX1; // f30
-    f32 nY0; // f29
-    f32 nY1; // f28
-    f32 scale; // f4
-    void* frameBuffer; // r26
-    struct _GXColor color; // r1+0x20
-
-    // References
-    // -> static struct _GXTexObj frameObj$1663;
-    // -> void* DemoCurrentBuffer;
-}
-
-// Erased
-static void ZeldaDrawFrameHiRes(struct __anon_0x24C38* pFrame, void* pSrc) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // void* pSrc; // r29
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x38
-    struct _GXColor color; // r1+0x14
-
-    // References
-    // -> static struct _GXTexObj sFrameObj$1660;
-}
-
-// Erased
-static void ZeldaCopyFrameHiRes(void* pSrc) {
-    // Parameters
-    // void* pSrc; // r31
-
-    // References
-    // -> static s32 sCopyFrameSyncReceived;
-}
-
-// Range: 0x80024A04 -> 0x80024D94
-static void ZeldaGreyScaleConvert(struct __anon_0x24C38* pFrame) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x38
-    void* dataP; // r29
-    struct _GXColor color; // r1+0x10
-
-    // References
-    // -> static struct _GXTexObj sFrameObj$1647;
-    // -> static u8 cAlpha$1648;
-    // -> static u32 gHackCreditsColor;
-    // -> void* DemoCurrentBuffer;
-}
-
-// Range: 0x80024D94 -> 0x800250D8
-void CopyAndConvertCFB(u16* srcP) {
-    // Parameters
-    // u16* srcP; // r29
-
-    // Local variables
-    u16* dataEndP; // r30
-    s32 tile; // r6
-    s32 y; // r7
-    s32 x; // r1+0x8
-    u16 val; // r1+0x8
-
-    // References
-    // -> static u16 line$1630[80][4][4];
-    // -> static s32 sCopyFrameSyncReceived;
-}
-
-// Erased
-static void ConvertCFB(u16* srcP) {
-    // Parameters
-    // u16* srcP; // r29
-
-    // Local variables
-    u16* dataEndP; // r30
-    s32 tile; // r6
-    s32 y; // r7
-    s32 x; // r1+0x8
-    u16 val; // r1+0x8
-
-    // References
-    // -> static u16 line$1606[80][4][4];
-}
-
-// Erased
-static void CopyCFB(u16* srcP) {
-    // Parameters
-    // u16* srcP; // r31
-
-    // References
-    // -> static s32 sCopyFrameSyncReceived;
-}
-
-// Erased
-static void ConvertZ(u16* srcP) {
-    // Parameters
-    // u16* srcP; // r29
-
-    // Local variables
-    u16* dataEndP; // r30
-    s32 tile; // r7
-    s32 y; // r8
-    s32 x; // r1+0x8
-    u16 val; // r9
-
-    // References
-    // -> static u32 line$1582[80][4][4];
-}
-
-// Erased
-static void CopyCFBZTexture(u32* srcP) {
-    // Parameters
-    // u32* srcP; // r31
-
-    // References
-    // -> static s32 sCopyFrameSyncReceived;
-}
-
-// Erased
-static void CopyCFBAlpha(u8* srcP) {
-    // Parameters
-    // u8* srcP; // r31
-
-    // References
-    // -> static s32 sCopyFrameSyncReceived;
-}
-
-// Range: 0x800250D8 -> 0x800253B8
-void ZeldaDrawFrame(struct __anon_0x24C38* pFrame, u16* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // u16* pData; // r29
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x38
-    struct _GXColor color; // r1+0x14
-
-    // References
-    // -> static struct _GXTexObj sFrameObj$1568;
-}
-
-// Range: 0x800253B8 -> 0x8002569C
-void ZeldaDrawFrameBlur(struct __anon_0x24C38* pFrame, u16* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // u16* pData; // r29
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x38
-    struct _GXColor color; // r1+0x14
-
-    // References
-    // -> static struct _GXTexObj sFrameObj$1565;
-}
-
-// Range: 0x8002569C -> 0x80025890
-void ZeldaDrawFrameNoBlend(struct __anon_0x24C38* pFrame, u16* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // u16* pData; // r30
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x30
-
-    // References
-    // -> static struct _GXTexObj sFrameObj$1564;
-}
-
-// Erased
-static void ZeldaDrawFrameZTexture(struct __anon_0x24C38* pFrame, u32* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // u32* pData; // r30
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x30
-
-    // References
-    // -> static struct _GXTexObj sFrameObj1$1562;
-}
-
-// Erased
-static s32 _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, s32 nSizeX, s32 nSizeY, s32 nX0, s32 nY0,
-                           s32 bAlpha) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // u16* pnImage; // r1+0xC
-    // s32 nSizeX; // r1+0x10
-    // s32 nSizeY; // r1+0x14
-    // s32 nX0; // r1+0x18
-    // s32 nY0; // r1+0x1C
-    // s32 bAlpha; // r1+0x20
-
-    // Local variables
-    s32 iY; // r30
-    s32 iX; // r1+0x8
-    s32 nSizeTargetX; // r30
-    u32* pnPixel; // r3
-    u32* aPixel; // r29
-    u32 nPixelSource; // r7
-    u32 nPixelTarget; // r29
-
-    // References
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> void* DemoCurrentBuffer;
-}
-
-// Range: 0x80025890 -> 0x800259B8
-s32 _frameDrawRectangle(struct __anon_0x24C38* pFrame, u32 nColor, s32 nX, s32 nY, s32 nSizeX, s32 nSizeY) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // u32 nColor; // r1+0x4
-    // s32 nX; // r11
-    // s32 nY; // r1+0xC
-    // s32 nSizeX; // r7
-    // s32 nSizeY; // r1+0x14
-
-    // Local variables
-    s32 iY; // r10
-    s32 iX; // r11
-    u32* pnPixel; // r3
-    s32 nSizeTargetX; // r9
-
-    // References
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> void* DemoCurrentBuffer;
-}
-
-// Range: 0x800259B8 -> 0x80025C40
-s32 frameEnd(struct __anon_0x24C38* pFrame) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-
-    // Local variables
-    struct _CPU* pCPU; // r31
-    s32 iHint; // r7
-    void* pData; // r29
-
-    // References
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> void* DemoCurrentBuffer;
-    // -> static s32 sCopyFrameSyncReceived;
-    // -> static u16 sTempZBuf[4800][4][4];
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
-}
-
-// Range: 0x80025C40 -> 0x80025ECC
-s32 frameBegin(struct __anon_0x24C38* pFrame, s32 nCountVertex) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // s32 nCountVertex; // r28
-
-    // Local variables
-    s32 i; // r28
-    f32 matrix[3][4]; // r1+0x14
-
-    // References
-    // -> enum _GXTexCoordID ganNameTexCoord[8];
-    // -> u32 ganNameTexMtx[8];
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
-}
-
-// Range: 0x80025ECC -> 0x80025EE8
-s32 frameBeginOK() {
-    // References
-    // -> static s32 gbFrameValid;
-}
-
-// Range: 0x80025EE8 -> 0x80025FE4
-s32 frameSetColor(struct __anon_0x24C38* pFrame, enum __anon_0x2D223 eType, u32 nRGBA) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // enum __anon_0x2D223 eType; // r30
-    // u32 nRGBA; // r1+0x10
-}
-
-// Range: 0x80025FE4 -> 0x80025FF4
-s32 frameSetDepth(struct __anon_0x24C38* pFrame, f32 rDepth, f32 rDelta) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // f32 rDepth; // r1+0x4
-    // f32 rDelta; // r1+0x8
-}
-
-// Erased
-static s32 frameGetScissor() {}
-
-// Range: 0x80025FF4 -> 0x8002611C
-s32 frameSetScissor(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pScissor) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // struct __anon_0x2D2B6* pScissor; // r1+0xC
-
-    // Local variables
-    s32 nTemp; // r1+0x8
-    s32 nX0; // r3
-    s32 nY0; // r4
-    s32 nX1; // r5
-    s32 nY1; // r6
-}
-
-// Erased
-static s32 frameHide() {}
-
-// Range: 0x8002611C -> 0x80026124
-s32 frameShow() {}
-
-// Erased
-static void CopyZBuffer() {}
-
-// Erased
-static s32 frameDraw() {}
-
-// Erased
-static s32 frameTick() {}
-
-// Range: 0x80026124 -> 0x80026514
-static s32 frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r22
-    // struct __anon_0x2D2B6* pRectangle; // r23
-
-    // Local variables
-    f32 matrix[3][4]; // r1+0x98
-    f32 matrixA[3][4]; // r1+0x68
-    f32 matrixB[3][4]; // r1+0x38
-    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x18
-    f32 rScaleS; // f29
-    f32 rScaleT; // f28
-    f32 rSlideS; // f2
-    f32 rSlideT; // r1+0x8
-    u32 bFlag; // r1+0x14
-    u32 nColors; // r1+0x10
-    s32 iTile; // r25
-    s32 firstTile; // r3
-    s32 nCount; // r24
-    s32 iIndex; // r6
-    char cTempAlpha; // r20
-
-    // References
-    // -> static s32 bSkip$1410;
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> u32 ganNameTexMtx[8];
-    // -> static u8 sSpecialZeldaHackON;
-}
-
-// Range: 0x80026514 -> 0x800269EC
-static s32 frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D2B6* pRectangle; // r31
-
-    // Local variables
-    s32 bCopy; // r11
-    f32 rDepth; // f31
-    f32 rDeltaT; // f5
-    f32 rX0; // f30
-    f32 rY0; // f29
-    f32 rX1; // f28
-    f32 rY1; // f27
-    f32 rS0; // f26
-    f32 rT0; // f25
-    f32 rS1; // f24
-    f32 rT1; // f23
-
-    // References
-    // -> static s32 gnCountMapHack;
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> static u8 sSpecialZeldaHackON;
-    // -> static s32 nCounter$1367;
-}
-
-// Range: 0x800269EC -> 0x80026A9C
-static s32 frameDrawRectFill_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D2B6* pRectangle; // r31
-
-    // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
-}
-
-// Range: 0x80026A9C -> 0x80026D30
-static s32 frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // struct __anon_0x2D2B6* pRectangle; // r1+0xC
-
-    // Local variables
-    s32 bFlag; // r8
-    f32 rDepth; // f31
-    f32 rX0; // f30
-    f32 rY0; // f29
-    f32 rX1; // f28
-    f32 rY1; // f27
-}
-
-// Range: 0x80026D30 -> 0x80026E0C
-static s32 frameDrawLine_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
-
-    // References
-    // -> static s32 (* gapfDrawLine[6])(void*, void*);
-}
-
-// Range: 0x80026E0C -> 0x80027028
-static s32 frameDrawLine_C2T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r8
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r9
-}
-
-// Range: 0x80027028 -> 0x80027234
-static s32 frameDrawLine_C1T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r10
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r1+0x8
-    struct __anon_0x23FC4* pVertexColor; // r3
-}
-
-// Range: 0x80027234 -> 0x800273EC
-static s32 frameDrawLine_C0T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r6
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r3
-}
-
-// Range: 0x800273EC -> 0x800275C4
-static s32 frameDrawLine_C2T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r8
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r9
-}
-
-// Range: 0x800275C4 -> 0x8002778C
-static s32 frameDrawLine_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r10
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r1+0x8
-    struct __anon_0x23FC4* pVertexColor; // r3
-}
-
-// Range: 0x8002778C -> 0x80027900
-static s32 frameDrawLine_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    s32 iData; // r6
-    u8* anData; // r31
-    struct __anon_0x23FC4* pVertex; // r3
-}
-
-// Range: 0x80027900 -> 0x800279DC
-static s32 frameDrawTriangle_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
-
-    // References
-    // -> static s32 (* gapfDrawTriangle[8])(void*, void*);
-}
-
-// Range: 0x800279DC -> 0x80027B80
-static s32 frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct __anon_0x2D45B* pPrimitive; // r30
-
-    // Local variables
-    f32(*pMatrix)[4]; // r3
-
-    // References
-    // -> static u32 gHackCreditsColor;
-    // -> struct __anon_0x26A4E* gpSystem;
-}
-
-// Range: 0x80027B80 -> 0x80028A44
-static s32 frameCheckTriangleDivide(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r22
-    // struct __anon_0x2D45B* pPrimitive; // r23
-
-    // Local variables
-    s32 iData; // r25
-    u8* anData; // r24
-    struct __anon_0x23FC4 aNewVertArray[8]; // r1+0x184
-    f32 fInterp; // r1+0x8
-    f32 fTempColor1; // f2
-    f32 fTempColor2; // f3
-    u32 nNewVertCount; // r5
-    u32 bInFront; // r7
-    u32 bBehind; // r8
-}
-
-// Range: 0x80028A44 -> 0x80028C34
-static s32 frameDrawTriangle_C1T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 iData; // r10
-    u8* anData; // r11
-    struct __anon_0x23FC4* pVertex; // r1+0x8
-    struct __anon_0x23FC4* pVertexColor; // r3
-}
-
-// Range: 0x80028C34 -> 0x80028DC0
-static s32 frameDrawTriangle_C0T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 iData; // r6
-    u8* anData; // r7
-    struct __anon_0x23FC4* pVertex; // r3
-}
-
-// Range: 0x80028DC0 -> 0x80028F7C
-static s32 frameDrawTriangle_C3T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 iData; // r9
-    u8* anData; // r10
-    struct __anon_0x23FC4* pVertex; // r8
-}
-
-// Range: 0x80028F7C -> 0x80029118
-static s32 frameDrawTriangle_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 iData; // r10
-    u8* anData; // r11
-    struct __anon_0x23FC4* pVertex; // r1+0x8
-    struct __anon_0x23FC4* pVertexColor; // r3
-}
-
-// Range: 0x80029118 -> 0x80029250
-static s32 frameDrawTriangle_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct __anon_0x2D45B* pPrimitive; // r31
-
-    // Local variables
-    s32 iData; // r6
-    u8* anData; // r7
-    struct __anon_0x23FC4* pVertex; // r3
-}
-
-// Range: 0x80029250 -> 0x800297BC
-static s32 frameDrawSetupDP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // s32* pnColors; // r1+0xC
-    // s32* pbFlag; // r1+0x10
-
-    // Local variables
+    enum _GXFogType nFogType; // r5
+    f32 rNear; // r1+0x8
+    f32 rFar; // f2
     u32 nMode; // r1+0x8
-    s32 numCycles; // r30
-    u32 mode; // r1+0x8
-    u32 cycle; // r4
+    u32 iHint; // r8
+    f32 rFogNear; // f3
+    f32 rFogFar; // f4
+    f32 rFogMin; // f1
+    f32 rFogMax; // f2
+    f32 rMultiplier; // f6
+    f32 rOffset; // f7
+    f32 rMinimum; // f1
+    f32 rMaximum; // f9
+    f32 dplane; // f6
+    f32 dplane; // f5
+    f32 dplane; // f5
+    f32 dplane; // f5
+    f32 dplane; // f5
+    f32 rFarScale; // f8
+    f32 rNearScale; // f10
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
-// Range: 0x800297BC -> 0x8002984C
-static s32 frameGetCombineAlpha(enum _GXTevAlphaArg* pnAlphaTEV, s32 nAlphaN64) {
-    // Parameters
-    // enum _GXTevAlphaArg* pnAlphaTEV; // r1+0x4
-    // s32 nAlphaN64; // r1+0x8
-}
-
-// Range: 0x8002984C -> 0x80029948
-static s32 frameGetCombineColor(enum _GXTevColorArg* pnColorTEV, s32 nColorN64) {
-    // Parameters
-    // enum _GXTevColorArg* pnColorTEV; // r1+0x4
-    // s32 nColorN64; // r1+0x8
-}
-
-// Range: 0x80029948 -> 0x8002A2FC
-static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag, s32 nVertexCount) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r28
-    // s32* pnColors; // r29
-    // s32* pbFlag; // r30
-    // s32 nVertexCount; // r31
-
-    // Local variables
-    f32 rValue23; // f1
-    s32 bTextureGen; // r22
-    f32 rNear; // f24
-    f32 rFar; // f4
-    f32 rScaleS; // f25
-    f32 rScaleT; // f24
-    f32 rSlideS; // f4
-    f32 rSlideT; // f2
-    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x12C
-    s32 nColors; // r21
-    s32 bFlag; // r20
-    s32 iTile; // r19
-    s32 iHint; // r1+0x8
-    f32 matrix[3][4]; // r1+0xFC
-    f32 matrixA[3][4]; // r1+0xCC
-    f32 matrixB[3][4]; // r1+0x9C
-    f32 matrix44[4][4]; // r1+0x5C
-    f32 matrixProjection[4][4]; // r1+0x1C
-    enum _GXProjectionType eTypeProjection; // r4
-    f32 scale; // r1+0x8
-    s32 nCount; // r18
-    s32 iIndex; // r6
-
-    // References
-    // -> u32 ganNameTexMtx[8];
-    // -> static s32 snScissorChanged;
-    // -> static u32 snScissorWidth;
-    // -> static u32 snScissorHeight;
-    // -> static u32 snScissorYOrig;
-    // -> static u32 snScissorXOrig;
-}
-
-// Range: 0x8002A2FC -> 0x8002A4A8
-s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
+// Range: 0x8002C378 -> 0x8002C67C
+static s32 frameDrawSetupFog_Default(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
 
     // Local variables
-    f32 matrix44[4][4]; // r1+0x10
-
-    // References
-    // -> static s32 snScissorChanged;
-    // -> static u32 snScissorHeight;
-    // -> static u32 snScissorWidth;
-    // -> static u32 snScissorYOrig;
-    // -> static u32 snScissorXOrig;
+    s32 iHint; // r6
+    f32 rNear; // f31
+    f32 rFar; // f30
+    f32 rFOVY; // f29
+    f32 matrixProjection[4][4]; // r1+0x34
+    struct _GXFogAdjTable fogTable; // r1+0x20
+    f32 rMax; // f2
+    f32 rMin; // r1+0x8
+    f32 rIntpV; // f4
+    f32 rMinimum; // r1+0x8
+    f32 rMultiplier; // f3
+    f32 rOffset; // r1+0x8
 }
 
-// Range: 0x8002A4A8 -> 0x8002A784
-static s32 frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 iTextureCode,
-                            struct __anon_0x247BF* pTile) {
+// Range: 0x8002C360 -> 0x8002C378
+static void frameDrawSyncCallback(u16 nToken) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r26
-    // struct _FRAME_TEXTURE* pTexture; // r27
-    // s32 iTextureCode; // r1+0x18
-    // struct __anon_0x247BF* pTile; // r1+0x1C
-
-    // Local variables
-    void* pData; // r4
-    s32 iName; // r30
-    s32 nFilter; // r4
-    enum _GXTexWrapMode eWrapS; // r29
-    enum _GXTexWrapMode eWrapT; // r28
+    // u16 nToken; // r1+0x0
 
     // References
-    // -> enum _GXTexMapID ganNamePixel[8];
-    // -> u32 ganNameColor[8];
+    // -> static s32 sCopyFrameSyncReceived;
 }
 
 // Erased
-static s32 frameFreePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static s32 frameSetVertexArray() {}
+
+// Range: 0x8002C2E4 -> 0x8002C360
+static void frameDrawDone() {
+    // References
+    // -> s32 gNoSwapBuffer;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> static s32 gbFrameValid;
+}
+
+// Erased
+static void* AllocateWrapper(u32 size) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // struct _FRAME_TEXTURE* pTexture; // r31
+    // u32 size; // r1+0x8
+
+    // Local variables
+    void* tempP; // r1+0xC
+}
+
+// Erased
+static void* DeallocateWrapper(void* dataP) {
+    // Parameters
+    // void* dataP; // r1+0x8
+}
+
+// Erased
+static void __DEMODoneRender() {
+    // References
+    // -> void* DemoCurrentBuffer;
+}
+
+// Range: 0x8002C178 -> 0x8002C2E4
+static s32 frameMakeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 nCount, s32 nOffsetTMEM,
+                         s32 bReload) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct _FRAME_TEXTURE* pTexture; // r28
+    // s32 nCount; // r30
+    // s32 nOffsetTMEM; // r31
+    // s32 bReload; // r1+0x18
+
+    // Local variables
+    s32 iColor; // r5
+    u16* anColor; // r3
+    u16 nData16; // r1+0x8
+}
+
+// Erased
+static s32 frameFreeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // struct _FRAME_TEXTURE* pTexture; // r1+0x4
 }
 
 // Range: 0x8002A784 -> 0x8002C178
@@ -1035,128 +178,985 @@ static s32 frameMakePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE*
 }
 
 // Erased
-static s32 frameFreeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static s32 frameFreePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // struct _FRAME_TEXTURE* pTexture; // r1+0x4
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct _FRAME_TEXTURE* pTexture; // r31
 }
 
-// Range: 0x8002C178 -> 0x8002C2E4
-static s32 frameMakeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 nCount, s32 nOffsetTMEM,
-                         s32 bReload) {
+// Range: 0x8002A4A8 -> 0x8002A784
+static s32 frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 iTextureCode,
+                            struct __anon_0x247BF* pTile) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct _FRAME_TEXTURE* pTexture; // r28
-    // s32 nCount; // r30
-    // s32 nOffsetTMEM; // r31
-    // s32 bReload; // r1+0x18
+    // struct __anon_0x24C38* pFrame; // r26
+    // struct _FRAME_TEXTURE* pTexture; // r27
+    // s32 iTextureCode; // r1+0x18
+    // struct __anon_0x247BF* pTile; // r1+0x1C
 
     // Local variables
-    s32 iColor; // r5
-    u16* anColor; // r3
-    u16 nData16; // r1+0x8
-}
-
-// Erased
-static void __DEMODoneRender() {
-    // References
-    // -> void* DemoCurrentBuffer;
-}
-
-// Erased
-static void* DeallocateWrapper(void* dataP) {
-    // Parameters
-    // void* dataP; // r1+0x8
-}
-
-// Erased
-static void* AllocateWrapper(u32 size) {
-    // Parameters
-    // u32 size; // r1+0x8
-
-    // Local variables
-    void* tempP; // r1+0xC
-}
-
-// Range: 0x8002C2E4 -> 0x8002C360
-static void frameDrawDone() {
-    // References
-    // -> s32 gNoSwapBuffer;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> static s32 gbFrameValid;
-}
-
-// Erased
-static s32 frameSetVertexArray() {}
-
-// Range: 0x8002C360 -> 0x8002C378
-static void frameDrawSyncCallback(u16 nToken) {
-    // Parameters
-    // u16 nToken; // r1+0x0
+    void* pData; // r4
+    s32 iName; // r30
+    s32 nFilter; // r4
+    enum _GXTexWrapMode eWrapS; // r29
+    enum _GXTexWrapMode eWrapT; // r28
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> enum _GXTexMapID ganNamePixel[8];
+    // -> u32 ganNameColor[8];
 }
 
-// Range: 0x8002C378 -> 0x8002C67C
-static s32 frameDrawSetupFog_Default(struct __anon_0x24C38* pFrame) {
+// Range: 0x8002A2FC -> 0x8002A4A8
+s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
 
     // Local variables
-    s32 iHint; // r6
-    f32 rNear; // f31
-    f32 rFar; // f30
-    f32 rFOVY; // f29
-    f32 matrixProjection[4][4]; // r1+0x34
-    struct _GXFogAdjTable fogTable; // r1+0x20
-    f32 rMax; // f2
-    f32 rMin; // r1+0x8
-    f32 rIntpV; // f4
-    f32 rMinimum; // r1+0x8
-    f32 rMultiplier; // f3
-    f32 rOffset; // r1+0x8
+    f32 matrix44[4][4]; // r1+0x10
+
+    // References
+    // -> static s32 snScissorChanged;
+    // -> static u32 snScissorHeight;
+    // -> static u32 snScissorWidth;
+    // -> static u32 snScissorYOrig;
+    // -> static u32 snScissorXOrig;
 }
 
-// Range: 0x8002C67C -> 0x8002CA14
-static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
+// Range: 0x80029948 -> 0x8002A2FC
+static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag, s32 nVertexCount) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x24C38* pFrame; // r28
+    // s32* pnColors; // r29
+    // s32* pbFlag; // r30
+    // s32 nVertexCount; // r31
 
     // Local variables
-    enum _GXFogType nFogType; // r5
-    f32 rNear; // r1+0x8
-    f32 rFar; // f2
+    f32 rValue23; // f1
+    s32 bTextureGen; // r22
+    f32 rNear; // f24
+    f32 rFar; // f4
+    f32 rScaleS; // f25
+    f32 rScaleT; // f24
+    f32 rSlideS; // f4
+    f32 rSlideT; // f2
+    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x12C
+    s32 nColors; // r21
+    s32 bFlag; // r20
+    s32 iTile; // r19
+    s32 iHint; // r1+0x8
+    f32 matrix[3][4]; // r1+0xFC
+    f32 matrixA[3][4]; // r1+0xCC
+    f32 matrixB[3][4]; // r1+0x9C
+    f32 matrix44[4][4]; // r1+0x5C
+    f32 matrixProjection[4][4]; // r1+0x1C
+    enum _GXProjectionType eTypeProjection; // r4
+    f32 scale; // r1+0x8
+    s32 nCount; // r18
+    s32 iIndex; // r6
+
+    // References
+    // -> u32 ganNameTexMtx[8];
+    // -> static s32 snScissorChanged;
+    // -> static u32 snScissorWidth;
+    // -> static u32 snScissorHeight;
+    // -> static u32 snScissorYOrig;
+    // -> static u32 snScissorXOrig;
+}
+
+// Range: 0x8002984C -> 0x80029948
+static s32 frameGetCombineColor(enum _GXTevColorArg* pnColorTEV, s32 nColorN64) {
+    // Parameters
+    // enum _GXTevColorArg* pnColorTEV; // r1+0x4
+    // s32 nColorN64; // r1+0x8
+}
+
+// Range: 0x800297BC -> 0x8002984C
+static s32 frameGetCombineAlpha(enum _GXTevAlphaArg* pnAlphaTEV, s32 nAlphaN64) {
+    // Parameters
+    // enum _GXTevAlphaArg* pnAlphaTEV; // r1+0x4
+    // s32 nAlphaN64; // r1+0x8
+}
+
+// Range: 0x80029250 -> 0x800297BC
+static s32 frameDrawSetupDP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32* pnColors; // r1+0xC
+    // s32* pbFlag; // r1+0x10
+
+    // Local variables
     u32 nMode; // r1+0x8
-    u32 iHint; // r8
-    f32 rFogNear; // f3
-    f32 rFogFar; // f4
-    f32 rFogMin; // f1
-    f32 rFogMax; // f2
-    f32 rMultiplier; // f6
-    f32 rOffset; // f7
-    f32 rMinimum; // f1
-    f32 rMaximum; // f9
-    f32 dplane; // f6
-    f32 dplane; // f5
-    f32 dplane; // f5
-    f32 dplane; // f5
-    f32 dplane; // f5
-    f32 rFarScale; // f8
-    f32 rNearScale; // f10
+    s32 numCycles; // r30
+    u32 mode; // r1+0x8
+    u32 cycle; // r4
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
-// Erased
-static s32 frameSetProjection(struct __anon_0x24C38* pFrame, s32 iHint) {
+// Range: 0x80029118 -> 0x80029250
+static s32 frameDrawTriangle_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
-    // s32 iHint; // r1+0xC
+    // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    struct __anon_0x24A81* pHint; // r1+0x8
+    s32 iData; // r6
+    u8* anData; // r7
+    struct __anon_0x23FC4* pVertex; // r3
+}
+
+// Range: 0x80028F7C -> 0x80029118
+static s32 frameDrawTriangle_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r11
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
+}
+
+// Range: 0x80028DC0 -> 0x80028F7C
+static s32 frameDrawTriangle_C3T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r9
+    u8* anData; // r10
+    struct __anon_0x23FC4* pVertex; // r8
+}
+
+// Range: 0x80028C34 -> 0x80028DC0
+static s32 frameDrawTriangle_C0T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r7
+    struct __anon_0x23FC4* pVertex; // r3
+}
+
+// Range: 0x80028A44 -> 0x80028C34
+static s32 frameDrawTriangle_C1T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r11
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
+}
+
+// Range: 0x80027B80 -> 0x80028A44
+static s32 frameCheckTriangleDivide(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r22
+    // struct __anon_0x2D45B* pPrimitive; // r23
+
+    // Local variables
+    s32 iData; // r25
+    u8* anData; // r24
+    struct __anon_0x23FC4 aNewVertArray[8]; // r1+0x184
+    f32 fInterp; // r1+0x8
+    f32 fTempColor1; // f2
+    f32 fTempColor2; // f3
+    u32 nNewVertCount; // r5
+    u32 bInFront; // r7
+    u32 bBehind; // r8
+}
+
+// Range: 0x800279DC -> 0x80027B80
+static s32 frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    f32(*pMatrix)[4]; // r3
+
+    // References
+    // -> static u32 gHackCreditsColor;
+    // -> struct __anon_0x26A4E* gpSystem;
+}
+
+// Range: 0x80027900 -> 0x800279DC
+static s32 frameDrawTriangle_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
+
+    // References
+    // -> static s32 (* gapfDrawTriangle[8])(void*, void*);
+}
+
+// Range: 0x8002778C -> 0x80027900
+static s32 frameDrawLine_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r3
+}
+
+// Range: 0x800275C4 -> 0x8002778C
+static s32 frameDrawLine_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
+}
+
+// Range: 0x800273EC -> 0x800275C4
+static s32 frameDrawLine_C2T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r8
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r9
+}
+
+// Range: 0x80027234 -> 0x800273EC
+static s32 frameDrawLine_C0T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r6
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r3
+}
+
+// Range: 0x80027028 -> 0x80027234
+static s32 frameDrawLine_C1T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r10
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r1+0x8
+    struct __anon_0x23FC4* pVertexColor; // r3
+}
+
+// Range: 0x80026E0C -> 0x80027028
+static s32 frameDrawLine_C2T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct __anon_0x2D45B* pPrimitive; // r30
+
+    // Local variables
+    s32 iData; // r8
+    u8* anData; // r31
+    struct __anon_0x23FC4* pVertex; // r9
+}
+
+// Range: 0x80026D30 -> 0x80026E0C
+static s32 frameDrawLine_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D45B* pPrimitive; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
+
+    // References
+    // -> static s32 (* gapfDrawLine[6])(void*, void*);
+}
+
+// Range: 0x80026A9C -> 0x80026D30
+static s32 frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x2D2B6* pRectangle; // r1+0xC
+
+    // Local variables
+    s32 bFlag; // r8
+    f32 rDepth; // f31
+    f32 rX0; // f30
+    f32 rY0; // f29
+    f32 rX1; // f28
+    f32 rY1; // f27
+}
+
+// Range: 0x800269EC -> 0x80026A9C
+static s32 frameDrawRectFill_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D2B6* pRectangle; // r31
+
+    // Local variables
+    s32 bFlag; // r1+0x14
+    s32 nColors; // r1+0x10
+}
+
+// Range: 0x80026514 -> 0x800269EC
+static s32 frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x2D2B6* pRectangle; // r31
+
+    // Local variables
+    s32 bCopy; // r11
+    f32 rDepth; // f31
+    f32 rDeltaT; // f5
+    f32 rX0; // f30
+    f32 rY0; // f29
+    f32 rX1; // f28
+    f32 rY1; // f27
+    f32 rS0; // f26
+    f32 rT0; // f25
+    f32 rS1; // f24
+    f32 rT1; // f23
+
+    // References
+    // -> static s32 gnCountMapHack;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static u8 sSpecialZeldaHackON;
+    // -> static s32 nCounter$1367;
+}
+
+// Range: 0x80026124 -> 0x80026514
+static s32 frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r22
+    // struct __anon_0x2D2B6* pRectangle; // r23
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x98
+    f32 matrixA[3][4]; // r1+0x68
+    f32 matrixB[3][4]; // r1+0x38
+    struct _FRAME_TEXTURE* pTexture[8]; // r1+0x18
+    f32 rScaleS; // f29
+    f32 rScaleT; // f28
+    f32 rSlideS; // f2
+    f32 rSlideT; // r1+0x8
+    u32 bFlag; // r1+0x14
+    u32 nColors; // r1+0x10
+    s32 iTile; // r25
+    s32 firstTile; // r3
+    s32 nCount; // r24
+    s32 iIndex; // r6
+    char cTempAlpha; // r20
+
+    // References
+    // -> static s32 bSkip$1410;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> u32 ganNameTexMtx[8];
+    // -> static u8 sSpecialZeldaHackON;
+}
+
+// Erased
+static s32 frameTick() {}
+
+// Erased
+static s32 frameDraw() {}
+
+// Erased
+static void CopyZBuffer() {}
+
+// Range: 0x8002611C -> 0x80026124
+s32 frameShow() {}
+
+// Erased
+static s32 frameHide() {}
+
+// Range: 0x80025FF4 -> 0x8002611C
+s32 frameSetScissor(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pScissor) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x2D2B6* pScissor; // r1+0xC
+
+    // Local variables
+    s32 nTemp; // r1+0x8
+    s32 nX0; // r3
+    s32 nY0; // r4
+    s32 nX1; // r5
+    s32 nY1; // r6
+}
+
+// Erased
+static s32 frameGetScissor() {}
+
+// Range: 0x80025FE4 -> 0x80025FF4
+s32 frameSetDepth(struct __anon_0x24C38* pFrame, f32 rDepth, f32 rDelta) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // f32 rDepth; // r1+0x4
+    // f32 rDelta; // r1+0x8
+}
+
+// Range: 0x80025EE8 -> 0x80025FE4
+s32 frameSetColor(struct __anon_0x24C38* pFrame, enum __anon_0x2D223 eType, u32 nRGBA) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // enum __anon_0x2D223 eType; // r30
+    // u32 nRGBA; // r1+0x10
+}
+
+// Range: 0x80025ECC -> 0x80025EE8
+s32 frameBeginOK() {
+    // References
+    // -> static s32 gbFrameValid;
+}
+
+// Range: 0x80025C40 -> 0x80025ECC
+s32 frameBegin(struct __anon_0x24C38* pFrame, s32 nCountVertex) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32 nCountVertex; // r28
+
+    // Local variables
+    s32 i; // r28
+    f32 matrix[3][4]; // r1+0x14
+
+    // References
+    // -> enum _GXTexCoordID ganNameTexCoord[8];
+    // -> u32 ganNameTexMtx[8];
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
+}
+
+// Range: 0x800259B8 -> 0x80025C40
+s32 frameEnd(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+
+    // Local variables
+    struct _CPU* pCPU; // r31
+    s32 iHint; // r7
+    void* pData; // r29
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> void* DemoCurrentBuffer;
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> static u16 sTempZBuf[4800][4][4];
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
+}
+
+// Range: 0x80025890 -> 0x800259B8
+s32 _frameDrawRectangle(struct __anon_0x24C38* pFrame, u32 nColor, s32 nX, s32 nY, s32 nSizeX, s32 nSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // u32 nColor; // r1+0x4
+    // s32 nX; // r11
+    // s32 nY; // r1+0xC
+    // s32 nSizeX; // r7
+    // s32 nSizeY; // r1+0x14
+
+    // Local variables
+    s32 iY; // r10
+    s32 iX; // r11
+    u32* pnPixel; // r3
+    s32 nSizeTargetX; // r9
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
+}
+
+// Erased
+static s32 _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, s32 nSizeX, s32 nSizeY, s32 nX0, s32 nY0,
+                           s32 bAlpha) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // u16* pnImage; // r1+0xC
+    // s32 nSizeX; // r1+0x10
+    // s32 nSizeY; // r1+0x14
+    // s32 nX0; // r1+0x18
+    // s32 nY0; // r1+0x1C
+    // s32 bAlpha; // r1+0x20
+
+    // Local variables
+    s32 iY; // r30
+    s32 iX; // r1+0x8
+    s32 nSizeTargetX; // r30
+    u32* pnPixel; // r3
+    u32* aPixel; // r29
+    u32 nPixelSource; // r7
+    u32 nPixelTarget; // r29
+
+    // References
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
+}
+
+// Erased
+static void ZeldaDrawFrameZTexture(struct __anon_0x24C38* pFrame, u32* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u32* pData; // r30
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x30
+
+    // References
+    // -> static struct _GXTexObj sFrameObj1$1562;
+}
+
+// Range: 0x8002569C -> 0x80025890
+void ZeldaDrawFrameNoBlend(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u16* pData; // r30
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x30
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1564;
+}
+
+// Range: 0x800253B8 -> 0x8002569C
+void ZeldaDrawFrameBlur(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // u16* pData; // r29
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1565;
+}
+
+// Range: 0x800250D8 -> 0x800253B8
+void ZeldaDrawFrame(struct __anon_0x24C38* pFrame, u16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // u16* pData; // r29
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1568;
+}
+
+// Erased
+static void CopyCFBAlpha(u8* srcP) {
+    // Parameters
+    // u8* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Erased
+static void CopyCFBZTexture(u32* srcP) {
+    // Parameters
+    // u32* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Erased
+static void ConvertZ(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r7
+    s32 y; // r8
+    s32 x; // r1+0x8
+    u16 val; // r9
+
+    // References
+    // -> static u32 line$1582[80][4][4];
+}
+
+// Erased
+static void CopyCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Erased
+static void ConvertCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u16 val; // r1+0x8
+
+    // References
+    // -> static u16 line$1606[80][4][4];
+}
+
+// Range: 0x80024D94 -> 0x800250D8
+void CopyAndConvertCFB(u16* srcP) {
+    // Parameters
+    // u16* srcP; // r29
+
+    // Local variables
+    u16* dataEndP; // r30
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u16 val; // r1+0x8
+
+    // References
+    // -> static u16 line$1630[80][4][4];
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Range: 0x80024A04 -> 0x80024D94
+static void ZeldaGreyScaleConvert(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x38
+    void* dataP; // r29
+    struct _GXColor color; // r1+0x10
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1647;
+    // -> static u8 cAlpha$1648;
+    // -> static u32 gHackCreditsColor;
+    // -> void* DemoCurrentBuffer;
+}
+
+// Erased
+static void ZeldaCopyFrameHiRes(void* pSrc) {
+    // Parameters
+    // void* pSrc; // r31
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+}
+
+// Erased
+static void ZeldaDrawFrameHiRes(struct __anon_0x24C38* pFrame, void* pSrc) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // void* pSrc; // r29
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x38
+    struct _GXColor color; // r1+0x14
+
+    // References
+    // -> static struct _GXTexObj sFrameObj$1660;
+}
+
+// Range: 0x800244F8 -> 0x80024A04
+void ZeldaDrawFrameShrink(struct __anon_0x24C38* pFrame, s32 posX, s32 posY, s32 size) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 posX; // r1+0xC
+    // s32 posY; // r1+0x10
+    // s32 size; // r1+0x14
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x28
+    f32 nX0; // f31
+    f32 nX1; // f30
+    f32 nY0; // f29
+    f32 nY1; // f28
+    f32 scale; // f4
+    void* frameBuffer; // r26
+    struct _GXColor color; // r1+0x20
+
+    // References
+    // -> static struct _GXTexObj frameObj$1663;
+    // -> void* DemoCurrentBuffer;
+}
+
+// Erased
+static void ZeldaCopyCamera(u16* buffer) {
+    // Parameters
+    // u16* buffer; // r31
+}
+
+// Range: 0x80024204 -> 0x800244F8
+void ZeldaDrawFrameCamera(struct __anon_0x24C38* pFrame, void* buffer) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // void* buffer; // r29
+
+    // Local variables
+    f32 matrix[3][4]; // r1+0x30
+    struct _GXColor color; // r1+0x2C
+
+    // References
+    // -> static struct _GXTexObj frameObj$1673;
+}
+
+// Range: 0x8002403C -> 0x80024204
+s32 frameHackTIMG_Zelda(struct __anon_0x24C38* pFrame, u64** pnGBI, u32* pnCommandLo, u32* pnCommandHi) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // u64** pnGBI; // r30
+    // u32* pnCommandLo; // r31
+    // u32* pnCommandHi; // r1+0x14
+
+    // Local variables
+    u32 i; // r7
+
+    // References
+    // -> static u32 sDestinationBuffer;
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static u32 sSrcBuffer;
+    // -> static u8 sSpecialZeldaHackON;
+    // -> static u32 sCommandCodes$1679[8];
+}
+
+// Range: 0x800239E4 -> 0x8002403C
+s32 frameHackCIMG_Zelda2(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x23B9E* pBuffer; // r31
+    // u64* pnGBI; // r1+0x10
+
+    // Local variables
+    u32 i; // r7
+    u32* pGBI; // r8
+
+    // References
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> s32 gNoSwapBuffer;
+    // -> static s32 nLastFrame$1695;
+    // -> static s32 nCopyFrame$1697;
+    // -> static u32 sCommandCodes2$1722[10];
+    // -> static u32 sCommandCodes$1702[10];
+}
+
+// Range: 0x800235A4 -> 0x800239E4
+s32 frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI, u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // struct __anon_0x23B9E* pBuffer; // r28
+    // u64* pnGBI; // r1+0x10
+    // u32 nCommandLo; // r29
+
+    // Local variables
+    u32 i; // r30
+    u32 low2; // r1+0x8
+    u32 high2; // r1+0x8
+    u16* srcP; // r1+0x20
+    u16* val; // r27
+    u16* valEnd; // r29
+    s32 tile; // r6
+    s32 y; // r7
+    s32 x; // r1+0x8
+    u8* val; // r3
+    u8* valEnd; // r4
+
+    // References
+    // -> static u16 tempLine$1785[16][4][4];
+    // -> static s32 sCopyFrameSyncReceived;
+    // -> s32 gNoSwapBuffer;
+    // -> static u32 sNumAddr;
+    // -> static u32 sConstantBufAddr[6];
+    // -> static s32 gnCountMapHack;
+    // -> static u32 sSrcBuffer;
+    // -> static u32 sDestinationBuffer;
+    // -> struct __anon_0x26A4E* gpSystem;
+}
+
+// Range: 0x80023430 -> 0x800235A4
+s32 frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, u64** ppnGBI) {
+    // Parameters
+    // struct __anon_0x2865F* pRDP; // r1+0x8
+    // struct __anon_0x24C38* pFrame; // r27
+    // u64** ppnGBI; // r28
+
+    // Local variables
+    u64* pnGBI; // r30
+    s32 count; // r8
+    s32 nAddress; // r4
+    u32 nCommandLo; // r6
+    u32 nCommandHi; // r1+0x8
+    struct __anon_0x297E0* pRSP; // r29
+    s32 done; // r3
+    union __anon_0x2ACA3 bg; // r1+0x18
+
+    // References
+    // -> static u32 GBIcode$1816[3];
+}
+
+// Range: 0x800232FC -> 0x80023430
+s32 frameHackCIMG_Zelda2_Camera(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u32 nCommandHi,
+                                u32 nCommandLo) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // struct __anon_0x23B9E* pBuffer; // r1+0xC
+    // u32 nCommandHi; // r1+0x10
+    // u32 nCommandLo; // r1+0x14
+}
+
+// Range: 0x80023250 -> 0x800232FC
+void PanelDrawBG8(u16* BG, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+    // Parameters
+    // u16* BG; // r1+0x8
+    // u16* LUT; // r1+0xC
+    // u8* bitmap; // r1+0x10
+    // s32 sizeX; // r1+0x14
+    // s32 sizeY; // r1+0x18
+    // s32 posX; // r1+0x1C
+    // s32 posY; // r1+0x20
+    // s32 flip; // r1+0x24
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r27
+    u16 color; // r1+0x8
+}
+
+// Range: 0x80023194 -> 0x80023250
+void PanelDrawBG16(u16* BG, u16* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+    // Parameters
+    // u16* BG; // r1+0x8
+    // u16* bitmap; // r1+0xC
+    // s32 sizeX; // r1+0x10
+    // s32 sizeY; // r1+0x14
+    // s32 posX; // r1+0x18
+    // s32 posY; // r1+0x1C
+    // s32 flip; // r1+0x20
+
+    // Local variables
+    s32 i; // r29
+    s32 j; // r28
+    u16 color; // r1+0x8
+}
+
+// Range: 0x800230E0 -> 0x80023194
+void PanelDrawFR3D(u16* FR, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 first) {
+    // Parameters
+    // u16* FR; // r1+0x8
+    // u16* LUT; // r1+0xC
+    // u8* bitmap; // r1+0x10
+    // s32 sizeX; // r1+0x14
+    // s32 sizeY; // r1+0x18
+    // s32 posX; // r1+0x1C
+    // s32 posY; // r1+0x20
+    // s32 first; // r1+0x24
+
+    // Local variables
+    s32 i; // r30
+    s32 j; // r1+0x8
+    u16 color; // r29
+}
+
+// Range: 0x8002303C -> 0x800230E0
+s32 frameHackTIMG_Panel(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // struct __anon_0x23B9E* pBuffer; // r1+0x4
+}
+
+// Range: 0x800217F8 -> 0x8002303C
+s32 frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer,
+                        u64** ppnGBI) {
+    // Parameters
+    // struct __anon_0x2865F* pRDP; // r29
+    // struct __anon_0x24C38* pFrame; // r30
+    // struct __anon_0x23B9E* pBuffer; // r17
+    // u64** ppnGBI; // r14
+
+    // Local variables
+    struct __anon_0x297E0* pRSP; // r17
+    u64* pnGBI; // r20
+    s32 count; // r8
+    s32 nAddress; // r5
+    s32 sizeX; // r6
+    u32 nCommandLo; // r7
+    u32 nCommandHi; // r3
+    u16* BG; // r18
+    u16* FR; // r28
+    u16* pLUT; // r16
+    u16* pBitmap16; // r4
+    u8* pBitmap8; // r5
+    s32 iTile; // r5
+    s32 nCount; // r4
+    struct __anon_0x247BF* pTile; // r5
+    s32 iTile; // r1+0x8
+    s32 nCount; // r4
+    s32 iTile; // r5
+    s32 nCount; // r4
+    union __anon_0x2ACA3 bg; // r1+0x50
+    union __anon_0x2B091 objTxtr; // r1+0x38
+    u32 nLoadType; // r1+0x34
+    struct __anon_0x23B9E* pBG; // r18
+
+    // References
+    // -> static u32 GBIcode2D2$1906[7];
+    // -> static u32 GBIcode3D2$1908[6];
+    // -> static u32 GBIcode3D1$1907[5];
+}
+
+// Range: 0x80021588 -> 0x800217F8
+s32 frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // u16* pnData; // r1+0xC
+    // s32 nAddress; // r1+0x10
+
+    // Local variables
+    u32 nX; // r7
+    u32 nY; // r8
+    u32 nOffset; // r1+0x8
+    s32 n64CalcValue; // r6
+    s32 exp; // r7
+    s32 mantissa; // r1+0x8
+    s32 compare; // r3
+    s32 val; // r7
+    struct __anon_0x285E5 z_format[8]; // r1+0x14
+
+    // References
+    // -> static u16 sTempZBuf[4800][4][4];
+}
+
+// Range: 0x80021204 -> 0x80021588
+static s32 frameEvent(struct __anon_0x24C38* pFrame, s32 nEvent) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // s32 nEvent; // r1+0xC
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> static s32 gnCountMapHack;
+    // -> static s32 gbFrameValid;
+    // -> static s32 gbFrameBegin;
 }

--- a/debug/Fire/_frameGCNcc.c
+++ b/debug/Fire/_frameGCNcc.c
@@ -141,23 +141,6 @@ static char* sAlphaNames[2][8];
 // size = 0x40, address = 0x800F0410
 static char* strings$288[4][4];
 
-// Erased
-static void UpdateRenderModeList(u32 renderMode, u32 cycle) {
-    // Parameters
-    // u32 renderMode; // r1+0x8
-    // u32 cycle; // r23
-
-    // Local variables
-    s32 i; // r5
-    u32 p[2][4]; // r1+0x10
-
-    // References
-    // -> static s32 sCurRenderMode$278;
-    // -> static u32 sFoundRenderModes$277[100];
-    // -> static char* strings$288[4][4];
-    // -> static u8 sMemShift$301[2][4];
-}
-
 typedef enum __anon_0x8573D {
     SM_NONE = -1,
     SM_RUNNING = 0,
@@ -546,28 +529,89 @@ typedef struct CombineModeTev {
     /* 0x238 */ enum _GXTevAlphaArg tevAlphaArg[8][4];
 } __anon_0x882D1; // size = 0x2B8
 
-// Range: 0x80097D9C -> 0x80097E5C
-s32 SetTevStageTable(struct __anon_0x87050* pFrame, s32 numCycles) {
-    // Parameters
-    // struct __anon_0x87050* pFrame; // r31
-    // s32 numCycles; // r7
-
-    // Local variables
-    u32 tempColor1; // r3
-    u32 tempAlpha1; // r4
-    u32 tempColor2; // r5
-    u32 tempAlpha2; // r6
-    struct CombineModeTev* ctP; // r4
-
-    // References
-    // -> struct __anon_0x85ACF* gpSystem;
-}
-
 // size = 0x0, address = 0x800EA8B8
 enum _GXTexCoordID ganNameTexCoord[];
 
 // size = 0x0, address = 0x800EA878
 enum _GXTexMapID ganNamePixel[];
+
+typedef struct _GXColor {
+    /* 0x0 */ u8 r;
+    /* 0x1 */ u8 g;
+    /* 0x2 */ u8 b;
+    /* 0x3 */ u8 a;
+} __anon_0x88E4A; // size = 0x4
+
+// Range: 0x800983A0 -> 0x800986A4
+static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeTev* ctP) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r30
+    // struct CombineModeTev* ctP; // r31
+
+    // Local variables
+    s32 i; // r23
+    s32 iStart; // r1+0x8
+    struct _GXColor color; // r1+0x30
+    struct TevOrder* toP; // r6
+    struct TevColorOp* tcP; // r22
+    enum _GXTevColorArg* cArgP; // r21
+    enum _GXTevAlphaArg* aArgP; // r20
+
+    // References
+    // -> static enum _GXTevStageID ganNameTevStage[16];
+}
+
+// Erased
+static void OutputCCMode(s32 cycle, u32 tempColor, u32 tempAlpha) {
+    // Parameters
+    // s32 cycle; // r1+0x8
+    // u32 tempColor; // r1+0xC
+    // u32 tempAlpha; // r1+0x10
+
+    // Local variables
+    s32 i; // r1+0x8
+    u8 nColor[4]; // r1+0x18
+    u8 nAlpha[4]; // r1+0x14
+
+    // References
+    // -> static char* sAlphaNames[2][8];
+    // -> static char* sColorNames[16];
+}
+
+// Erased
+static void CheckNewCCMode(struct __anon_0x87050* pFrame, s32 numCycles) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r1+0x8
+    // s32 numCycles; // r29
+
+    // Local variables
+    s32 i; // r3
+    u32 tempColor1; // r8
+    u32 tempAlpha1; // r5
+    u32 tempColor2; // r31
+    u32 tempAlpha2; // r30
+
+    // References
+    // -> static u32 sCurCCMode;
+    // -> static u32 sPrevCCModes[100][2][2];
+}
+
+// Range: 0x800981E0 -> 0x800983A0
+void SetNumTexGensChans(struct __anon_0x87050* pFrame, s32 numCycles) {
+    // Parameters
+    // struct __anon_0x87050* pFrame; // r1+0x8
+    // s32 numCycles; // r1+0xC
+
+    // Local variables
+    u8 nColor[4]; // r1+0x14
+    u8 nAlpha[4]; // r1+0x10
+    u32 tempColor; // r5
+    u32 tempAlpha; // r7
+    s32 i; // r8
+    s32 j; // r1+0x8
+    s32 numGens; // r9
+    s32 numChans; // r1+0x8
+}
 
 // Range: 0x80097E5C -> 0x800981E0
 void SetTevStages(struct __anon_0x87050* pFrame, s32 cycle) {
@@ -603,80 +647,36 @@ void SetTevStages(struct __anon_0x87050* pFrame, s32 cycle) {
     // -> static enum _GXTevStageID ganNameTevStage[16];
 }
 
-// Range: 0x800981E0 -> 0x800983A0
-void SetNumTexGensChans(struct __anon_0x87050* pFrame, s32 numCycles) {
+// Range: 0x80097D9C -> 0x80097E5C
+s32 SetTevStageTable(struct __anon_0x87050* pFrame, s32 numCycles) {
     // Parameters
-    // struct __anon_0x87050* pFrame; // r1+0x8
-    // s32 numCycles; // r1+0xC
+    // struct __anon_0x87050* pFrame; // r31
+    // s32 numCycles; // r7
 
     // Local variables
-    u8 nColor[4]; // r1+0x14
-    u8 nAlpha[4]; // r1+0x10
-    u32 tempColor; // r5
-    u32 tempAlpha; // r7
-    s32 i; // r8
-    s32 j; // r1+0x8
-    s32 numGens; // r9
-    s32 numChans; // r1+0x8
+    u32 tempColor1; // r3
+    u32 tempAlpha1; // r4
+    u32 tempColor2; // r5
+    u32 tempAlpha2; // r6
+    struct CombineModeTev* ctP; // r4
+
+    // References
+    // -> struct __anon_0x85ACF* gpSystem;
 }
 
 // Erased
-static void CheckNewCCMode(struct __anon_0x87050* pFrame, s32 numCycles) {
+static void UpdateRenderModeList(u32 renderMode, u32 cycle) {
     // Parameters
-    // struct __anon_0x87050* pFrame; // r1+0x8
-    // s32 numCycles; // r29
+    // u32 renderMode; // r1+0x8
+    // u32 cycle; // r23
 
     // Local variables
-    s32 i; // r3
-    u32 tempColor1; // r8
-    u32 tempAlpha1; // r5
-    u32 tempColor2; // r31
-    u32 tempAlpha2; // r30
+    s32 i; // r5
+    u32 p[2][4]; // r1+0x10
 
     // References
-    // -> static u32 sCurCCMode;
-    // -> static u32 sPrevCCModes[100][2][2];
-}
-
-// Erased
-static void OutputCCMode(s32 cycle, u32 tempColor, u32 tempAlpha) {
-    // Parameters
-    // s32 cycle; // r1+0x8
-    // u32 tempColor; // r1+0xC
-    // u32 tempAlpha; // r1+0x10
-
-    // Local variables
-    s32 i; // r1+0x8
-    u8 nColor[4]; // r1+0x18
-    u8 nAlpha[4]; // r1+0x14
-
-    // References
-    // -> static char* sAlphaNames[2][8];
-    // -> static char* sColorNames[16];
-}
-
-typedef struct _GXColor {
-    /* 0x0 */ u8 r;
-    /* 0x1 */ u8 g;
-    /* 0x2 */ u8 b;
-    /* 0x3 */ u8 a;
-} __anon_0x88E4A; // size = 0x4
-
-// Range: 0x800983A0 -> 0x800986A4
-static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeTev* ctP) {
-    // Parameters
-    // struct __anon_0x87050* pFrame; // r30
-    // struct CombineModeTev* ctP; // r31
-
-    // Local variables
-    s32 i; // r23
-    s32 iStart; // r1+0x8
-    struct _GXColor color; // r1+0x30
-    struct TevOrder* toP; // r6
-    struct TevColorOp* tcP; // r22
-    enum _GXTevColorArg* cArgP; // r21
-    enum _GXTevAlphaArg* aArgP; // r20
-
-    // References
-    // -> static enum _GXTevStageID ganNameTevStage[16];
+    // -> static s32 sCurRenderMode$278;
+    // -> static u32 sFoundRenderModes$277[100];
+    // -> static char* strings$288[4][4];
+    // -> static u8 sMemShift$301[2][4];
 }

--- a/debug/Fire/_gspF3DEX.c
+++ b/debug/Fire/_gspF3DEX.c
@@ -7,6 +7,116 @@
 
 #include "types.h"
 
+// Erased
+static s32 MulMatrices(f32 (*aOutMatrix)[4], f32 (*aLeftMatrix)[4], f32 (*aRightMatrix)[4]) {
+    // Parameters
+    // f32 (* aOutMatrix)[4]; // r3
+    // f32 (* aLeftMatrix)[4]; // r4
+    // f32 (* aRightMatrix)[4]; // r5
+
+    // Local variables
+    s32 i; // r8
+    s32 j; // r1+0x0
+}
+
+// Range: 0x80077790 -> 0x80077850
+static s32 rspSetGeometryMode1(struct __anon_0x5845E* pRSP, s32 nMode) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nMode; // r1+0xC
+
+    // Local variables
+    s32 nModeFrame; // r5
+}
+
+// Range: 0x8007610C -> 0x80077790
+static s32 rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+    // u64** ppnGBI; // r27
+    // s32* pbDone; // r24
+
+    // Local variables
+    f32 matrix[4][4]; // r1+0x3B0
+    struct __anon_0x5EBE0 primitive; // r1+0xAC
+    u32 iVertex; // r4
+    u32 bDone; // r24
+    u64* pnGBI; // r28
+    u32 nCommandLo; // r6
+    u32 nCommandHi; // r7
+    struct __anon_0x5A89F* pFrame; // r30
+    s32 nAddress; // r5
+    s32 nAddress; // r24
+    s32 nAddress; // r24
+    s32 nAddress; // r24
+    s32 bPush; // r24
+    u8 nSid2D; // r1+0x8
+    u32 nDLAdrs; // r7
+    u32 nFlag2D; // r1+0x8
+    union __anon_0x5F2FB bg; // r1+0x80
+    s32 nAddress; // r4
+    s32 nMode; // r24
+    s32 nAddress; // r26
+    s32 nMode; // r1+0x78
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    void* pData; // r1+0x74
+    s32 nAddress; // r5
+    void* pData; // r1+0x6C
+    s32 nAddress; // r5
+    void* pData; // r1+0x68
+    s32 nAddress; // r5
+    char* pData; // r1+0x64
+    s32 iLight; // r24
+    s32 nAddress; // r5
+    s32 nAddress; // r24
+    s32 nAddress; // r5
+    void* pBuffer; // r1+0x60
+    s32 nCount; // r6
+    s32 iVertex0; // r5
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    s32 nAddress; // r5
+    u32 nVertexStart; // r4
+    u32 nVertexEnd; // r5
+    s32 nWhere; // r1+0x8
+    s32 nData1; // r8
+    s32 nData2; // r1+0x8
+    s32 iRow; // r3
+    s32 iCol; // r4
+    u32 nSid; // r1+0x8
+    s32 nLight; // r1+0x8
+    u32 nData; // r1+0x8
+    u32 nSize; // r3
+    u32 nMove; // r5
+    u32 nData; // r1+0x8
+    u32 nSize; // r3
+    u32 nMove; // r5
+    u32 nValue; // r1+0x8
+    struct __anon_0x575BD* pTask; // r4
+    s32 nAddress; // r5
+    s32 iVertex; // r4
+    s32 nVal; // r1+0x8
+
+    // References
+    // -> static u8 flagBilerp;
+    // -> static u16 scissorY1;
+    // -> static u16 scissorX1;
+    // -> static u16 scissorY0;
+    // -> static u16 scissorX0;
+}
+
+// Range: 0x80076024 -> 0x8007610C
+static s32 rspGeometryMode(struct __anon_0x5845E* pRSP, s32 nSet, s32 nClr) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nSet; // r1+0xC
+    // s32 nClr; // r1+0x10
+
+    // Local variables
+    s32 nMode; // r6
+}
+
 // Range: 0x80074454 -> 0x80076024
 static s32 rspParseGBI_F3DEX2(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
     // Parameters
@@ -101,114 +211,4 @@ static s32 rspParseGBI_F3DEX2(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pb
     // -> static u16 scissorX1;
     // -> static u16 scissorY0;
     // -> static u16 scissorX0;
-}
-
-// Range: 0x80076024 -> 0x8007610C
-static s32 rspGeometryMode(struct __anon_0x5845E* pRSP, s32 nSet, s32 nClr) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nSet; // r1+0xC
-    // s32 nClr; // r1+0x10
-
-    // Local variables
-    s32 nMode; // r6
-}
-
-// Range: 0x8007610C -> 0x80077790
-static s32 rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // u64** ppnGBI; // r27
-    // s32* pbDone; // r24
-
-    // Local variables
-    f32 matrix[4][4]; // r1+0x3B0
-    struct __anon_0x5EBE0 primitive; // r1+0xAC
-    u32 iVertex; // r4
-    u32 bDone; // r24
-    u64* pnGBI; // r28
-    u32 nCommandLo; // r6
-    u32 nCommandHi; // r7
-    struct __anon_0x5A89F* pFrame; // r30
-    s32 nAddress; // r5
-    s32 nAddress; // r24
-    s32 nAddress; // r24
-    s32 nAddress; // r24
-    s32 bPush; // r24
-    u8 nSid2D; // r1+0x8
-    u32 nDLAdrs; // r7
-    u32 nFlag2D; // r1+0x8
-    union __anon_0x5F2FB bg; // r1+0x80
-    s32 nAddress; // r4
-    s32 nMode; // r24
-    s32 nAddress; // r26
-    s32 nMode; // r1+0x78
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    void* pData; // r1+0x74
-    s32 nAddress; // r5
-    void* pData; // r1+0x6C
-    s32 nAddress; // r5
-    void* pData; // r1+0x68
-    s32 nAddress; // r5
-    char* pData; // r1+0x64
-    s32 iLight; // r24
-    s32 nAddress; // r5
-    s32 nAddress; // r24
-    s32 nAddress; // r5
-    void* pBuffer; // r1+0x60
-    s32 nCount; // r6
-    s32 iVertex0; // r5
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    u32 nVertexStart; // r4
-    u32 nVertexEnd; // r5
-    s32 nWhere; // r1+0x8
-    s32 nData1; // r8
-    s32 nData2; // r1+0x8
-    s32 iRow; // r3
-    s32 iCol; // r4
-    u32 nSid; // r1+0x8
-    s32 nLight; // r1+0x8
-    u32 nData; // r1+0x8
-    u32 nSize; // r3
-    u32 nMove; // r5
-    u32 nData; // r1+0x8
-    u32 nSize; // r3
-    u32 nMove; // r5
-    u32 nValue; // r1+0x8
-    struct __anon_0x575BD* pTask; // r4
-    s32 nAddress; // r5
-    s32 iVertex; // r4
-    s32 nVal; // r1+0x8
-
-    // References
-    // -> static u8 flagBilerp;
-    // -> static u16 scissorY1;
-    // -> static u16 scissorX1;
-    // -> static u16 scissorY0;
-    // -> static u16 scissorX0;
-}
-
-// Range: 0x80077790 -> 0x80077850
-static s32 rspSetGeometryMode1(struct __anon_0x5845E* pRSP, s32 nMode) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nMode; // r1+0xC
-
-    // Local variables
-    s32 nModeFrame; // r5
-}
-
-// Erased
-static s32 MulMatrices(f32 (*aOutMatrix)[4], f32 (*aLeftMatrix)[4], f32 (*aRightMatrix)[4]) {
-    // Parameters
-    // f32 (* aOutMatrix)[4]; // r3
-    // f32 (* aLeftMatrix)[4]; // r4
-    // f32 (* aRightMatrix)[4]; // r5
-
-    // Local variables
-    s32 i; // r8
-    s32 j; // r1+0x0
 }

--- a/debug/Fire/_gspJPEG.c
+++ b/debug/Fire/_gspJPEG.c
@@ -7,59 +7,268 @@
 
 #include "types.h"
 
-// Range: 0x8007AC6C -> 0x8007AD68
-static s32 rspParseJPEG_DecodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x575BD* pTask; // r4
-
-    // Local variables
-    s32 y; // r31
-    s16* temp; // r1+0x8
-    s16* temp2; // r30
-    u64* system_imb; // r1+0x20
-    u32* infoStruct; // r1+0x1C
-    s32 size; // r29
-}
-
-// Range: 0x8007AD68 -> 0x8007AE64
-static s32 rspParseJPEG_EncodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x575BD* pTask; // r4
-
-    // Local variables
-    s32 y; // r31
-    s16* temp; // r1+0x8
-    s16* temp2; // r30
-    u64* system_imb; // r1+0x20
-    u32* infoStruct; // r1+0x1C
-    s32 size; // r29
-}
-
-// Range: 0x8007AE64 -> 0x8007B244
-s32 rspRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
+// Range: 0x800801C0 -> 0x80080AA4
+static s32 rspCreateJPEGArrays(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s16* imgBuf; // r1+0xC
-
-    // Local variables
-    s32 i; // r1+0x10
-    s32 j; // r26
-    s32 r; // r10
-    s32 g; // r7
-    s32 b; // r11
-    s32 y; // r6
-    s32 u; // r9
-    s32 v; // r1+0x8
 }
 
 // Erased
-static s32 rspLoadColorBufferZ(s32* r, s32* g, s32* b, s16* imgBuf, s32 index) {
+static s32 rspDestroyJPEGArrays() {}
+
+// Erased
+static void rspConvertBufferToRGBA(u8* buf, struct __anon_0x58360* rgba) {
     // Parameters
-    // s32* r; // r1+0x4
-    // s32* g; // r1+0x8
-    // s32* b; // r1+0xC
+    // u8* buf; // r1+0x4
+    // struct __anon_0x58360* rgba; // r1+0x8
+}
+
+// Range: 0x80080028 -> 0x800801C0
+static void rspConvertRGBAtoYUV(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 i; // r30
+    s32 j; // r1+0x8
+    s32 Y; // r20
+    s32 U; // r20
+    s32 V; // r12
+}
+
+// Range: 0x8007F938 -> 0x80080028
+static void rspYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Range: 0x8007F668 -> 0x8007F938
+static void rspDCT(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r1+0x8
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
+}
+
+// Range: 0x8007F4EC -> 0x8007F668
+static void rspQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 scale; // r1+0xC
+
+    // Local variables
+    s32 c; // r29
+    s32 i; // r28
+    s32 j; // r27
+    s16 q; // r6
+    s16 s; // r1+0x8
+}
+
+// Erased
+static void rspZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u8** databuf; // r1+0xC
+    // s32 n; // r1+0x10
+    // s32* preDc; // r1+0x14
+
+    // Local variables
+    s16 Ac; // r30
+    s32 i; // r6
+    s32 z; // r7
+}
+
+// Erased
+static void rspUndoZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // u8** databuf; // r1+0xC
+    // s32 n; // r1+0x10
+    // s32* preDc; // r1+0x14
+
+    // Local variables
+    s16 Dc; // r12
+    s16 Ac; // r12
+    s32 i; // r7
+    s32 z; // r31
+}
+
+// Range: 0x8007F368 -> 0x8007F4EC
+void rspUndoQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 scale; // r1+0xC
+
+    // Local variables
+    s32 c; // r29
+    s32 i; // r28
+    s32 j; // r27
+    s16 q; // r6
+    s16 s; // r1+0x8
+}
+
+// Range: 0x8007F07C -> 0x8007F368
+void rspUndoDCT(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r5
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
+}
+
+// Range: 0x8007E8F4 -> 0x8007F07C
+void rspUndoYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 i; // r1+0x8
+    s32 j; // r1+0x8
+}
+
+// Range: 0x8007E744 -> 0x8007E8F4
+void rspFormatYUV(struct __anon_0x5845E* pRSP, char* imgBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // char* imgBuf; // r4
+
+    // Local variables
+    s32 i; // r10
+    s32 j; // r11
+}
+
+// Range: 0x8007DD0C -> 0x8007E744
+static s32 rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r19
+    // struct __anon_0x575BD* pTask; // r16
+
+    // Local variables
+    u8* temp; // r24
+    u8* temp2; // r23
+    s32 i; // r10
+    s32 j; // r11
+    s32 x; // r22
+    s32 y; // r21
+    u8* system_imb; // r1+0x30
+    u8* system_cfb; // r1+0x2C
+    s32 scale; // r20
+}
+
+// Range: 0x8007D4C0 -> 0x8007DD0C
+static s32 rspParseJPEG_Decode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r20
+
+    // Local variables
+    s32 i; // r3
+    s32 y; // r25
+    u8* temp; // r31
+    u8* temp2; // r26
+    u64* system_imb; // r1+0x1C
+    s32 size; // r21
+    s32 scale; // r22
+}
+
+// Range: 0x8007D1C8 -> 0x8007D4C0
+static s32 rspCreateJPEGArraysZ(struct __anon_0x5845E* pRSP, s32 qYAddress, s32 qCbAddress, s32 qCrAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r24
+    // s32 qYAddress; // r4
+    // s32 qCbAddress; // r25
+    // s32 qCrAddress; // r26
+}
+
+// Erased
+static s32 rspDestroyJPEGArraysZ() {}
+
+// Range: 0x8007CEF8 -> 0x8007D1C8
+static void rspDCTZ(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r1+0x8
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
+}
+
+// Range: 0x8007C8CC -> 0x8007CEF8
+static void rspQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r1+0xC
+
+    // Local variables
+    s32 c; // r12
+    s32 i; // r1+0x8
+}
+
+// Range: 0x8007C3A4 -> 0x8007C8CC
+void rspZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r4
+
+    // Local variables
+    s32 c; // r1+0x8
+}
+
+// Range: 0x8007BDD8 -> 0x8007C3A4
+void rspUndoQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r1+0xC
+
+    // Local variables
+    s32 c; // r12
+    s32 i; // r1+0x8
+}
+
+// Range: 0x8007B9B0 -> 0x8007BDD8
+void rspUndoZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* dataBuf; // r4
+
+    // Local variables
+    s32 c; // r1+0x8
+}
+
+// Range: 0x8007B6E0 -> 0x8007B9B0
+void rspUndoDCTZ(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    s32 c; // r1+0xA4
+    s32 i; // r1+0xA0
+    s32 j; // r5
+    s32 dd; // r6
+    s16 t[8][8]; // r1+0x1C
+}
+
+// Range: 0x8007B64C -> 0x8007B6E0
+s32 rspUndoLoadColorBufferZ(s32 r, s32 g, s32 b, s16* imgBuf, s32 index) {
+    // Parameters
+    // s32 r; // r3
+    // s32 g; // r1+0x8
+    // s32 b; // r4
     // s16* imgBuf; // r1+0x10
     // s32 index; // r1+0x14
 }
@@ -81,268 +290,59 @@ s32 rspUndoRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
     s32 v; // r1+0x8
 }
 
-// Range: 0x8007B64C -> 0x8007B6E0
-s32 rspUndoLoadColorBufferZ(s32 r, s32 g, s32 b, s16* imgBuf, s32 index) {
+// Erased
+static s32 rspLoadColorBufferZ(s32* r, s32* g, s32* b, s16* imgBuf, s32 index) {
     // Parameters
-    // s32 r; // r3
-    // s32 g; // r1+0x8
-    // s32 b; // r4
+    // s32* r; // r1+0x4
+    // s32* g; // r1+0x8
+    // s32* b; // r1+0xC
     // s16* imgBuf; // r1+0x10
     // s32 index; // r1+0x14
 }
 
-// Range: 0x8007B6E0 -> 0x8007B9B0
-void rspUndoDCTZ(struct __anon_0x5845E* pRSP) {
+// Range: 0x8007AE64 -> 0x8007B244
+s32 rspRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s16* imgBuf; // r1+0xC
 
     // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r5
-    s32 dd; // r6
-    s16 t[8][8]; // r1+0x1C
+    s32 i; // r1+0x10
+    s32 j; // r26
+    s32 r; // r10
+    s32 g; // r7
+    s32 b; // r11
+    s32 y; // r6
+    s32 u; // r9
+    s32 v; // r1+0x8
 }
 
-// Range: 0x8007B9B0 -> 0x8007BDD8
-void rspUndoZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+// Range: 0x8007AD68 -> 0x8007AE64
+static s32 rspParseJPEG_EncodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s16* dataBuf; // r4
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r4
 
     // Local variables
-    s32 c; // r1+0x8
+    s32 y; // r31
+    s16* temp; // r1+0x8
+    s16* temp2; // r30
+    u64* system_imb; // r1+0x20
+    u32* infoStruct; // r1+0x1C
+    s32 size; // r29
 }
 
-// Range: 0x8007BDD8 -> 0x8007C3A4
-void rspUndoQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
+// Range: 0x8007AC6C -> 0x8007AD68
+static s32 rspParseJPEG_DecodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s16* dataBuf; // r1+0xC
+    // struct __anon_0x5845E* pRSP; // r28
+    // struct __anon_0x575BD* pTask; // r4
 
     // Local variables
-    s32 c; // r12
-    s32 i; // r1+0x8
-}
-
-// Range: 0x8007C3A4 -> 0x8007C8CC
-void rspZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s16* dataBuf; // r4
-
-    // Local variables
-    s32 c; // r1+0x8
-}
-
-// Range: 0x8007C8CC -> 0x8007CEF8
-static void rspQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s16* dataBuf; // r1+0xC
-
-    // Local variables
-    s32 c; // r12
-    s32 i; // r1+0x8
-}
-
-// Range: 0x8007CEF8 -> 0x8007D1C8
-static void rspDCTZ(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r1+0x8
-    s32 dd; // r6
-    s16 t[8][8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspDestroyJPEGArraysZ() {}
-
-// Range: 0x8007D1C8 -> 0x8007D4C0
-static s32 rspCreateJPEGArraysZ(struct __anon_0x5845E* pRSP, s32 qYAddress, s32 qCbAddress, s32 qCrAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r24
-    // s32 qYAddress; // r4
-    // s32 qCbAddress; // r25
-    // s32 qCrAddress; // r26
-}
-
-// Range: 0x8007D4C0 -> 0x8007DD0C
-static s32 rspParseJPEG_Decode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // struct __anon_0x575BD* pTask; // r20
-
-    // Local variables
-    s32 i; // r3
-    s32 y; // r25
-    u8* temp; // r31
-    u8* temp2; // r26
-    u64* system_imb; // r1+0x1C
-    s32 size; // r21
-    s32 scale; // r22
-}
-
-// Range: 0x8007DD0C -> 0x8007E744
-static s32 rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r19
-    // struct __anon_0x575BD* pTask; // r16
-
-    // Local variables
-    u8* temp; // r24
-    u8* temp2; // r23
-    s32 i; // r10
-    s32 j; // r11
-    s32 x; // r22
-    s32 y; // r21
-    u8* system_imb; // r1+0x30
-    u8* system_cfb; // r1+0x2C
-    s32 scale; // r20
-}
-
-// Range: 0x8007E744 -> 0x8007E8F4
-void rspFormatYUV(struct __anon_0x5845E* pRSP, char* imgBuf) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // char* imgBuf; // r4
-
-    // Local variables
-    s32 i; // r10
-    s32 j; // r11
-}
-
-// Range: 0x8007E8F4 -> 0x8007F07C
-void rspUndoYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    s32 i; // r1+0x8
-    s32 j; // r1+0x8
-}
-
-// Range: 0x8007F07C -> 0x8007F368
-void rspUndoDCT(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r5
-    s32 dd; // r6
-    s16 t[8][8]; // r1+0x1C
-}
-
-// Range: 0x8007F368 -> 0x8007F4EC
-void rspUndoQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 scale; // r1+0xC
-
-    // Local variables
-    s32 c; // r29
-    s32 i; // r28
-    s32 j; // r27
-    s16 q; // r6
-    s16 s; // r1+0x8
-}
-
-// Erased
-static void rspUndoZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u8** databuf; // r1+0xC
-    // s32 n; // r1+0x10
-    // s32* preDc; // r1+0x14
-
-    // Local variables
-    s16 Dc; // r12
-    s16 Ac; // r12
-    s32 i; // r7
-    s32 z; // r31
-}
-
-// Erased
-static void rspZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u8** databuf; // r1+0xC
-    // s32 n; // r1+0x10
-    // s32* preDc; // r1+0x14
-
-    // Local variables
-    s16 Ac; // r30
-    s32 i; // r6
-    s32 z; // r7
-}
-
-// Range: 0x8007F4EC -> 0x8007F668
-static void rspQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 scale; // r1+0xC
-
-    // Local variables
-    s32 c; // r29
-    s32 i; // r28
-    s32 j; // r27
-    s16 q; // r6
-    s16 s; // r1+0x8
-}
-
-// Range: 0x8007F668 -> 0x8007F938
-static void rspDCT(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r1+0x8
-    s32 dd; // r6
-    s16 t[8][8]; // r1+0x1C
-}
-
-// Range: 0x8007F938 -> 0x80080028
-static void rspYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-
-    // Local variables
-    s32 i; // r1+0x0
-}
-
-// Range: 0x80080028 -> 0x800801C0
-static void rspConvertRGBAtoYUV(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    s32 i; // r30
-    s32 j; // r1+0x8
-    s32 Y; // r20
-    s32 U; // r20
-    s32 V; // r12
-}
-
-// Erased
-static void rspConvertBufferToRGBA(u8* buf, struct __anon_0x58360* rgba) {
-    // Parameters
-    // u8* buf; // r1+0x4
-    // struct __anon_0x58360* rgba; // r1+0x8
-}
-
-// Erased
-static s32 rspDestroyJPEGArrays() {}
-
-// Range: 0x800801C0 -> 0x80080AA4
-static s32 rspCreateJPEGArrays(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
+    s32 y; // r31
+    s16* temp; // r1+0x8
+    s16* temp2; // r30
+    u64* system_imb; // r1+0x20
+    u32* infoStruct; // r1+0x1C
+    s32 size; // r29
 }

--- a/debug/Fire/_gspS2DEX.c
+++ b/debug/Fire/_gspS2DEX.c
@@ -7,64 +7,142 @@
 
 #include "types.h"
 
-// Range: 0x80077850 -> 0x800779B0
-static s32 rspSetupS2DEX(struct __anon_0x5845E* pRSP) {
+// Erased
+static s32 frameFillVertex(struct __anon_0x5A89F* pFrame, s32 nIndex, s16 nX, s16 nY, s16 nZ, f32 rS, f32 rT) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-
-    // Local variables
-    f32 fL; // f31
-    f32 fR; // f30
-    f32 fB; // f29
-    f32 fT; // f28
-    struct __anon_0x5A89F* pFrame; // r4
+    // struct __anon_0x5A89F* pFrame; // r1+0x8
+    // s32 nIndex; // r1+0xC
+    // s16 nX; // r1+0x10
+    // s16 nY; // r1+0x12
+    // s16 nZ; // r1+0x14
+    // f32 rS; // r1+0x18
+    // f32 rT; // r1+0x1C
 }
 
-// Range: 0x800779B0 -> 0x80077B18
-static s32 rspObjMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+// Range: 0x8007AC1C -> 0x8007AC6C
+static s32 Matrix4by4Identity(f32 (*matrix4b4)[4]) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // s32 nAddress; // r5
+    // f32 (* matrix4b4)[4]; // r1+0x0
+}
+
+// Range: 0x8007AB54 -> 0x8007AC1C
+static s32 rspFillObjSprite(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F63B* pSprite) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F63B* pSprite; // r31
 
     // Local variables
-    u32* pnData32; // r1+0x8
     u16* pnData16; // r1+0x8
-    u8* pObjMtx; // r1+0x18
-    u16 nBaseScaleX; // r6
-    u16 nBaseScaleY; // r8
-    s32 nA; // r5
-    s32 nB; // r4
-    s32 nC; // r1+0x8
-    s32 nD; // r9
-    s16 nY; // r1+0x8
+    u8* pnData8; // r1+0x8
+    u8* pObjSprite; // r1+0x14
+}
+
+// Range: 0x8007AA74 -> 0x8007AB54
+s32 rspFillObjBgScale(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F2FB* pBg; // r31
+
+    // Local variables
+    u8* pnData8; // r1+0x8
+    u8* pObjBg; // r1+0x14
+    u16* pnData16; // r1+0x8
+    u32* pnData32; // r1+0x8
+}
+
+// Range: 0x8007A97C -> 0x8007AA74
+s32 rspFillObjBg(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5F2FB* pBg; // r31
+
+    // Local variables
+    u8* pnData8; // r1+0x8
+    u8* pObjBg; // r1+0x18
+    u16* pnData16; // r1+0x8
 }
 
 // Erased
-static s32 rspObjSubMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+static s32 rspSetTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nSize, s32 nTmem, s32 nTLUT,
+                      s32 nFormat, s32 nMaskS, s32 nMaskT, s32 nModeS, s32 nModeT, s32 nShiftS, s32 nShiftT) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-    // s32 nAddress; // r5
-
-    // Local variables
-    u16* pnData16; // r6
-    u8* pObjSubMtx; // r1+0x18
-    u16 nBaseScaleX; // r7
-    u16 nBaseScaleY; // r5
-    s16 nY; // r1+0x8
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nSize; // r1+0x10
+    // s32 nTmem; // r1+0x14
+    // s32 nTLUT; // r1+0x18
+    // s32 nFormat; // r1+0x20
+    // s32 nMaskS; // r1+0x24
+    // s32 nMaskT; // r1+0x8
+    // s32 nModeS; // r8
+    // s32 nModeT; // r6
+    // s32 nShiftS; // r9
+    // s32 nShiftT; // r8
 }
 
-// Range: 0x80077B18 -> 0x80077CB8
-s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+// Range: 0x8007A8E8 -> 0x8007A97C
+s32 rspSetImage(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, s32 nFormat, s32 nWidth, s32 nSize,
+                s32 nImage) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
     // struct __anon_0x5A89F* pFrame; // r31
-    // s32 nAddress; // r5
+    // struct __anon_0x5845E* pRSP; // r1+0xC
+    // s32 nFormat; // r1+0x10
+    // s32 nWidth; // r1+0x14
+    // s32 nSize; // r1+0x18
+    // s32 nImage; // r1+0x1C
 
     // Local variables
-    union __anon_0x5F2FB bg; // r1+0x48
-    union __anon_0x5F2FB bgScale; // r1+0x20
-    u32 nOldMode1; // r1+0x18
-    u32 nOldMode2; // r1+0x14
+    s32 addr; // r5
+    struct __anon_0x59558* pBuffer; // r9
+}
+
+// Erased
+static s32 rspLoadBlock(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                        s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
+}
+
+// Erased
+static s32 rspLoadTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                       s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
+}
+
+// Erased
+static s32 rspSetTileSize(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
+                          s32 nY1) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r3
+    // struct __anon_0x5A2EC* pTile; // r1+0xC
+    // s32 nX0; // r1+0x10
+    // s32 nY0; // r1+0x14
+    // s32 nX1; // r1+0x18
+    // s32 nY1; // r1+0x1C
+}
+
+// Erased
+static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
+    // Parameters
+    // u32 ulx; // r1+0x0
+    // u32 uly; // r1+0x4
+    // u32 lrx; // r1+0x8
+    // u32 lry; // r1+0xC
+    // u8 flag; // r1+0x10
 
     // References
     // -> static u8 flagBilerp;
@@ -74,148 +152,72 @@ s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s3
     // -> static u16 scissorX0;
 }
 
-// Erased
-static s32 rspObjLoadTxSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+// Range: 0x8007A7D4 -> 0x8007A8E8
+static s32 tmemLoad_B(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+                      s16 tmemSH) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
-}
-
-// Erased
-static s32 rspObjLoadTxRectR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
-}
-
-// Erased
-static s32 rspObjLoadTxRect(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
-}
-
-// Range: 0x80077CB8 -> 0x8007876C
-static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
+    // struct __anon_0x5845E* pRSP; // r1+0xC
+    // u32 imagePtr; // r1+0x10
+    // s16 loadLines; // r31
+    // s16 tmemSH; // r28
 
     // Local variables
-    u16 nSizLineBytes; // r5
-    f32 fLeft; // f30
-    f32 fRight; // f29
-    f32 fTop; // f28
-    f32 fBottom; // f27
-    f32 fTexRight; // f26
-    f32 fTexBottom; // f25
-    f32 fTexLeft; // f24
-    f32 fTexTop; // f23
-    s32 nTexTrim2; // r28
-    s32 nTexTrim5; // r27
-    f32 fSpriteWidth; // f22
-    f32 fSpriteHeight; // f1
-    s32 nClampSetting; // r1+0x8
-    union __anon_0x5F63B objSprite; // r1+0x438
-    struct __anon_0x5A2EC* pTile; // r31
-    struct __anon_0x5EBE0 primitive; // r1+0x12C
-    f32 mtxTransL[3][4]; // r1+0xFC
-    f32 mtxTransW[3][4]; // r1+0xCC
-    f32 mtxScale[3][4]; // r1+0x9C
-    f32 mtxTemp[3][4]; // r1+0x6C
-    f32 mtxOut[3][4]; // r1+0x3C
-    struct __anon_0x5F6E9 vecIn; // r1+0x30
-    struct __anon_0x5F6E9 vecOut; // r1+0x24
-}
-
-// Range: 0x8007876C -> 0x80079234
-static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
-
-    // Local variables
-    u16 nSizLineBytes; // r5
-    f32 fLeft; // f29
-    f32 fRight; // r1+0x8
-    f32 fTop; // f28
-    f32 fBottom; // r1+0x8
-    f32 fTexRight; // f27
-    f32 fTexBottom; // f26
-    f32 fTexLeft; // f25
-    f32 fTexTop; // f24
-    f32 fScaleX; // f23
-    f32 fScaleY; // f22
-    f32 fSpriteWidth; // f2
-    f32 fSpriteHeight; // f4
-    s32 nTexTrim2; // r28
-    s32 nTexTrim5; // r27
-    s32 nClampSetting; // r1+0x8
-    union __anon_0x5F63B objSprite; // r1+0x438
-    struct __anon_0x5A2EC* pTile; // r31
-    struct __anon_0x5EBE0 primitive; // r1+0x12C
-    f32 mtxTransL[3][4]; // r1+0xFC
-    f32 mtxTransW[3][4]; // r1+0xCC
-    f32 mtxScale[3][4]; // r1+0x9C
-    f32 mtxTemp[3][4]; // r1+0x6C
-    f32 mtxOut[3][4]; // r1+0x3C
-    struct __anon_0x5F6E9 vecIn; // r1+0x30
-    struct __anon_0x5F6E9 vecOut; // r1+0x24
-}
-
-// Range: 0x80079234 -> 0x800797D0
-static s32 rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r27
-    // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
-
-    // Local variables
-    u16 nSizLineBytes; // r5
-    f32 fDeltaS; // f3
-    f32 fDeltaT; // f4
-    union __anon_0x5F63B objSprite; // r1+0x48
-    struct __anon_0x5A2EC* pTile; // r31
-    struct __anon_0x5F759 primitive; // r1+0x1C
-    s32 nClampSetting; // r1+0x8
-    s32 nTexTrim2; // r29
-    s32 nTexTrim5; // r28
-}
-
-// Range: 0x800797D0 -> 0x80079C1C
-static s32 rspObjLoadTxtr(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // struct __anon_0x5A89F* pFrame; // r29
-    // s32 nAddress; // r5
-
-    // Local variables
-    u32 nSizDefine; // r26
-    u32 nLoadType; // r1+0x30
+    struct __anon_0x59558* pBuffer; // r8
     s32 nAddr; // r5
-    struct __anon_0x5A2EC* pTile; // r31
-    struct __anon_0x59558* pBuffer; // r30
-    union __anon_0x5FC1B objTxtr; // r1+0x18
+
+    // References
+    // -> static u16 imageSrcWsize;
 }
 
-// Range: 0x80079C1C -> 0x80079D7C
-s32 rspFillObjTxtr(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5FC1B* pTxtr, u32* pLoadType) {
+// Range: 0x8007A728 -> 0x8007A7D4
+static s32 tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+                      s16 tmemAdrs, s16 tmemSH) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
-    // union __anon_0x5FC1B* pTxtr; // r30
-    // u32* pLoadType; // r31
+    // struct __anon_0x5A89F* pFrame; // r27
+    // struct __anon_0x5845E* pRSP; // r28
+    // u32 imagePtr; // r29
+    // s16 loadLines; // r30
+    // s16 tmemAdrs; // r1+0x16
+    // s16 tmemSH; // r31
+
+    // References
+    // -> static u16 tmemSliceWmax;
+}
+
+// Range: 0x8007A4B8 -> 0x8007A728
+static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32* imagePtr, s16* imageRemain,
+                    s16 drawLines, s16 flagBilerp) {
+    // Parameters
+    // struct __anon_0x5A89F* pFrame; // r21
+    // struct __anon_0x5845E* pRSP; // r22
+    // u32* imagePtr; // r23
+    // s16* imageRemain; // r24
+    // s16 drawLines; // r25
+    // s16 flagBilerp; // r1+0x1A
 
     // Local variables
-    u32* pnData32; // r1+0x8
-    u16* pnData16; // r1+0x8
-    u8* pTxtrBlock; // r1+0x18
-    u32 nLoadType; // r1+0x8
+    s16 loadLines; // r6
+    s16 iLoadable; // r29
+    s16 SubSliceL2; // r6
+    s16 SubSliceD2; // r28
+    s16 SubSliceY2; // r7
+    u32 imageTopSeg; // r30
+    u32 imagePtr2; // r5
+    u32 imagePtr1A; // r27
+    u32 imagePtr1B; // r5
+    s16 SubSliceY1; // r4
+    s16 SubSliceL1; // r26
+    s16 tmemSH_A; // r20
+    s16 tmemSH_B; // r8
+
+    // References
+    // -> static u16 imageSrcWsize;
+    // -> static u32 imageTop;
+    // -> static u16 imagePtrX0;
+    // -> static s16 tmemSrcLines;
+    // -> static u16 tmemSliceWmax;
+    // -> static u16 flagSplit;
 }
 
 // Range: 0x80079D7C -> 0x8007A4B8
@@ -293,82 +295,162 @@ static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F
     // -> static u16 scissorX0;
 }
 
-// Range: 0x8007A4B8 -> 0x8007A728
-static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32* imagePtr, s16* imageRemain,
-                    s16 drawLines, s16 flagBilerp) {
+// Range: 0x80079C1C -> 0x80079D7C
+s32 rspFillObjTxtr(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5FC1B* pTxtr, u32* pLoadType) {
     // Parameters
-    // struct __anon_0x5A89F* pFrame; // r21
-    // struct __anon_0x5845E* pRSP; // r22
-    // u32* imagePtr; // r23
-    // s16* imageRemain; // r24
-    // s16 drawLines; // r25
-    // s16 flagBilerp; // r1+0x1A
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // union __anon_0x5FC1B* pTxtr; // r30
+    // u32* pLoadType; // r31
 
     // Local variables
-    s16 loadLines; // r6
-    s16 iLoadable; // r29
-    s16 SubSliceL2; // r6
-    s16 SubSliceD2; // r28
-    s16 SubSliceY2; // r7
-    u32 imageTopSeg; // r30
-    u32 imagePtr2; // r5
-    u32 imagePtr1A; // r27
-    u32 imagePtr1B; // r5
-    s16 SubSliceY1; // r4
-    s16 SubSliceL1; // r26
-    s16 tmemSH_A; // r20
-    s16 tmemSH_B; // r8
-
-    // References
-    // -> static u16 imageSrcWsize;
-    // -> static u32 imageTop;
-    // -> static u16 imagePtrX0;
-    // -> static s16 tmemSrcLines;
-    // -> static u16 tmemSliceWmax;
-    // -> static u16 flagSplit;
+    u32* pnData32; // r1+0x8
+    u16* pnData16; // r1+0x8
+    u8* pTxtrBlock; // r1+0x18
+    u32 nLoadType; // r1+0x8
 }
 
-// Range: 0x8007A728 -> 0x8007A7D4
-static s32 tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
-                      s16 tmemAdrs, s16 tmemSH) {
+// Range: 0x800797D0 -> 0x80079C1C
+static s32 rspObjLoadTxtr(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
     // Parameters
-    // struct __anon_0x5A89F* pFrame; // r27
     // struct __anon_0x5845E* pRSP; // r28
-    // u32 imagePtr; // r29
-    // s16 loadLines; // r30
-    // s16 tmemAdrs; // r1+0x16
-    // s16 tmemSH; // r31
-
-    // References
-    // -> static u16 tmemSliceWmax;
-}
-
-// Range: 0x8007A7D4 -> 0x8007A8E8
-static s32 tmemLoad_B(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
-                      s16 tmemSH) {
-    // Parameters
-    // struct __anon_0x5A89F* pFrame; // r30
-    // struct __anon_0x5845E* pRSP; // r1+0xC
-    // u32 imagePtr; // r1+0x10
-    // s16 loadLines; // r31
-    // s16 tmemSH; // r28
+    // struct __anon_0x5A89F* pFrame; // r29
+    // s32 nAddress; // r5
 
     // Local variables
-    struct __anon_0x59558* pBuffer; // r8
+    u32 nSizDefine; // r26
+    u32 nLoadType; // r1+0x30
     s32 nAddr; // r5
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x59558* pBuffer; // r30
+    union __anon_0x5FC1B objTxtr; // r1+0x18
+}
 
-    // References
-    // -> static u16 imageSrcWsize;
+// Range: 0x80079234 -> 0x800797D0
+static s32 rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    f32 fDeltaS; // f3
+    f32 fDeltaT; // f4
+    union __anon_0x5F63B objSprite; // r1+0x48
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5F759 primitive; // r1+0x1C
+    s32 nClampSetting; // r1+0x8
+    s32 nTexTrim2; // r29
+    s32 nTexTrim5; // r28
+}
+
+// Range: 0x8007876C -> 0x80079234
+static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    f32 fLeft; // f29
+    f32 fRight; // r1+0x8
+    f32 fTop; // f28
+    f32 fBottom; // r1+0x8
+    f32 fTexRight; // f27
+    f32 fTexBottom; // f26
+    f32 fTexLeft; // f25
+    f32 fTexTop; // f24
+    f32 fScaleX; // f23
+    f32 fScaleY; // f22
+    f32 fSpriteWidth; // f2
+    f32 fSpriteHeight; // f4
+    s32 nTexTrim2; // r28
+    s32 nTexTrim5; // r27
+    s32 nClampSetting; // r1+0x8
+    union __anon_0x5F63B objSprite; // r1+0x438
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5EBE0 primitive; // r1+0x12C
+    f32 mtxTransL[3][4]; // r1+0xFC
+    f32 mtxTransW[3][4]; // r1+0xCC
+    f32 mtxScale[3][4]; // r1+0x9C
+    f32 mtxTemp[3][4]; // r1+0x6C
+    f32 mtxOut[3][4]; // r1+0x3C
+    struct __anon_0x5F6E9 vecIn; // r1+0x30
+    struct __anon_0x5F6E9 vecOut; // r1+0x24
+}
+
+// Range: 0x80077CB8 -> 0x8007876C
+static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r5
+
+    // Local variables
+    u16 nSizLineBytes; // r5
+    f32 fLeft; // f30
+    f32 fRight; // f29
+    f32 fTop; // f28
+    f32 fBottom; // f27
+    f32 fTexRight; // f26
+    f32 fTexBottom; // f25
+    f32 fTexLeft; // f24
+    f32 fTexTop; // f23
+    s32 nTexTrim2; // r28
+    s32 nTexTrim5; // r27
+    f32 fSpriteWidth; // f22
+    f32 fSpriteHeight; // f1
+    s32 nClampSetting; // r1+0x8
+    union __anon_0x5F63B objSprite; // r1+0x438
+    struct __anon_0x5A2EC* pTile; // r31
+    struct __anon_0x5EBE0 primitive; // r1+0x12C
+    f32 mtxTransL[3][4]; // r1+0xFC
+    f32 mtxTransW[3][4]; // r1+0xCC
+    f32 mtxScale[3][4]; // r1+0x9C
+    f32 mtxTemp[3][4]; // r1+0x6C
+    f32 mtxOut[3][4]; // r1+0x3C
+    struct __anon_0x5F6E9 vecIn; // r1+0x30
+    struct __anon_0x5F6E9 vecOut; // r1+0x24
 }
 
 // Erased
-static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
+static s32 rspObjLoadTxRect(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
     // Parameters
-    // u32 ulx; // r1+0x0
-    // u32 uly; // r1+0x4
-    // u32 lrx; // r1+0x8
-    // u32 lry; // r1+0xC
-    // u8 flag; // r1+0x10
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
+}
+
+// Erased
+static s32 rspObjLoadTxRectR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
+}
+
+// Erased
+static s32 rspObjLoadTxSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // struct __anon_0x5A89F* pFrame; // r30
+    // s32 nAddress; // r31
+}
+
+// Range: 0x80077B18 -> 0x80077CB8
+s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x5A89F* pFrame; // r31
+    // s32 nAddress; // r5
+
+    // Local variables
+    union __anon_0x5F2FB bg; // r1+0x48
+    union __anon_0x5F2FB bgScale; // r1+0x20
+    u32 nOldMode1; // r1+0x18
+    u32 nOldMode2; // r1+0x14
 
     // References
     // -> static u8 flagBilerp;
@@ -379,129 +461,47 @@ static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
 }
 
 // Erased
-static s32 rspSetTileSize(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                          s32 nY1) {
+static s32 rspObjSubMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
     // Parameters
-    // struct __anon_0x5A89F* pFrame; // r3
-    // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
-}
-
-// Erased
-static s32 rspLoadTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                       s32 nY1) {
-    // Parameters
-    // struct __anon_0x5A89F* pFrame; // r3
-    // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
-}
-
-// Erased
-static s32 rspLoadBlock(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                        s32 nY1) {
-    // Parameters
-    // struct __anon_0x5A89F* pFrame; // r3
-    // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
-}
-
-// Range: 0x8007A8E8 -> 0x8007A97C
-s32 rspSetImage(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, s32 nFormat, s32 nWidth, s32 nSize,
-                s32 nImage) {
-    // Parameters
-    // struct __anon_0x5A89F* pFrame; // r31
-    // struct __anon_0x5845E* pRSP; // r1+0xC
-    // s32 nFormat; // r1+0x10
-    // s32 nWidth; // r1+0x14
-    // s32 nSize; // r1+0x18
-    // s32 nImage; // r1+0x1C
+    // struct __anon_0x5845E* pRSP; // r31
+    // s32 nAddress; // r5
 
     // Local variables
-    s32 addr; // r5
-    struct __anon_0x59558* pBuffer; // r9
+    u16* pnData16; // r6
+    u8* pObjSubMtx; // r1+0x18
+    u16 nBaseScaleX; // r7
+    u16 nBaseScaleY; // r5
+    s16 nY; // r1+0x8
 }
 
-// Erased
-static s32 rspSetTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nSize, s32 nTmem, s32 nTLUT,
-                      s32 nFormat, s32 nMaskS, s32 nMaskT, s32 nModeS, s32 nModeT, s32 nShiftS, s32 nShiftT) {
+// Range: 0x800779B0 -> 0x80077B18
+static s32 rspObjMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
     // Parameters
-    // struct __anon_0x5A89F* pFrame; // r3
-    // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nSize; // r1+0x10
-    // s32 nTmem; // r1+0x14
-    // s32 nTLUT; // r1+0x18
-    // s32 nFormat; // r1+0x20
-    // s32 nMaskS; // r1+0x24
-    // s32 nMaskT; // r1+0x8
-    // s32 nModeS; // r8
-    // s32 nModeT; // r6
-    // s32 nShiftS; // r9
-    // s32 nShiftT; // r8
-}
-
-// Range: 0x8007A97C -> 0x8007AA74
-s32 rspFillObjBg(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
-    // union __anon_0x5F2FB* pBg; // r31
+    // struct __anon_0x5845E* pRSP; // r31
+    // s32 nAddress; // r5
 
     // Local variables
-    u8* pnData8; // r1+0x8
-    u8* pObjBg; // r1+0x18
-    u16* pnData16; // r1+0x8
-}
-
-// Range: 0x8007AA74 -> 0x8007AB54
-s32 rspFillObjBgScale(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
-    // union __anon_0x5F2FB* pBg; // r31
-
-    // Local variables
-    u8* pnData8; // r1+0x8
-    u8* pObjBg; // r1+0x14
-    u16* pnData16; // r1+0x8
     u32* pnData32; // r1+0x8
+    u16* pnData16; // r1+0x8
+    u8* pObjMtx; // r1+0x18
+    u16 nBaseScaleX; // r6
+    u16 nBaseScaleY; // r8
+    s32 nA; // r5
+    s32 nB; // r4
+    s32 nC; // r1+0x8
+    s32 nD; // r9
+    s16 nY; // r1+0x8
 }
 
-// Range: 0x8007AB54 -> 0x8007AC1C
-static s32 rspFillObjSprite(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F63B* pSprite) {
+// Range: 0x80077850 -> 0x800779B0
+static s32 rspSetupS2DEX(struct __anon_0x5845E* pRSP) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
-    // union __anon_0x5F63B* pSprite; // r31
+    // struct __anon_0x5845E* pRSP; // r31
 
     // Local variables
-    u16* pnData16; // r1+0x8
-    u8* pnData8; // r1+0x8
-    u8* pObjSprite; // r1+0x14
-}
-
-// Range: 0x8007AC1C -> 0x8007AC6C
-static s32 Matrix4by4Identity(f32 (*matrix4b4)[4]) {
-    // Parameters
-    // f32 (* matrix4b4)[4]; // r1+0x0
-}
-
-// Erased
-static s32 frameFillVertex(struct __anon_0x5A89F* pFrame, s32 nIndex, s16 nX, s16 nY, s16 nZ, f32 rS, f32 rT) {
-    // Parameters
-    // struct __anon_0x5A89F* pFrame; // r1+0x8
-    // s32 nIndex; // r1+0xC
-    // s16 nX; // r1+0x10
-    // s16 nY; // r1+0x12
-    // s16 nZ; // r1+0x14
-    // f32 rS; // r1+0x18
-    // f32 rT; // r1+0x1C
+    f32 fL; // f31
+    f32 fR; // f30
+    f32 fB; // f29
+    f32 fT; // f28
+    struct __anon_0x5A89F* pFrame; // r4
 }

--- a/debug/Fire/audio.c
+++ b/debug/Fire/audio.c
@@ -28,40 +28,11 @@ typedef struct __anon_0x753E7 {
     /* 0x1C */ s32 nStatus;
 } __anon_0x753E7; // size = 0x20
 
-// Range: 0x8008E4A8 -> 0x8008E5C8
-s32 audioEvent(struct __anon_0x753E7* pAudio, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x753E7* pAudio; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
+// Range: 0x8008E898 -> 0x8008E8A0
+s32 audioPut8() {}
 
-// Range: 0x8008E5C8 -> 0x8008E620
-s32 audioEnable(struct __anon_0x753E7* pAudio, s32 bEnable) {
-    // Parameters
-    // struct __anon_0x753E7* pAudio; // r3
-    // s32 bEnable; // r1+0xC
-}
-
-// Range: 0x8008E620 -> 0x8008E628
-s32 audioGet64() {}
-
-// Range: 0x8008E628 -> 0x8008E730
-s32 audioGet32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x753E7* pAudio; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r31
-}
-
-// Range: 0x8008E730 -> 0x8008E738
-s32 audioGet16() {}
-
-// Range: 0x8008E738 -> 0x8008E740
-s32 audioGet8() {}
-
-// Range: 0x8008E740 -> 0x8008E748
-s32 audioPut64() {}
+// Range: 0x8008E890 -> 0x8008E898
+s32 audioPut16() {}
 
 // Range: 0x8008E748 -> 0x8008E890
 s32 audioPut32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
@@ -74,8 +45,37 @@ s32 audioPut32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
     void* pBuffer; // r1+0x14
 }
 
-// Range: 0x8008E890 -> 0x8008E898
-s32 audioPut16() {}
+// Range: 0x8008E740 -> 0x8008E748
+s32 audioPut64() {}
 
-// Range: 0x8008E898 -> 0x8008E8A0
-s32 audioPut8() {}
+// Range: 0x8008E738 -> 0x8008E740
+s32 audioGet8() {}
+
+// Range: 0x8008E730 -> 0x8008E738
+s32 audioGet16() {}
+
+// Range: 0x8008E628 -> 0x8008E730
+s32 audioGet32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r31
+}
+
+// Range: 0x8008E620 -> 0x8008E628
+s32 audioGet64() {}
+
+// Range: 0x8008E5C8 -> 0x8008E620
+s32 audioEnable(struct __anon_0x753E7* pAudio, s32 bEnable) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r3
+    // s32 bEnable; // r1+0xC
+}
+
+// Range: 0x8008E4A8 -> 0x8008E5C8
+s32 audioEvent(struct __anon_0x753E7* pAudio, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x753E7* pAudio; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}

--- a/debug/Fire/codeGCN.c
+++ b/debug/Fire/codeGCN.c
@@ -79,15 +79,23 @@ typedef struct _CODE_CACHE_NODE {
     /* 0xC */ struct _CODE_CACHE_NODE* child;
 } __anon_0x20141; // size = 0x10
 
-// Range: 0x8001C444 -> 0x8001C498
-s32 codeEvent(s32 nEvent) {
-    // Parameters
-    // s32 nEvent; // r1+0x4
+// Erased
+static s32 hioInitSend() {}
 
-    // References
-    // -> static u32* ganDataCode;
-    // -> static void* gpBufferFunction;
-}
+// Erased
+static s32 hioCallbackDevice() {}
+
+// Erased
+static void hioCallback() {}
+
+// Erased
+static s32 hioSendBuffer() {}
+
+// Erased
+static s32 hioInit() {}
+
+// Erased
+static s32 codeSendFilePart() {}
 
 // Erased
 static s32 codeCheckCatalog(s32 nAddress0, s32 nAddress1) {
@@ -106,20 +114,12 @@ static s32 codeCheckCatalog(s32 nAddress0, s32 nAddress1) {
     // -> static s32 gCatalogLoaded;
 }
 
-// Erased
-static s32 codeSendFilePart() {}
+// Range: 0x8001C444 -> 0x8001C498
+s32 codeEvent(s32 nEvent) {
+    // Parameters
+    // s32 nEvent; // r1+0x4
 
-// Erased
-static s32 hioInit() {}
-
-// Erased
-static s32 hioSendBuffer() {}
-
-// Erased
-static void hioCallback() {}
-
-// Erased
-static s32 hioCallbackDevice() {}
-
-// Erased
-static s32 hioInitSend() {}
+    // References
+    // -> static u32* ganDataCode;
+    // -> static void* gpBufferFunction;
+}

--- a/debug/Fire/cpu.c
+++ b/debug/Fire/cpu.c
@@ -226,24 +226,6 @@ typedef struct __anon_0x3DB14 {
 // size = 0x4, address = 0x80135600
 struct __anon_0x3DB14* gpSystem;
 
-// Erased
-static s32 cpuUpdateDiskChecksum(u32* checksum, s32 startAddress, s32 endAddress) {
-    // Parameters
-    // u32* checksum; // r29
-    // s32 startAddress; // r4
-    // s32 endAddress; // r1+0x10
-
-    // Local variables
-    s32 count; // r31
-    s32 instruction; // r30
-    s32 check; // r1+0x8
-    u32* opcode; // r1+0x14
-    u32 part; // r27
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-}
-
 typedef struct __anon_0x3DE78 {
     /* 0x0 */ s32 nOffsetHost;
     /* 0x4 */ s32 nAddressN64;
@@ -446,18 +428,6 @@ typedef struct _CPU {
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x3F6CA; // size = 0x12090
 
-// Erased
-static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instruction) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 startAddress; // r30
-    // s32 instruction; // r31
-
-    // Local variables
-    s32 iHack; // r1+0x8
-    u32* opcode; // r1+0x14
-}
-
 typedef struct cpu_disk_node {
     /* 0x00 */ u32 functionLength;
     /* 0x04 */ u32 checksum;
@@ -477,766 +447,11 @@ typedef struct cpu_disk_node {
     /* 0x3C */ struct cpu_disk_node* same;
 } __anon_0x3FE5C; // size = 0x40
 
-// Erased
-static s32 cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, s32 start) {
-    // Parameters
-    // struct cpu_disk_node* pDisk; // r30
-    // s32 start; // r4
-
-    // Local variables
-    s32 count; // r1+0x8
-    s32 instruction; // r1+0x8
-    u32* last; // r31
-    u32* current; // r1+0x10
-
-    // References
-    // -> struct __anon_0x3DB14* gpSystem;
-}
-
-// Range: 0x80030E70 -> 0x80030F84
-static s32 cpuOpcodeChecksum(u32 opcode) {
-    // Parameters
-    // u32 opcode; // r1+0x0
-
-    // Local variables
-    s32 flag; // r5
-}
-
-// Erased
-static s32 treeMemory(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x80030F84 -> 0x80031168
-static s32 treePrintNode(struct _CPU* pCPU, struct cpu_function* tree, s32 print_flag, s32* left, s32* right) {
-    // Parameters
-    // struct _CPU* pCPU; // r21
-    // struct cpu_function* tree; // r22
-    // s32 print_flag; // r1+0x10
-    // s32* left; // r23
-    // s32* right; // r24
-
-    // Local variables
-    struct cpu_function* current; // r27
-    s32 flag; // r26
-    s32 level; // r25
-
-    // References
-    // -> s32 ganMapGPR[32];
-}
-
-// Erased
-static s32 treePrint(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 left; // r1+0x10
-    s32 right; // r1+0xC
-}
-
-// Range: 0x80031168 -> 0x8003133C
-static s32 treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, s32 kill_limit) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // struct cpu_function* tree; // r1+0xC
-    // s32 kill_limit; // r29
-
-    // Local variables
-    struct cpu_function* current; // r31
-    struct cpu_function* kill; // r30
-}
-
-// Erased
-static s32 treeForceCleanUp(struct _CPU* pCPU, struct cpu_function* node, s32 kill_value) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // struct cpu_function* node; // r1+0xC
-    // s32 kill_value; // r5
-
-    // Local variables
-    struct cpu_treeRoot* root; // r31
-}
-
-// Range: 0x8003133C -> 0x8003161C
-static s32 treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
-    // Parameters
-    // struct _CPU* pCPU; // r27
-    // struct cpu_function* top; // r1+0xC
-
-    // Local variables
-    struct cpu_function** current; // r30
-    struct cpu_function* kill; // r29
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 kill_limit; // r28
-}
-
-// Range: 0x8003161C -> 0x8003174C
-static s32 treeCleanUp(struct _CPU* pCPU, struct cpu_treeRoot* root) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // struct cpu_treeRoot* root; // r31
-
-    // Local variables
-    s32 done; // r3
-    s32 complete; // r30
-}
-
-// Erased
-static s32 treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // struct cpu_function* node; // r30
-
-    // Local variables
-    struct cpu_treeRoot* root; // r31
-}
-
-// Range: 0x8003174C -> 0x80031860
-static s32 treeTimerCheck(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 begin; // r1+0x10
-    s32 end; // r1+0xC
-}
-
-// Range: 0x80031860 -> 0x800318F0
-static s32 treeKillReason(struct _CPU* pCPU, s32* value) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32* value; // r1+0x4
-}
-
-// Range: 0x800318F0 -> 0x80032088
-static s32 treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, s32 start, s32 end) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // struct cpu_function* tree; // r24
-    // s32 start; // r25
-    // s32 end; // r26
-
-    // Local variables
-    struct cpu_treeRoot* root; // r29
-    struct cpu_function* node1; // r1+0x3C
-    struct cpu_function* node2; // r1+0x38
-    struct cpu_function* save1; // r3
-    struct cpu_function* save2; // r4
-    struct cpu_function* connect; // r5
-    s32 update; // r28
-    s32 count; // r27
-
-    // References
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80032088 -> 0x800320EC
-static s32 treeSearchNode(struct cpu_function* tree, s32 target, struct cpu_function** node) {
-    // Parameters
-    // struct cpu_function* tree; // r3
-    // s32 target; // r1+0x4
-    // struct cpu_function** node; // r1+0x8
-
-    // Local variables
-    struct cpu_function* current; // r3
-}
-
-// Erased
-static s32 treeSearch(struct _CPU* pCPU, s32 target, struct cpu_function** node) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // s32 target; // r4
-    // struct cpu_function** node; // r5
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 flag; // r3
-}
-
-// Range: 0x800320EC -> 0x800322D8
-static s32 treeAdjustRoot(struct _CPU* pCPU, s32 new_end) {
-    // Parameters
-    // struct _CPU* pCPU; // r23
-    // s32 new_end; // r24
-
-    // Local variables
-    s32 old_root; // r1+0x8
-    s32 new_root; // r30
-    s32 kill_start; // r29
-    s32 check1; // r1+0x8
-    s32 check2; // r28
-    u16 total; // r27
-    s32 total_memory; // r26
-    s32 address; // r22
-    struct cpu_treeRoot* root; // r25
-    struct cpu_function* node; // r1+0x18
-    struct cpu_function* change; // r1+0x14
-}
-
-// Range: 0x800322D8 -> 0x80032470
-static s32 treeBalance(struct cpu_treeRoot* root) {
-    // Parameters
-    // struct cpu_treeRoot* root; // r1+0x0
-
-    // Local variables
-    struct cpu_function* tree; // r8
-    struct cpu_function* current; // r4
-    struct cpu_function* save; // r6
-    s32 total; // r9
-    s32 count; // r7
-}
-
-// Range: 0x80032470 -> 0x80032558
-static s32 treeInsertNode(struct cpu_function** tree, s32 start, s32 end, struct cpu_function** ppFunction) {
-    // Parameters
-    // struct cpu_function** tree; // r31
-    // s32 start; // r8
-    // s32 end; // r7
-    // struct cpu_function** ppFunction; // r30
-
-    // Local variables
-    struct cpu_function** current; // r31
-    struct cpu_function* prev; // r4
-}
-
-// Range: 0x80032558 -> 0x80032674
-s32 treeInsert(struct _CPU* pCPU, s32 start, s32 end) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // s32 start; // r29
-    // s32 end; // r30
-
-    // Local variables
-    struct cpu_treeRoot* root; // r31
-    struct cpu_function* current; // r1+0x14
-    s32 flag; // r3
-}
-
-// Erased
-static s32 treeInsertAndReturn(struct _CPU* pCPU, s32 start, s32 end, struct cpu_function** ppFunction) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // s32 start; // r28
-    // s32 end; // r29
-    // struct cpu_function** ppFunction; // r30
-
-    // Local variables
-    struct cpu_treeRoot* root; // r31
-    s32 flag; // r3
-}
-
-// Erased
-static s32 treeRebuild(struct _CPU* pCPU, s32 start_address, struct cpu_function** node) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 start_address; // r30
-    // struct cpu_function** node; // r31
-}
-
-// Range: 0x80032674 -> 0x800329D4
-static s32 treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct cpu_function* kill) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // struct cpu_function** top; // r1+0xC
-    // struct cpu_function* kill; // r31
-
-    // Local variables
-    struct cpu_treeRoot* root; // r3
-    struct cpu_function* save1; // r5
-    struct cpu_function* save2; // r8
-    struct cpu_function* connect; // r1+0x8
-
-    // References
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x800329D4 -> 0x80032C84
-static s32 treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
-    // Parameters
-    // struct _CPU* pCPU; // r24
-    // struct cpu_function* tree; // r25
-
-    // Local variables
-    struct cpu_function* current; // r27
-    struct cpu_function* kill; // r28
-    s32 count; // r26
-
-    // References
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80032C84 -> 0x80032F2C
-static s32 treeKill(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 count; // r29
-
-    // References
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80032F2C -> 0x80033048
-static s32 treeInitNode(struct cpu_function** tree, struct cpu_function* prev, s32 start, s32 end) {
-    // Parameters
-    // struct cpu_function** tree; // r30
-    // struct cpu_function* prev; // r31
-    // s32 start; // r28
-    // s32 end; // r29
-
-    // Local variables
-    struct cpu_function* node; // r1+0x1C
-    s32 where; // r1+0x18
-}
-
-// Range: 0x80033048 -> 0x800330A0
-static s32 treeInit(struct _CPU* pCPU, s32 root_address) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 root_address; // r1+0x4
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x0
-}
-
-// Range: 0x800330A0 -> 0x800331A4
-static s32 treeCallerCheck(struct _CPU* pCPU, struct cpu_function* tree, s32 flag, s32 nAddress0, s32 nAddress1) {
-    // Parameters
-    // struct _CPU* pCPU; // r24
-    // struct cpu_function* tree; // r25
-    // s32 flag; // r26
-    // s32 nAddress0; // r27
-    // s32 nAddress1; // r28
-
-    // Local variables
-    s32 count; // r30
-    s32 saveGCN; // r6
-    s32 saveN64; // r1+0x8
-    s32* addr_function; // r1+0x8
-    s32* addr_call; // r29
-}
-
-// Erased
-static s32 treeCallerKill(struct _CPU* pCPU, struct cpu_function* kill) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // struct cpu_function* kill; // r30
-
-    // Local variables
-    s32 left; // r1+0x14
-    s32 right; // r1+0x10
-    struct cpu_treeRoot* root; // r31
-}
-
-// Erased
-static void treeCallerInit(struct cpu_callerID* block, s32 total) {
-    // Parameters
-    // struct cpu_callerID* block; // r3
-    // s32 total; // r1+0x4
-
-    // Local variables
-    s32 count; // r6
-}
-
-// Range: 0x800331A4 -> 0x80033304
-static s32 cpuDMAUpdateFunction(struct _CPU* pCPU, s32 start, s32 end) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32 start; // r29
-    // s32 end; // r30
-
-    // Local variables
-    struct cpu_treeRoot* root; // r1+0x8
-    s32 count; // r1+0x8
-    s32 cancel; // r5
-}
-
-// Range: 0x80033304 -> 0x80033E88
-s32 cpuFindFunction(struct _CPU* pCPU, s32 theAddress, struct cpu_function** tree_node) {
-    // Parameters
-    // struct _CPU* pCPU; // r22
-    // s32 theAddress; // r1+0x38
-    // struct cpu_function** tree_node; // r28
-
-    // Local variables
-    struct __anon_0x3EB4F** apDevice; // r26
-    u8* aiDevice; // r27
-    u32 opcode; // r1+0x34
-    u8 follow; // r1+0x3D
-    u8 valid; // r16
-    u8 check; // r1+0x3C
-    u8 end_flag; // r18
-    u8 save_restore; // r14
-    u8 alert; // r15
-    s32 beginAddress; // r21
-    s32 cheat_address; // r17
-    s32 current_address; // r31
-    s32 temp_address; // r30
-    s32 branch; // r1+0x8
-
-    // References
-    // -> static u8 Opcode[64];
-    // -> static u8 RegimmOpcode[32];
-    // -> static u8 SpecialOpcode[64];
-}
-
-// Erased
-static s32 cpuTreeFree(struct cpu_function* pFunction) {
-    // Parameters
-    // struct cpu_function* pFunction; // r1+0x0
-
-    // Local variables
-    u32* anPack; // r1+0x0
-    s32 iPack; // r1+0x0
-    u32 nMask; // r5
-
-    // References
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80033E88 -> 0x80033F3C
-static s32 cpuTreeTake(void* heap, s32* where) {
-    // Parameters
-    // void* heap; // r1+0x0
-    // s32* where; // r1+0x4
-
-    // Local variables
-    s32 done; // r5
-    s32 nOffset; // r8
-    s32 nCount; // r1+0x0
-    s32 iPack; // r1+0x0
-    u32 nPack; // r9
-    u32 nMask; // r10
-    u32 nMask0; // r1+0x0
-
-    // References
-    // -> void* gHeapTree;
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80033F3C -> 0x80034028
-s32 cpuHeapFree(struct _CPU* pCPU, struct cpu_function* pFunction) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // struct cpu_function* pFunction; // r4
-
-    // Local variables
-    u32* anPack; // r8
-    s32 iPack; // r1+0x8
-    u32 nMask; // r6
-}
-
-// Range: 0x80034028 -> 0x80034288
-s32 cpuHeapTake(void* heap, struct _CPU* pCPU, struct cpu_function* pFunction, s32 memory_size) {
-    // Parameters
-    // void* heap; // r3
-    // struct _CPU* pCPU; // r1+0xC
-    // struct cpu_function* pFunction; // r1+0x10
-    // s32 memory_size; // r6
-
-    // Local variables
-    s32 done; // r12
-    s32 second; // r7
-    u32* anPack; // r8
-    s32 nPackCount; // r9
-    s32 nBlockCount; // r10
-    s32 nOffset; // r27
-    s32 nCount; // r26
-    s32 iPack; // r1+0x8
-    u32 nPack; // r25
-    u32 nMask; // r24
-    u32 nMask0; // r23
-}
-
-// Range: 0x80034288 -> 0x80034324
-static s32 cpuHeapReset(u32* array, s32 count) {
-    // Parameters
-    // u32* array; // r3
-    // s32 count; // r1+0x4
-
-    // Local variables
-    s32 i; // r6
-}
-
-// Range: 0x80034324 -> 0x80034564
-s32 cpuGetFunctionChecksum(struct _CPU* pCPU, u32* pnChecksum, struct cpu_function* pFunction) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // u32* pnChecksum; // r30
-    // struct cpu_function* pFunction; // r31
-
-    // Local variables
-    s32 nSize; // r10
-    u32* pnBuffer; // r1+0x18
-    u32 nChecksum; // r11
-    u32 nData; // r12
-}
-
-// Range: 0x80034564 -> 0x800345F0
-s32 cpuInvalidateCache(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 nAddress0; // r30
-    // s32 nAddress1; // r31
-}
-
-// Range: 0x800345F0 -> 0x80034780
-s32 cpuGetOffsetAddress(struct _CPU* pCPU, u32* anAddress, s32* pnCount, u32 nOffset, u32 nSize) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u32* anAddress; // r1+0xC
-    // s32* pnCount; // r1+0x10
-    // u32 nOffset; // r1+0x14
-    // u32 nSize; // r1+0x18
-
-    // Local variables
-    s32 iEntry; // r1+0x8
-    s32 iAddress; // r7
-    u32 nAddress; // r1+0x8
-    u32 nMask; // r1+0x8
-    u32 nSizeMapped; // r26
-}
-
-// Range: 0x80034780 -> 0x800347F8
-s32 cpuGetAddressBuffer(struct _CPU* pCPU, void* ppBuffer, u32 nAddress) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // void* ppBuffer; // r4
-    // u32 nAddress; // r5
-
-    // Local variables
-    struct __anon_0x3EB4F* pDevice; // r1+0x8
-}
-
-// Range: 0x800347F8 -> 0x80034864
-s32 cpuGetAddressOffset(struct _CPU* pCPU, s32* pnOffset, u32 nAddress) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32* pnOffset; // r1+0x4
-    // u32 nAddress; // r1+0x8
-
-    // Local variables
-    s32 iDevice; // r1+0x0
-}
-
-// Range: 0x80034864 -> 0x80034A6C
-s32 cpuEvent(struct _CPU* pCPU, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r1+0x10
-}
-
-// Erased
-static s32 cpuSetFCR(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuSetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // f64* arRegister; // r30
-    // s32 bDouble; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuSetCP0(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
 typedef enum __anon_0x42F73 {
     CS_NONE = -1,
     CS_32BIT = 0,
     CS_64BIT = 1,
 } __anon_0x42F73;
-
-// Erased
-static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-    enum __anon_0x42F73 eSize; // r1+0x18
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Range: 0x80034A6C -> 0x80034AE8
-s32 cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
-    // Parameters
-    // struct _CPU* pCPU; // r26
-    // s64 nPC; // r0
-    // s64 nLo; // r29
-    // s64 nHi; // r31
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuGetFCR(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuGetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // f64* arRegister; // r30
-    // s32 bDouble; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuGetCP0(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuGetGPR(struct _CPU* pCPU, s32* anRegister) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-    enum __anon_0x42F73 eSize; // r1+0x18
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Erased
-static s32 cpuGetXPC(struct _CPU* pCPU, s32* pnPC, s32* pnLo, s32* pnHi) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32* pnPC; // r29
-    // s32* pnLo; // r30
-    // s32* pnHi; // r31
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-}
-
-// Range: 0x80034AE8 -> 0x80034FCC
-s32 cpuReset(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32 iRegister; // r1+0x8
-    s32 iTLB; // r1+0x8
-
-    // References
-    // -> void* gHeapTree;
-    // -> u32 aHeapTreeFlag[125];
-}
-
-// Range: 0x80034FCC -> 0x80035038
-s32 cpuSetCodeHack(struct _CPU* pCPU, s32 nAddress, s32 nOpcodeOld, s32 nOpcodeNew) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // s32 nAddress; // r1+0x4
-    // s32 nOpcodeOld; // r1+0x8
-    // s32 nOpcodeNew; // r1+0xC
-
-    // Local variables
-    s32 iHack; // r9
-}
-
-// Range: 0x80035038 -> 0x80035050
-s32 cpuSetDevicePut(struct __anon_0x3EB4F* pDevice, s32 (*pfPut8)(void*, u32, char*), s32 (*pfPut16)(void*, u32, s16*),
-                    s32 (*pfPut32)(void*, u32, s32*), s32 (*pfPut64)(void*, u32, s64*)) {
-    // Parameters
-    // struct __anon_0x3EB4F* pDevice; // r1+0x4
-    // s32 (* pfPut8)(void*, u32, char*); // r1+0x8
-    // s32 (* pfPut16)(void*, u32, s16*); // r1+0xC
-    // s32 (* pfPut32)(void*, u32, s32*); // r1+0x10
-    // s32 (* pfPut64)(void*, u32, s64*); // r1+0x14
-}
-
-// Range: 0x80035050 -> 0x80035068
-s32 cpuSetDeviceGet(struct __anon_0x3EB4F* pDevice, s32 (*pfGet8)(void*, u32, char*), s32 (*pfGet16)(void*, u32, s16*),
-                    s32 (*pfGet32)(void*, u32, s32*), s32 (*pfGet64)(void*, u32, s64*)) {
-    // Parameters
-    // struct __anon_0x3EB4F* pDevice; // r1+0x4
-    // s32 (* pfGet8)(void*, u32, char*); // r1+0x8
-    // s32 (* pfGet16)(void*, u32, s16*); // r1+0xC
-    // s32 (* pfGet32)(void*, u32, s32*); // r1+0x10
-    // s32 (* pfGet64)(void*, u32, s64*); // r1+0x14
-}
-
-// Range: 0x80035068 -> 0x80035218
-s32 cpuMapObject(struct _CPU* pCPU, void* pObject, u32 nAddress0, u32 nAddress1, s32 nType) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-    // void* pObject; // r27
-    // u32 nAddress0; // r28
-    // u32 nAddress1; // r29
-    // s32 nType; // r30
-
-    // Local variables
-    s32 iDevice; // r1+0x24
-    s32 iAddress; // r4
-    u32 nAddressVirtual0; // r5
-    u32 nAddressVirtual1; // r6
-}
-
-// Erased
-static s32 cpuGetOpcodeText() {}
 
 typedef enum __anon_0x43B0A {
     RLM_NONE = -1,
@@ -1348,235 +563,12 @@ typedef enum __anon_0x44829 {
     RUM_IDLE = 1,
 } __anon_0x44829;
 
-// Range: 0x80035218 -> 0x8003522C
-s32 __cpuBreak(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x8003522C -> 0x800352C8
-s32 __cpuERET(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x800352C8 -> 0x80035570
-s32 cpuGetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64* pnData) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // s32 iRegister; // r1+0xC
-    // s64* pnData; // r1+0x10
-
-    // Local variables
-    s32 bFlag; // r1+0x8
-
-    // References
-    // -> static s64 ganMaskGetCP0[32];
-}
-
-// Range: 0x80035570 -> 0x8003573C
-s32 cpuSetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64 nData) {
-    // Parameters
-    // struct _CPU* pCPU; // r26
-    // s32 iRegister; // r27
-    // s64 nData; // r29
-
-    // Local variables
-    s32 bFlag; // r30
-
-    // References
-    // -> static s64 ganMaskSetCP0[32];
-}
-
 typedef enum __anon_0x44AE9 {
     CM_NONE = -1,
     CM_USER = 0,
     CM_SUPER = 1,
     CM_KERNEL = 2,
 } __anon_0x44AE9;
-
-// Range: 0x8003573C -> 0x800357D0
-static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // u64 nStatus; // r31
-
-    // Local variables
-    enum __anon_0x44AE9 eMode; // r1+0x28
-    enum __anon_0x44AE9 eModeLast; // r1+0x24
-    enum __anon_0x42F73 eSize; // r1+0x20
-    enum __anon_0x42F73 eSizeLast; // r1+0x1C
-}
-
-// Erased
-static s32 cpuSetCP0_Config(struct _CPU* pCPU, u32 nConfig) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // u32 nConfig; // r1+0x4
-}
-
-// Range: 0x800357D0 -> 0x80035914
-static s32 cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44AE9* peMode) {
-    // Parameters
-    // u64 nStatus; // r29
-    // enum __anon_0x42F73* peSize; // r30
-    // enum __anon_0x44AE9* peMode; // r31
-
-    // Local variables
-    enum __anon_0x44AE9 eMode; // r1+0x18
-}
-
-// Range: 0x80035914 -> 0x800359EC
-static s32 cpuGetMode(u64 nStatus, enum __anon_0x44AE9* peMode) {
-    // Parameters
-    // u64 nStatus; // r1+0x0
-    // enum __anon_0x44AE9* peMode; // r1+0x8
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_Kernel64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // u64 nAddressVirtual; // r30
-    // u32* pnAddressPhysical; // r31
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_Kernel32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_Super64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_Super32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_User64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-}
-
-// Erased
-static s32 cpuVirtualToPhysical_User32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-}
-
-// Erased
-static s32 cpuFindTLB(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
-
-    // Local variables
-    s32 iEntry; // r12
-    u32 nMask; // r1+0x0
-    u32 nVirtual; // r1+0x0
-}
-
-// Erased
-static s32 cpuGetTLB(struct _CPU* pCPU, s32 iEntry) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 iEntry; // r1+0x4
-}
-
-// Range: 0x800359EC -> 0x80035CD0
-static s32 cpuSetTLB(struct _CPU* pCPU, s32 iEntry) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32 iEntry; // r1+0xC
-
-    // Local variables
-    s32 iDevice; // r1+0x10
-    u32 nMask; // r1+0x8
-    u32 nVirtual; // r27
-    u32 nPhysical; // r30
-}
-
-// Erased
-static s32 cpuCountTLB(struct _CPU* pCPU, s32* pnCount) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-    // s32* pnCount; // r1+0x4
-
-    // Local variables
-    s32 iEntry; // r8
-    s32 nCount; // r9
-}
-
-// Range: 0x80035CD0 -> 0x80035E98
-static s32 cpuMapAddress(struct _CPU* pCPU, s32* piDevice, u32 nVirtual, u32 nPhysical, s32 nSize) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-    // s32* piDevice; // r31
-    // u32 nVirtual; // r28
-    // u32 nPhysical; // r6
-    // s32 nSize; // r29
-
-    // Local variables
-    s32 iDeviceTarget; // r1+0x1C
-    s32 iDeviceSource; // r5
-    u32 nAddressVirtual0; // r5
-    u32 nAddressVirtual1; // r6
-}
-
-// Erased
-static s32 cpuWipeDevices(struct _CPU* pCPU, s32 bFree) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-    // s32 bFree; // r29
-
-    // Local variables
-    s32 iDevice; // r30
-}
-
-// Range: 0x80035E98 -> 0x80035F3C
-static s32 cpuFreeDevice(struct _CPU* pCPU, s32 iDevice) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-    // s32 iDevice; // r30
-
-    // Local variables
-    s32 iAddress; // r4
-}
-
-// Range: 0x80035F3C -> 0x8003604C
-static s32 cpuMakeDevice(struct _CPU* pCPU, s32* piDevice, void* pObject, s32 nOffset, u32 nAddress0, u32 nAddress1,
-                         s32 nType) {
-    // Parameters
-    // struct _CPU* pCPU; // r25
-    // s32* piDevice; // r1+0xC
-    // void* pObject; // r26
-    // s32 nOffset; // r27
-    // u32 nAddress0; // r28
-    // u32 nAddress1; // r29
-    // s32 nType; // r30
-
-    // Local variables
-    struct __anon_0x3EB4F* pDevice; // r1+0x28
-    s32 iDevice; // r31
-}
 
 typedef enum __anon_0x45AE1 {
     CEC_NONE = -1,
@@ -1615,77 +607,32 @@ typedef enum __anon_0x45AE1 {
     CEC_COUNT = 32,
 } __anon_0x45AE1;
 
-// Range: 0x8003604C -> 0x8003630C
-s32 cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, s32 nMaskIP) {
-    // Parameters
-    // struct _CPU* pCPU; // r27
-    // enum __anon_0x45AE1 eCode; // r28
-    // s32 nMaskIP; // r29
-}
-
-// Erased
-static s32 cpuResetInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 nMaskIP; // r1+0x4
-}
-
-// Range: 0x8003630C -> 0x800363E8
-s32 cpuTestInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-    // s32 nMaskIP; // r31
-}
-
 typedef struct _CPU_ADDRESS {
     /* 0x0 */ s32 nN64;
     /* 0x4 */ s32 nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x45F28; // size = 0xC
 
-// Range: 0x800363E8 -> 0x800365C4
-static s32 cpuFindCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressHost) {
+// size = 0x10, address = 0x800ED6C8
+struct _XL_OBJECTTYPE gClassRAM;
+
+// Erased
+static s32 cpuHackIdle(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // s32 nAddressN64; // r1+0xC
-    // s32* pnAddressHost; // r1+0x10
 
     // Local variables
-    s32 iAddress; // r10
-    struct cpu_function* pFunction; // r1+0x8
-    struct _CPU_ADDRESS addressFound; // r1+0x14
-    struct _CPU_ADDRESS* aAddressCache; // r6
-}
-
-// Range: 0x800365C4 -> 0x80036658
-s32 cpuFreeCachedAddress(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 nAddress0; // r1+0x4
-    // s32 nAddress1; // r1+0x8
-
-    // Local variables
-    s32 iAddress; // r10
-    s32 iAddressNext; // r11
-    s32 nAddressN64; // r1+0x0
-    struct _CPU_ADDRESS* aAddressCache; // r12
+    struct __anon_0x3DB14* pSystem; // r3
 }
 
 // Erased
-static s32 cpuMakeCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressHost, struct cpu_function* pFunction) {
+static s32 cpuHackCacheInstruction(struct _CPU* pCPU) {
     // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-    // s32 nAddressN64; // r1+0x4
-    // s32 nAddressHost; // r1+0x8
-    // struct cpu_function* pFunction; // r1+0xC
+    // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 iAddress; // r7
-    struct _CPU_ADDRESS* aAddressCache; // r9
+    u32* pnCode; // r1+0x10
 }
-
-// size = 0x10, address = 0x800ED6C8
-struct _XL_OBJECTTYPE gClassRAM;
 
 // Range: 0x80036658 -> 0x80036870
 static s32 cpuHackHandler(struct _CPU* pCPU) {
@@ -1709,19 +656,1072 @@ static s32 cpuHackHandler(struct _CPU* pCPU) {
 }
 
 // Erased
-static s32 cpuHackCacheInstruction(struct _CPU* pCPU) {
+static s32 cpuMakeCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressHost, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nAddressN64; // r1+0x4
+    // s32 nAddressHost; // r1+0x8
+    // struct cpu_function* pFunction; // r1+0xC
+
+    // Local variables
+    s32 iAddress; // r7
+    struct _CPU_ADDRESS* aAddressCache; // r9
+}
+
+// Range: 0x800365C4 -> 0x80036658
+s32 cpuFreeCachedAddress(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nAddress0; // r1+0x4
+    // s32 nAddress1; // r1+0x8
+
+    // Local variables
+    s32 iAddress; // r10
+    s32 iAddressNext; // r11
+    s32 nAddressN64; // r1+0x0
+    struct _CPU_ADDRESS* aAddressCache; // r12
+}
+
+// Range: 0x800363E8 -> 0x800365C4
+static s32 cpuFindCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressHost) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 nAddressN64; // r1+0xC
+    // s32* pnAddressHost; // r1+0x10
+
+    // Local variables
+    s32 iAddress; // r10
+    struct cpu_function* pFunction; // r1+0x8
+    struct _CPU_ADDRESS addressFound; // r1+0x14
+    struct _CPU_ADDRESS* aAddressCache; // r6
+}
+
+// Range: 0x8003630C -> 0x800363E8
+s32 cpuTestInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 nMaskIP; // r31
+}
+
+// Erased
+static s32 cpuResetInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 nMaskIP; // r1+0x4
+}
+
+// Range: 0x8003604C -> 0x8003630C
+s32 cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, s32 nMaskIP) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+    // enum __anon_0x45AE1 eCode; // r28
+    // s32 nMaskIP; // r29
+}
+
+// Range: 0x80035F3C -> 0x8003604C
+static s32 cpuMakeDevice(struct _CPU* pCPU, s32* piDevice, void* pObject, s32 nOffset, u32 nAddress0, u32 nAddress1,
+                         s32 nType) {
+    // Parameters
+    // struct _CPU* pCPU; // r25
+    // s32* piDevice; // r1+0xC
+    // void* pObject; // r26
+    // s32 nOffset; // r27
+    // u32 nAddress0; // r28
+    // u32 nAddress1; // r29
+    // s32 nType; // r30
+
+    // Local variables
+    struct __anon_0x3EB4F* pDevice; // r1+0x28
+    s32 iDevice; // r31
+}
+
+// Range: 0x80035E98 -> 0x80035F3C
+static s32 cpuFreeDevice(struct _CPU* pCPU, s32 iDevice) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 iDevice; // r30
+
+    // Local variables
+    s32 iAddress; // r4
+}
+
+// Erased
+static s32 cpuWipeDevices(struct _CPU* pCPU, s32 bFree) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 bFree; // r29
+
+    // Local variables
+    s32 iDevice; // r30
+}
+
+// Range: 0x80035CD0 -> 0x80035E98
+static s32 cpuMapAddress(struct _CPU* pCPU, s32* piDevice, u32 nVirtual, u32 nPhysical, s32 nSize) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* piDevice; // r31
+    // u32 nVirtual; // r28
+    // u32 nPhysical; // r6
+    // s32 nSize; // r29
+
+    // Local variables
+    s32 iDeviceTarget; // r1+0x1C
+    s32 iDeviceSource; // r5
+    u32 nAddressVirtual0; // r5
+    u32 nAddressVirtual1; // r6
+}
+
+// Erased
+static s32 cpuCountTLB(struct _CPU* pCPU, s32* pnCount) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32* pnCount; // r1+0x4
+
+    // Local variables
+    s32 iEntry; // r8
+    s32 nCount; // r9
+}
+
+// Range: 0x800359EC -> 0x80035CD0
+static s32 cpuSetTLB(struct _CPU* pCPU, s32 iEntry) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 iEntry; // r1+0xC
+
+    // Local variables
+    s32 iDevice; // r1+0x10
+    u32 nMask; // r1+0x8
+    u32 nVirtual; // r27
+    u32 nPhysical; // r30
+}
+
+// Erased
+static s32 cpuGetTLB(struct _CPU* pCPU, s32 iEntry) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 iEntry; // r1+0x4
+}
+
+// Erased
+static s32 cpuFindTLB(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+
+    // Local variables
+    s32 iEntry; // r12
+    u32 nMask; // r1+0x0
+    u32 nVirtual; // r1+0x0
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_User32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_User64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_Super32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_Super64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_Kernel32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u64 nAddressVirtual; // r1+0x8
+    // u32* pnAddressPhysical; // r1+0x10
+}
+
+// Erased
+static s32 cpuVirtualToPhysical_Kernel64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // u64 nAddressVirtual; // r30
+    // u32* pnAddressPhysical; // r31
+}
+
+// Range: 0x80035914 -> 0x800359EC
+static s32 cpuGetMode(u64 nStatus, enum __anon_0x44AE9* peMode) {
+    // Parameters
+    // u64 nStatus; // r1+0x0
+    // enum __anon_0x44AE9* peMode; // r1+0x8
+}
+
+// Range: 0x800357D0 -> 0x80035914
+static s32 cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44AE9* peMode) {
+    // Parameters
+    // u64 nStatus; // r29
+    // enum __anon_0x42F73* peSize; // r30
+    // enum __anon_0x44AE9* peMode; // r31
+
+    // Local variables
+    enum __anon_0x44AE9 eMode; // r1+0x18
+}
+
+// Erased
+static s32 cpuSetCP0_Config(struct _CPU* pCPU, u32 nConfig) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // u32 nConfig; // r1+0x4
+}
+
+// Range: 0x8003573C -> 0x800357D0
+static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // u64 nStatus; // r31
+
+    // Local variables
+    enum __anon_0x44AE9 eMode; // r1+0x28
+    enum __anon_0x44AE9 eModeLast; // r1+0x24
+    enum __anon_0x42F73 eSize; // r1+0x20
+    enum __anon_0x42F73 eSizeLast; // r1+0x1C
+}
+
+// Range: 0x80035570 -> 0x8003573C
+s32 cpuSetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64 nData) {
+    // Parameters
+    // struct _CPU* pCPU; // r26
+    // s32 iRegister; // r27
+    // s64 nData; // r29
+
+    // Local variables
+    s32 bFlag; // r30
+
+    // References
+    // -> static s64 ganMaskSetCP0[32];
+}
+
+// Range: 0x800352C8 -> 0x80035570
+s32 cpuGetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64* pnData) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 iRegister; // r1+0xC
+    // s64* pnData; // r1+0x10
+
+    // Local variables
+    s32 bFlag; // r1+0x8
+
+    // References
+    // -> static s64 ganMaskGetCP0[32];
+}
+
+// Range: 0x8003522C -> 0x800352C8
+s32 __cpuERET(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80035218 -> 0x8003522C
+s32 __cpuBreak(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Erased
+static s32 cpuGetOpcodeText() {}
+
+// Range: 0x80035068 -> 0x80035218
+s32 cpuMapObject(struct _CPU* pCPU, void* pObject, u32 nAddress0, u32 nAddress1, s32 nType) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // void* pObject; // r27
+    // u32 nAddress0; // r28
+    // u32 nAddress1; // r29
+    // s32 nType; // r30
+
+    // Local variables
+    s32 iDevice; // r1+0x24
+    s32 iAddress; // r4
+    u32 nAddressVirtual0; // r5
+    u32 nAddressVirtual1; // r6
+}
+
+// Range: 0x80035050 -> 0x80035068
+s32 cpuSetDeviceGet(struct __anon_0x3EB4F* pDevice, s32 (*pfGet8)(void*, u32, char*), s32 (*pfGet16)(void*, u32, s16*),
+                    s32 (*pfGet32)(void*, u32, s32*), s32 (*pfGet64)(void*, u32, s64*)) {
+    // Parameters
+    // struct __anon_0x3EB4F* pDevice; // r1+0x4
+    // s32 (* pfGet8)(void*, u32, char*); // r1+0x8
+    // s32 (* pfGet16)(void*, u32, s16*); // r1+0xC
+    // s32 (* pfGet32)(void*, u32, s32*); // r1+0x10
+    // s32 (* pfGet64)(void*, u32, s64*); // r1+0x14
+}
+
+// Range: 0x80035038 -> 0x80035050
+s32 cpuSetDevicePut(struct __anon_0x3EB4F* pDevice, s32 (*pfPut8)(void*, u32, char*), s32 (*pfPut16)(void*, u32, s16*),
+                    s32 (*pfPut32)(void*, u32, s32*), s32 (*pfPut64)(void*, u32, s64*)) {
+    // Parameters
+    // struct __anon_0x3EB4F* pDevice; // r1+0x4
+    // s32 (* pfPut8)(void*, u32, char*); // r1+0x8
+    // s32 (* pfPut16)(void*, u32, s16*); // r1+0xC
+    // s32 (* pfPut32)(void*, u32, s32*); // r1+0x10
+    // s32 (* pfPut64)(void*, u32, s64*); // r1+0x14
+}
+
+// Range: 0x80034FCC -> 0x80035038
+s32 cpuSetCodeHack(struct _CPU* pCPU, s32 nAddress, s32 nOpcodeOld, s32 nOpcodeNew) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 nAddress; // r1+0x4
+    // s32 nOpcodeOld; // r1+0x8
+    // s32 nOpcodeNew; // r1+0xC
+
+    // Local variables
+    s32 iHack; // r9
+}
+
+// Range: 0x80034AE8 -> 0x80034FCC
+s32 cpuReset(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    u32* pnCode; // r1+0x10
+    s32 iRegister; // r1+0x8
+    s32 iTLB; // r1+0x8
+
+    // References
+    // -> void* gHeapTree;
+    // -> u32 aHeapTreeFlag[125];
 }
 
 // Erased
-static s32 cpuHackIdle(struct _CPU* pCPU) {
+static s32 cpuGetXPC(struct _CPU* pCPU, s32* pnPC, s32* pnLo, s32* pnHi) {
     // Parameters
-    // struct _CPU* pCPU; // r1+0x8
+    // struct _CPU* pCPU; // r28
+    // s32* pnPC; // r29
+    // s32* pnLo; // r30
+    // s32* pnHi; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetGPR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
 
     // Local variables
-    struct __anon_0x3DB14* pSystem; // r3
+    s32 iRegister; // r1+0x8
+    enum __anon_0x42F73 eSize; // r1+0x18
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetCP0(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // f64* arRegister; // r30
+    // s32 bDouble; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuGetFCR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Range: 0x80034A6C -> 0x80034AE8
+s32 cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
+    // Parameters
+    // struct _CPU* pCPU; // r26
+    // s64 nPC; // r0
+    // s64 nLo; // r29
+    // s64 nHi; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+    enum __anon_0x42F73 eSize; // r1+0x18
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetCP0(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // f64* arRegister; // r30
+    // s32 bDouble; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Erased
+static s32 cpuSetFCR(struct _CPU* pCPU, s32* anRegister) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // s32* anRegister; // r31
+
+    // Local variables
+    s32 iRegister; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+}
+
+// Range: 0x80034864 -> 0x80034A6C
+s32 cpuEvent(struct _CPU* pCPU, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r1+0x10
+}
+
+// Range: 0x800347F8 -> 0x80034864
+s32 cpuGetAddressOffset(struct _CPU* pCPU, s32* pnOffset, u32 nAddress) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32* pnOffset; // r1+0x4
+    // u32 nAddress; // r1+0x8
+
+    // Local variables
+    s32 iDevice; // r1+0x0
+}
+
+// Range: 0x80034780 -> 0x800347F8
+s32 cpuGetAddressBuffer(struct _CPU* pCPU, void* ppBuffer, u32 nAddress) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // void* ppBuffer; // r4
+    // u32 nAddress; // r5
+
+    // Local variables
+    struct __anon_0x3EB4F* pDevice; // r1+0x8
+}
+
+// Range: 0x800345F0 -> 0x80034780
+s32 cpuGetOffsetAddress(struct _CPU* pCPU, u32* anAddress, s32* pnCount, u32 nOffset, u32 nSize) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // u32* anAddress; // r1+0xC
+    // s32* pnCount; // r1+0x10
+    // u32 nOffset; // r1+0x14
+    // u32 nSize; // r1+0x18
+
+    // Local variables
+    s32 iEntry; // r1+0x8
+    s32 iAddress; // r7
+    u32 nAddress; // r1+0x8
+    u32 nMask; // r1+0x8
+    u32 nSizeMapped; // r26
+}
+
+// Range: 0x80034564 -> 0x800345F0
+s32 cpuInvalidateCache(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 nAddress0; // r30
+    // s32 nAddress1; // r31
+}
+
+// Range: 0x80034324 -> 0x80034564
+s32 cpuGetFunctionChecksum(struct _CPU* pCPU, u32* pnChecksum, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // u32* pnChecksum; // r30
+    // struct cpu_function* pFunction; // r31
+
+    // Local variables
+    s32 nSize; // r10
+    u32* pnBuffer; // r1+0x18
+    u32 nChecksum; // r11
+    u32 nData; // r12
+}
+
+// Range: 0x80034288 -> 0x80034324
+static s32 cpuHeapReset(u32* array, s32 count) {
+    // Parameters
+    // u32* array; // r3
+    // s32 count; // r1+0x4
+
+    // Local variables
+    s32 i; // r6
+}
+
+// Range: 0x80034028 -> 0x80034288
+s32 cpuHeapTake(void* heap, struct _CPU* pCPU, struct cpu_function* pFunction, s32 memory_size) {
+    // Parameters
+    // void* heap; // r3
+    // struct _CPU* pCPU; // r1+0xC
+    // struct cpu_function* pFunction; // r1+0x10
+    // s32 memory_size; // r6
+
+    // Local variables
+    s32 done; // r12
+    s32 second; // r7
+    u32* anPack; // r8
+    s32 nPackCount; // r9
+    s32 nBlockCount; // r10
+    s32 nOffset; // r27
+    s32 nCount; // r26
+    s32 iPack; // r1+0x8
+    u32 nPack; // r25
+    u32 nMask; // r24
+    u32 nMask0; // r23
+}
+
+// Range: 0x80033F3C -> 0x80034028
+s32 cpuHeapFree(struct _CPU* pCPU, struct cpu_function* pFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // struct cpu_function* pFunction; // r4
+
+    // Local variables
+    u32* anPack; // r8
+    s32 iPack; // r1+0x8
+    u32 nMask; // r6
+}
+
+// Range: 0x80033E88 -> 0x80033F3C
+static s32 cpuTreeTake(void* heap, s32* where) {
+    // Parameters
+    // void* heap; // r1+0x0
+    // s32* where; // r1+0x4
+
+    // Local variables
+    s32 done; // r5
+    s32 nOffset; // r8
+    s32 nCount; // r1+0x0
+    s32 iPack; // r1+0x0
+    u32 nPack; // r9
+    u32 nMask; // r10
+    u32 nMask0; // r1+0x0
+
+    // References
+    // -> void* gHeapTree;
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Erased
+static s32 cpuTreeFree(struct cpu_function* pFunction) {
+    // Parameters
+    // struct cpu_function* pFunction; // r1+0x0
+
+    // Local variables
+    u32* anPack; // r1+0x0
+    s32 iPack; // r1+0x0
+    u32 nMask; // r5
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80033304 -> 0x80033E88
+s32 cpuFindFunction(struct _CPU* pCPU, s32 theAddress, struct cpu_function** tree_node) {
+    // Parameters
+    // struct _CPU* pCPU; // r22
+    // s32 theAddress; // r1+0x38
+    // struct cpu_function** tree_node; // r28
+
+    // Local variables
+    struct __anon_0x3EB4F** apDevice; // r26
+    u8* aiDevice; // r27
+    u32 opcode; // r1+0x34
+    u8 follow; // r1+0x3D
+    u8 valid; // r16
+    u8 check; // r1+0x3C
+    u8 end_flag; // r18
+    u8 save_restore; // r14
+    u8 alert; // r15
+    s32 beginAddress; // r21
+    s32 cheat_address; // r17
+    s32 current_address; // r31
+    s32 temp_address; // r30
+    s32 branch; // r1+0x8
+
+    // References
+    // -> static u8 Opcode[64];
+    // -> static u8 RegimmOpcode[32];
+    // -> static u8 SpecialOpcode[64];
+}
+
+// Range: 0x800331A4 -> 0x80033304
+static s32 cpuDMAUpdateFunction(struct _CPU* pCPU, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // s32 start; // r29
+    // s32 end; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 count; // r1+0x8
+    s32 cancel; // r5
+}
+
+// Erased
+static void treeCallerInit(struct cpu_callerID* block, s32 total) {
+    // Parameters
+    // struct cpu_callerID* block; // r3
+    // s32 total; // r1+0x4
+
+    // Local variables
+    s32 count; // r6
+}
+
+// Erased
+static s32 treeCallerKill(struct _CPU* pCPU, struct cpu_function* kill) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_function* kill; // r30
+
+    // Local variables
+    s32 left; // r1+0x14
+    s32 right; // r1+0x10
+    struct cpu_treeRoot* root; // r31
+}
+
+// Range: 0x800330A0 -> 0x800331A4
+static s32 treeCallerCheck(struct _CPU* pCPU, struct cpu_function* tree, s32 flag, s32 nAddress0, s32 nAddress1) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // struct cpu_function* tree; // r25
+    // s32 flag; // r26
+    // s32 nAddress0; // r27
+    // s32 nAddress1; // r28
+
+    // Local variables
+    s32 count; // r30
+    s32 saveGCN; // r6
+    s32 saveN64; // r1+0x8
+    s32* addr_function; // r1+0x8
+    s32* addr_call; // r29
+}
+
+// Range: 0x80033048 -> 0x800330A0
+static s32 treeInit(struct _CPU* pCPU, s32 root_address) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32 root_address; // r1+0x4
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x0
+}
+
+// Range: 0x80032F2C -> 0x80033048
+static s32 treeInitNode(struct cpu_function** tree, struct cpu_function* prev, s32 start, s32 end) {
+    // Parameters
+    // struct cpu_function** tree; // r30
+    // struct cpu_function* prev; // r31
+    // s32 start; // r28
+    // s32 end; // r29
+
+    // Local variables
+    struct cpu_function* node; // r1+0x1C
+    s32 where; // r1+0x18
+}
+
+// Range: 0x80032C84 -> 0x80032F2C
+static s32 treeKill(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 count; // r29
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x800329D4 -> 0x80032C84
+static s32 treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
+    // Parameters
+    // struct _CPU* pCPU; // r24
+    // struct cpu_function* tree; // r25
+
+    // Local variables
+    struct cpu_function* current; // r27
+    struct cpu_function* kill; // r28
+    s32 count; // r26
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80032674 -> 0x800329D4
+static s32 treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct cpu_function* kill) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+    // struct cpu_function** top; // r1+0xC
+    // struct cpu_function* kill; // r31
+
+    // Local variables
+    struct cpu_treeRoot* root; // r3
+    struct cpu_function* save1; // r5
+    struct cpu_function* save2; // r8
+    struct cpu_function* connect; // r1+0x8
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Erased
+static s32 treeRebuild(struct _CPU* pCPU, s32 start_address, struct cpu_function** node) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 start_address; // r30
+    // struct cpu_function** node; // r31
+}
+
+// Erased
+static s32 treeInsertAndReturn(struct _CPU* pCPU, s32 start, s32 end, struct cpu_function** ppFunction) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 start; // r28
+    // s32 end; // r29
+    // struct cpu_function** ppFunction; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+    s32 flag; // r3
+}
+
+// Range: 0x80032558 -> 0x80032674
+s32 treeInsert(struct _CPU* pCPU, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // s32 start; // r29
+    // s32 end; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+    struct cpu_function* current; // r1+0x14
+    s32 flag; // r3
+}
+
+// Range: 0x80032470 -> 0x80032558
+static s32 treeInsertNode(struct cpu_function** tree, s32 start, s32 end, struct cpu_function** ppFunction) {
+    // Parameters
+    // struct cpu_function** tree; // r31
+    // s32 start; // r8
+    // s32 end; // r7
+    // struct cpu_function** ppFunction; // r30
+
+    // Local variables
+    struct cpu_function** current; // r31
+    struct cpu_function* prev; // r4
+}
+
+// Range: 0x800322D8 -> 0x80032470
+static s32 treeBalance(struct cpu_treeRoot* root) {
+    // Parameters
+    // struct cpu_treeRoot* root; // r1+0x0
+
+    // Local variables
+    struct cpu_function* tree; // r8
+    struct cpu_function* current; // r4
+    struct cpu_function* save; // r6
+    s32 total; // r9
+    s32 count; // r7
+}
+
+// Range: 0x800320EC -> 0x800322D8
+static s32 treeAdjustRoot(struct _CPU* pCPU, s32 new_end) {
+    // Parameters
+    // struct _CPU* pCPU; // r23
+    // s32 new_end; // r24
+
+    // Local variables
+    s32 old_root; // r1+0x8
+    s32 new_root; // r30
+    s32 kill_start; // r29
+    s32 check1; // r1+0x8
+    s32 check2; // r28
+    u16 total; // r27
+    s32 total_memory; // r26
+    s32 address; // r22
+    struct cpu_treeRoot* root; // r25
+    struct cpu_function* node; // r1+0x18
+    struct cpu_function* change; // r1+0x14
+}
+
+// Erased
+static s32 treeSearch(struct _CPU* pCPU, s32 target, struct cpu_function** node) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+    // s32 target; // r4
+    // struct cpu_function** node; // r5
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 flag; // r3
+}
+
+// Range: 0x80032088 -> 0x800320EC
+static s32 treeSearchNode(struct cpu_function* tree, s32 target, struct cpu_function** node) {
+    // Parameters
+    // struct cpu_function* tree; // r3
+    // s32 target; // r1+0x4
+    // struct cpu_function** node; // r1+0x8
+
+    // Local variables
+    struct cpu_function* current; // r3
+}
+
+// Range: 0x800318F0 -> 0x80032088
+static s32 treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, s32 start, s32 end) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+    // struct cpu_function* tree; // r24
+    // s32 start; // r25
+    // s32 end; // r26
+
+    // Local variables
+    struct cpu_treeRoot* root; // r29
+    struct cpu_function* node1; // r1+0x3C
+    struct cpu_function* node2; // r1+0x38
+    struct cpu_function* save1; // r3
+    struct cpu_function* save2; // r4
+    struct cpu_function* connect; // r5
+    s32 update; // r28
+    s32 count; // r27
+
+    // References
+    // -> u32 aHeapTreeFlag[125];
+}
+
+// Range: 0x80031860 -> 0x800318F0
+static s32 treeKillReason(struct _CPU* pCPU, s32* value) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+    // s32* value; // r1+0x4
+}
+
+// Range: 0x8003174C -> 0x80031860
+static s32 treeTimerCheck(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 begin; // r1+0x10
+    s32 end; // r1+0xC
+}
+
+// Erased
+static s32 treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_function* node; // r30
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+}
+
+// Range: 0x8003161C -> 0x8003174C
+static s32 treeCleanUp(struct _CPU* pCPU, struct cpu_treeRoot* root) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // struct cpu_treeRoot* root; // r31
+
+    // Local variables
+    s32 done; // r3
+    s32 complete; // r30
+}
+
+// Range: 0x8003133C -> 0x8003161C
+static s32 treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+    // struct cpu_function* top; // r1+0xC
+
+    // Local variables
+    struct cpu_function** current; // r30
+    struct cpu_function* kill; // r29
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 kill_limit; // r28
+}
+
+// Erased
+static s32 treeForceCleanUp(struct _CPU* pCPU, struct cpu_function* node, s32 kill_value) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+    // struct cpu_function* node; // r1+0xC
+    // s32 kill_value; // r5
+
+    // Local variables
+    struct cpu_treeRoot* root; // r31
+}
+
+// Range: 0x80031168 -> 0x8003133C
+static s32 treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, s32 kill_limit) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+    // struct cpu_function* tree; // r1+0xC
+    // s32 kill_limit; // r29
+
+    // Local variables
+    struct cpu_function* current; // r31
+    struct cpu_function* kill; // r30
+}
+
+// Erased
+static s32 treePrint(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    struct cpu_treeRoot* root; // r1+0x8
+    s32 left; // r1+0x10
+    s32 right; // r1+0xC
+}
+
+// Range: 0x80030F84 -> 0x80031168
+static s32 treePrintNode(struct _CPU* pCPU, struct cpu_function* tree, s32 print_flag, s32* left, s32* right) {
+    // Parameters
+    // struct _CPU* pCPU; // r21
+    // struct cpu_function* tree; // r22
+    // s32 print_flag; // r1+0x10
+    // s32* left; // r23
+    // s32* right; // r24
+
+    // Local variables
+    struct cpu_function* current; // r27
+    s32 flag; // r26
+    s32 level; // r25
+
+    // References
+    // -> s32 ganMapGPR[32];
+}
+
+// Erased
+static s32 treeMemory(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80030E70 -> 0x80030F84
+static s32 cpuOpcodeChecksum(u32 opcode) {
+    // Parameters
+    // u32 opcode; // r1+0x0
+
+    // Local variables
+    s32 flag; // r5
+}
+
+// Erased
+static s32 cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, s32 start) {
+    // Parameters
+    // struct cpu_disk_node* pDisk; // r30
+    // s32 start; // r4
+
+    // Local variables
+    s32 count; // r1+0x8
+    s32 instruction; // r1+0x8
+    u32* last; // r31
+    u32* current; // r1+0x10
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
+}
+
+// Erased
+static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instruction) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+    // s32 startAddress; // r30
+    // s32 instruction; // r31
+
+    // Local variables
+    s32 iHack; // r1+0x8
+    u32* opcode; // r1+0x14
+}
+
+// Erased
+static s32 cpuUpdateDiskChecksum(u32* checksum, s32 startAddress, s32 endAddress) {
+    // Parameters
+    // u32* checksum; // r29
+    // s32 startAddress; // r4
+    // s32 endAddress; // r1+0x10
+
+    // Local variables
+    s32 count; // r31
+    s32 instruction; // r30
+    s32 check; // r1+0x8
+    u32* opcode; // r1+0x14
+    u32 part; // r27
+
+    // References
+    // -> struct __anon_0x3DB14* gpSystem;
 }

--- a/debug/Fire/disk.c
+++ b/debug/Fire/disk.c
@@ -21,55 +21,22 @@ typedef struct __anon_0x73B29 {
     /* 0x0 */ void* pHost;
 } __anon_0x73B29; // size = 0x4
 
-// Range: 0x8008D788 -> 0x8008D924
-s32 diskEvent(struct __anon_0x73B29* pDisk, s32 nEvent, void* pArgument) {
+// Range: 0x8008DA14 -> 0x8008DA1C
+static s32 diskPutROM8() {}
+
+// Range: 0x8008DA0C -> 0x8008DA14
+static s32 diskPutROM16() {}
+
+// Range: 0x8008DA04 -> 0x8008DA0C
+static s32 diskPutROM32() {}
+
+// Range: 0x8008D9FC -> 0x8008DA04
+static s32 diskPutROM64() {}
+
+// Range: 0x8008D9EC -> 0x8008D9FC
+static s32 diskGetROM8(char* pData) {
     // Parameters
-    // struct __anon_0x73B29* pDisk; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Range: 0x8008D924 -> 0x8008D92C
-static s32 diskGetDrive64() {}
-
-// Range: 0x8008D92C -> 0x8008D964
-static s32 diskGetDrive32(u32 nAddress, s32* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8008D964 -> 0x8008D96C
-static s32 diskGetDrive16() {}
-
-// Range: 0x8008D96C -> 0x8008D974
-static s32 diskGetDrive8() {}
-
-// Range: 0x8008D974 -> 0x8008D97C
-static s32 diskPutDrive64() {}
-
-// Range: 0x8008D97C -> 0x8008D9A8
-static s32 diskPutDrive32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x8008D9A8 -> 0x8008D9B0
-static s32 diskPutDrive16() {}
-
-// Range: 0x8008D9B0 -> 0x8008D9B8
-static s32 diskPutDrive8() {}
-
-// Range: 0x8008D9B8 -> 0x8008D9CC
-static s32 diskGetROM64(s64* pData) {
-    // Parameters
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8008D9CC -> 0x8008D9DC
-static s32 diskGetROM32(s32* pData) {
-    // Parameters
-    // s32* pData; // r1+0x8
+    // char* pData; // r1+0x8
 }
 
 // Range: 0x8008D9DC -> 0x8008D9EC
@@ -78,20 +45,53 @@ static s32 diskGetROM16(s16* pData) {
     // s16* pData; // r1+0x8
 }
 
-// Range: 0x8008D9EC -> 0x8008D9FC
-static s32 diskGetROM8(char* pData) {
+// Range: 0x8008D9CC -> 0x8008D9DC
+static s32 diskGetROM32(s32* pData) {
     // Parameters
-    // char* pData; // r1+0x8
+    // s32* pData; // r1+0x8
 }
 
-// Range: 0x8008D9FC -> 0x8008DA04
-static s32 diskPutROM64() {}
+// Range: 0x8008D9B8 -> 0x8008D9CC
+static s32 diskGetROM64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
+}
 
-// Range: 0x8008DA04 -> 0x8008DA0C
-static s32 diskPutROM32() {}
+// Range: 0x8008D9B0 -> 0x8008D9B8
+static s32 diskPutDrive8() {}
 
-// Range: 0x8008DA0C -> 0x8008DA14
-static s32 diskPutROM16() {}
+// Range: 0x8008D9A8 -> 0x8008D9B0
+static s32 diskPutDrive16() {}
 
-// Range: 0x8008DA14 -> 0x8008DA1C
-static s32 diskPutROM8() {}
+// Range: 0x8008D97C -> 0x8008D9A8
+static s32 diskPutDrive32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
+
+// Range: 0x8008D974 -> 0x8008D97C
+static s32 diskPutDrive64() {}
+
+// Range: 0x8008D96C -> 0x8008D974
+static s32 diskGetDrive8() {}
+
+// Range: 0x8008D964 -> 0x8008D96C
+static s32 diskGetDrive16() {}
+
+// Range: 0x8008D92C -> 0x8008D964
+static s32 diskGetDrive32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8008D924 -> 0x8008D92C
+static s32 diskGetDrive64() {}
+
+// Range: 0x8008D788 -> 0x8008D924
+s32 diskEvent(struct __anon_0x73B29* pDisk, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x73B29* pDisk; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}

--- a/debug/Fire/flash.c
+++ b/debug/Fire/flash.c
@@ -24,49 +24,17 @@ typedef struct __anon_0x7428F {
     /* 0xC */ s32 flashStatus;
 } __anon_0x7428F; // size = 0x10
 
-// Range: 0x8008DA1C -> 0x8008DB3C
-s32 flashEvent(struct __anon_0x7428F* pFLASH, s32 nEvent, void* pArgument) {
+// Range: 0x8008DFF4 -> 0x8008E138
+s32 flashCopyFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nOffsetFLASH, s32 nSize) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Range: 0x8008DB3C -> 0x8008DB44
-static s32 flashGet64() {}
-
-// Range: 0x8008DB44 -> 0x8008DBE8
-static s32 flashGet32(struct __anon_0x7428F* pFLASH, s32* pData) {
-    // Parameters
-    // struct __anon_0x7428F* pFLASH; // r1+0x0
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8008DBE8 -> 0x8008DBF0
-static s32 flashGet16() {}
-
-// Range: 0x8008DBF0 -> 0x8008DBF8
-static s32 flashGet8() {}
-
-// Range: 0x8008DBF8 -> 0x8008DC00
-static s32 flashPut64() {}
-
-// Range: 0x8008DC00 -> 0x8008DED0
-static s32 flashPut32(struct __anon_0x7428F* pFLASH, s32* pData) {
-    // Parameters
-    // struct __anon_0x7428F* pFLASH; // r30
-    // s32* pData; // r31
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetFLASH; // r31
+    // s32 nSize; // r1+0x14
 
     // Local variables
-    s32 i; // r1+0x8
-    char buffer[128]; // r1+0x1C
+    void* pTarget; // r1+0x18
 }
-
-// Range: 0x8008DED0 -> 0x8008DED8
-static s32 flashPut16() {}
-
-// Range: 0x8008DED8 -> 0x8008DEE0
-static s32 flashPut8() {}
 
 // Range: 0x8008DEE0 -> 0x8008DFF4
 s32 flashTransferFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nSize) {
@@ -80,14 +48,46 @@ s32 flashTransferFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nSize)
     s32 i; // r4
 }
 
-// Range: 0x8008DFF4 -> 0x8008E138
-s32 flashCopyFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nOffsetFLASH, s32 nSize) {
+// Range: 0x8008DED8 -> 0x8008DEE0
+static s32 flashPut8() {}
+
+// Range: 0x8008DED0 -> 0x8008DED8
+static s32 flashPut16() {}
+
+// Range: 0x8008DC00 -> 0x8008DED0
+static s32 flashPut32(struct __anon_0x7428F* pFLASH, s32* pData) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r30
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetFLASH; // r31
-    // s32 nSize; // r1+0x14
+    // s32* pData; // r31
 
     // Local variables
-    void* pTarget; // r1+0x18
+    s32 i; // r1+0x8
+    char buffer[128]; // r1+0x1C
+}
+
+// Range: 0x8008DBF8 -> 0x8008DC00
+static s32 flashPut64() {}
+
+// Range: 0x8008DBF0 -> 0x8008DBF8
+static s32 flashGet8() {}
+
+// Range: 0x8008DBE8 -> 0x8008DBF0
+static s32 flashGet16() {}
+
+// Range: 0x8008DB44 -> 0x8008DBE8
+static s32 flashGet32(struct __anon_0x7428F* pFLASH, s32* pData) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r1+0x0
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8008DB3C -> 0x8008DB44
+static s32 flashGet64() {}
+
+// Range: 0x8008DA1C -> 0x8008DB3C
+s32 flashEvent(struct __anon_0x7428F* pFLASH, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7428F* pFLASH; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/frame.c
+++ b/debug/Fire/frame.c
@@ -225,14 +225,6 @@ typedef struct __anon_0x239BA {
     /* 0x8 */ f32 z;
 } __anon_0x239BA; // size = 0xC
 
-// Range: 0x8001D34C -> 0x8001D39C
-void PSMTX44MultVecNoW(f32 (*m)[4], struct __anon_0x239BA* src, struct __anon_0x239BA* dst) {
-    // Parameters
-    // f32 (* m)[4]; // r3
-    // struct __anon_0x239BA* src; // r4
-    // struct __anon_0x239BA* dst; // r5
-}
-
 typedef struct __anon_0x23B04 {
     /* 0x0 */ f32 rX;
     /* 0x4 */ f32 rY;
@@ -476,79 +468,11 @@ typedef struct __anon_0x25A82 {
     /* 0x4 */ s32 nCountTextures;
 } __anon_0x25A82; // size = 0x8
 
-// Range: 0x8001D39C -> 0x8001D4B8
-s32 frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // struct __anon_0x25A82* pInfo; // r1+0xC
-
-    // Local variables
-    struct _FRAME_TEXTURE* pTexture; // r10
-    s32 iTexture; // r5
-    s32 nCount; // r6
-    s32 nSize; // r1+0x8
-}
-
-// Range: 0x8001D4B8 -> 0x8001D624
-s32 frameInvalidateCache(struct __anon_0x24C38* pFrame, s32 nOffset0, s32 nOffset1) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r25
-    // s32 nOffset0; // r1+0xC
-    // s32 nOffset1; // r1+0x10
-
-    // Local variables
-    s32 iTexture0; // r28
-    s32 iTexture1; // r27
-    struct _FRAME_TEXTURE* pTexture; // r23
-    struct _FRAME_TEXTURE* pTextureNext; // r26
-}
-
 typedef enum __anon_0x25D5E {
     FMP_NONE = -1,
     FMP_PERSPECTIVE = 0,
     FMP_ORTHOGRAPHIC = 1,
 } __anon_0x25D5E;
-
-// Range: 0x8001D624 -> 0x8001D740
-s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, s32 nAddressFloat,
-                       s32 nAddressFixed, f32 rNear, f32 rFar, f32 rFOVY, f32 rAspect, f32 rScale) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // enum __anon_0x25D5E eProjection; // r1+0x4
-    // s32 nAddressFloat; // r5
-    // s32 nAddressFixed; // r6
-    // f32 rNear; // f1
-    // f32 rFar; // r1+0x14
-    // f32 rFOVY; // r1+0x18
-    // f32 rAspect; // r1+0x1C
-    // f32 rScale; // r1+0x20
-
-    // Local variables
-    s32 iHint; // r10
-}
-
-// Erased
-static s32 frameGetMatrixHint(struct __anon_0x24C38* pFrame, u32 nAddress, s32* piHint) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // u32 nAddress; // r1+0x4
-    // s32* piHint; // r1+0x8
-
-    // Local variables
-    s32 iHint; // r8
-}
-
-// Range: 0x8001D740 -> 0x8001D7F8
-s32 frameFixMatrixHint(struct __anon_0x24C38* pFrame, s32 nAddressFloat, s32 nAddressFixed) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r3
-    // s32 nAddressFloat; // r1+0x4
-    // s32 nAddressFixed; // r1+0x8
-
-    // Local variables
-    s32 iHint; // r8
-    s32 iHintTest; // r9
-}
 
 typedef enum __anon_0x2614E {
     FBT_NONE = -1,
@@ -559,68 +483,11 @@ typedef enum __anon_0x2614E {
     FBT_COUNT = 4,
 } __anon_0x2614E;
 
-// Range: 0x8001D7F8 -> 0x8001D830
-s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // enum __anon_0x2614E eType; // r1+0x4
-}
-
 typedef enum __anon_0x2625D {
     FRT_NONE = -1,
     FRT_COLD = 0,
     FRT_WARM = 1,
 } __anon_0x2625D;
-
-// Range: 0x8001D830 -> 0x8001D8E0
-s32 frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // enum __anon_0x2625D eType; // r1+0x4
-
-    // Local variables
-    s32 iMode; // r6
-}
-
-// Range: 0x8001D8E0 -> 0x8001DA74
-s32 frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // s16* pData; // r1+0xC
-
-    // Local variables
-    s32 iScale; // r1+0x8
-    f32 rY; // f1
-    f32 rSizeX; // f3
-    f32 rSizeY; // r1+0x8
-    f32 arScale[3]; // r1+0x28
-}
-
-// Range: 0x8001DA74 -> 0x8001DB24
-s32 frameSetLookAt(struct __anon_0x24C38* pFrame, s32 iLookAt, char* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 iLookAt; // r1+0x4
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8001DB24 -> 0x8001DC4C
-s32 frameSetLight(struct __anon_0x24C38* pFrame, s32 iLight, char* pData) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // s32 iLight; // r1+0xC
-    // char* pData; // r1+0x10
-
-    // Local variables
-    struct __anon_0x23CAB* pLight; // r6
-}
-
-// Range: 0x8001DC4C -> 0x8001DC58
-s32 frameSetLightCount(struct __anon_0x24C38* pFrame, s32 nCount) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nCount; // r1+0x4
-}
 
 typedef enum __anon_0x266CE {
     SM_NONE = -1,
@@ -696,74 +563,6 @@ typedef enum __anon_0x26C3F {
     FLT_BLOCK = 1,
 } __anon_0x26C3F;
 
-// Range: 0x8001DC58 -> 0x8001EBA0
-s32 frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, s32 iTile) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // enum __anon_0x26C3F eType; // r30
-    // s32 iTile; // r31
-
-    // Local variables
-    s32 bFlip; // r10
-    s32 iTMEM; // r5
-    s32 nSize; // r6
-    s32 nStep; // r11
-    s32 nDelta; // r12
-    s32 iScan; // r12
-    s32 nOffset; // r7
-    struct __anon_0x247BF* pTile; // r1+0x8
-    u8 nData8; // r30
-    u16 nData16; // r30
-    u32 nData32; // r30
-    u32 nSum; // r1+0x8
-    u64* pSource; // r4
-    s32 nCount; // r6
-    s32 nScanFull; // r7
-    s32 nScanPart; // r8
-    u8* pSource8; // r31
-    u16* pSource16; // r31
-    u32* pSource32; // r31
-
-    // References
-    // -> struct __anon_0x26A4E* gpSystem;
-}
-
-// Range: 0x8001EBA0 -> 0x8001EC80
-s32 frameLoadTLUT(struct __anon_0x24C38* pFrame, s32 nCount, s32 iTile) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // s32 nCount; // r1+0xC
-    // s32 iTile; // r1+0x10
-
-    // Local variables
-    s32 iTMEM; // r28
-    s32 nSize; // r27
-    u32 nSum; // r26
-    u64 nData64; // r25
-    u16 nData16; // r3
-    u16* pSource; // r31
-    s32 tileNum; // r4
-}
-
-// Range: 0x8001EC80 -> 0x8001EDCC
-s32 frameCullDL(struct __anon_0x24C38* pFrame, s32 nVertexStart, s32 nVertexEnd) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nVertexStart; // r1+0x4
-    // s32 nVertexEnd; // r1+0x8
-
-    // Local variables
-    f32 rX; // r1+0x0
-    f32 rY; // f2
-    f32 rZ; // f1
-    f32 rW; // r1+0x0
-    f32(*matrix)[4]; // r5
-    struct __anon_0x23FC4* vtxP; // r6
-    struct __anon_0x23FC4* endVtxP; // r4
-    s32 nCode; // r1+0x0
-    s32 nCodeFull; // r7
-}
-
 // size = 0x0, address = 0x800F3E78
 s32 __float_nan[];
 
@@ -776,98 +575,10 @@ typedef struct __anon_0x274AD {
     /* 0x8 */ f32 z;
 } __anon_0x274AD; // size = 0xC
 
-// Range: 0x8001EDCC -> 0x8001F850
-s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // void* pBuffer; // r4
-    // s32 iVertex0; // r20
-    // s32 nCount; // r31
-
-    // Local variables
-    f32 mag; // f5
-    s32 iLight; // r29
-    s32 nLight; // r28
-    s32 nTexGen; // r27
-    f32 colorS; // f7
-    f32 colorT; // f6
-    f32 rS; // f8
-    f32 rT; // f9
-    f32 arNormal[3]; // r1+0x40
-    f32 arPosition[3]; // r1+0x34
-    struct __anon_0x23FC4* pVertex; // r8
-    u32 nData32; // r12
-    struct __anon_0x23CAB* aLight; // r26
-    struct __anon_0x23CAB* pLight; // r25
-    s32 iVertex1; // r1+0x8
-    f32 rScale; // r1+0x8
-    f32 rScaleST; // r1+0x8
-    char* pnData8; // r24
-    s16* pnData16; // r23
-    f32(*matrixView)[4]; // r22
-    f32(*matrixModel)[4]; // r21
-    f32 rColorR; // f7
-    f32 rColorG; // f8
-    f32 rColorB; // f9
-    f32 rDiffuse; // f27
-    f32 rInverseW; // f6
-    f32 rInverseLength; // r1+0x8
-    struct __anon_0x274AD vec; // r1+0x28
-    f32 distance; // r1+0x8
-
-    // References
-    // -> struct __anon_0x26A4E* gpSystem;
-    // -> s32 __float_huge[];
-    // -> s32 __float_nan[];
-}
-
-// Erased
-static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, f32* prX, f32* prY, f32* prZ) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 iVertex; // r1+0x4
-    // f32* prX; // r1+0x8
-    // f32* prY; // r1+0xC
-    // f32* prZ; // r1+0x10
-
-    // Local variables
-    f32 rW; // r1+0x0
-    struct __anon_0x23FC4* pVertex; // r8
-}
-
 typedef enum __anon_0x27B8C {
     FMT_MODELVIEW = 0,
     FMT_PROJECTION = 1,
 } __anon_0x27B8C;
-
-// Range: 0x8001F850 -> 0x8001F970
-s32 frameGetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bPull) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r30
-    // f32 (* matrix)[4]; // r7
-    // enum __anon_0x27B8C eType; // r1+0x10
-    // s32 bPull; // r31
-}
-
-// Range: 0x8001F970 -> 0x8001FFFC
-s32 frameSetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bLoad, s32 bPush,
-                   s32 nAddressN64) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // f32 (* matrix)[4]; // r30
-    // enum __anon_0x27B8C eType; // r26
-    // s32 bLoad; // r28
-    // s32 bPush; // r27
-    // s32 nAddressN64; // r31
-
-    // Local variables
-    s32 bFlag; // r28
-    f32(*matrixTarget)[4]; // r3
-    f32 matrixResult[4][4]; // r1+0x48
-
-    // References
-    // -> struct __anon_0x26A4E* gpSystem;
-}
 
 typedef enum __anon_0x27E96 {
     FMT_NONE = -1,
@@ -884,85 +595,12 @@ typedef enum __anon_0x27E96 {
     FMT_COUNT = 10,
 } __anon_0x27E96;
 
-// Range: 0x8001FFFC -> 0x80020014
-s32 frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32* pnMode) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // enum __anon_0x27E96 eType; // r1+0x4
-    // u32* pnMode; // r1+0x8
-}
-
-// Range: 0x80020014 -> 0x800201A8
-s32 frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32 nMode) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // enum __anon_0x27E96 eType; // r1+0x4
-    // u32 nMode; // r1+0x8
-
-    // Local variables
-    u32 nFlag; // r8
-    u32 nModeChanged; // r9
-}
-
 typedef enum __anon_0x2813A {
     FS_NONE = -1,
     FS_SOURCE = 0,
     FS_TARGET = 1,
     FS_COUNT = 2,
 } __anon_0x2813A;
-
-// Erased
-static s32 frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32* pnSizeX, s32* pnSizeY) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // enum __anon_0x2813A eSize; // r1+0x4
-    // s32* pnSizeX; // r1+0x8
-    // s32* pnSizeY; // r1+0xC
-}
-
-// Range: 0x800201A8 -> 0x800202D0
-s32 frameSetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32 nSizeX, s32 nSizeY) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x8
-    // enum __anon_0x2813A eSize; // r1+0xC
-    // s32 nSizeX; // r1+0x10
-    // s32 nSizeY; // r1+0x14
-}
-
-// Erased
-static s32 frameGetWire(struct __anon_0x24C38* pFrame, s32* pbWire) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32* pbWire; // r1+0x4
-}
-
-// Erased
-static s32 frameSetWire(struct __anon_0x24C38* pFrame, s32 bWire) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 bWire; // r1+0x4
-}
-
-// Erased
-static s32 frameGetFill(struct __anon_0x24C38* pFrame, s32* pbFill) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32* pbFill; // r1+0x4
-}
-
-// Range: 0x800202D0 -> 0x800202FC
-s32 frameSetFill(struct __anon_0x24C38* pFrame, s32 bFill) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 bFill; // r1+0x4
-}
-
-// Range: 0x800202FC -> 0x80020340
-s32 frameDrawReset(struct __anon_0x24C38* pFrame, s32 nFlag) {
-    // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nFlag; // r1+0x4
-}
 
 typedef struct __anon_0x285E5 {
     /* 0x0 */ s32 shift;
@@ -1615,44 +1253,115 @@ typedef enum _GXFogType {
 } __anon_0x2D8A4;
 
 // Erased
-static s32 frameUpdateTrackBuffer() {}
-
-// Erased
-static s32 frameCheckTrackBuffer() {}
-
-// Erased
-static s32 frameSetupTrackBuffer() {}
-
-// Range: 0x80020340 -> 0x80020764
-static s32 frameLoadTile(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture, s32 iTileCode) {
+static s32 frameVectorTimesMatrix(f32* fOutVector, f32* fInVector, f32 (*matrix)[4]) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r29
-    // struct _FRAME_TEXTURE** ppTexture; // r30
-    // s32 iTileCode; // r31
+    // f32* fOutVector; // r1+0x4
+    // f32* fInVector; // r1+0x8
+    // f32 (* matrix)[4]; // r1+0xC
+}
 
-    // Local variables
-    s32 bFlag; // r27
-    struct __anon_0x247BF* pTile; // r26
-    struct _FRAME_TEXTURE* pTexture; // r1+0x18
-    struct _FRAME_TEXTURE* pTextureLast; // r25
-    u32 nData0; // r24
-    u32 nData1; // r23
-    u32 nData2; // r22
-    u32 nData3; // r21
-    s32 iTexture; // r1+0x8
-    s32 nShift; // r3
+// Range: 0x8002113C -> 0x80021204
+s32 frameScaleMatrix(f32 (*matrixResult)[4], f32 (*matrix)[4], f32 rScale) {
+    // Parameters
+    // f32 (* matrixResult)[4]; // r1+0x0
+    // f32 (* matrix)[4]; // r1+0x4
+    // f32 rScale; // r1+0x8
 }
 
 // Erased
-static s32 frameMultiTexture(struct __anon_0x24C38* pFrame) {
+static s32 frameConcatenateMatrix(f32 (*matrixResult)[4], f32 (*matrixA)[4], f32 (*matrixB)[4]) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // f32 (* matrixResult)[4]; // r1+0x8
+    // f32 (* matrixA)[4]; // r4
+    // f32 (* matrixB)[4]; // r5
+}
+
+// Range: 0x80021070 -> 0x8002113C
+static s32 frameConvertYUVtoRGB(u32* YUV, u32* RGB) {
+    // Parameters
+    // u32* YUV; // r1+0x0
+    // u32* RGB; // r1+0x4
 
     // Local variables
-    s32 iMode; // r5
-    s32 iType; // r1+0x0
-    s32 nMode; // r1+0x0
-    s32 nUsed; // r6
+    s32 Yl; // r7
+    s32 R; // r1+0x0
+    s32 G; // r5
+    s32 B; // r8
+}
+
+// Range: 0x80020FA4 -> 0x80021070
+static s32 packTakeBlocks(s32* piPack, u32* anPack, s32 nPackCount, s32 nBlockCount) {
+    // Parameters
+    // s32* piPack; // r1+0x0
+    // u32* anPack; // r4
+    // s32 nPackCount; // r5
+    // s32 nBlockCount; // r1+0xC
+
+    // Local variables
+    s32 nOffset; // r9
+    s32 nCount; // r10
+    s32 iPack; // r11
+    u32 nPack; // r5
+    u32 nMask; // r12
+    u32 nMask0; // r7
+}
+
+// Range: 0x80020F3C -> 0x80020FA4
+static s32 packFreeBlocks(s32* piPack, u32* anPack) {
+    // Parameters
+    // s32* piPack; // r1+0x0
+    // u32* anPack; // r1+0x4
+
+    // Local variables
+    s32 iPack; // r1+0x0
+    u32 nMask; // r7
+}
+
+// Erased
+static s32 packReset(u32* anPack, s32 nPackCount) {
+    // Parameters
+    // u32* anPack; // r3
+    // s32 nPackCount; // r1+0x4
+
+    // Local variables
+    s32 iPack; // r7
+}
+
+// Range: 0x80020E20 -> 0x80020F3C
+static s32 frameMakeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r3
+    // struct _FRAME_TEXTURE** ppTexture; // r1+0xC
+
+    // Local variables
+    u32 nMask; // r5
+    s32 iTexture; // r9
+    s32 iTextureUsed; // r8
+}
+
+// Erased
+static s32 frameFreeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
+    // struct _FRAME_TEXTURE* pTexture; // r29
+
+    // Local variables
+    s32 iTexture; // r30
+}
+
+// Range: 0x80020958 -> 0x80020E20
+static s32 frameSetupCache(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+
+    // Local variables
+    s32 iTexture; // r1+0x8
+}
+
+// Erased
+static s32 frameResetCache(struct __anon_0x24C38* pFrame) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r31
 }
 
 // Range: 0x80020764 -> 0x80020958
@@ -1675,113 +1384,404 @@ static s32 frameUpdateCache(struct __anon_0x24C38* pFrame) {
 }
 
 // Erased
-static s32 frameResetCache(struct __anon_0x24C38* pFrame) {
+static s32 frameMultiTexture(struct __anon_0x24C38* pFrame) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+
+    // Local variables
+    s32 iMode; // r5
+    s32 iType; // r1+0x0
+    s32 nMode; // r1+0x0
+    s32 nUsed; // r6
 }
 
-// Range: 0x80020958 -> 0x80020E20
-static s32 frameSetupCache(struct __anon_0x24C38* pFrame) {
+// Range: 0x80020340 -> 0x80020764
+static s32 frameLoadTile(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture, s32 iTileCode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // struct _FRAME_TEXTURE** ppTexture; // r30
+    // s32 iTileCode; // r31
+
+    // Local variables
+    s32 bFlag; // r27
+    struct __anon_0x247BF* pTile; // r26
+    struct _FRAME_TEXTURE* pTexture; // r1+0x18
+    struct _FRAME_TEXTURE* pTextureLast; // r25
+    u32 nData0; // r24
+    u32 nData1; // r23
+    u32 nData2; // r22
+    u32 nData3; // r21
+    s32 iTexture; // r1+0x8
+    s32 nShift; // r3
+}
+
+// Erased
+static s32 frameSetupTrackBuffer() {}
+
+// Erased
+static s32 frameCheckTrackBuffer() {}
+
+// Erased
+static s32 frameUpdateTrackBuffer() {}
+
+// Range: 0x800202FC -> 0x80020340
+s32 frameDrawReset(struct __anon_0x24C38* pFrame, s32 nFlag) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nFlag; // r1+0x4
+}
+
+// Range: 0x800202D0 -> 0x800202FC
+s32 frameSetFill(struct __anon_0x24C38* pFrame, s32 bFill) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 bFill; // r1+0x4
+}
+
+// Erased
+static s32 frameGetFill(struct __anon_0x24C38* pFrame, s32* pbFill) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32* pbFill; // r1+0x4
+}
+
+// Erased
+static s32 frameSetWire(struct __anon_0x24C38* pFrame, s32 bWire) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 bWire; // r1+0x4
+}
+
+// Erased
+static s32 frameGetWire(struct __anon_0x24C38* pFrame, s32* pbWire) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32* pbWire; // r1+0x4
+}
+
+// Range: 0x800201A8 -> 0x800202D0
+s32 frameSetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32 nSizeX, s32 nSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // enum __anon_0x2813A eSize; // r1+0xC
+    // s32 nSizeX; // r1+0x10
+    // s32 nSizeY; // r1+0x14
+}
+
+// Erased
+static s32 frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32* pnSizeX, s32* pnSizeY) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2813A eSize; // r1+0x4
+    // s32* pnSizeX; // r1+0x8
+    // s32* pnSizeY; // r1+0xC
+}
+
+// Range: 0x80020014 -> 0x800201A8
+s32 frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32 nMode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x27E96 eType; // r1+0x4
+    // u32 nMode; // r1+0x8
+
+    // Local variables
+    u32 nFlag; // r8
+    u32 nModeChanged; // r9
+}
+
+// Range: 0x8001FFFC -> 0x80020014
+s32 frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32* pnMode) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x27E96 eType; // r1+0x4
+    // u32* pnMode; // r1+0x8
+}
+
+// Range: 0x8001F970 -> 0x8001FFFC
+s32 frameSetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bLoad, s32 bPush,
+                   s32 nAddressN64) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // f32 (* matrix)[4]; // r30
+    // enum __anon_0x27B8C eType; // r26
+    // s32 bLoad; // r28
+    // s32 bPush; // r27
+    // s32 nAddressN64; // r31
+
+    // Local variables
+    s32 bFlag; // r28
+    f32(*matrixTarget)[4]; // r3
+    f32 matrixResult[4][4]; // r1+0x48
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+}
+
+// Range: 0x8001F850 -> 0x8001F970
+s32 frameGetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bPull) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
-
-    // Local variables
-    s32 iTexture; // r1+0x8
+    // f32 (* matrix)[4]; // r7
+    // enum __anon_0x27B8C eType; // r1+0x10
+    // s32 bPull; // r31
 }
 
 // Erased
-static s32 frameFreeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, f32* prX, f32* prY, f32* prZ) {
     // Parameters
-    // struct __anon_0x24C38* pFrame; // r31
-    // struct _FRAME_TEXTURE* pTexture; // r29
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 iVertex; // r1+0x4
+    // f32* prX; // r1+0x8
+    // f32* prY; // r1+0xC
+    // f32* prZ; // r1+0x10
 
     // Local variables
-    s32 iTexture; // r30
+    f32 rW; // r1+0x0
+    struct __anon_0x23FC4* pVertex; // r8
 }
 
-// Range: 0x80020E20 -> 0x80020F3C
-static s32 frameMakeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture) {
+// Range: 0x8001EDCC -> 0x8001F850
+s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // void* pBuffer; // r4
+    // s32 iVertex0; // r20
+    // s32 nCount; // r31
+
+    // Local variables
+    f32 mag; // f5
+    s32 iLight; // r29
+    s32 nLight; // r28
+    s32 nTexGen; // r27
+    f32 colorS; // f7
+    f32 colorT; // f6
+    f32 rS; // f8
+    f32 rT; // f9
+    f32 arNormal[3]; // r1+0x40
+    f32 arPosition[3]; // r1+0x34
+    struct __anon_0x23FC4* pVertex; // r8
+    u32 nData32; // r12
+    struct __anon_0x23CAB* aLight; // r26
+    struct __anon_0x23CAB* pLight; // r25
+    s32 iVertex1; // r1+0x8
+    f32 rScale; // r1+0x8
+    f32 rScaleST; // r1+0x8
+    char* pnData8; // r24
+    s16* pnData16; // r23
+    f32(*matrixView)[4]; // r22
+    f32(*matrixModel)[4]; // r21
+    f32 rColorR; // f7
+    f32 rColorG; // f8
+    f32 rColorB; // f9
+    f32 rDiffuse; // f27
+    f32 rInverseW; // f6
+    f32 rInverseLength; // r1+0x8
+    struct __anon_0x274AD vec; // r1+0x28
+    f32 distance; // r1+0x8
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+    // -> s32 __float_huge[];
+    // -> s32 __float_nan[];
+}
+
+// Range: 0x8001EC80 -> 0x8001EDCC
+s32 frameCullDL(struct __anon_0x24C38* pFrame, s32 nVertexStart, s32 nVertexEnd) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nVertexStart; // r1+0x4
+    // s32 nVertexEnd; // r1+0x8
+
+    // Local variables
+    f32 rX; // r1+0x0
+    f32 rY; // f2
+    f32 rZ; // f1
+    f32 rW; // r1+0x0
+    f32(*matrix)[4]; // r5
+    struct __anon_0x23FC4* vtxP; // r6
+    struct __anon_0x23FC4* endVtxP; // r4
+    s32 nCode; // r1+0x0
+    s32 nCodeFull; // r7
+}
+
+// Range: 0x8001EBA0 -> 0x8001EC80
+s32 frameLoadTLUT(struct __anon_0x24C38* pFrame, s32 nCount, s32 iTile) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r30
+    // s32 nCount; // r1+0xC
+    // s32 iTile; // r1+0x10
+
+    // Local variables
+    s32 iTMEM; // r28
+    s32 nSize; // r27
+    u32 nSum; // r26
+    u64 nData64; // r25
+    u16 nData16; // r3
+    u16* pSource; // r31
+    s32 tileNum; // r4
+}
+
+// Range: 0x8001DC58 -> 0x8001EBA0
+s32 frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, s32 iTile) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r29
+    // enum __anon_0x26C3F eType; // r30
+    // s32 iTile; // r31
+
+    // Local variables
+    s32 bFlip; // r10
+    s32 iTMEM; // r5
+    s32 nSize; // r6
+    s32 nStep; // r11
+    s32 nDelta; // r12
+    s32 iScan; // r12
+    s32 nOffset; // r7
+    struct __anon_0x247BF* pTile; // r1+0x8
+    u8 nData8; // r30
+    u16 nData16; // r30
+    u32 nData32; // r30
+    u32 nSum; // r1+0x8
+    u64* pSource; // r4
+    s32 nCount; // r6
+    s32 nScanFull; // r7
+    s32 nScanPart; // r8
+    u8* pSource8; // r31
+    u16* pSource16; // r31
+    u32* pSource32; // r31
+
+    // References
+    // -> struct __anon_0x26A4E* gpSystem;
+}
+
+// Range: 0x8001DC4C -> 0x8001DC58
+s32 frameSetLightCount(struct __anon_0x24C38* pFrame, s32 nCount) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 nCount; // r1+0x4
+}
+
+// Range: 0x8001DB24 -> 0x8001DC4C
+s32 frameSetLight(struct __anon_0x24C38* pFrame, s32 iLight, char* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // s32 iLight; // r1+0xC
+    // char* pData; // r1+0x10
+
+    // Local variables
+    struct __anon_0x23CAB* pLight; // r6
+}
+
+// Range: 0x8001DA74 -> 0x8001DB24
+s32 frameSetLookAt(struct __anon_0x24C38* pFrame, s32 iLookAt, char* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // s32 iLookAt; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8001D8E0 -> 0x8001DA74
+s32 frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x8
+    // s16* pData; // r1+0xC
+
+    // Local variables
+    s32 iScale; // r1+0x8
+    f32 rY; // f1
+    f32 rSizeX; // f3
+    f32 rSizeY; // r1+0x8
+    f32 arScale[3]; // r1+0x28
+}
+
+// Range: 0x8001D830 -> 0x8001D8E0
+s32 frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2625D eType; // r1+0x4
+
+    // Local variables
+    s32 iMode; // r6
+}
+
+// Range: 0x8001D7F8 -> 0x8001D830
+s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
+    // Parameters
+    // struct __anon_0x24C38* pFrame; // r1+0x0
+    // enum __anon_0x2614E eType; // r1+0x4
+}
+
+// Range: 0x8001D740 -> 0x8001D7F8
+s32 frameFixMatrixHint(struct __anon_0x24C38* pFrame, s32 nAddressFloat, s32 nAddressFixed) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
-    // struct _FRAME_TEXTURE** ppTexture; // r1+0xC
+    // s32 nAddressFloat; // r1+0x4
+    // s32 nAddressFixed; // r1+0x8
 
     // Local variables
-    u32 nMask; // r5
-    s32 iTexture; // r9
-    s32 iTextureUsed; // r8
+    s32 iHint; // r8
+    s32 iHintTest; // r9
 }
 
 // Erased
-static s32 packReset(u32* anPack, s32 nPackCount) {
+static s32 frameGetMatrixHint(struct __anon_0x24C38* pFrame, u32 nAddress, s32* piHint) {
     // Parameters
-    // u32* anPack; // r3
-    // s32 nPackCount; // r1+0x4
+    // struct __anon_0x24C38* pFrame; // r3
+    // u32 nAddress; // r1+0x4
+    // s32* piHint; // r1+0x8
 
     // Local variables
-    s32 iPack; // r7
+    s32 iHint; // r8
 }
 
-// Range: 0x80020F3C -> 0x80020FA4
-static s32 packFreeBlocks(s32* piPack, u32* anPack) {
+// Range: 0x8001D624 -> 0x8001D740
+s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, s32 nAddressFloat,
+                       s32 nAddressFixed, f32 rNear, f32 rFar, f32 rFOVY, f32 rAspect, f32 rScale) {
     // Parameters
-    // s32* piPack; // r1+0x0
-    // u32* anPack; // r1+0x4
+    // struct __anon_0x24C38* pFrame; // r3
+    // enum __anon_0x25D5E eProjection; // r1+0x4
+    // s32 nAddressFloat; // r5
+    // s32 nAddressFixed; // r6
+    // f32 rNear; // f1
+    // f32 rFar; // r1+0x14
+    // f32 rFOVY; // r1+0x18
+    // f32 rAspect; // r1+0x1C
+    // f32 rScale; // r1+0x20
 
     // Local variables
-    s32 iPack; // r1+0x0
-    u32 nMask; // r7
+    s32 iHint; // r10
 }
 
-// Range: 0x80020FA4 -> 0x80021070
-static s32 packTakeBlocks(s32* piPack, u32* anPack, s32 nPackCount, s32 nBlockCount) {
+// Range: 0x8001D4B8 -> 0x8001D624
+s32 frameInvalidateCache(struct __anon_0x24C38* pFrame, s32 nOffset0, s32 nOffset1) {
     // Parameters
-    // s32* piPack; // r1+0x0
-    // u32* anPack; // r4
-    // s32 nPackCount; // r5
-    // s32 nBlockCount; // r1+0xC
+    // struct __anon_0x24C38* pFrame; // r25
+    // s32 nOffset0; // r1+0xC
+    // s32 nOffset1; // r1+0x10
 
     // Local variables
-    s32 nOffset; // r9
-    s32 nCount; // r10
-    s32 iPack; // r11
-    u32 nPack; // r5
-    u32 nMask; // r12
-    u32 nMask0; // r7
+    s32 iTexture0; // r28
+    s32 iTexture1; // r27
+    struct _FRAME_TEXTURE* pTexture; // r23
+    struct _FRAME_TEXTURE* pTextureNext; // r26
 }
 
-// Range: 0x80021070 -> 0x8002113C
-static s32 frameConvertYUVtoRGB(u32* YUV, u32* RGB) {
+// Range: 0x8001D39C -> 0x8001D4B8
+s32 frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
     // Parameters
-    // u32* YUV; // r1+0x0
-    // u32* RGB; // r1+0x4
+    // struct __anon_0x24C38* pFrame; // r3
+    // struct __anon_0x25A82* pInfo; // r1+0xC
 
     // Local variables
-    s32 Yl; // r7
-    s32 R; // r1+0x0
-    s32 G; // r5
-    s32 B; // r8
+    struct _FRAME_TEXTURE* pTexture; // r10
+    s32 iTexture; // r5
+    s32 nCount; // r6
+    s32 nSize; // r1+0x8
 }
 
-// Erased
-static s32 frameConcatenateMatrix(f32 (*matrixResult)[4], f32 (*matrixA)[4], f32 (*matrixB)[4]) {
+// Range: 0x8001D34C -> 0x8001D39C
+void PSMTX44MultVecNoW(f32 (*m)[4], struct __anon_0x239BA* src, struct __anon_0x239BA* dst) {
     // Parameters
-    // f32 (* matrixResult)[4]; // r1+0x8
-    // f32 (* matrixA)[4]; // r4
-    // f32 (* matrixB)[4]; // r5
-}
-
-// Range: 0x8002113C -> 0x80021204
-s32 frameScaleMatrix(f32 (*matrixResult)[4], f32 (*matrix)[4], f32 rScale) {
-    // Parameters
-    // f32 (* matrixResult)[4]; // r1+0x0
-    // f32 (* matrix)[4]; // r1+0x4
-    // f32 rScale; // r1+0x8
-}
-
-// Erased
-static s32 frameVectorTimesMatrix(f32* fOutVector, f32* fInVector, f32 (*matrix)[4]) {
-    // Parameters
-    // f32* fOutVector; // r1+0x4
-    // f32* fInVector; // r1+0x8
-    // f32 (* matrix)[4]; // r1+0xC
+    // f32 (* m)[4]; // r3
+    // struct __anon_0x239BA* src; // r4
+    // struct __anon_0x239BA* dst; // r5
 }

--- a/debug/Fire/library.c
+++ b/debug/Fire/library.c
@@ -245,156 +245,6 @@ typedef struct __anon_0x7AE26 {
     /* 0x40 */ s32 anAddress[10];
 } __anon_0x7AE26; // size = 0x68
 
-// Range: 0x8008F0F4 -> 0x8008F234
-s32 libraryEvent(struct __anon_0x7AE26* pLibrary, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r1+0x10
-
-    // References
-    // -> struct __anon_0x7AD10 gaFunction[54];
-}
-
-// Range: 0x8008F234 -> 0x8008F32C
-s32 libraryCall(struct __anon_0x7AE26* pLibrary, struct _CPU* pCPU, s32 iFunction) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r29
-    // struct _CPU* pCPU; // r30
-    // s32 iFunction; // r31
-
-    // References
-    // -> struct __anon_0x7AD10 gaFunction[54];
-}
-
-// Range: 0x8008F32C -> 0x8008F420
-s32 libraryFunctionReplaced(s32 iFunction) {
-    // Parameters
-    // s32 iFunction; // r1+0x4
-
-    // References
-    // -> struct __anon_0x7AD10 gaFunction[54];
-}
-
-// Erased
-static s32 libraryUpdate(struct __anon_0x7AE26* pLibrary) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r31
-
-    // Local variables
-    struct _CPU* pCPU; // r29
-    struct cpu_function* pFunction; // r1+0xC
-}
-
-// Range: 0x8008F420 -> 0x8008F584
-static s32 librarySearch(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r29
-    // struct cpu_function* pFunction; // r30
-}
-
-// Range: 0x8008F584 -> 0x8008FB6C
-s32 libraryTestFunction(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r30
-    // struct cpu_function* pFunction; // r26
-
-    // Local variables
-    s32 iFunction; // r31
-    s32 iData; // r24
-    s32 bFlag; // r29
-    s32 bDone; // r27
-    s32 bReturn; // r21
-    u32 iCode; // r5
-    u32* pnCode; // r1+0x1C
-    u32* pnCodeTemp; // r1+0x18
-    u32 nSizeCode; // r1+0x8
-    u32 nChecksum; // r1+0x14
-    u32 nOpcode; // r1+0x8
-    u32 nAddress; // r1+0x8
-
-    // References
-    // -> struct __anon_0x7AD10 gaFunction[54];
-}
-
-// Erased
-static s32 libraryCheckHandler(struct __anon_0x7AE26* pLibrary, s32 bException) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r31
-    // s32 bException; // r4
-}
-
-// Range: 0x8008FB6C -> 0x8009007C
-static s32 libraryFindFunctions(struct __anon_0x7AE26* pLibrary) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r24
-
-    // Local variables
-    struct _CPU* pCPU; // r3
-    s32 iFunction; // r29
-    struct __anon_0x79A22** apDevice; // r28
-    u8* aiDevice; // r27
-    u32 nOpcode; // r1+0x10
-    u32* pnCode; // r1+0xC
-    u32 nAddress; // r29
-    u32 nAddressLast; // r31
-    u32 nAddressEnqueueThread; // r26
-    u32 nAddressDispatchThread; // r25
-
-    // References
-    // -> struct __anon_0x7AD10 gaFunction[54];
-}
-
-// Range: 0x8009007C -> 0x800907B0
-static s32 libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r24
-
-    // Local variables
-    struct _CPU* pCPU; // r27
-    struct __anon_0x79A22** apDevice; // r26
-    u8* aiDevice; // r25
-    u32 nAddress; // r23
-    u32 nAddressLast; // r28
-    u32 nOffset; // r1+0x28
-    u32 nOpcode; // r1+0x24
-    u32 anCode[6]; // r1+0xC
-}
-
-// Range: 0x800907B0 -> 0x80090AB0
-static s32 libraryFindException(struct __anon_0x7AE26* pLibrary, s32 bException) {
-    // Parameters
-    // struct __anon_0x7AE26* pLibrary; // r27
-    // s32 bException; // r28
-
-    // Local variables
-    struct _CPU* pCPU; // r30
-    struct __anon_0x79A22** apDevice; // r29
-    u8* aiDevice; // r31
-    u32 anCode[6]; // r1+0x10
-}
-
-// Range: 0x80090AB0 -> 0x80090AC4
-s32 zeldaLoadSZS_Exit(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x80090AC4 -> 0x80090AD8
-s32 zeldaLoadSZS_Entry(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x80090AD8 -> 0x80090B40
-s32 osViSwapBuffer_Entry(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-
-    // References
-    // -> static u32 nAddress$605;
-}
-
 typedef struct __anon_0x7BB81 {
     /* 0x0 */ f32 f_odd;
     /* 0x4 */ f32 f_even;
@@ -498,128 +348,6 @@ typedef struct __anon_0x7C62D {
     /* 0x14 */ void* piHandle;
 } __anon_0x7C62D; // size = 0x18
 
-// Range: 0x80090B40 -> 0x80090C68
-s32 dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    void* pTarget; // r1+0x18
-    struct OSMesgQueue_s* mq; // r1+0x14
-    u32* msg; // r1+0x10
-    struct __anon_0x7C62D* pIOMessage; // r1+0xC
-    s32 first; // r30
-    s32 msgCount; // r29
-    s32 validCount; // r28
-    s32 nSize; // r6
-    s32 nAddress; // r5
-    s32 nOffsetRAM; // r5
-    s32 nOffsetROM; // r5
-}
-
-// Range: 0x80090C68 -> 0x80090C78
-s32 pictureSnap_Zelda2(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x80090C78 -> 0x80090DE0
-s32 starfoxCopy(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r25
-
-    // Local variables
-    s32* A0; // r1+0x18
-    s32 A1; // r31
-    s32 A2; // r30
-    s32 A3; // r29
-    s32 T0; // r28
-    s32 T1; // r24
-    s32 T2; // r1+0x8
-    s32 T3; // r23
-    s32 T8; // r27
-    s32 T9; // r26
-    s16* pData16; // r1+0x14
-    char* source; // r1+0x10
-    char* target; // r1+0xC
-}
-
-// Range: 0x80090DE0 -> 0x80090E8C
-s32 osEepromLongWrite(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-
-    // Local variables
-    s32 length; // r31
-    s32 ret; // r30
-    u8 address; // r29
-    u8* buffer; // r1+0xC
-}
-
-// Range: 0x80090E8C -> 0x80090F38
-s32 osEepromLongRead(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r28
-
-    // Local variables
-    s32 length; // r31
-    s32 ret; // r30
-    u8 address; // r29
-    u8* buffer; // r1+0xC
-}
-
-// Range: 0x80090F38 -> 0x80090FB0
-s32 osEepromWrite(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-
-    // Local variables
-    u8 address; // r31
-    u8* buffer; // r1+0xC
-}
-
-// Range: 0x80090FB0 -> 0x80091028
-s32 osEepromRead(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-
-    // Local variables
-    u8 address; // r31
-    u8* buffer; // r1+0xC
-}
-
-// Range: 0x80091028 -> 0x80091100
-s32 __osEepStatus(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32 ret; // r5
-    s32 nSize; // r1+0x10
-    u8* status; // r1+0xC
-}
-
-// Range: 0x80091100 -> 0x8009120C
-s32 osAiSetNextBuffer(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-
-    // Local variables
-    u32 size; // r31
-    u32 nData32; // r1+0x10
-}
-
-// Range: 0x8009120C -> 0x80091338
-s32 osAiSetFrequency(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    u32 dacRate; // r1+0x8
-    u8 bitRate; // r28
-    u32 nData32; // r1+0x10
-}
-
 typedef struct __anon_0x7D115 {
     /* 0x0 */ u8 col[3];
     /* 0x3 */ char pad1;
@@ -650,69 +378,6 @@ typedef union __anon_0x7D2DB {
     /* 0x0 */ u64 u64;
 } __anon_0x7D2DB;
 
-// Range: 0x80091338 -> 0x8009190C
-void guLookAtReflect(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    struct __anon_0x7D2A5* l; // r1+0x70
-    s32 i; // r7
-    s32 j; // r1+0x8
-    s32 e1; // r5
-    s32 e2; // r8
-    union __anon_0x7D2DB data; // r1+0x68
-    f32 mf[4][4]; // r1+0x28
-    u32* m; // r1+0x24
-    u32* sp; // r1+0x20
-    s32* ai; // r9
-    s32* af; // r10
-    f32 xEye; // f3
-    f32 yEye; // f4
-    f32 zEye; // f5
-    f32 xAt; // r1+0x8
-    f32 yAt; // r1+0x8
-    f32 zAt; // f1
-    f32 xUp; // r1+0x8
-    f32 yUp; // f1
-    f32 zUp; // f2
-    f32 len; // f9
-    f32 xLook; // f6
-    f32 yLook; // f7
-    f32 zLook; // f8
-    f32 xRight; // f9
-    f32 yRight; // f10
-    f32 zRight; // f11
-}
-
-// Range: 0x8009190C -> 0x80091E60
-void guLookAtReflectF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    struct __anon_0x7D2A5* l; // r1+0x28
-    union __anon_0x7D2DB data; // r1+0x20
-    u32* mf; // r1+0x1C
-    u32* sp; // r1+0x18
-    f32 xEye; // f3
-    f32 yEye; // f4
-    f32 zEye; // f5
-    f32 xAt; // r1+0x8
-    f32 yAt; // r1+0x8
-    f32 zAt; // f1
-    f32 xUp; // r1+0x8
-    f32 yUp; // f1
-    f32 zUp; // f2
-    f32 len; // f9
-    f32 xLook; // f6
-    f32 yLook; // f7
-    f32 zLook; // f8
-    f32 xRight; // f9
-    f32 yRight; // f10
-    f32 zRight; // f11
-}
-
 typedef struct __anon_0x7DB47 {
     /* 0x0 */ s32 x1;
     /* 0x4 */ s32 y1;
@@ -724,283 +389,6 @@ typedef union __anon_0x7DBF9 {
     /* 0x0 */ struct __anon_0x7DB47 h;
     /* 0x0 */ s32 force_structure_alignment[4];
 } __anon_0x7DBF9;
-
-// Range: 0x80091E60 -> 0x80092834
-void guLookAtHilite(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    struct __anon_0x7D2A5* l; // r1+0x84
-    union __anon_0x7DBF9* h; // r1+0x80
-    s32 i; // r7
-    s32 j; // r1+0x8
-    s32 e1; // r5
-    s32 e2; // r8
-    union __anon_0x7D2DB data; // r1+0x78
-    f32 mf[4][4]; // r1+0x38
-    u32* m; // r1+0x34
-    u32* sp; // r1+0x30
-    s32* ai; // r9
-    s32* af; // r10
-    f32 len; // f5
-    f32 xLook; // r1+0x8
-    f32 yLook; // f1
-    f32 zLook; // f2
-    f32 xRight; // f3
-    f32 yRight; // f4
-    f32 zRight; // f5
-    f32 xHilite; // f29
-    f32 yHilite; // f28
-    f32 zHilite; // f27
-    f32 xEye; // f6
-    f32 yEye; // f7
-    f32 zEye; // f8
-    f32 xAt; // r1+0x8
-    f32 yAt; // f1
-    f32 zAt; // f2
-    f32 xUp; // f3
-    f32 yUp; // f12
-    f32 zUp; // f4
-    f32 xl1; // f27
-    f32 yl1; // f28
-    f32 zl1; // f26
-    f32 xl2; // f9
-    f32 yl2; // f10
-    f32 zl2; // f11
-    s32 twidth; // r6
-    s32 theight; // r7
-}
-
-// Range: 0x80092834 -> 0x80093188
-void guLookAtHiliteF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    struct __anon_0x7D2A5* l; // r1+0x3C
-    union __anon_0x7DBF9* h; // r1+0x38
-    union __anon_0x7D2DB data; // r1+0x30
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
-    f32 len; // f5
-    f32 xLook; // r1+0x8
-    f32 yLook; // f1
-    f32 zLook; // f2
-    f32 xRight; // f3
-    f32 yRight; // f4
-    f32 zRight; // f5
-    f32 xHilite; // f29
-    f32 yHilite; // f28
-    f32 zHilite; // f27
-    f32 xEye; // f6
-    f32 yEye; // f7
-    f32 zEye; // f8
-    f32 xAt; // r1+0x8
-    f32 yAt; // f1
-    f32 zAt; // f2
-    f32 xUp; // f3
-    f32 yUp; // f12
-    f32 zUp; // f4
-    f32 xl1; // f27
-    f32 yl1; // f28
-    f32 zl1; // f26
-    f32 xl2; // f9
-    f32 yl2; // f10
-    f32 zl2; // f11
-    s32 twidth; // r6
-    s32 theight; // r7
-}
-
-// Erased
-static s32 __float2int(f32 x) {
-    // Parameters
-    // f32 x; // r1+0x8
-}
-
-// Range: 0x80093188 -> 0x800935A0
-void guLookAt(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    f32 mf[4][4]; // r1+0x30
-    s32* m; // r1+0x2C
-    u32* sp; // r1+0x28
-    union __anon_0x7D2DB data; // r1+0x20
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
-    s32* ai; // r9
-    s32* af; // r10
-    f32 len; // f6
-    f32 xLook; // f3
-    f32 yLook; // f4
-    f32 zLook; // f5
-    f32 xRight; // f6
-    f32 yRight; // f7
-    f32 zRight; // f8
-    f32 xEye; // f9
-    f32 yEye; // f10
-    f32 zEye; // f11
-    f32 xAt; // r1+0x8
-    f32 yAt; // r1+0x8
-    f32 zAt; // f1
-    f32 xUp; // r1+0x8
-    f32 yUp; // f1
-    f32 zUp; // f2
-}
-
-// Range: 0x800935A0 -> 0x8009392C
-void guLookAtF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    f32 len; // f9
-    f32 xAt; // r1+0x8
-    f32 yAt; // r1+0x8
-    f32 zAt; // f1
-    f32 xUp; // r1+0x8
-    f32 yUp; // f1
-    f32 zUp; // f2
-    f32 xEye; // f3
-    f32 yEye; // f4
-    f32 zEye; // f5
-    u32* mf; // r1+0x34
-    u32* sp; // r1+0x30
-    f32 xLook; // f6
-    f32 yLook; // f7
-    f32 zLook; // f8
-    f32 xRight; // f9
-    f32 yRight; // f10
-    f32 zRight; // f11
-    union __anon_0x7D2DB data; // r1+0x28
-    union __anon_0x7D2DB data0; // r1+0x20
-    union __anon_0x7D2DB data1; // r1+0x18
-}
-
-// Range: 0x8009392C -> 0x80093C78
-void guRotate(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32* m; // r1+0x64
-    u32* sp; // r1+0x60
-    union __anon_0x7D2DB data; // r1+0x58
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
-    f32 mf[4][4]; // r1+0x18
-    f32 sine; // r1+0x8
-    f32 cosine; // r1+0x8
-    f32 a; // f30
-    f32 x; // f29
-    f32 y; // f28
-    f32 z; // f27
-    f32 ab; // f13
-    f32 bc; // f30
-    f32 ca; // f29
-    f32 t; // f26
-    f32 magnitude; // f2
-    s32* ai; // r9
-    s32* af; // r10
-
-    // References
-    // -> static f32 dtor$480;
-}
-
-// Range: 0x80093C78 -> 0x80093F88
-void guRotateF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    f32 m; // f2
-    s32 i; // r8
-    s32 j; // r4
-    f32 a; // f31
-    f32 x; // f30
-    f32 y; // f29
-    f32 z; // f28
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
-    union __anon_0x7D2DB data; // r1+0x20
-    union __anon_0x7D2DB data0; // r1+0x18
-    union __anon_0x7D2DB data1; // r1+0x10
-    f32 sine; // r1+0x8
-    f32 cosine; // r1+0x8
-    f32 ab; // f27
-    f32 bc; // f26
-    f32 ca; // f25
-    f32 t; // f4
-
-    // References
-    // -> static f32 dtor$466;
-}
-
-// Range: 0x80093F88 -> 0x80094174
-void guTranslate(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32* m; // r1+0x60
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
-    union __anon_0x7D2DB data; // r1+0x58
-    f32 mf[4][4]; // r1+0x14
-    s32* ai; // r9
-    s32* af; // r10
-}
-
-// Range: 0x80094174 -> 0x80094294
-void guTranslateF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32 i; // r8
-    s32 j; // r4
-    u32* mf; // r1+0x20
-    union __anon_0x7D2DB data0; // r1+0x18
-    union __anon_0x7D2DB data1; // r1+0x10
-}
-
-// Range: 0x80094294 -> 0x80094480
-void guScale(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    f32 mf[4][4]; // r1+0x24
-    s32* m; // r1+0x20
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
-    union __anon_0x7D2DB data; // r1+0x18
-    s32* ai; // r9
-    s32* af; // r10
-}
-
-// Range: 0x80094480 -> 0x800945A8
-void guScaleF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    s32 i; // r8
-    s32 j; // r4
-    u32* mf; // r1+0x20
-    union __anon_0x7D2DB data0; // r1+0x18
-    union __anon_0x7D2DB data1; // r1+0x10
-}
 
 typedef struct __anon_0x7F9D8 {
     /* 0x0 */ f32 rX;
@@ -1270,66 +658,276 @@ typedef struct __anon_0x80DBD {
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x80DBD; // size = 0x3D150
 
-// Range: 0x800945A8 -> 0x80094658
-void GenPerspective_1080(struct _CPU* pCPU) {
+// Range: 0x80096AB8 -> 0x8009779C
+static s32 __osException(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    s32 iBit; // r3
+    struct __anon_0x7AE26* pLibrary; // r1+0x8
+    s64 nData64; // r1+0x28
+    s64 nCause; // r1+0x20
+    struct __OSThread_s* __osRunningThread; // r1+0x18
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
+    u32 nStatus; // r22
+    u32 nStatusRSP; // r1+0x14
+    u32 nData32; // r1+0x10
+    u32 __OSGlobalIntMask; // r23
+    u32 nS0; // r18
+    u32 nS1; // r17
+    u32 nMask; // r1+0xC
+}
+
+// Range: 0x80096728 -> 0x80096AB8
+static s32 send_mesg(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r28
+
+    // Local variables
+    struct __anon_0x7AE26* pLibrary; // r1+0x8
+    struct __anon_0x79A22** apDevice; // r30
+    u8* aiDevice; // r29
+}
+
+// Range: 0x8009643C -> 0x80096728
+static s32 __osEnqueueAndYield(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
     // Local variables
-    union __anon_0x7D2DB data; // r1+0x18
-    u32* mf; // r1+0x10
-    u32* sp; // r1+0xC
-    f32 fovy; // f3
-    f32 aspect; // f4
-    f32 rNear; // f1
-    f32 rFar; // f2
-    struct __anon_0x80DBD* pFrame; // r31
+    s64 nData64; // r1+0x18
+    struct __anon_0x7AE26* pLibrary; // r3
+    struct __OSThread_s* __osRunningThread; // r1+0x10
+    u32 __OSGlobalIntMask; // r31
+    u32 nStatus; // r1+0x8
+    u32 nData32; // r5
+    u32 nMask; // r1+0xC
+    struct __anon_0x79A22** apDevice; // r6
+    u8* aiDevice; // r7
 }
 
-// Range: 0x80094658 -> 0x8009491C
-void guPerspective(struct _CPU* pCPU) {
+// Range: 0x80096214 -> 0x8009643C
+static s32 __osEnqueueThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
+}
+
+// Range: 0x80096140 -> 0x80096214
+static s32 __osPopThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    struct __anon_0x79A22** apDevice; // r31
+    u8* aiDevice; // r30
+}
+
+// Range: 0x80095B9C -> 0x80096140
+static s32 __osDispatchThread(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r27
+
+    // Local variables
+    struct __anon_0x7AE26* pLibrary; // r29
+    u32 nAddress; // r5
+    u64 nData64; // r0
+    struct __OSThread_s* __osRunningThread; // r1+0x10
+    u32 nData32; // r1+0xC
+    u32 __OSGlobalIntMask; // r28
+    u32 nStatus; // r6
+    u32 nMask; // r6
+
+    // References
+    // -> static u32 __osRcpImTable[64];
+}
+
+// Erased
+static s32 __ptException() {}
+
+// Range: 0x80095B48 -> 0x80095B9C
+static s32 osGetMemSize(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32* m; // r1+0x60
-    f32 fovy; // f30
-    f32 aspect; // f29
-    f32 rNear; // f28
-    f32 rFar; // f27
-    f32 scale; // f5
-    f32 _cot; // f2
-    s32 i; // r6
+    u32 nSize; // r1+0xC
+}
+
+// Range: 0x80095AC0 -> 0x80095B48
+static s32 osInvalICache(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r29
+
+    // Local variables
+    u32 nAddress; // r30
+    u32 nSize; // r1+0x8
+}
+
+// Range: 0x80095A30 -> 0x80095AC0
+static s32 __osDisableInt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u32 nStatus; // r1+0x8
+    u64 nData64; // r1+0x18
+}
+
+// Range: 0x800959A4 -> 0x80095A30
+static s32 __osRestoreInt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    u64 nStatus; // r1+0x10
+}
+
+// Range: 0x80095954 -> 0x800959A4
+static s32 __osSpSetStatus(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+
+    // Local variables
+    u32 nData32; // r1+0xC
+}
+
+// Range: 0x80095920 -> 0x80095954
+static void __cosf(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+}
+
+// Range: 0x800958EC -> 0x80095920
+static void __sinf(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+}
+
+// Range: 0x800958A8 -> 0x800958EC
+void _bzero(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pBuffer; // r1+0xC
+}
+
+// Range: 0x8009584C -> 0x800958A8
+void _bcopy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pSource; // r1+0x10
+    void* pTarget; // r1+0xC
+}
+
+// Range: 0x800957F0 -> 0x8009584C
+void _memcpy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 nSize; // r5
+    void* pSource; // r1+0x10
+    void* pTarget; // r1+0xC
+}
+
+// Range: 0x800957E0 -> 0x800957F0
+void osPhysicalToVirtual(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x8009576C -> 0x800957E0
+void osVirtualToPhysical(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80095454 -> 0x8009576C
+void guMtxCatF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r23
+
+    // Local variables
+    s32 i; // r9
+    s32 j; // r23
+    f32 temp[4][4]; // r1+0x38
+    union __anon_0x7D2DB data1; // r1+0x30
+    union __anon_0x7D2DB data2; // r1+0x28
+    u32* mf; // r1+0x24
+    u32* nf; // r1+0x20
+    u32* res; // r1+0x1C
+}
+
+// Range: 0x8009524C -> 0x80095454
+void guMtxF2L(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    f32* mf; // r1+0x24
+    s32 e1; // r6
+    s32 e2; // r7
+    s32 i; // r8
     s32 j; // r1+0x8
-    union __anon_0x7D2DB data; // r1+0x58
-    f32 mf[4][4]; // r1+0x18
-    s32 e1; // r7
-    s32 e2; // r8
-    u32* sp; // r1+0x14
+    s32* m; // r1+0x20
+    union __anon_0x7D2DB data; // r1+0x18
     s32* ai; // r9
     s32* af; // r10
 }
 
-// Range: 0x8009491C -> 0x80094B78
-void guPerspectiveF(struct _CPU* pCPU) {
+// Range: 0x80095178 -> 0x8009524C
+void guMtxIdentF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+
+    // Local variables
+    f32* mf; // r1+0x20
+    s32 i; // r7
+    s32 j; // r1+0x8
+    union __anon_0x7D2DB data1; // r1+0x18
+    union __anon_0x7D2DB data0; // r1+0x10
+}
+
+// Range: 0x800950C4 -> 0x80095178
+void guMtxIdent(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r3
+
+    // Local variables
+    s32* m; // r1+0xC
+}
+
+// Range: 0x80094E54 -> 0x800950C4
+void guOrthoF(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
     s32 i; // r8
     s32 j; // r4
-    f32 cot; // f2
-    s16* perspNorm; // r1+0x30
     u32* mf; // r1+0x2C
     u32* sp; // r1+0x28
+    f32 l; // f29
+    f32 r; // f28
+    f32 b; // f27
+    f32 t; // f26
+    f32 n; // f31
+    f32 f; // f30
+    f32 scale; // f5
     union __anon_0x7D2DB data0; // r1+0x20
     union __anon_0x7D2DB data1; // r1+0x18
     union __anon_0x7D2DB data; // r1+0x10
-    f32 fovy; // f29
-    f32 aspect; // f28
-    f32 rNear; // f27
-    f32 rFar; // f31
-    f32 scale; // f5
 }
 
 // Range: 0x80094B78 -> 0x80094E54
@@ -1357,274 +955,676 @@ void guOrtho(struct _CPU* pCPU) {
     f32 scale; // f5
 }
 
-// Range: 0x80094E54 -> 0x800950C4
-void guOrthoF(struct _CPU* pCPU) {
+// Range: 0x8009491C -> 0x80094B78
+void guPerspectiveF(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
     s32 i; // r8
     s32 j; // r4
+    f32 cot; // f2
+    s16* perspNorm; // r1+0x30
     u32* mf; // r1+0x2C
     u32* sp; // r1+0x28
-    f32 l; // f29
-    f32 r; // f28
-    f32 b; // f27
-    f32 t; // f26
-    f32 n; // f31
-    f32 f; // f30
-    f32 scale; // f5
     union __anon_0x7D2DB data0; // r1+0x20
     union __anon_0x7D2DB data1; // r1+0x18
     union __anon_0x7D2DB data; // r1+0x10
+    f32 fovy; // f29
+    f32 aspect; // f28
+    f32 rNear; // f27
+    f32 rFar; // f31
+    f32 scale; // f5
 }
 
-// Range: 0x800950C4 -> 0x80095178
-void guMtxIdent(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-
-    // Local variables
-    s32* m; // r1+0xC
-}
-
-// Range: 0x80095178 -> 0x8009524C
-void guMtxIdentF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r3
-
-    // Local variables
-    f32* mf; // r1+0x20
-    s32 i; // r7
-    s32 j; // r1+0x8
-    union __anon_0x7D2DB data1; // r1+0x18
-    union __anon_0x7D2DB data0; // r1+0x10
-}
-
-// Range: 0x8009524C -> 0x80095454
-void guMtxF2L(struct _CPU* pCPU) {
+// Range: 0x80094658 -> 0x8009491C
+void guPerspective(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    f32* mf; // r1+0x24
-    s32 e1; // r6
-    s32 e2; // r7
-    s32 i; // r8
+    s32* m; // r1+0x60
+    f32 fovy; // f30
+    f32 aspect; // f29
+    f32 rNear; // f28
+    f32 rFar; // f27
+    f32 scale; // f5
+    f32 _cot; // f2
+    s32 i; // r6
     s32 j; // r1+0x8
+    union __anon_0x7D2DB data; // r1+0x58
+    f32 mf[4][4]; // r1+0x18
+    s32 e1; // r7
+    s32 e2; // r8
+    u32* sp; // r1+0x14
+    s32* ai; // r9
+    s32* af; // r10
+}
+
+// Range: 0x800945A8 -> 0x80094658
+void GenPerspective_1080(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    union __anon_0x7D2DB data; // r1+0x18
+    u32* mf; // r1+0x10
+    u32* sp; // r1+0xC
+    f32 fovy; // f3
+    f32 aspect; // f4
+    f32 rNear; // f1
+    f32 rFar; // f2
+    struct __anon_0x80DBD* pFrame; // r31
+}
+
+// Range: 0x80094480 -> 0x800945A8
+void guScaleF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 i; // r8
+    s32 j; // r4
+    u32* mf; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
+}
+
+// Range: 0x80094294 -> 0x80094480
+void guScale(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    f32 mf[4][4]; // r1+0x24
     s32* m; // r1+0x20
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
     union __anon_0x7D2DB data; // r1+0x18
     s32* ai; // r9
     s32* af; // r10
 }
 
-// Range: 0x80095454 -> 0x8009576C
-void guMtxCatF(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r23
-
-    // Local variables
-    s32 i; // r9
-    s32 j; // r23
-    f32 temp[4][4]; // r1+0x38
-    union __anon_0x7D2DB data1; // r1+0x30
-    union __anon_0x7D2DB data2; // r1+0x28
-    u32* mf; // r1+0x24
-    u32* nf; // r1+0x20
-    u32* res; // r1+0x1C
-}
-
-// Range: 0x8009576C -> 0x800957E0
-void osVirtualToPhysical(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x800957E0 -> 0x800957F0
-void osPhysicalToVirtual(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x0
-}
-
-// Range: 0x800957F0 -> 0x8009584C
-void _memcpy(struct _CPU* pCPU) {
+// Range: 0x80094174 -> 0x80094294
+void guTranslateF(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
-    void* pSource; // r1+0x10
-    void* pTarget; // r1+0xC
+    s32 i; // r8
+    s32 j; // r4
+    u32* mf; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
 }
 
-// Range: 0x8009584C -> 0x800958A8
-void _bcopy(struct _CPU* pCPU) {
+// Range: 0x80093F88 -> 0x80094174
+void guTranslate(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
-    void* pSource; // r1+0x10
-    void* pTarget; // r1+0xC
+    s32* m; // r1+0x60
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x58
+    f32 mf[4][4]; // r1+0x14
+    s32* ai; // r9
+    s32* af; // r10
 }
 
-// Range: 0x800958A8 -> 0x800958EC
-void _bzero(struct _CPU* pCPU) {
+// Range: 0x80093C78 -> 0x80093F88
+void guRotateF(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
-    void* pBuffer; // r1+0xC
+    f32 m; // f2
+    s32 i; // r8
+    s32 j; // r4
+    f32 a; // f31
+    f32 x; // f30
+    f32 y; // f29
+    f32 z; // f28
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    union __anon_0x7D2DB data0; // r1+0x18
+    union __anon_0x7D2DB data1; // r1+0x10
+    f32 sine; // r1+0x8
+    f32 cosine; // r1+0x8
+    f32 ab; // f27
+    f32 bc; // f26
+    f32 ca; // f25
+    f32 t; // f4
+
+    // References
+    // -> static f32 dtor$466;
 }
 
-// Range: 0x800958EC -> 0x80095920
-static void __sinf(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-}
-
-// Range: 0x80095920 -> 0x80095954
-static void __cosf(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-}
-
-// Range: 0x80095954 -> 0x800959A4
-static s32 __osSpSetStatus(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r1+0x8
-
-    // Local variables
-    u32 nData32; // r1+0xC
-}
-
-// Range: 0x800959A4 -> 0x80095A30
-static s32 __osRestoreInt(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r31
-
-    // Local variables
-    u64 nStatus; // r1+0x10
-}
-
-// Range: 0x80095A30 -> 0x80095AC0
-static s32 __osDisableInt(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r30
-
-    // Local variables
-    u32 nStatus; // r1+0x8
-    u64 nData64; // r1+0x18
-}
-
-// Range: 0x80095AC0 -> 0x80095B48
-static s32 osInvalICache(struct _CPU* pCPU) {
-    // Parameters
-    // struct _CPU* pCPU; // r29
-
-    // Local variables
-    u32 nAddress; // r30
-    u32 nSize; // r1+0x8
-}
-
-// Range: 0x80095B48 -> 0x80095B9C
-static s32 osGetMemSize(struct _CPU* pCPU) {
+// Range: 0x8009392C -> 0x80093C78
+void guRotate(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    u32 nSize; // r1+0xC
+    s32* m; // r1+0x64
+    u32* sp; // r1+0x60
+    union __anon_0x7D2DB data; // r1+0x58
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    f32 mf[4][4]; // r1+0x18
+    f32 sine; // r1+0x8
+    f32 cosine; // r1+0x8
+    f32 a; // f30
+    f32 x; // f29
+    f32 y; // f28
+    f32 z; // f27
+    f32 ab; // f13
+    f32 bc; // f30
+    f32 ca; // f29
+    f32 t; // f26
+    f32 magnitude; // f2
+    s32* ai; // r9
+    s32* af; // r10
+
+    // References
+    // -> static f32 dtor$480;
+}
+
+// Range: 0x800935A0 -> 0x8009392C
+void guLookAtF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    f32 len; // f9
+    f32 xAt; // r1+0x8
+    f32 yAt; // r1+0x8
+    f32 zAt; // f1
+    f32 xUp; // r1+0x8
+    f32 yUp; // f1
+    f32 zUp; // f2
+    f32 xEye; // f3
+    f32 yEye; // f4
+    f32 zEye; // f5
+    u32* mf; // r1+0x34
+    u32* sp; // r1+0x30
+    f32 xLook; // f6
+    f32 yLook; // f7
+    f32 zLook; // f8
+    f32 xRight; // f9
+    f32 yRight; // f10
+    f32 zRight; // f11
+    union __anon_0x7D2DB data; // r1+0x28
+    union __anon_0x7D2DB data0; // r1+0x20
+    union __anon_0x7D2DB data1; // r1+0x18
+}
+
+// Range: 0x80093188 -> 0x800935A0
+void guLookAt(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    f32 mf[4][4]; // r1+0x30
+    s32* m; // r1+0x2C
+    u32* sp; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    s32 i; // r6
+    s32 j; // r1+0x8
+    s32 e1; // r7
+    s32 e2; // r8
+    s32* ai; // r9
+    s32* af; // r10
+    f32 len; // f6
+    f32 xLook; // f3
+    f32 yLook; // f4
+    f32 zLook; // f5
+    f32 xRight; // f6
+    f32 yRight; // f7
+    f32 zRight; // f8
+    f32 xEye; // f9
+    f32 yEye; // f10
+    f32 zEye; // f11
+    f32 xAt; // r1+0x8
+    f32 yAt; // r1+0x8
+    f32 zAt; // f1
+    f32 xUp; // r1+0x8
+    f32 yUp; // f1
+    f32 zUp; // f2
 }
 
 // Erased
-static s32 __ptException() {}
-
-// Range: 0x80095B9C -> 0x80096140
-static s32 __osDispatchThread(struct _CPU* pCPU) {
+static s32 __float2int(f32 x) {
     // Parameters
-    // struct _CPU* pCPU; // r27
-
-    // Local variables
-    struct __anon_0x7AE26* pLibrary; // r29
-    u32 nAddress; // r5
-    u64 nData64; // r0
-    struct __OSThread_s* __osRunningThread; // r1+0x10
-    u32 nData32; // r1+0xC
-    u32 __OSGlobalIntMask; // r28
-    u32 nStatus; // r6
-    u32 nMask; // r6
-
-    // References
-    // -> static u32 __osRcpImTable[64];
+    // f32 x; // r1+0x8
 }
 
-// Range: 0x80096140 -> 0x80096214
-static s32 __osPopThread(struct _CPU* pCPU) {
+// Range: 0x80092834 -> 0x80093188
+void guLookAtHiliteF(struct _CPU* pCPU) {
     // Parameters
-    // struct _CPU* pCPU; // r29
+    // struct _CPU* pCPU; // r31
 
     // Local variables
-    struct __anon_0x79A22** apDevice; // r31
-    u8* aiDevice; // r30
+    struct __anon_0x7D2A5* l; // r1+0x3C
+    union __anon_0x7DBF9* h; // r1+0x38
+    union __anon_0x7D2DB data; // r1+0x30
+    u32* mf; // r1+0x2C
+    u32* sp; // r1+0x28
+    f32 len; // f5
+    f32 xLook; // r1+0x8
+    f32 yLook; // f1
+    f32 zLook; // f2
+    f32 xRight; // f3
+    f32 yRight; // f4
+    f32 zRight; // f5
+    f32 xHilite; // f29
+    f32 yHilite; // f28
+    f32 zHilite; // f27
+    f32 xEye; // f6
+    f32 yEye; // f7
+    f32 zEye; // f8
+    f32 xAt; // r1+0x8
+    f32 yAt; // f1
+    f32 zAt; // f2
+    f32 xUp; // f3
+    f32 yUp; // f12
+    f32 zUp; // f4
+    f32 xl1; // f27
+    f32 yl1; // f28
+    f32 zl1; // f26
+    f32 xl2; // f9
+    f32 yl2; // f10
+    f32 zl2; // f11
+    s32 twidth; // r6
+    s32 theight; // r7
 }
 
-// Range: 0x80096214 -> 0x8009643C
-static s32 __osEnqueueThread(struct _CPU* pCPU) {
+// Range: 0x80091E60 -> 0x80092834
+void guLookAtHilite(struct _CPU* pCPU) {
     // Parameters
-    // struct _CPU* pCPU; // r29
+    // struct _CPU* pCPU; // r31
 
     // Local variables
-    struct __anon_0x79A22** apDevice; // r31
-    u8* aiDevice; // r30
+    struct __anon_0x7D2A5* l; // r1+0x84
+    union __anon_0x7DBF9* h; // r1+0x80
+    s32 i; // r7
+    s32 j; // r1+0x8
+    s32 e1; // r5
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x78
+    f32 mf[4][4]; // r1+0x38
+    u32* m; // r1+0x34
+    u32* sp; // r1+0x30
+    s32* ai; // r9
+    s32* af; // r10
+    f32 len; // f5
+    f32 xLook; // r1+0x8
+    f32 yLook; // f1
+    f32 zLook; // f2
+    f32 xRight; // f3
+    f32 yRight; // f4
+    f32 zRight; // f5
+    f32 xHilite; // f29
+    f32 yHilite; // f28
+    f32 zHilite; // f27
+    f32 xEye; // f6
+    f32 yEye; // f7
+    f32 zEye; // f8
+    f32 xAt; // r1+0x8
+    f32 yAt; // f1
+    f32 zAt; // f2
+    f32 xUp; // f3
+    f32 yUp; // f12
+    f32 zUp; // f4
+    f32 xl1; // f27
+    f32 yl1; // f28
+    f32 zl1; // f26
+    f32 xl2; // f9
+    f32 yl2; // f10
+    f32 zl2; // f11
+    s32 twidth; // r6
+    s32 theight; // r7
 }
 
-// Range: 0x8009643C -> 0x80096728
-static s32 __osEnqueueAndYield(struct _CPU* pCPU) {
+// Range: 0x8009190C -> 0x80091E60
+void guLookAtReflectF(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x28
+    union __anon_0x7D2DB data; // r1+0x20
+    u32* mf; // r1+0x1C
+    u32* sp; // r1+0x18
+    f32 xEye; // f3
+    f32 yEye; // f4
+    f32 zEye; // f5
+    f32 xAt; // r1+0x8
+    f32 yAt; // r1+0x8
+    f32 zAt; // f1
+    f32 xUp; // r1+0x8
+    f32 yUp; // f1
+    f32 zUp; // f2
+    f32 len; // f9
+    f32 xLook; // f6
+    f32 yLook; // f7
+    f32 zLook; // f8
+    f32 xRight; // f9
+    f32 yRight; // f10
+    f32 zRight; // f11
+}
+
+// Range: 0x80091338 -> 0x8009190C
+void guLookAtReflect(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    struct __anon_0x7D2A5* l; // r1+0x70
+    s32 i; // r7
+    s32 j; // r1+0x8
+    s32 e1; // r5
+    s32 e2; // r8
+    union __anon_0x7D2DB data; // r1+0x68
+    f32 mf[4][4]; // r1+0x28
+    u32* m; // r1+0x24
+    u32* sp; // r1+0x20
+    s32* ai; // r9
+    s32* af; // r10
+    f32 xEye; // f3
+    f32 yEye; // f4
+    f32 zEye; // f5
+    f32 xAt; // r1+0x8
+    f32 yAt; // r1+0x8
+    f32 zAt; // f1
+    f32 xUp; // r1+0x8
+    f32 yUp; // f1
+    f32 zUp; // f2
+    f32 len; // f9
+    f32 xLook; // f6
+    f32 yLook; // f7
+    f32 zLook; // f8
+    f32 xRight; // f9
+    f32 yRight; // f10
+    f32 zRight; // f11
+}
+
+// Range: 0x8009120C -> 0x80091338
+s32 osAiSetFrequency(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    u32 dacRate; // r1+0x8
+    u8 bitRate; // r28
+    u32 nData32; // r1+0x10
+}
+
+// Range: 0x80091100 -> 0x8009120C
+s32 osAiSetNextBuffer(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
     // Local variables
-    s64 nData64; // r1+0x18
-    struct __anon_0x7AE26* pLibrary; // r3
-    struct __OSThread_s* __osRunningThread; // r1+0x10
-    u32 __OSGlobalIntMask; // r31
-    u32 nStatus; // r1+0x8
-    u32 nData32; // r5
-    u32 nMask; // r1+0xC
-    struct __anon_0x79A22** apDevice; // r6
-    u8* aiDevice; // r7
+    u32 size; // r31
+    u32 nData32; // r1+0x10
 }
 
-// Range: 0x80096728 -> 0x80096AB8
-static s32 send_mesg(struct _CPU* pCPU) {
+// Range: 0x80091028 -> 0x80091100
+s32 __osEepStatus(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    s32 ret; // r5
+    s32 nSize; // r1+0x10
+    u8* status; // r1+0xC
+}
+
+// Range: 0x80090FB0 -> 0x80091028
+s32 osEepromRead(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u8 address; // r31
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090F38 -> 0x80090FB0
+s32 osEepromWrite(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r30
+
+    // Local variables
+    u8 address; // r31
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090E8C -> 0x80090F38
+s32 osEepromLongRead(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r28
 
     // Local variables
-    struct __anon_0x7AE26* pLibrary; // r1+0x8
-    struct __anon_0x79A22** apDevice; // r30
-    u8* aiDevice; // r29
+    s32 length; // r31
+    s32 ret; // r30
+    u8 address; // r29
+    u8* buffer; // r1+0xC
 }
 
-// Range: 0x80096AB8 -> 0x8009779C
-static s32 __osException(struct _CPU* pCPU) {
+// Range: 0x80090DE0 -> 0x80090E8C
+s32 osEepromLongWrite(struct _CPU* pCPU) {
     // Parameters
-    // struct _CPU* pCPU; // r29
+    // struct _CPU* pCPU; // r28
 
     // Local variables
-    s32 iBit; // r3
-    struct __anon_0x7AE26* pLibrary; // r1+0x8
-    s64 nData64; // r1+0x28
-    s64 nCause; // r1+0x20
-    struct __OSThread_s* __osRunningThread; // r1+0x18
-    struct __anon_0x79A22** apDevice; // r31
-    u8* aiDevice; // r30
-    u32 nStatus; // r22
-    u32 nStatusRSP; // r1+0x14
-    u32 nData32; // r1+0x10
-    u32 __OSGlobalIntMask; // r23
-    u32 nS0; // r18
-    u32 nS1; // r17
-    u32 nMask; // r1+0xC
+    s32 length; // r31
+    s32 ret; // r30
+    u8 address; // r29
+    u8* buffer; // r1+0xC
+}
+
+// Range: 0x80090C78 -> 0x80090DE0
+s32 starfoxCopy(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r25
+
+    // Local variables
+    s32* A0; // r1+0x18
+    s32 A1; // r31
+    s32 A2; // r30
+    s32 A3; // r29
+    s32 T0; // r28
+    s32 T1; // r24
+    s32 T2; // r1+0x8
+    s32 T3; // r23
+    s32 T8; // r27
+    s32 T9; // r26
+    s16* pData16; // r1+0x14
+    char* source; // r1+0x10
+    char* target; // r1+0xC
+}
+
+// Range: 0x80090C68 -> 0x80090C78
+s32 pictureSnap_Zelda2(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80090B40 -> 0x80090C68
+s32 dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r31
+
+    // Local variables
+    void* pTarget; // r1+0x18
+    struct OSMesgQueue_s* mq; // r1+0x14
+    u32* msg; // r1+0x10
+    struct __anon_0x7C62D* pIOMessage; // r1+0xC
+    s32 first; // r30
+    s32 msgCount; // r29
+    s32 validCount; // r28
+    s32 nSize; // r6
+    s32 nAddress; // r5
+    s32 nOffsetRAM; // r5
+    s32 nOffsetROM; // r5
+}
+
+// Range: 0x80090AD8 -> 0x80090B40
+s32 osViSwapBuffer_Entry(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x8
+
+    // References
+    // -> static u32 nAddress$605;
+}
+
+// Range: 0x80090AC4 -> 0x80090AD8
+s32 zeldaLoadSZS_Entry(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x80090AB0 -> 0x80090AC4
+s32 zeldaLoadSZS_Exit(struct _CPU* pCPU) {
+    // Parameters
+    // struct _CPU* pCPU; // r1+0x0
+}
+
+// Range: 0x800907B0 -> 0x80090AB0
+static s32 libraryFindException(struct __anon_0x7AE26* pLibrary, s32 bException) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r27
+    // s32 bException; // r28
+
+    // Local variables
+    struct _CPU* pCPU; // r30
+    struct __anon_0x79A22** apDevice; // r29
+    u8* aiDevice; // r31
+    u32 anCode[6]; // r1+0x10
+}
+
+// Range: 0x8009007C -> 0x800907B0
+static s32 libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r24
+
+    // Local variables
+    struct _CPU* pCPU; // r27
+    struct __anon_0x79A22** apDevice; // r26
+    u8* aiDevice; // r25
+    u32 nAddress; // r23
+    u32 nAddressLast; // r28
+    u32 nOffset; // r1+0x28
+    u32 nOpcode; // r1+0x24
+    u32 anCode[6]; // r1+0xC
+}
+
+// Range: 0x8008FB6C -> 0x8009007C
+static s32 libraryFindFunctions(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r24
+
+    // Local variables
+    struct _CPU* pCPU; // r3
+    s32 iFunction; // r29
+    struct __anon_0x79A22** apDevice; // r28
+    u8* aiDevice; // r27
+    u32 nOpcode; // r1+0x10
+    u32* pnCode; // r1+0xC
+    u32 nAddress; // r29
+    u32 nAddressLast; // r31
+    u32 nAddressEnqueueThread; // r26
+    u32 nAddressDispatchThread; // r25
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Erased
+static s32 libraryCheckHandler(struct __anon_0x7AE26* pLibrary, s32 bException) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r31
+    // s32 bException; // r4
+}
+
+// Range: 0x8008F584 -> 0x8008FB6C
+s32 libraryTestFunction(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r30
+    // struct cpu_function* pFunction; // r26
+
+    // Local variables
+    s32 iFunction; // r31
+    s32 iData; // r24
+    s32 bFlag; // r29
+    s32 bDone; // r27
+    s32 bReturn; // r21
+    u32 iCode; // r5
+    u32* pnCode; // r1+0x1C
+    u32* pnCodeTemp; // r1+0x18
+    u32 nSizeCode; // r1+0x8
+    u32 nChecksum; // r1+0x14
+    u32 nOpcode; // r1+0x8
+    u32 nAddress; // r1+0x8
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8008F420 -> 0x8008F584
+static s32 librarySearch(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r29
+    // struct cpu_function* pFunction; // r30
+}
+
+// Erased
+static s32 libraryUpdate(struct __anon_0x7AE26* pLibrary) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r31
+
+    // Local variables
+    struct _CPU* pCPU; // r29
+    struct cpu_function* pFunction; // r1+0xC
+}
+
+// Range: 0x8008F32C -> 0x8008F420
+s32 libraryFunctionReplaced(s32 iFunction) {
+    // Parameters
+    // s32 iFunction; // r1+0x4
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8008F234 -> 0x8008F32C
+s32 libraryCall(struct __anon_0x7AE26* pLibrary, struct _CPU* pCPU, s32 iFunction) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r29
+    // struct _CPU* pCPU; // r30
+    // s32 iFunction; // r31
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
+}
+
+// Range: 0x8008F0F4 -> 0x8008F234
+s32 libraryEvent(struct __anon_0x7AE26* pLibrary, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7AE26* pLibrary; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r1+0x10
+
+    // References
+    // -> struct __anon_0x7AD10 gaFunction[54];
 }

--- a/debug/Fire/mcardGCN.c
+++ b/debug/Fire/mcardGCN.c
@@ -281,233 +281,8 @@ typedef enum __anon_0x1BD8E {
     MC_C_FORMAT_CARD = 6,
 } __anon_0x1BD8E;
 
-// Range: 0x80013440 -> 0x800136F4
-s32 mcardUpdate() {
-    // Local variables
-    s32 j; // r5
-    s32 i; // r5
-    s32 toggle; // r25
-    enum __anon_0x1BD8E command; // r1+0x8
-    s32 prevIndex; // r24
-    s32 index; // r23
-    s32 counter; // r22
-
-    // References
-    // -> struct _MCARD mCard;
-    // -> s32 bWrite2Card;
-    // -> struct __anon_0x1BB9D* gpSystem;
-}
-
-// Range: 0x800136F4 -> 0x800145FC
-s32 mcardStore(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-
-    // Local variables
-    s32 i; // r30
-    s32 checksum; // r1+0x4DC
-    s32 bufferOffset; // r4
-    enum __anon_0x1BD8E command; // r1+0x4C8
-
-    // References
-    // -> static s32 checkFailCount$1490;
-    // -> struct _MCARD mCard;
-    // -> struct OSCalendarTime gDate;
-}
-
 // size = 0x4, address = 0x801355D4
 s32 gButtonDownToggle;
-
-// Range: 0x800145FC -> 0x8001514C
-s32 mcardOpenDuringGame(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-
-    // Local variables
-    s32 i; // r28
-    enum __anon_0x1BD8E command; // r1+0x18
-    s32 loadToggle; // r27
-
-    // References
-    // -> s32 gButtonDownToggle;
-}
-
-// Range: 0x8001514C -> 0x80016950
-s32 mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
-              s32* defaultConfiguration, s32 fileSize, s32 gameSize) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // char* fileName; // r28
-    // char* comment; // r25
-    // char* icon; // r23
-    // char* banner; // r22
-    // char* gameName; // r29
-    // s32* defaultConfiguration; // r21
-    // s32 fileSize; // r26
-    // s32 gameSize; // r30
-
-    // Local variables
-    s32 i; // r19
-    enum __anon_0x1BD8E command; // r1+0x34
-
-    // References
-    // -> struct __anon_0x1BB9D* gpSystem;
-    // -> s32 gButtonDownToggle;
-}
-
-// Erased
-static s32 mcardCheckSpace(struct _MCARD* pMCard, s32 size) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // s32 size; // r31
-
-    // Local variables
-    s32 freeBytes; // r1+0x18
-    s32 freeFiles; // r1+0x14
-}
-
-// Erased
-static s32 mcardGetError(struct _MCARD* pMCard, enum __anon_0x1B0CB* pMCardError) {
-    // Parameters
-    // struct _MCARD* pMCard; // r1+0x0
-    // enum __anon_0x1B0CB* pMCardError; // r1+0x4
-}
-
-// Range: 0x80016950 -> 0x80016CB0
-s32 mcardWrite(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
-    // Parameters
-    // struct _MCARD* pMCard; // r28
-    // s32 address; // r29
-    // s32 size; // r30
-    // char* data; // r31
-
-    // Local variables
-    s32 i; // r1+0x8
-    char testByte; // r25
-
-    // References
-    // -> static s32 toggle2$1029;
-    // -> static s32 toggle$1034;
-    // -> struct __anon_0x1BB9D* gpSystem;
-    // -> s32 currentIdx;
-    // -> s32 bNoWriteInCurrentFrame[10];
-    // -> s32 bWrite2Card;
-}
-
-// Erased
-static s32 corruptionCheck(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r23
-
-    // Local variables
-    char* buffer; // r1+0x4AC
-    s32 checksum1; // r1+0x4A8
-    s32 checksum2; // r26
-    s32 i; // r25
-    s32 toggle; // r24
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80016CB0 -> 0x80016D90
-s32 mcardOpenDuringGameError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
-    // Parameters
-    // struct _MCARD* pMCard; // r3
-    // enum __anon_0x1BD8E* pCommand; // r4
-}
-
-// Range: 0x80016D90 -> 0x80016E70
-s32 mcardOpenError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
-    // Parameters
-    // struct _MCARD* pMCard; // r3
-    // enum __anon_0x1BD8E* pCommand; // r4
-}
-
-// Range: 0x80016E70 -> 0x80017814
-s32 mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_0x1BD8E* pCommand) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // enum __anon_0x1A5F0 menuEntry; // r4
-    // enum __anon_0x1BD8E* pCommand; // r30
-
-    // References
-    // -> static enum __anon_0x1A5F0 nextMenuEntry$773;
-    // -> static s32 yes$771;
-    // -> static enum __anon_0x1A5F0 prevMenuEntry$772;
-}
-
-// Range: 0x80017814 -> 0x80017844
-s32 mcardRead(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
-    // Parameters
-    // struct _MCARD* pMCard; // r3
-    // s32 address; // r4
-    // s32 size; // r5
-    // char* data; // r6
-}
-
-// Range: 0x80017844 -> 0x800178EC
-s32 mcardGameRelease(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-}
-
-// Erased
-static s32 mcardFileRelease(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-}
-
-// Range: 0x800178EC -> 0x80017A94
-s32 mcardGameErase(struct _MCARD* pMCard, s32 index) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // s32 index; // r30
-}
-
-// Range: 0x80017A94 -> 0x80017C24
-s32 mcardFileErase(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-}
-
-// Range: 0x80017C24 -> 0x80017D60
-s32 mcardCardErase(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-
-    // Local variables
-    s32 slot; // r30
-}
-
-// Erased
-static s32 mcardGameCreateDuringGame(struct _MCARD* pMCard, char* name, s32 size) {
-    // Parameters
-    // struct _MCARD* pMCard; // r25
-    // char* name; // r29
-    // s32 size; // r24
-
-    // Local variables
-    s32 i; // r26
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80017D60 -> 0x800185F8
-s32 mcardGameCreate(struct _MCARD* pMCard, char* name, s32 defaultConfiguration, s32 size) {
-    // Parameters
-    // struct _MCARD* pMCard; // r25
-    // char* name; // r30
-    // s32 defaultConfiguration; // r29
-    // s32 size; // r27
-
-    // Local variables
-    s32 i; // r26
-
-    // References
-    // -> struct _MCARD mCard;
-}
 
 typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
@@ -531,536 +306,6 @@ typedef struct CARDStat {
     /* 0x64 */ u32 offsetIconTlut;
     /* 0x68 */ u32 offsetData;
 } __anon_0x1CDF9; // size = 0x6C
-
-// Range: 0x800185F8 -> 0x80018C50
-s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, s32 size) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // char* name; // r21
-    // char* comment; // r25
-    // char* icon; // r27
-    // char* banner; // r26
-    // s32 size; // r1+0x1C
-
-    // Local variables
-    s32 freeBytes; // r1+0x104
-    s32 freeFiles; // r1+0x100
-    s32 totalSize; // r30
-    s32 i; // r21
-    char* buffer; // r1+0xFC
-    struct _GXTexObj texObj; // r1+0xDC
-    void* dataP; // r4
-    struct CARDStat cardStatus; // r1+0x70
-    s32 fileNo; // r21
-    struct OSCalendarTime date; // r1+0x48
-    char dateString[32]; // r1+0x28
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80018C50 -> 0x80019058
-s32 mcardGameSet(struct _MCARD* pMCard, char* name) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // char* name; // r28
-
-    // Local variables
-    s32 i; // r29
-
-    // References
-    // -> struct __anon_0x1BB9D* gpSystem;
-}
-
-// Erased
-static s32 mcardGameSetNoSave(struct _MCARD* pMCard, s32 size) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // s32 size; // r31
-
-    // References
-    // -> struct __anon_0x1BB9D* gpSystem;
-}
-
-// Range: 0x80019058 -> 0x8001947C
-s32 mcardFileSet(struct _MCARD* pMCard, char* name) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // char* name; // r4
-
-    // Local variables
-    s32 i; // r7
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001947C -> 0x800194D8
-s32 mcardInit(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-}
-
-// Range: 0x800194D8 -> 0x80019670
-s32 mcardReInit(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-}
-
-// Range: 0x80019670 -> 0x800196D8
-s32 mcardWriteGameDataReset(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteGameDataWait(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r24
-
-    // Local variables
-    s32 checksum; // r1+0x258
-    s32 i; // r25
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteGameData(struct _MCARD* pMCard, s32 offset) {
-    // Parameters
-    // struct _MCARD* pMCard; // r3
-    // s32 offset; // r4
-}
-
-// Range: 0x800196D8 -> 0x80019A70
-s32 mcardReadGameData(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r23
-
-    // Local variables
-    s32 checksum1; // r1+0x260
-    s32 checksum2; // r26
-    s32 i; // r25
-    s32 toggle; // r24
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardReplaceBlock(struct _MCARD* pMCard, s32 index) {
-    // Parameters
-    // struct _MCARD* pMCard; // r27
-    // s32 index; // r28
-
-    // Local variables
-    s32 checksum1; // r1+0x4A4
-    s32 checksum2; // r29
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80019A70 -> 0x80019C74
-static s32 mcardWriteTimeAsynch(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // References
-    // -> struct OSCalendarTime gDate;
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-
-    // Local variables
-    char dateString[32]; // r1+0x4A4
-    s32 checksum; // r1+0x4A0
-
-    // References
-    // -> struct OSCalendarTime gDate;
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80019C74 -> 0x80019E38
-static s32 mcardWriteConfigAsynch(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteConfigPrepareWriteBuffer(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-
-    // Local variables
-    s32 checksum; // r1+0x4A0
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80019E38 -> 0x80019FDC
-static s32 mcardReadBufferAsynch(struct _MCARD* pMCard, s32 offset) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // s32 offset; // r27
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80019FDC -> 0x8001A1C0
-static s32 mcardWriteBufferAsynch(struct _MCARD* pMCard, s32 offset) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // s32 offset; // r30
-
-    // Local variables
-    struct OSCalendarTime date; // r1+0x258
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // char* cardHeader; // r30
-
-    // Local variables
-    char buffer[24608]; // r1+0x4A0
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // char* cardHeader; // r31
-
-    // Local variables
-    char buffer[24608]; // r1+0x258
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001A1C0 -> 0x8001A3E4
-static s32 mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-
-    // Local variables
-    char buffer[24608]; // r1+0xC
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001A3E4 -> 0x8001A53C
-static s32 mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // Local variables
-    char buffer[24608]; // r1+0xC
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001A53C -> 0x8001A8F8
-static s32 mcardWriteFileHeader(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // Local variables
-    char buffer[24608]; // r1+0x49C
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001A8F8 -> 0x8001AB1C
-static s32 mcardReadFileHeader(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-
-    // Local variables
-    char buffer[24608]; // r1+0x254
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001AB1C -> 0x8001ACC8
-static s32 mcardWriteAnywherePartial(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer, s32 partialOffset,
-                                     s32 totalSize) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // s32 offset; // r25
-    // s32 size; // r26
-    // char* buffer; // r27
-    // s32 partialOffset; // r28
-    // s32 totalSize; // r29
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001ACC8 -> 0x8001AE64
-static s32 mcardWriteAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-    // s32 offset; // r27
-    // s32 size; // r28
-    // char* buffer; // r29
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001AE64 -> 0x8001AFD4
-static s32 mcardReadAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r27
-    // s32 offset; // r28
-    // s32 size; // r29
-    // char* buffer; // r30
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardTimeCheck(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // Local variables
-    struct OSCalendarTime time; // r1+0x22C
-}
-
-// Erased
-static s32 mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // struct OSCalendarTime* time; // r31
-
-    // Local variables
-    char buffer[24608]; // r1+0x10
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardWriteAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r28
-    // s32 offset; // r29
-    // s32 size; // r30
-    // char* buffer; // r31
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardReadAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // s32 offset; // r3
-    // s32 size; // r30
-    // char* buffer; // r31
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardFinishFile(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-}
-
-// Erased
-static s32 mcardReadyFile(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-}
-
-// Erased
-static s32 mcardFinishCard(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r3
-}
-
-// Range: 0x8001AFD4 -> 0x8001B168
-static s32 mcardReadyCard(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // Local variables
-    s32 i; // r31
-    s32 sectorSize; // r1+0xC
-
-    // References
-    // -> static char gMCardCardWorkArea[40960];
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001B168 -> 0x8001B254
-static s32 mcardPoll(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r31
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardCopyName(char* name1, char* name2) {
-    // Parameters
-    // char* name1; // r4
-    // char* name2; // r5
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardCompareName(char* name1, char* name2) {
-    // Parameters
-    // char* name1; // r4
-    // char* name2; // r5
-}
-
-// Range: 0x8001B254 -> 0x8001B480
-static s32 mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-
-    // Local variables
-    char* buffer; // r1+0xC
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001B480 -> 0x8001B794
-static s32 mcardCheckChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // char* buffer; // r27
-
-    // Local variables
-    s32 checksum; // r31
-    char buffer2[8192]; // r1+0x18
-    s32 toggle; // r30
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001B794 -> 0x8001BC14
-static s32 mcardReplaceFileBlock(struct _MCARD* pMCard, s32 index) {
-    // Parameters
-    // struct _MCARD* pMCard; // r28
-    // s32 index; // r29
-
-    // Local variables
-    s32 checksum1; // r1+0x2238
-    s32 checksum2; // r30
-    char buffer[8192]; // r1+0x238
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Erased
-static s32 mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
-    // Parameters
-    // struct _MCARD* pMCard; // r29
-    // struct OSCalendarTime* time; // r30
-
-    // Local variables
-    char buffer[544]; // r1+0x10
-}
-
-// Range: 0x8001BC14 -> 0x8001BF70
-static s32 mcardSaveChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
-    // Parameters
-    // struct _MCARD* pMCard; // r30
-    // char* buffer; // r31
-
-    // Local variables
-    char buffer2[8192]; // r1+0x1C
-    s32 checksum; // r1+0x18
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001BF70 -> 0x8001C0D8
-static s32 mcardCalculateChecksumFileBlock2(struct _MCARD* pMCard, s32* checksum) {
-    // Parameters
-    // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
-
-    // Local variables
-    s32 i; // r8
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001C0D8 -> 0x8001C240
-static s32 mcardCalculateChecksumFileBlock1(struct _MCARD* pMCard, s32* checksum) {
-    // Parameters
-    // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
-
-    // Local variables
-    s32 i; // r8
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001C240 -> 0x8001C2A0
-static s32 mcardCalculateChecksum(struct _MCARD* pMCard, s32* checksum) {
-    // Parameters
-    // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
-
-    // Local variables
-    s32 i; // r1+0x0
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x8001C2A0 -> 0x8001C444
-static s32 mcardGCErrorHandler(struct _MCARD* pMCard, s32 gcError) {
-    // Parameters
-    // struct _MCARD* pMCard; // r1+0x0
-    // s32 gcError; // r1+0x4
-}
 
 typedef enum _GXTexWrapMode {
     GX_CLAMP = 0,
@@ -1127,4 +372,759 @@ static void mcardUnpackTexPalette(struct __anon_0x1F5D4* pal) {
 
     // Local variables
     u16 i; // r4
+}
+
+// Range: 0x8001C2A0 -> 0x8001C444
+static s32 mcardGCErrorHandler(struct _MCARD* pMCard, s32 gcError) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32 gcError; // r1+0x4
+}
+
+// Range: 0x8001C240 -> 0x8001C2A0
+static s32 mcardCalculateChecksum(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r1+0x0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001C0D8 -> 0x8001C240
+static s32 mcardCalculateChecksumFileBlock1(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r8
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001BF70 -> 0x8001C0D8
+static s32 mcardCalculateChecksumFileBlock2(struct _MCARD* pMCard, s32* checksum) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // s32* checksum; // r1+0x4
+
+    // Local variables
+    s32 i; // r8
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001BC14 -> 0x8001BF70
+static s32 mcardSaveChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* buffer; // r31
+
+    // Local variables
+    char buffer2[8192]; // r1+0x1C
+    s32 checksum; // r1+0x18
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // struct OSCalendarTime* time; // r30
+
+    // Local variables
+    char buffer[544]; // r1+0x10
+}
+
+// Range: 0x8001B794 -> 0x8001BC14
+static s32 mcardReplaceFileBlock(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 index; // r29
+
+    // Local variables
+    s32 checksum1; // r1+0x2238
+    s32 checksum2; // r30
+    char buffer[8192]; // r1+0x238
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B480 -> 0x8001B794
+static s32 mcardCheckChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // char* buffer; // r27
+
+    // Local variables
+    s32 checksum; // r31
+    char buffer2[8192]; // r1+0x18
+    s32 toggle; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B254 -> 0x8001B480
+static s32 mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char* buffer; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardCompareName(char* name1, char* name2) {
+    // Parameters
+    // char* name1; // r4
+    // char* name2; // r5
+}
+
+// Erased
+static s32 mcardCopyName(char* name1, char* name2) {
+    // Parameters
+    // char* name1; // r4
+    // char* name2; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001B168 -> 0x8001B254
+static s32 mcardPoll(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001AFD4 -> 0x8001B168
+static s32 mcardReadyCard(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    s32 i; // r31
+    s32 sectorSize; // r1+0xC
+
+    // References
+    // -> static char gMCardCardWorkArea[40960];
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardFinishCard(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+}
+
+// Erased
+static s32 mcardReadyFile(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Erased
+static s32 mcardFinishFile(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Erased
+static s32 mcardReadAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // s32 offset; // r3
+    // s32 size; // r30
+    // char* buffer; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 offset; // r29
+    // s32 size; // r30
+    // char* buffer; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // struct OSCalendarTime* time; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardTimeCheck(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    struct OSCalendarTime time; // r1+0x22C
+}
+
+// Range: 0x8001AE64 -> 0x8001AFD4
+static s32 mcardReadAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r27
+    // s32 offset; // r28
+    // s32 size; // r29
+    // char* buffer; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001ACC8 -> 0x8001AE64
+static s32 mcardWriteAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 offset; // r27
+    // s32 size; // r28
+    // char* buffer; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001AB1C -> 0x8001ACC8
+static s32 mcardWriteAnywherePartial(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer, s32 partialOffset,
+                                     s32 totalSize) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 offset; // r25
+    // s32 size; // r26
+    // char* buffer; // r27
+    // s32 partialOffset; // r28
+    // s32 totalSize; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A8F8 -> 0x8001AB1C
+static s32 mcardReadFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x254
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A53C -> 0x8001A8F8
+static s32 mcardWriteFileHeader(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0x49C
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A3E4 -> 0x8001A53C
+static s32 mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x8001A1C0 -> 0x8001A3E4
+static s32 mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0xC
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* cardHeader; // r31
+
+    // Local variables
+    char buffer[24608]; // r1+0x258
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // char* cardHeader; // r30
+
+    // Local variables
+    char buffer[24608]; // r1+0x4A0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019FDC -> 0x8001A1C0
+static s32 mcardWriteBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // s32 offset; // r30
+
+    // Local variables
+    struct OSCalendarTime date; // r1+0x258
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019E38 -> 0x80019FDC
+static s32 mcardReadBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 offset; // r27
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteConfigPrepareWriteBuffer(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 checksum; // r1+0x4A0
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019C74 -> 0x80019E38
+static s32 mcardWriteConfigAsynch(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    char dateString[32]; // r1+0x4A4
+    s32 checksum; // r1+0x4A0
+
+    // References
+    // -> struct OSCalendarTime gDate;
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019A70 -> 0x80019C74
+static s32 mcardWriteTimeAsynch(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct OSCalendarTime gDate;
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardReplaceBlock(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r27
+    // s32 index; // r28
+
+    // Local variables
+    s32 checksum1; // r1+0x4A4
+    s32 checksum2; // r29
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x800196D8 -> 0x80019A70
+s32 mcardReadGameData(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r23
+
+    // Local variables
+    s32 checksum1; // r1+0x260
+    s32 checksum2; // r26
+    s32 i; // r25
+    s32 toggle; // r24
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardWriteGameData(struct _MCARD* pMCard, s32 offset) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // s32 offset; // r4
+}
+
+// Erased
+static s32 mcardWriteGameDataWait(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r24
+
+    // Local variables
+    s32 checksum; // r1+0x258
+    s32 i; // r25
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80019670 -> 0x800196D8
+s32 mcardWriteGameDataReset(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x800194D8 -> 0x80019670
+s32 mcardReInit(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x8001947C -> 0x800194D8
+s32 mcardInit(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Range: 0x80019058 -> 0x8001947C
+s32 mcardFileSet(struct _MCARD* pMCard, char* name) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // char* name; // r4
+
+    // Local variables
+    s32 i; // r7
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardGameSetNoSave(struct _MCARD* pMCard, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 size; // r31
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+}
+
+// Range: 0x80018C50 -> 0x80019058
+s32 mcardGameSet(struct _MCARD* pMCard, char* name) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* name; // r28
+
+    // Local variables
+    s32 i; // r29
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+}
+
+// Range: 0x800185F8 -> 0x80018C50
+s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* name; // r21
+    // char* comment; // r25
+    // char* icon; // r27
+    // char* banner; // r26
+    // s32 size; // r1+0x1C
+
+    // Local variables
+    s32 freeBytes; // r1+0x104
+    s32 freeFiles; // r1+0x100
+    s32 totalSize; // r30
+    s32 i; // r21
+    char* buffer; // r1+0xFC
+    struct _GXTexObj texObj; // r1+0xDC
+    void* dataP; // r4
+    struct CARDStat cardStatus; // r1+0x70
+    s32 fileNo; // r21
+    struct OSCalendarTime date; // r1+0x48
+    char dateString[32]; // r1+0x28
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80017D60 -> 0x800185F8
+s32 mcardGameCreate(struct _MCARD* pMCard, char* name, s32 defaultConfiguration, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r25
+    // char* name; // r30
+    // s32 defaultConfiguration; // r29
+    // s32 size; // r27
+
+    // Local variables
+    s32 i; // r26
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 mcardGameCreateDuringGame(struct _MCARD* pMCard, char* name, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r25
+    // char* name; // r29
+    // s32 size; // r24
+
+    // Local variables
+    s32 i; // r26
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80017C24 -> 0x80017D60
+s32 mcardCardErase(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 slot; // r30
+}
+
+// Range: 0x80017A94 -> 0x80017C24
+s32 mcardFileErase(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x800178EC -> 0x80017A94
+s32 mcardGameErase(struct _MCARD* pMCard, s32 index) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // s32 index; // r30
+}
+
+// Erased
+static s32 mcardFileRelease(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+}
+
+// Range: 0x80017844 -> 0x800178EC
+s32 mcardGameRelease(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+}
+
+// Range: 0x80017814 -> 0x80017844
+s32 mcardRead(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // s32 address; // r4
+    // s32 size; // r5
+    // char* data; // r6
+}
+
+// Range: 0x80016E70 -> 0x80017814
+s32 mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+    // enum __anon_0x1A5F0 menuEntry; // r4
+    // enum __anon_0x1BD8E* pCommand; // r30
+
+    // References
+    // -> static enum __anon_0x1A5F0 nextMenuEntry$773;
+    // -> static s32 yes$771;
+    // -> static enum __anon_0x1A5F0 prevMenuEntry$772;
+}
+
+// Range: 0x80016D90 -> 0x80016E70
+s32 mcardOpenError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // enum __anon_0x1BD8E* pCommand; // r4
+}
+
+// Range: 0x80016CB0 -> 0x80016D90
+s32 mcardOpenDuringGameError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+    // Parameters
+    // struct _MCARD* pMCard; // r3
+    // enum __anon_0x1BD8E* pCommand; // r4
+}
+
+// Erased
+static s32 corruptionCheck(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r23
+
+    // Local variables
+    char* buffer; // r1+0x4AC
+    s32 checksum1; // r1+0x4A8
+    s32 checksum2; // r26
+    s32 i; // r25
+    s32 toggle; // r24
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80016950 -> 0x80016CB0
+s32 mcardWrite(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+    // Parameters
+    // struct _MCARD* pMCard; // r28
+    // s32 address; // r29
+    // s32 size; // r30
+    // char* data; // r31
+
+    // Local variables
+    s32 i; // r1+0x8
+    char testByte; // r25
+
+    // References
+    // -> static s32 toggle2$1029;
+    // -> static s32 toggle$1034;
+    // -> struct __anon_0x1BB9D* gpSystem;
+    // -> s32 currentIdx;
+    // -> s32 bNoWriteInCurrentFrame[10];
+    // -> s32 bWrite2Card;
+}
+
+// Erased
+static s32 mcardGetError(struct _MCARD* pMCard, enum __anon_0x1B0CB* pMCardError) {
+    // Parameters
+    // struct _MCARD* pMCard; // r1+0x0
+    // enum __anon_0x1B0CB* pMCardError; // r1+0x4
+}
+
+// Erased
+static s32 mcardCheckSpace(struct _MCARD* pMCard, s32 size) {
+    // Parameters
+    // struct _MCARD* pMCard; // r30
+    // s32 size; // r31
+
+    // Local variables
+    s32 freeBytes; // r1+0x18
+    s32 freeFiles; // r1+0x14
+}
+
+// Range: 0x8001514C -> 0x80016950
+s32 mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
+              s32* defaultConfiguration, s32 fileSize, s32 gameSize) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+    // char* fileName; // r28
+    // char* comment; // r25
+    // char* icon; // r23
+    // char* banner; // r22
+    // char* gameName; // r29
+    // s32* defaultConfiguration; // r21
+    // s32 fileSize; // r26
+    // s32 gameSize; // r30
+
+    // Local variables
+    s32 i; // r19
+    enum __anon_0x1BD8E command; // r1+0x34
+
+    // References
+    // -> struct __anon_0x1BB9D* gpSystem;
+    // -> s32 gButtonDownToggle;
+}
+
+// Range: 0x800145FC -> 0x8001514C
+s32 mcardOpenDuringGame(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r31
+
+    // Local variables
+    s32 i; // r28
+    enum __anon_0x1BD8E command; // r1+0x18
+    s32 loadToggle; // r27
+
+    // References
+    // -> s32 gButtonDownToggle;
+}
+
+// Range: 0x800136F4 -> 0x800145FC
+s32 mcardStore(struct _MCARD* pMCard) {
+    // Parameters
+    // struct _MCARD* pMCard; // r29
+
+    // Local variables
+    s32 i; // r30
+    s32 checksum; // r1+0x4DC
+    s32 bufferOffset; // r4
+    enum __anon_0x1BD8E command; // r1+0x4C8
+
+    // References
+    // -> static s32 checkFailCount$1490;
+    // -> struct _MCARD mCard;
+    // -> struct OSCalendarTime gDate;
+}
+
+// Range: 0x80013440 -> 0x800136F4
+s32 mcardUpdate() {
+    // Local variables
+    s32 j; // r5
+    s32 i; // r5
+    s32 toggle; // r25
+    enum __anon_0x1BD8E command; // r1+0x8
+    s32 prevIndex; // r24
+    s32 index; // r23
+    s32 counter; // r22
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> s32 bWrite2Card;
+    // -> struct __anon_0x1BB9D* gpSystem;
 }

--- a/debug/Fire/mips.c
+++ b/debug/Fire/mips.c
@@ -24,33 +24,41 @@ typedef struct __anon_0x7331D {
     /* 0xC */ s32 nInterrupt;
 } __anon_0x7331D; // size = 0x10
 
-// Range: 0x8008D248 -> 0x8008D358
-s32 mipsEvent(struct __anon_0x7331D* pMips, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x7331D* pMips; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
+typedef enum __anon_0x736C0 {
+    MIT_NONE = -1,
+    MIT_SP = 0,
+    MIT_SI = 1,
+    MIT_AI = 2,
+    MIT_VI = 3,
+    MIT_PI = 4,
+    MIT_DP = 5,
+} __anon_0x736C0;
 
-// Range: 0x8008D358 -> 0x8008D360
-s32 mipsGet64() {}
-
-// Range: 0x8008D360 -> 0x8008D3C8
-s32 mipsGet32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
+// Range: 0x8008D69C -> 0x8008D788
+s32 mipsSetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // enum __anon_0x736C0 eType; // r1+0x4
+
+    // Local variables
+    s32 nInterrupt; // r5
 }
 
-// Range: 0x8008D3C8 -> 0x8008D3D0
-s32 mipsGet16() {}
+// Range: 0x8008D5F8 -> 0x8008D69C
+s32 mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r1+0x0
+    // enum __anon_0x736C0 eType; // r1+0x4
 
-// Range: 0x8008D3D0 -> 0x8008D3D8
-s32 mipsGet8() {}
+    // Local variables
+    s32 nInterrupt; // r5
+}
 
-// Range: 0x8008D3D8 -> 0x8008D3E0
-s32 mipsPut64() {}
+// Range: 0x8008D5F0 -> 0x8008D5F8
+s32 mipsPut8() {}
+
+// Range: 0x8008D5E8 -> 0x8008D5F0
+s32 mipsPut16() {}
 
 // Range: 0x8008D3E0 -> 0x8008D5E8
 s32 mipsPut32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
@@ -63,38 +71,30 @@ s32 mipsPut32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
     s32 nData; // r31
 }
 
-// Range: 0x8008D5E8 -> 0x8008D5F0
-s32 mipsPut16() {}
+// Range: 0x8008D3D8 -> 0x8008D3E0
+s32 mipsPut64() {}
 
-// Range: 0x8008D5F0 -> 0x8008D5F8
-s32 mipsPut8() {}
+// Range: 0x8008D3D0 -> 0x8008D3D8
+s32 mipsGet8() {}
 
-typedef enum __anon_0x736C0 {
-    MIT_NONE = -1,
-    MIT_SP = 0,
-    MIT_SI = 1,
-    MIT_AI = 2,
-    MIT_VI = 3,
-    MIT_PI = 4,
-    MIT_DP = 5,
-} __anon_0x736C0;
+// Range: 0x8008D3C8 -> 0x8008D3D0
+s32 mipsGet16() {}
 
-// Range: 0x8008D5F8 -> 0x8008D69C
-s32 mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+// Range: 0x8008D360 -> 0x8008D3C8
+s32 mipsGet32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r1+0x0
-    // enum __anon_0x736C0 eType; // r1+0x4
-
-    // Local variables
-    s32 nInterrupt; // r5
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
 }
 
-// Range: 0x8008D69C -> 0x8008D788
-s32 mipsSetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
-    // Parameters
-    // struct __anon_0x7331D* pMips; // r1+0x0
-    // enum __anon_0x736C0 eType; // r1+0x4
+// Range: 0x8008D358 -> 0x8008D360
+s32 mipsGet64() {}
 
-    // Local variables
-    s32 nInterrupt; // r5
+// Range: 0x8008D248 -> 0x8008D358
+s32 mipsEvent(struct __anon_0x7331D* pMips, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x7331D* pMips; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/movie.c
+++ b/debug/Fire/movie.c
@@ -13,13 +13,6 @@ u8* gBufferP;
 // size = 0x4, address = 0x80135420
 s32 __OSCurrHeap;
 
-// Erased
-static void MovieDestroy() {
-    // References
-    // -> u8* gBufferP;
-    // -> s32 __OSCurrHeap;
-}
-
 typedef enum __anon_0xEF02 {
     VI_TVMODE_NTSC_INT = 0,
     VI_TVMODE_NTSC_DS = 1,
@@ -59,6 +52,20 @@ typedef struct _GXRenderModeObj {
 // size = 0x4, address = 0x8013559C
 struct _GXRenderModeObj* rmode;
 
+// Range: 0x8000F804 -> 0x8000F890
+void MovieInit() {
+    // Local variables
+    char* szText; // r1+0x8
+    u32 size; // r4
+
+    // References
+    // -> u8* gBufferP;
+    // -> s32 __OSCurrHeap;
+}
+
+// Erased
+static void MovieUpdate() {}
+
 // Range: 0x8000F7CC -> 0x8000F804
 void MovieDraw() {
     // References
@@ -66,14 +73,7 @@ void MovieDraw() {
 }
 
 // Erased
-static void MovieUpdate() {}
-
-// Range: 0x8000F804 -> 0x8000F890
-void MovieInit() {
-    // Local variables
-    char* szText; // r1+0x8
-    u32 size; // r4
-
+static void MovieDestroy() {
     // References
     // -> u8* gBufferP;
     // -> s32 __OSCurrHeap;

--- a/debug/Fire/peripheral.c
+++ b/debug/Fire/peripheral.c
@@ -34,34 +34,6 @@ typedef struct __anon_0x83D15 {
     /* 0x34 */ s32 nWidthPulse2;
 } __anon_0x83D15; // size = 0x38
 
-// Range: 0x8009779C -> 0x800978A4
-s32 peripheralEvent(struct __anon_0x83D15* pPeripheral, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x83D15* pPeripheral; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Range: 0x800978A4 -> 0x800978AC
-s32 peripheralGet64() {}
-
-// Range: 0x800978AC -> 0x800979AC
-s32 peripheralGet32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x83D15* pPeripheral; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x800979AC -> 0x800979B4
-s32 peripheralGet16() {}
-
-// Range: 0x800979B4 -> 0x800979BC
-s32 peripheralGet8() {}
-
-// Range: 0x800979BC -> 0x800979C4
-s32 peripheralPut64() {}
-
 typedef enum __anon_0x8415D {
     SOT_NONE = -1,
     SOT_CPU = 0,
@@ -82,24 +54,6 @@ typedef enum __anon_0x8415D {
     SOT_RDB = 15,
     SOT_COUNT = 16,
 } __anon_0x8415D;
-
-// Range: 0x800979C4 -> 0x80097D48
-s32 peripheralPut32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x83D15* pPeripheral; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
-
-    // Local variables
-    s32 bFlag; // r31
-    enum __anon_0x8415D storageDevice; // r1+0x14
-}
-
-// Range: 0x80097D48 -> 0x80097D50
-s32 peripheralPut16() {}
-
-// Range: 0x80097D50 -> 0x80097D58
-s32 peripheralPut8() {}
 
 typedef enum __anon_0x843DE {
     SM_NONE = -1,
@@ -155,4 +109,50 @@ static s32 peripheralDMA_Complete() {
 
     // References
     // -> struct __anon_0x8464B* gpSystem;
+}
+
+// Range: 0x80097D50 -> 0x80097D58
+s32 peripheralPut8() {}
+
+// Range: 0x80097D48 -> 0x80097D50
+s32 peripheralPut16() {}
+
+// Range: 0x800979C4 -> 0x80097D48
+s32 peripheralPut32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 bFlag; // r31
+    enum __anon_0x8415D storageDevice; // r1+0x14
+}
+
+// Range: 0x800979BC -> 0x800979C4
+s32 peripheralPut64() {}
+
+// Range: 0x800979B4 -> 0x800979BC
+s32 peripheralGet8() {}
+
+// Range: 0x800979AC -> 0x800979B4
+s32 peripheralGet16() {}
+
+// Range: 0x800978AC -> 0x800979AC
+s32 peripheralGet32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x800978A4 -> 0x800978AC
+s32 peripheralGet64() {}
+
+// Range: 0x8009779C -> 0x800978A4
+s32 peripheralEvent(struct __anon_0x83D15* pPeripheral, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x83D15* pPeripheral; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/pif.c
+++ b/debug/Fire/pif.c
@@ -26,128 +26,6 @@ typedef struct __anon_0x4A974 {
     /* 0x1C */ enum __anon_0x4B3FE eControllerType[5];
 } __anon_0x4A974; // size = 0x30
 
-// Range: 0x8006BE68 -> 0x8006C090
-s32 pifEvent(struct __anon_0x4A974* pPIF, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-
-    // Local variables
-    s32 i; // r31
-}
-
-// Range: 0x8006C090 -> 0x8006C0FC
-s32 pifGetData(struct __anon_0x4A974* pPIF, u8* acData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r30
-    // u8* acData; // r31
-}
-
-// Range: 0x8006C0FC -> 0x8006C15C
-s32 pifSetData(struct __anon_0x4A974* pPIF, u8* acData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r31
-    // u8* acData; // r4
-}
-
-// Range: 0x8006C15C -> 0x8006C2F8
-s32 pifProcessOutputData(struct __anon_0x4A974* pPIF) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r29
-
-    // Local variables
-    u8* prx; // r6
-    u8* ptx; // r5
-    s32 iData; // r31
-    s32 channel; // r30
-}
-
-// Range: 0x8006C2F8 -> 0x8006C488
-s32 pifProcessInputData(struct __anon_0x4A974* pPIF) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r30
-
-    // Local variables
-    u8* prx; // r6
-    u8* ptx; // r5
-    s32 iData; // r29
-    s32 channel; // r31
-}
-
-// Range: 0x8006C488 -> 0x8006C72C
-s32 pifExecuteCommand(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r30
-    // u8* buffer; // r31
-    // u8* prx; // r1+0x14
-    // s32 channel; // r7
-}
-
-// Range: 0x8006C72C -> 0x8006C780
-static s32 pifGet64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8006C780 -> 0x8006C7BC
-static s32 pifGet32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8006C7BC -> 0x8006C7F8
-static s32 pifGet16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8006C7F8 -> 0x8006C82C
-static s32 pifGet8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8006C82C -> 0x8006C860
-static s32 pifPut64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8006C860 -> 0x8006C888
-static s32 pifPut32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8006C888 -> 0x8006C8B0
-static s32 pifPut16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8006C8B0 -> 0x8006C8D4
-static s32 pifPut8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // char* pData; // r1+0x8
-}
-
 typedef enum __anon_0x4B3FE {
     CT_NONE = 0,
     CT_CONTROLLER = 1,
@@ -161,31 +39,74 @@ typedef enum __anon_0x4B3FE {
 } __anon_0x4B3FE;
 
 // Erased
-static s32 pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+static s32 pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
     // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x8
-    // u8* buffer; // r4
-    // u8* prx; // r1+0x14
-    // s32 channel; // r7
+    // u16* ptr; // r4
+    // u16* csum; // r1+0x8
+    // u16* icsum; // r1+0xC
 
     // Local variables
-    enum __anon_0x4B3FE type; // r1+0x8
+    u16 data; // r7
+    u32 j; // r1+0x0
+}
+
+// Range: 0x8006CC74 -> 0x8006CD98
+s32 pifReadRumble(u16 address, u8* data) {
+    // Parameters
+    // u16 address; // r1+0x8
+    // u8* data; // r1+0xC
+
+    // Local variables
+    s32 i; // r1+0x0
+}
+
+// Range: 0x8006CC1C -> 0x8006CC74
+s32 pifWriteRumble(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r4
+    // u16 address; // r1+0x10
+    // u8* data; // r1+0x14
+}
+
+// Range: 0x8006CAA4 -> 0x8006CC1C
+static u8 pifContDataCrc(u8* data) {
+    // Parameters
+    // u8* data; // r4
+
+    // Local variables
+    u32 temp; // r3
+    u32 i; // r5
+    u32 j; // r6
+}
+
+// Range: 0x8006C994 -> 0x8006CAA4
+s32 pifSetControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r29
+    // s32 channel; // r30
+    // enum __anon_0x4B3FE type; // r31
+}
+
+// Range: 0x8006C97C -> 0x8006C994
+s32 pifGetEControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE* type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // s32 channel; // r1+0x4
+    // enum __anon_0x4B3FE* type; // r1+0x8
+}
+
+// Range: 0x8006C918 -> 0x8006C97C
+s32 pifSetEEPROMType(struct __anon_0x4A974* pPIF, enum __anon_0x4B3FE type) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // enum __anon_0x4B3FE type; // r1+0x4
 }
 
 // Erased
-static s32 pifQueryController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+static s32 pifGetControllerInput(s32 channel, u32* controllerInput) {
     // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u8* buffer; // r1+0x4
-    // u8* prx; // r1+0xC
-    // s32 channel; // r1+0x10
-}
-
-// Range: 0x8006C8D4 -> 0x8006C918
-s32 pifGetEEPROMSize(struct __anon_0x4A974* pPIF, u32* size) {
-    // Parameters
-    // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32* size; // r1+0x4
+    // s32 channel; // r4
+    // u32* controllerInput; // r5
 }
 
 // Erased
@@ -200,73 +121,152 @@ static s32 pifGetControllerType(struct __anon_0x4A974* pPIF, s32 channel, u16* t
     enum __anon_0x4B3FE eType; // r1+0x0
 }
 
+// Range: 0x8006C8D4 -> 0x8006C918
+s32 pifGetEEPROMSize(struct __anon_0x4A974* pPIF, u32* size) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32* size; // r1+0x4
+}
+
 // Erased
-static s32 pifGetControllerInput(s32 channel, u32* controllerInput) {
-    // Parameters
-    // s32 channel; // r4
-    // u32* controllerInput; // r5
-}
-
-// Range: 0x8006C918 -> 0x8006C97C
-s32 pifSetEEPROMType(struct __anon_0x4A974* pPIF, enum __anon_0x4B3FE type) {
+static s32 pifQueryController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // enum __anon_0x4B3FE type; // r1+0x4
+    // u8* buffer; // r1+0x4
+    // u8* prx; // r1+0xC
+    // s32 channel; // r1+0x10
 }
 
-// Range: 0x8006C97C -> 0x8006C994
-s32 pifGetEControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE* type) {
+// Erased
+static s32 pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x8
+    // u8* buffer; // r4
+    // u8* prx; // r1+0x14
+    // s32 channel; // r7
+
+    // Local variables
+    enum __anon_0x4B3FE type; // r1+0x8
+}
+
+// Range: 0x8006C8B0 -> 0x8006C8D4
+static s32 pifPut8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // s32 channel; // r1+0x4
-    // enum __anon_0x4B3FE* type; // r1+0x8
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
 }
 
-// Range: 0x8006C994 -> 0x8006CAA4
-s32 pifSetControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE type) {
+// Range: 0x8006C888 -> 0x8006C8B0
+static s32 pifPut16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006C860 -> 0x8006C888
+static s32 pifPut32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006C82C -> 0x8006C860
+static s32 pifPut64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006C7F8 -> 0x8006C82C
+static s32 pifGet8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8006C7BC -> 0x8006C7F8
+static s32 pifGet16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006C780 -> 0x8006C7BC
+static s32 pifGet32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006C72C -> 0x8006C780
+static s32 pifGet64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006C488 -> 0x8006C72C
+s32 pifExecuteCommand(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+    // u8* buffer; // r31
+    // u8* prx; // r1+0x14
+    // s32 channel; // r7
+}
+
+// Range: 0x8006C2F8 -> 0x8006C488
+s32 pifProcessInputData(struct __anon_0x4A974* pPIF) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+
+    // Local variables
+    u8* prx; // r6
+    u8* ptx; // r5
+    s32 iData; // r29
+    s32 channel; // r31
+}
+
+// Range: 0x8006C15C -> 0x8006C2F8
+s32 pifProcessOutputData(struct __anon_0x4A974* pPIF) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r29
-    // s32 channel; // r30
-    // enum __anon_0x4B3FE type; // r31
-}
-
-// Range: 0x8006CAA4 -> 0x8006CC1C
-static u8 pifContDataCrc(u8* data) {
-    // Parameters
-    // u8* data; // r4
 
     // Local variables
-    u32 temp; // r3
-    u32 i; // r5
-    u32 j; // r6
+    u8* prx; // r6
+    u8* ptx; // r5
+    s32 iData; // r31
+    s32 channel; // r30
 }
 
-// Range: 0x8006CC1C -> 0x8006CC74
-s32 pifWriteRumble(s32 channel, u16 address, u8* data) {
+// Range: 0x8006C0FC -> 0x8006C15C
+s32 pifSetData(struct __anon_0x4A974* pPIF, u8* acData) {
     // Parameters
-    // s32 channel; // r4
-    // u16 address; // r1+0x10
-    // u8* data; // r1+0x14
+    // struct __anon_0x4A974* pPIF; // r31
+    // u8* acData; // r4
 }
 
-// Range: 0x8006CC74 -> 0x8006CD98
-s32 pifReadRumble(u16 address, u8* data) {
+// Range: 0x8006C090 -> 0x8006C0FC
+s32 pifGetData(struct __anon_0x4A974* pPIF, u8* acData) {
     // Parameters
-    // u16 address; // r1+0x8
-    // u8* data; // r1+0xC
+    // struct __anon_0x4A974* pPIF; // r30
+    // u8* acData; // r31
+}
+
+// Range: 0x8006BE68 -> 0x8006C090
+s32 pifEvent(struct __anon_0x4A974* pPIF, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x4A974* pPIF; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 
     // Local variables
-    s32 i; // r1+0x0
-}
-
-// Erased
-static s32 pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
-    // Parameters
-    // u16* ptr; // r4
-    // u16* csum; // r1+0x8
-    // u16* icsum; // r1+0xC
-
-    // Local variables
-    u16 data; // r7
-    u32 j; // r1+0x0
+    s32 i; // r31
 }

--- a/debug/Fire/ram.c
+++ b/debug/Fire/ram.c
@@ -23,32 +23,128 @@ typedef struct __anon_0x4BFE7 {
     /* 0x8 */ u32 nSize;
 } __anon_0x4BFE7; // size = 0xC
 
-// Range: 0x8006CD98 -> 0x8006CFD0
-s32 ramEvent(struct __anon_0x4BFE7* pRAM, s32 nEvent, void* pArgument) {
+// Range: 0x8006D3A4 -> 0x8006D3AC
+static s32 ramPutControl8() {}
+
+// Range: 0x8006D39C -> 0x8006D3A4
+static s32 ramPutControl16() {}
+
+// Range: 0x8006D368 -> 0x8006D39C
+static s32 ramPutControl32(u32 nAddress) {
     // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
+    // u32 nAddress; // r1+0x4
 }
 
-// Range: 0x8006CFD0 -> 0x8006CFE8
-s32 ramGetSize(struct __anon_0x4BFE7* pRAM, u32* pnSize) {
+// Range: 0x8006D360 -> 0x8006D368
+static s32 ramPutControl64() {}
+
+// Range: 0x8006D358 -> 0x8006D360
+static s32 ramGetControl8() {}
+
+// Range: 0x8006D350 -> 0x8006D358
+static s32 ramGetControl16() {}
+
+// Range: 0x8006D31C -> 0x8006D350
+static s32 ramGetControl32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
+
+// Range: 0x8006D314 -> 0x8006D31C
+static s32 ramGetControl64() {}
+
+// Range: 0x8006D30C -> 0x8006D314
+static s32 ramPutRI8() {}
+
+// Range: 0x8006D304 -> 0x8006D30C
+static s32 ramPutRI16() {}
+
+// Range: 0x8006D2D0 -> 0x8006D304
+static s32 ramPutRI32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
+
+// Range: 0x8006D2C8 -> 0x8006D2D0
+static s32 ramPutRI64() {}
+
+// Range: 0x8006D2C0 -> 0x8006D2C8
+static s32 ramGetRI8() {}
+
+// Range: 0x8006D2B8 -> 0x8006D2C0
+static s32 ramGetRI16() {}
+
+// Range: 0x8006D284 -> 0x8006D2B8
+static s32 ramGetRI32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
+
+// Range: 0x8006D27C -> 0x8006D284
+static s32 ramGetRI64() {}
+
+// Range: 0x8006D258 -> 0x8006D27C
+static s32 ramPut8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32* pnSize; // r1+0x4
+    // u32 nAddress; // r6
+    // char* pData; // r1+0x8
 }
 
-// Range: 0x8006CFE8 -> 0x8006D058
-s32 ramSetSize(struct __anon_0x4BFE7* pRAM, u32 nSize) {
+// Range: 0x8006D230 -> 0x8006D258
+static s32 ramPut16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
     // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r30
-    // u32 nSize; // r31
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r6
+    // s16* pData; // r1+0x8
 }
 
-// Range: 0x8006D058 -> 0x8006D0A0
-s32 ramWipe(struct __anon_0x4BFE7* pRAM) {
+// Range: 0x8006D208 -> 0x8006D230
+static s32 ramPut32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
     // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r3
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r6
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006D1D4 -> 0x8006D208
+static s32 ramPut64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8006D1A4 -> 0x8006D1D4
+static s32 ramGet8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8006D170 -> 0x8006D1A4
+static s32 ramGet16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006D13C -> 0x8006D170
+static s32 ramGet32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006D0F8 -> 0x8006D13C
+static s32 ramGet64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r1+0x0
+    // u32 nAddress; // r4
+    // s64* pData; // r1+0x8
 }
 
 // Range: 0x8006D0A0 -> 0x8006D0F8
@@ -60,126 +156,30 @@ s32 ramGetBuffer(struct __anon_0x4BFE7* pRAM, void* ppRAM, u32 nOffset, u32* pnS
     // u32* pnSize; // r1+0xC
 }
 
-// Range: 0x8006D0F8 -> 0x8006D13C
-static s32 ramGet64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+// Range: 0x8006D058 -> 0x8006D0A0
+s32 ramWipe(struct __anon_0x4BFE7* pRAM) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r3
+}
+
+// Range: 0x8006CFE8 -> 0x8006D058
+s32 ramSetSize(struct __anon_0x4BFE7* pRAM, u32 nSize) {
+    // Parameters
+    // struct __anon_0x4BFE7* pRAM; // r30
+    // u32 nSize; // r31
+}
+
+// Range: 0x8006CFD0 -> 0x8006CFE8
+s32 ramGetSize(struct __anon_0x4BFE7* pRAM, u32* pnSize) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // s64* pData; // r1+0x8
+    // u32* pnSize; // r1+0x4
 }
 
-// Range: 0x8006D13C -> 0x8006D170
-static s32 ramGet32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+// Range: 0x8006CD98 -> 0x8006CFD0
+s32 ramEvent(struct __anon_0x4BFE7* pRAM, s32 nEvent, void* pArgument) {
     // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // s32* pData; // r1+0x8
+    // struct __anon_0x4BFE7* pRAM; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }
-
-// Range: 0x8006D170 -> 0x8006D1A4
-static s32 ramGet16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8006D1A4 -> 0x8006D1D4
-static s32 ramGet8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8006D1D4 -> 0x8006D208
-static s32 ramPut64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8006D208 -> 0x8006D230
-static s32 ramPut32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8006D230 -> 0x8006D258
-static s32 ramPut16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8006D258 -> 0x8006D27C
-static s32 ramPut8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8006D27C -> 0x8006D284
-static s32 ramGetRI64() {}
-
-// Range: 0x8006D284 -> 0x8006D2B8
-static s32 ramGetRI32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x8006D2B8 -> 0x8006D2C0
-static s32 ramGetRI16() {}
-
-// Range: 0x8006D2C0 -> 0x8006D2C8
-static s32 ramGetRI8() {}
-
-// Range: 0x8006D2C8 -> 0x8006D2D0
-static s32 ramPutRI64() {}
-
-// Range: 0x8006D2D0 -> 0x8006D304
-static s32 ramPutRI32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x8006D304 -> 0x8006D30C
-static s32 ramPutRI16() {}
-
-// Range: 0x8006D30C -> 0x8006D314
-static s32 ramPutRI8() {}
-
-// Range: 0x8006D314 -> 0x8006D31C
-static s32 ramGetControl64() {}
-
-// Range: 0x8006D31C -> 0x8006D350
-static s32 ramGetControl32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x8006D350 -> 0x8006D358
-static s32 ramGetControl16() {}
-
-// Range: 0x8006D358 -> 0x8006D360
-static s32 ramGetControl8() {}
-
-// Range: 0x8006D360 -> 0x8006D368
-static s32 ramPutControl64() {}
-
-// Range: 0x8006D368 -> 0x8006D39C
-static s32 ramPutControl32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x8006D39C -> 0x8006D3A4
-static s32 ramPutControl16() {}
-
-// Range: 0x8006D3A4 -> 0x8006D3AC
-static s32 ramPutControl8() {}

--- a/debug/Fire/rdb.c
+++ b/debug/Fire/rdb.c
@@ -25,31 +25,11 @@ typedef struct __anon_0x56A0F {
     /* 0x10C */ void* pHost;
 } __anon_0x56A0F; // size = 0x110
 
-// Range: 0x800715D0 -> 0x800716D8
-s32 rdbEvent(struct __anon_0x56A0F* pRDB, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x56A0F* pRDB; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
+// Range: 0x80071BB0 -> 0x80071BB8
+static s32 rdbPut8() {}
 
-// Range: 0x800716D8 -> 0x800716E0
-static s32 rdbGet64() {}
-
-// Range: 0x800716E0 -> 0x80071714
-static s32 rdbGet32(u32 nAddress) {
-    // Parameters
-    // u32 nAddress; // r1+0x4
-}
-
-// Range: 0x80071714 -> 0x8007171C
-static s32 rdbGet16() {}
-
-// Range: 0x8007171C -> 0x80071724
-static s32 rdbGet8() {}
-
-// Range: 0x80071724 -> 0x8007172C
-static s32 rdbPut64() {}
+// Range: 0x80071BA8 -> 0x80071BB0
+static s32 rdbPut16() {}
 
 // Range: 0x8007172C -> 0x80071BA8
 static s32 rdbPut32(struct __anon_0x56A0F* pRDB, u32 nAddress, s32* pData) {
@@ -63,8 +43,28 @@ static s32 rdbPut32(struct __anon_0x56A0F* pRDB, u32 nAddress, s32* pData) {
     s32 iCounter; // r5
 }
 
-// Range: 0x80071BA8 -> 0x80071BB0
-static s32 rdbPut16() {}
+// Range: 0x80071724 -> 0x8007172C
+static s32 rdbPut64() {}
 
-// Range: 0x80071BB0 -> 0x80071BB8
-static s32 rdbPut8() {}
+// Range: 0x8007171C -> 0x80071724
+static s32 rdbGet8() {}
+
+// Range: 0x80071714 -> 0x8007171C
+static s32 rdbGet16() {}
+
+// Range: 0x800716E0 -> 0x80071714
+static s32 rdbGet32(u32 nAddress) {
+    // Parameters
+    // u32 nAddress; // r1+0x4
+}
+
+// Range: 0x800716D8 -> 0x800716E0
+static s32 rdbGet64() {}
+
+// Range: 0x800715D0 -> 0x800716D8
+s32 rdbEvent(struct __anon_0x56A0F* pRDB, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x56A0F* pRDB; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}

--- a/debug/Fire/rdp.c
+++ b/debug/Fire/rdp.c
@@ -50,85 +50,6 @@ typedef struct __anon_0x52CD0 {
     /* 0x2C */ s32 nClockTMEM;
 } __anon_0x52CD0; // size = 0x30
 
-// Range: 0x8006FEC0 -> 0x80070064
-s32 rdpEvent(struct __anon_0x52CD0* pRDP, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x52CD0* pRDP; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Range: 0x80070064 -> 0x8007006C
-static s32 rdpGetSpan64() {}
-
-// Range: 0x8007006C -> 0x800700DC
-static s32 rdpGetSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x800700DC -> 0x800700E4
-static s32 rdpGetSpan16() {}
-
-// Range: 0x800700E4 -> 0x800700EC
-static s32 rdpGetSpan8() {}
-
-// Range: 0x800700EC -> 0x800700F4
-static s32 rdpPutSpan64() {}
-
-// Range: 0x800700F4 -> 0x80070158
-static s32 rdpPutSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x80070158 -> 0x80070160
-static s32 rdpPutSpan16() {}
-
-// Range: 0x80070160 -> 0x80070168
-static s32 rdpPutSpan8() {}
-
-// Range: 0x80070168 -> 0x80070170
-static s32 rdpGet64() {}
-
-// Range: 0x80070170 -> 0x80070214
-static s32 rdpGet32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x80070214 -> 0x8007021C
-static s32 rdpGet16() {}
-
-// Range: 0x8007021C -> 0x80070224
-static s32 rdpGet8() {}
-
-// Range: 0x80070224 -> 0x8007022C
-static s32 rdpPut64() {}
-
-// Range: 0x8007022C -> 0x80070330
-static s32 rdpPut32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x52CD0* pRDP; // r3
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
-
-    // Local variables
-    s32 nData; // r4
-}
-
-// Range: 0x80070330 -> 0x80070338
-static s32 rdpPut16() {}
-
-// Range: 0x80070338 -> 0x80070340
-static s32 rdpPut8() {}
-
 typedef enum __anon_0x533F6 {
     SM_NONE = -1,
     SM_RUNNING = 0,
@@ -572,4 +493,83 @@ s32 rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {
     // -> static s32 nZCount$125;
     // -> static u32 sCommandCodes$168[3];
     // -> static s32 nZBufferCount$126;
+}
+
+// Range: 0x80070338 -> 0x80070340
+static s32 rdpPut8() {}
+
+// Range: 0x80070330 -> 0x80070338
+static s32 rdpPut16() {}
+
+// Range: 0x8007022C -> 0x80070330
+static s32 rdpPut32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r3
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    s32 nData; // r4
+}
+
+// Range: 0x80070224 -> 0x8007022C
+static s32 rdpPut64() {}
+
+// Range: 0x8007021C -> 0x80070224
+static s32 rdpGet8() {}
+
+// Range: 0x80070214 -> 0x8007021C
+static s32 rdpGet16() {}
+
+// Range: 0x80070170 -> 0x80070214
+static s32 rdpGet32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x80070168 -> 0x80070170
+static s32 rdpGet64() {}
+
+// Range: 0x80070160 -> 0x80070168
+static s32 rdpPutSpan8() {}
+
+// Range: 0x80070158 -> 0x80070160
+static s32 rdpPutSpan16() {}
+
+// Range: 0x800700F4 -> 0x80070158
+static s32 rdpPutSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x800700EC -> 0x800700F4
+static s32 rdpPutSpan64() {}
+
+// Range: 0x800700E4 -> 0x800700EC
+static s32 rdpGetSpan8() {}
+
+// Range: 0x800700DC -> 0x800700E4
+static s32 rdpGetSpan16() {}
+
+// Range: 0x8007006C -> 0x800700DC
+static s32 rdpGetSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x80070064 -> 0x8007006C
+static s32 rdpGetSpan64() {}
+
+// Range: 0x8006FEC0 -> 0x80070064
+s32 rdpEvent(struct __anon_0x52CD0* pRDP, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x52CD0* pRDP; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/rom.c
+++ b/debug/Fire/rom.c
@@ -125,24 +125,6 @@ typedef struct __anon_0x4D873 {
     /* 0x10EF4 */ s32 offsetToRom;
 } __anon_0x4D873; // size = 0x10EF8
 
-// Range: 0x8006D3AC -> 0x8006D5D8
-s32 romEvent(struct __anon_0x4D873* pROM, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Range: 0x8006D5D8 -> 0x8006D620
-s32 romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // char* acNameFile; // r1+0x4
-
-    // Local variables
-    s32 iName; // r6
-}
-
 typedef enum __anon_0x4DD08 {
     XLFT_NONE = -1,
     XLFT_TEXT = 0,
@@ -159,261 +141,6 @@ typedef struct tXL_FILE {
     /* 0x18 */ enum __anon_0x4DD08 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x4DD5C; // size = 0x58
-
-// Range: 0x8006D620 -> 0x8006D794
-s32 romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r28
-    // char* szNameFile; // r29
-
-    // Local variables
-    struct tXL_FILE* pFile; // r1+0x14
-    s32 iName; // r5
-    s32 nSize; // r1+0x10
-}
-
-// Erased
-static s32 romGetCacheSize(struct __anon_0x4D873* pROM, s32* pnSize) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnSize; // r1+0x4
-}
-
-// Range: 0x8006D794 -> 0x8006D830
-s32 romSetCacheSize(struct __anon_0x4D873* pROM, s32 nSize) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r30
-    // s32 nSize; // r4
-}
-
-// Erased
-static s32 romCopyBusy(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-}
-
-// Range: 0x8006D830 -> 0x8006D990
-s32 romUpdate(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r31
-
-    // Local variables
-    s32 nStatus; // r30
-}
-
-// Range: 0x8006D990 -> 0x8006DBF8
-s32 romCopyImmediate(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffsetROM, u32 nSize) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r26
-    // void* pTarget; // r27
-    // s32 nOffsetROM; // r28
-    // u32 nSize; // r29
-
-    // Local variables
-    void* pSource; // r4
-    struct __anon_0x4CFE6* pBlock; // r3
-    s32 nOffsetARAM; // r23
-    s32 nSizeCopy; // r31
-    s32 nOffsetBlock; // r1+0x8
-    s32 nSizeCopyARAM; // r22
-    s32 nSizeDMA; // r21
-    s32 nOffset; // r20
-    s32 nOffsetTarget; // r19
-    u8* pBuffer; // r30
-    u8 anBuffer[608]; // r1+0x18
-}
-
-// Range: 0x8006DBF8 -> 0x8006DE90
-s32 romCopy(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffset, u32 nSize, s32 (*pCallback)()) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r27
-    // void* pTarget; // r28
-    // s32 nOffset; // r29
-    // u32 nSize; // r30
-    // s32 (* pCallback)(); // r31
-
-    // Local variables
-    void* pSource; // r4
-    struct tXL_FILE* pFile; // r1+0x1C
-}
-
-// Erased
-static s32 romGetSize(struct __anon_0x4D873* pROM, s32* pnSize) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnSize; // r1+0x4
-}
-
-// Range: 0x8006DE90 -> 0x8006DEA4
-static s32 romGetDebug64(s64* pData) {
-    // Parameters
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8006DEA4 -> 0x8006DEB4
-static s32 romGetDebug32(s32* pData) {
-    // Parameters
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8006DEB4 -> 0x8006DEC4
-static s32 romGetDebug16(s16* pData) {
-    // Parameters
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8006DEC4 -> 0x8006DED4
-static s32 romGetDebug8(char* pData) {
-    // Parameters
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8006DED4 -> 0x8006DEDC
-static s32 romPutDebug64() {}
-
-// Range: 0x8006DEDC -> 0x8006DEE4
-static s32 romPutDebug32() {}
-
-// Range: 0x8006DEE4 -> 0x8006DEEC
-static s32 romPutDebug16() {}
-
-// Range: 0x8006DEEC -> 0x8006DEF4
-static s32 romPutDebug8() {}
-
-// Range: 0x8006DEF4 -> 0x8006DF70
-static s32 romGet64(struct __anon_0x4D873* pROM, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
-    // s64* pData; // r31
-
-    // Local variables
-    u64 nData; // r1+0x18
-}
-
-// Range: 0x8006DF70 -> 0x8006DFE0
-static s32 romGet32(struct __anon_0x4D873* pROM, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
-    // s32* pData; // r31
-
-    // Local variables
-    u32 nData; // r1+0x14
-}
-
-// Range: 0x8006DFE0 -> 0x8006E050
-static s32 romGet16(struct __anon_0x4D873* pROM, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
-    // s16* pData; // r31
-
-    // Local variables
-    u16 nData; // r1+0x14
-}
-
-// Range: 0x8006E050 -> 0x8006E0C0
-static s32 romGet8(struct __anon_0x4D873* pROM, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
-    // char* pData; // r31
-
-    // Local variables
-    u8 nData; // r1+0x14
-}
-
-// Range: 0x8006E0C0 -> 0x8006E0C8
-static s32 romPut64() {}
-
-// Range: 0x8006E0C8 -> 0x8006E0D0
-static s32 romPut32() {}
-
-// Range: 0x8006E0D0 -> 0x8006E0D8
-static s32 romPut16() {}
-
-// Range: 0x8006E0D8 -> 0x8006E0E0
-static s32 romPut8() {}
-
-// Range: 0x8006E0E0 -> 0x8006E1A4
-s32 romTestCode(struct __anon_0x4D873* pROM, char* acCode) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x8
-    // char* acCode; // r1+0xC
-
-    // Local variables
-    s32 iCode; // r1+0x8
-    char acCodeCurrent[5]; // r1+0x1C
-}
-
-// Erased
-static s32 romGetMask(struct __anon_0x4D873* pROM, s32* pnMask) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnMask; // r1+0x4
-}
-
-// Erased
-static s32 romGetName(struct __anon_0x4D873* pROM, char* acName) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // char* acName; // r1+0x4
-
-    // Local variables
-    s32 iName; // r10
-}
-
-// Range: 0x8006E1A4 -> 0x8006E1D8
-s32 romGetCode(struct __anon_0x4D873* pROM, char* acCode) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-    // char* acCode; // r1+0x4
-}
-
-// Range: 0x8006E1D8 -> 0x8006E3D4
-s32 romGetPC(struct __anon_0x4D873* pROM, u64* pnPC) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r3
-    // u64* pnPC; // r31
-
-    // Local variables
-    s32 nOffset; // r5
-    u32 nData; // r5
-    u32 iData; // r1+0x8
-    u32 anData[1024]; // r1+0x18
-}
-
-// Erased
-static s32 romLoad(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r31
-}
-
-// Range: 0x8006E3D4 -> 0x8006E83C
-static s32 romLoadFullOrPart(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r31
-
-    // Local variables
-    struct tXL_FILE* pFile; // r1+0x1C
-    s32 iBlock; // r1+0x8
-    s32 nLoad; // r27
-    s32 nStep; // r28
-    s32 iData; // r7
-    u32 nData; // r1+0x8
-}
-
-// Erased
-static s32 romCacheAllBlocks(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r27
-
-    // Local variables
-    s32 iCache; // r1+0xC
-    u32 iBlock; // r28
-    u32 iBlockLast; // r1+0x8
-}
 
 typedef struct __anon_0x4F17B {
     /* 0x0 */ s32 nOffsetHost;
@@ -623,22 +350,6 @@ typedef struct _CPU {
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x50A60; // size = 0x12090
 
-// Range: 0x8006E83C -> 0x8006EAC0
-static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r29
-
-    // Local variables
-    struct __anon_0x4CFE6* pBlock; // r28
-    s32 iCache; // r1+0xC
-    s32 nTickLast; // r27
-    u8* anData; // r1+0x8
-    u32 iBlock; // r26
-    u32 nSize; // r26
-    u32 nOffsetBlock; // r1+0x8
-    struct _CPU* pCPU; // r30
-}
-
 typedef enum __anon_0x51281 {
     SM_NONE = -1,
     SM_RUNNING = 0,
@@ -707,37 +418,6 @@ typedef struct __anon_0x515FB {
 // size = 0x4, address = 0x80135600
 struct __anon_0x515FB* gpSystem;
 
-// Range: 0x8006EAC0 -> 0x8006EADC
-static s32 __romCopyUpdate_Complete() {
-    // References
-    // -> struct __anon_0x515FB* gpSystem;
-}
-
-// Range: 0x8006EADC -> 0x8006EC3C
-static s32 romLoadUpdate(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r29
-
-    // Local variables
-    s32 iCache; // r1+0xC
-    struct __anon_0x4CFE6* pBlock; // r4
-    u32 iBlock0; // r31
-    u32 iBlock1; // r25
-    struct _CPU* pCPU; // r30
-}
-
-// Erased
-static s32 romLoadInProgress(struct __anon_0x4D873* pROM) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x0
-}
-
-// Range: 0x8006EC3C -> 0x8006EC58
-static s32 __romLoadUpdate_Complete() {
-    // References
-    // -> struct __anon_0x515FB* gpSystem;
-}
-
 // size = 0x4, address = 0x801355D8
 s32 gDVDResetToggle;
 
@@ -746,6 +426,173 @@ u32 gnFlagZelda;
 
 // size = 0x4, address = 0x801355FC
 s32 gbDisplayedError;
+
+typedef struct _GXTexObj {
+    /* 0x0 */ u32 dummy[8];
+} __anon_0x51BD0; // size = 0x20
+
+typedef enum __anon_0x5219D {
+    RCT_NONE = -1,
+    RCT_RAM = 0,
+    RCT_ARAM = 1,
+} __anon_0x5219D;
+
+// Erased
+static s32 romTestARAM() {}
+
+// Erased
+static s32 romMatchRange(struct __anon_0x4D873* pROM, u32 nOffset, s32* pnOffset0, s32* pnOffset1) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // u32 nOffset; // r1+0x4
+    // s32* pnOffset0; // r1+0x8
+    // s32* pnOffset1; // r1+0xC
+
+    // Local variables
+    s32 iBlock; // r10
+}
+
+// Erased
+static s32 romFreeBlock(struct __anon_0x4D873* pROM, s32 iBlock) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32 iBlock; // r1+0x4
+
+    // Local variables
+    s32 iCache; // r4
+    struct __anon_0x4CFE6* pBlock; // r1+0x0
+}
+
+// Range: 0x8006FDFC -> 0x8006FEC0
+static s32 romFindFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* piCache; // r1+0x4
+    // enum __anon_0x5219D eType; // r1+0x8
+
+    // Local variables
+    s32 iBlock; // r7
+}
+
+// Range: 0x8006FC4C -> 0x8006FDFC
+static s32 romFindOldestBlock(struct __anon_0x4D873* pROM, s32* piBlock, enum __anon_0x5219D eTypeCache,
+                              s32 whichBlock) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // s32* piBlock; // r1+0x4
+    // enum __anon_0x5219D eTypeCache; // r1+0x8
+    // s32 whichBlock; // r1+0xC
+
+    // Local variables
+    struct __anon_0x4CFE6* pBlock; // r7
+    s32 iBlock; // r8
+    s32 iBlockOldest; // r9
+    u32 nTick; // r10
+    u32 nTickDelta; // r11
+    u32 nTickDeltaOldest; // r12
+}
+
+// Range: 0x8006FA38 -> 0x8006FC4C
+static s32 romMakeFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32* piCache; // r31
+    // enum __anon_0x5219D eType; // r1+0x10
+
+    // Local variables
+    s32 iCache; // r1+0x20
+    s32 iBlockOldest; // r1+0x1C
+}
+
+// Range: 0x8006F7E0 -> 0x8006FA38
+static s32 romSetBlockCache(struct __anon_0x4D873* pROM, s32 iBlock, enum __anon_0x5219D eType) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 iBlock; // r1+0xC
+    // enum __anon_0x5219D eType; // r1+0x10
+
+    // Local variables
+    struct __anon_0x4CFE6* pBlock; // r31
+    s32 iCacheRAM; // r1+0x18
+    s32 iCacheARAM; // r1+0x14
+    s32 nOffsetRAM; // r28
+    s32 nOffsetARAM; // r29
+}
+
+// Range: 0x8006F6EC -> 0x8006F7E0
+static s32 __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x8
+
+    // Local variables
+    u32 iData; // r9
+    u32 nData; // r1+0x8
+}
+
+// Range: 0x8006F6D0 -> 0x8006F6EC
+static void __romLoadBlock_CompleteGCN(s32 nResult) {
+    // Parameters
+    // s32 nResult; // r1+0x0
+
+    // Local variables
+    struct __anon_0x4D873* pROM; // r4
+
+    // References
+    // -> struct __anon_0x515FB* gpSystem;
+}
+
+// Range: 0x8006F5D4 -> 0x8006F6D0
+static s32 romLoadBlock(struct __anon_0x4D873* pROM, s32 iBlock, s32 iCache, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+    // s32 iBlock; // r1+0xC
+    // s32 iCache; // r1+0x10
+    // s32 (* pCallback)(); // r1+0x14
+
+    // Local variables
+    u8* anData; // r8
+    s32 nSizeRead; // r10
+    u32 nSize; // r10
+    u32 nOffset; // r1+0x8
+}
+
+// Erased
+static s32 romKeepCheck() {}
+
+// Range: 0x8006F488 -> 0x8006F5D4
+static s32 romLoadRange(struct __anon_0x4D873* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
+                        s32 (*pfProgress)(f32)) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r26
+    // s32 begin; // r1+0xC
+    // s32 end; // r1+0x10
+    // s32* blockCount; // r27
+    // s32 whichBlock; // r1+0x18
+    // s32 (* pfProgress)(f32); // r28
+
+    // Local variables
+    s32 iCache; // r1+0x20
+    u32 iBlock; // r30
+    u32 iBlockLast; // r29
+}
+
+// Range: 0x8006F208 -> 0x8006F488
+static s32 romCacheGame_ZELDA(f32 rProgress) {
+    // Parameters
+    // f32 rProgress; // f31
+
+    // Local variables
+    s32 nSize; // r31
+    f32 matrix44[4][4]; // r1+0x2C
+    struct _GXTexObj textureObject; // r1+0xC
+
+    // References
+    // -> static s32 gbProgress;
+    // -> static s32 iImage$294;
+    // -> struct __anon_0x515FB* gpSystem;
+    // -> static void* gpImageBack;
+    // -> s32 gbDisplayedError;
+}
 
 // Range: 0x8006EC58 -> 0x8006F208
 static s32 romCacheGame(struct __anon_0x4D873* pROM) {
@@ -768,169 +615,322 @@ static s32 romCacheGame(struct __anon_0x4D873* pROM) {
     // -> static u32 ganOffsetBlock_ZLJ[198];
 }
 
-typedef struct _GXTexObj {
-    /* 0x0 */ u32 dummy[8];
-} __anon_0x51BD0; // size = 0x20
-
-// Range: 0x8006F208 -> 0x8006F488
-static s32 romCacheGame_ZELDA(f32 rProgress) {
-    // Parameters
-    // f32 rProgress; // f31
-
-    // Local variables
-    s32 nSize; // r31
-    f32 matrix44[4][4]; // r1+0x2C
-    struct _GXTexObj textureObject; // r1+0xC
-
+// Range: 0x8006EC3C -> 0x8006EC58
+static s32 __romLoadUpdate_Complete() {
     // References
-    // -> static s32 gbProgress;
-    // -> static s32 iImage$294;
     // -> struct __anon_0x515FB* gpSystem;
-    // -> static void* gpImageBack;
-    // -> s32 gbDisplayedError;
-}
-
-// Range: 0x8006F488 -> 0x8006F5D4
-static s32 romLoadRange(struct __anon_0x4D873* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
-                        s32 (*pfProgress)(f32)) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r26
-    // s32 begin; // r1+0xC
-    // s32 end; // r1+0x10
-    // s32* blockCount; // r27
-    // s32 whichBlock; // r1+0x18
-    // s32 (* pfProgress)(f32); // r28
-
-    // Local variables
-    s32 iCache; // r1+0x20
-    u32 iBlock; // r30
-    u32 iBlockLast; // r29
 }
 
 // Erased
-static s32 romKeepCheck() {}
-
-// Range: 0x8006F5D4 -> 0x8006F6D0
-static s32 romLoadBlock(struct __anon_0x4D873* pROM, s32 iBlock, s32 iCache, s32 (*pCallback)()) {
+static s32 romLoadInProgress(struct __anon_0x4D873* pROM) {
     // Parameters
-    // struct __anon_0x4D873* pROM; // r31
-    // s32 iBlock; // r1+0xC
-    // s32 iCache; // r1+0x10
-    // s32 (* pCallback)(); // r1+0x14
-
-    // Local variables
-    u8* anData; // r8
-    s32 nSizeRead; // r10
-    u32 nSize; // r10
-    u32 nOffset; // r1+0x8
+    // struct __anon_0x4D873* pROM; // r1+0x0
 }
 
-// Range: 0x8006F6D0 -> 0x8006F6EC
-static void __romLoadBlock_CompleteGCN(s32 nResult) {
+// Range: 0x8006EADC -> 0x8006EC3C
+static s32 romLoadUpdate(struct __anon_0x4D873* pROM) {
     // Parameters
-    // s32 nResult; // r1+0x0
+    // struct __anon_0x4D873* pROM; // r29
 
     // Local variables
-    struct __anon_0x4D873* pROM; // r4
+    s32 iCache; // r1+0xC
+    struct __anon_0x4CFE6* pBlock; // r4
+    u32 iBlock0; // r31
+    u32 iBlock1; // r25
+    struct _CPU* pCPU; // r30
+}
 
+// Range: 0x8006EAC0 -> 0x8006EADC
+static s32 __romCopyUpdate_Complete() {
     // References
     // -> struct __anon_0x515FB* gpSystem;
 }
 
-// Range: 0x8006F6EC -> 0x8006F7E0
-static s32 __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
+// Range: 0x8006E83C -> 0x8006EAC0
+static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
     // Parameters
-    // struct __anon_0x4D873* pROM; // r1+0x8
+    // struct __anon_0x4D873* pROM; // r29
 
     // Local variables
-    u32 iData; // r9
+    struct __anon_0x4CFE6* pBlock; // r28
+    s32 iCache; // r1+0xC
+    s32 nTickLast; // r27
+    u8* anData; // r1+0x8
+    u32 iBlock; // r26
+    u32 nSize; // r26
+    u32 nOffsetBlock; // r1+0x8
+    struct _CPU* pCPU; // r30
+}
+
+// Erased
+static s32 romCacheAllBlocks(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r27
+
+    // Local variables
+    s32 iCache; // r1+0xC
+    u32 iBlock; // r28
+    u32 iBlockLast; // r1+0x8
+}
+
+// Range: 0x8006E3D4 -> 0x8006E83C
+static s32 romLoadFullOrPart(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x1C
+    s32 iBlock; // r1+0x8
+    s32 nLoad; // r27
+    s32 nStep; // r28
+    s32 iData; // r7
     u32 nData; // r1+0x8
 }
 
-typedef enum __anon_0x5219D {
-    RCT_NONE = -1,
-    RCT_RAM = 0,
-    RCT_ARAM = 1,
-} __anon_0x5219D;
-
-// Range: 0x8006F7E0 -> 0x8006FA38
-static s32 romSetBlockCache(struct __anon_0x4D873* pROM, s32 iBlock, enum __anon_0x5219D eType) {
+// Erased
+static s32 romLoad(struct __anon_0x4D873* pROM) {
     // Parameters
-    // struct __anon_0x4D873* pROM; // r30
-    // s32 iBlock; // r1+0xC
-    // enum __anon_0x5219D eType; // r1+0x10
-
-    // Local variables
-    struct __anon_0x4CFE6* pBlock; // r31
-    s32 iCacheRAM; // r1+0x18
-    s32 iCacheARAM; // r1+0x14
-    s32 nOffsetRAM; // r28
-    s32 nOffsetARAM; // r29
+    // struct __anon_0x4D873* pROM; // r31
 }
 
-// Range: 0x8006FA38 -> 0x8006FC4C
-static s32 romMakeFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
-    // Parameters
-    // struct __anon_0x4D873* pROM; // r30
-    // s32* piCache; // r31
-    // enum __anon_0x5219D eType; // r1+0x10
-
-    // Local variables
-    s32 iCache; // r1+0x20
-    s32 iBlockOldest; // r1+0x1C
-}
-
-// Range: 0x8006FC4C -> 0x8006FDFC
-static s32 romFindOldestBlock(struct __anon_0x4D873* pROM, s32* piBlock, enum __anon_0x5219D eTypeCache,
-                              s32 whichBlock) {
+// Range: 0x8006E1D8 -> 0x8006E3D4
+s32 romGetPC(struct __anon_0x4D873* pROM, u64* pnPC) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // s32* piBlock; // r1+0x4
-    // enum __anon_0x5219D eTypeCache; // r1+0x8
-    // s32 whichBlock; // r1+0xC
+    // u64* pnPC; // r31
 
     // Local variables
-    struct __anon_0x4CFE6* pBlock; // r7
-    s32 iBlock; // r8
-    s32 iBlockOldest; // r9
-    u32 nTick; // r10
-    u32 nTickDelta; // r11
-    u32 nTickDeltaOldest; // r12
+    s32 nOffset; // r5
+    u32 nData; // r5
+    u32 iData; // r1+0x8
+    u32 anData[1024]; // r1+0x18
 }
 
-// Range: 0x8006FDFC -> 0x8006FEC0
-static s32 romFindFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+// Range: 0x8006E1A4 -> 0x8006E1D8
+s32 romGetCode(struct __anon_0x4D873* pROM, char* acCode) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* piCache; // r1+0x4
-    // enum __anon_0x5219D eType; // r1+0x8
-
-    // Local variables
-    s32 iBlock; // r7
+    // char* acCode; // r1+0x4
 }
 
 // Erased
-static s32 romFreeBlock(struct __anon_0x4D873* pROM, s32 iBlock) {
+static s32 romGetName(struct __anon_0x4D873* pROM, char* acName) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32 iBlock; // r1+0x4
+    // char* acName; // r1+0x4
 
     // Local variables
-    s32 iCache; // r4
-    struct __anon_0x4CFE6* pBlock; // r1+0x0
+    s32 iName; // r10
 }
 
 // Erased
-static s32 romMatchRange(struct __anon_0x4D873* pROM, u32 nOffset, s32* pnOffset0, s32* pnOffset1) {
+static s32 romGetMask(struct __anon_0x4D873* pROM, s32* pnMask) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // u32 nOffset; // r1+0x4
-    // s32* pnOffset0; // r1+0x8
-    // s32* pnOffset1; // r1+0xC
+    // s32* pnMask; // r1+0x4
+}
+
+// Range: 0x8006E0E0 -> 0x8006E1A4
+s32 romTestCode(struct __anon_0x4D873* pROM, char* acCode) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x8
+    // char* acCode; // r1+0xC
 
     // Local variables
-    s32 iBlock; // r10
+    s32 iCode; // r1+0x8
+    char acCodeCurrent[5]; // r1+0x1C
+}
+
+// Range: 0x8006E0D8 -> 0x8006E0E0
+static s32 romPut8() {}
+
+// Range: 0x8006E0D0 -> 0x8006E0D8
+static s32 romPut16() {}
+
+// Range: 0x8006E0C8 -> 0x8006E0D0
+static s32 romPut32() {}
+
+// Range: 0x8006E0C0 -> 0x8006E0C8
+static s32 romPut64() {}
+
+// Range: 0x8006E050 -> 0x8006E0C0
+static s32 romGet8(struct __anon_0x4D873* pROM, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // char* pData; // r31
+
+    // Local variables
+    u8 nData; // r1+0x14
+}
+
+// Range: 0x8006DFE0 -> 0x8006E050
+static s32 romGet16(struct __anon_0x4D873* pROM, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s16* pData; // r31
+
+    // Local variables
+    u16 nData; // r1+0x14
+}
+
+// Range: 0x8006DF70 -> 0x8006DFE0
+static s32 romGet32(struct __anon_0x4D873* pROM, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s32* pData; // r31
+
+    // Local variables
+    u32 nData; // r1+0x14
+}
+
+// Range: 0x8006DEF4 -> 0x8006DF70
+static s32 romGet64(struct __anon_0x4D873* pROM, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r3
+    // u32 nAddress; // r4
+    // s64* pData; // r31
+
+    // Local variables
+    u64 nData; // r1+0x18
+}
+
+// Range: 0x8006DEEC -> 0x8006DEF4
+static s32 romPutDebug8() {}
+
+// Range: 0x8006DEE4 -> 0x8006DEEC
+static s32 romPutDebug16() {}
+
+// Range: 0x8006DEDC -> 0x8006DEE4
+static s32 romPutDebug32() {}
+
+// Range: 0x8006DED4 -> 0x8006DEDC
+static s32 romPutDebug64() {}
+
+// Range: 0x8006DEC4 -> 0x8006DED4
+static s32 romGetDebug8(char* pData) {
+    // Parameters
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8006DEB4 -> 0x8006DEC4
+static s32 romGetDebug16(s16* pData) {
+    // Parameters
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8006DEA4 -> 0x8006DEB4
+static s32 romGetDebug32(s32* pData) {
+    // Parameters
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8006DE90 -> 0x8006DEA4
+static s32 romGetDebug64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
 }
 
 // Erased
-static s32 romTestARAM() {}
+static s32 romGetSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* pnSize; // r1+0x4
+}
+
+// Range: 0x8006DBF8 -> 0x8006DE90
+s32 romCopy(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffset, u32 nSize, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r27
+    // void* pTarget; // r28
+    // s32 nOffset; // r29
+    // u32 nSize; // r30
+    // s32 (* pCallback)(); // r31
+
+    // Local variables
+    void* pSource; // r4
+    struct tXL_FILE* pFile; // r1+0x1C
+}
+
+// Range: 0x8006D990 -> 0x8006DBF8
+s32 romCopyImmediate(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffsetROM, u32 nSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r26
+    // void* pTarget; // r27
+    // s32 nOffsetROM; // r28
+    // u32 nSize; // r29
+
+    // Local variables
+    void* pSource; // r4
+    struct __anon_0x4CFE6* pBlock; // r3
+    s32 nOffsetARAM; // r23
+    s32 nSizeCopy; // r31
+    s32 nOffsetBlock; // r1+0x8
+    s32 nSizeCopyARAM; // r22
+    s32 nSizeDMA; // r21
+    s32 nOffset; // r20
+    s32 nOffsetTarget; // r19
+    u8* pBuffer; // r30
+    u8 anBuffer[608]; // r1+0x18
+}
+
+// Range: 0x8006D830 -> 0x8006D990
+s32 romUpdate(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r31
+
+    // Local variables
+    s32 nStatus; // r30
+}
+
+// Erased
+static s32 romCopyBusy(struct __anon_0x4D873* pROM) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+}
+
+// Range: 0x8006D794 -> 0x8006D830
+s32 romSetCacheSize(struct __anon_0x4D873* pROM, s32 nSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 nSize; // r4
+}
+
+// Erased
+static s32 romGetCacheSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // s32* pnSize; // r1+0x4
+}
+
+// Range: 0x8006D620 -> 0x8006D794
+s32 romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r28
+    // char* szNameFile; // r29
+
+    // Local variables
+    struct tXL_FILE* pFile; // r1+0x14
+    s32 iName; // r5
+    s32 nSize; // r1+0x10
+}
+
+// Range: 0x8006D5D8 -> 0x8006D620
+s32 romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r1+0x0
+    // char* acNameFile; // r1+0x4
+
+    // Local variables
+    s32 iName; // r6
+}
+
+// Range: 0x8006D3AC -> 0x8006D5D8
+s32 romEvent(struct __anon_0x4D873* pROM, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x4D873* pROM; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}

--- a/debug/Fire/rsp.c
+++ b/debug/Fire/rsp.c
@@ -286,14 +286,6 @@ typedef struct __anon_0x5845E {
     /* 0x39C8 */ s32* dctBuf;
 } __anon_0x5845E; // size = 0x39CC
 
-// Range: 0x80071BB8 -> 0x80071D8C
-s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
 // size = 0x4, address = 0x801356BC
 s32 gNoSwapBuffer;
 
@@ -570,35 +562,6 @@ typedef struct __anon_0x5A89F {
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x5A89F; // size = 0x3D150
 
-// Range: 0x80071D8C -> 0x80071F6C
-s32 rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r29
-    // enum __anon_0x5943B eMode; // r30
-
-    // Local variables
-    struct __anon_0x575BD* pTask; // r4
-    s32 bDone; // r1+0x10
-    s32 nCount; // r31
-    struct __anon_0x5A89F* pFrame; // r28
-
-    // References
-    // -> s32 gNoSwapBuffer;
-}
-
-// Range: 0x80071F6C -> 0x80071FC0
-s32 rspFrameComplete(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r31
-}
-
-// Range: 0x80071FC0 -> 0x80071FE0
-s32 rspEnableABI(struct __anon_0x5845E* pRSP, s32 bFlag) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s32 bFlag; // r1+0x4
-}
-
 typedef struct __anon_0x5B8F2 {
     /* 0x00 */ s32 nOffsetCode;
     /* 0x04 */ s32 nLengthCode;
@@ -609,95 +572,6 @@ typedef struct __anon_0x5B8F2 {
     /* 0x58 */ s32 nCountVertex;
     /* 0x5C */ enum __anon_0x60B3F eType;
 } __anon_0x5B8F2; // size = 0x60
-
-// Range: 0x80071FE0 -> 0x800720B8
-s32 rspInvalidateCache(struct __anon_0x5845E* pRSP, s32 nOffset0, s32 nOffset1) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-    // s32 nOffset0; // r29
-    // s32 nOffset1; // r30
-
-    // Local variables
-    struct __anon_0x5B8F2* pUCode; // r1+0x14
-    void* pListNode; // r31
-    s32 nOffsetUCode0; // r3
-    s32 nOffsetUCode1; // r1+0x8
-}
-
-// Range: 0x800720B8 -> 0x80072124
-s32 rspGet64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x80072124 -> 0x80072270
-s32 rspGet32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x80072270 -> 0x800722C4
-s32 rspGet16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x800722C4 -> 0x80072318
-s32 rspGet8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x80072318 -> 0x80072384
-s32 rspPut64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x80072384 -> 0x800729B4
-s32 rspPut32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
-
-    // Local variables
-    struct __anon_0x575BD* pTask; // r4
-    s32 nData; // r31
-    s32 nSize; // r1+0x24
-    void* pTarget; // r1+0x20
-    void* pSource; // r4
-    s32 nLength; // r5
-}
-
-// Range: 0x800729B4 -> 0x80072A08
-s32 rspPut16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x80072A08 -> 0x80072A5C
-s32 rspPut8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // char* pData; // r1+0x8
-}
-
-// Erased
-static s32 rspSaveUCode() {}
 
 typedef struct __anon_0x5C1E6 {
     /* 0x0 */ s32 nOffsetHost;
@@ -906,70 +780,6 @@ typedef struct _CPU {
     /* 0x12060 */ u32 nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x5DACB; // size = 0x12090
-
-// Range: 0x80072A5C -> 0x80072C10
-static s32 rspParseGBI(struct __anon_0x5845E* pRSP, s32* pbDone, s32 nCount) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r27
-    // s32* pbDone; // r28
-    // s32 nCount; // r29
-
-    // Local variables
-    s32 bDone; // r1+0x14
-    s32 nStatus; // r3
-    u64* pDL; // r26
-    struct _CPU* pCPU; // r30
-}
-
-// Range: 0x80072C10 -> 0x80072D6C
-static s32 rspParseGBI_Setup(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // struct __anon_0x575BD* pTask; // r31
-
-    // Local variables
-    s32 iSegment; // r1+0x8
-}
-
-// Erased
-static s32 rspTaskComplete(struct __anon_0x5845E* pRSP, s32 bUsedSP, s32 bUsedDP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-    // s32 bUsedSP; // r1+0xC
-    // s32 bUsedDP; // r31
-}
-
-// Erased
-static s32 rspParseDisplayLists(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r28
-
-    // Local variables
-    s32 bDone; // r1+0xC
-    s32 nStatus; // r3
-    s32* pDL; // r1+0x8
-    u64 nGBI; // r30
-}
-
-// Range: 0x80072D6C -> 0x80072EF4
-static s32 rspLoadYield(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r30
-
-    // Local variables
-    s32 iData; // r1+0x8
-    struct __anon_0x575BD* pTask; // r3
-}
-
-// Range: 0x80072EF4 -> 0x8007306C
-static s32 rspSaveYield(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r7
-
-    // Local variables
-    s32 iData; // r1+0x8
-    struct __anon_0x575BD* pTask; // r4
-}
 
 typedef enum __anon_0x5E613 {
     SM_NONE = -1,
@@ -1253,6 +1063,68 @@ typedef enum __anon_0x60B3F {
     RUT_JPEG = 13,
 } __anon_0x60B3F;
 
+// Range: 0x800741CC -> 0x80074454
+static s32 rspLoadMatrix(struct __anon_0x5845E* pRSP, s32 nAddress, f32 (*matrix)[4]) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nAddress; // r4
+    // f32 (* matrix)[4]; // r31
+
+    // Local variables
+    s32* pMtx; // r1+0x18
+    s32 nDataA; // r6
+    s32 nDataB; // r7
+    f32 rScale; // f31
+    f32 rUpper; // r1+0x8
+    f32 rLower; // r1+0x8
+    u16 nUpper; // r1+0x16
+    u16 nLower; // r1+0x14
+}
+
+// Erased
+static s32 rspSetDL(struct __anon_0x5845E* pRSP, s32 nOffsetRDRAM, s32 bPush) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 nOffsetRDRAM; // r1+0xC
+    // s32 bPush; // r31
+
+    // Local variables
+    s32 nAddress; // r5
+    s32* pDL; // r1+0x14
+}
+
+// Erased
+static s32 rspPopDL(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+}
+
+// Erased
+static s32 rspSetupUCode(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+
+    // Local variables
+    struct __anon_0x5A89F* pFrame; // r3
+}
+
+// Erased
+static s32 rspGetNumUCodes(struct __anon_0x5845E* pRSP, u32* pNumCodes) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32* pNumCodes; // r1+0x4
+}
+
+// Erased
+static s32 rspGetUCodeName(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+
+    // Local variables
+    u32 nItemCount; // r1+0x0
+    void* pListNode; // r3
+}
+
 // Range: 0x8007306C -> 0x800741CC
 static s32 rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
@@ -1277,64 +1149,192 @@ static s32 rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTas
     char acUCodeName[64]; // r1+0x1C
 }
 
-// Erased
-static s32 rspGetUCodeName(struct __anon_0x5845E* pRSP) {
+// Range: 0x80072EF4 -> 0x8007306C
+static s32 rspSaveYield(struct __anon_0x5845E* pRSP) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // struct __anon_0x5845E* pRSP; // r7
 
     // Local variables
-    u32 nItemCount; // r1+0x0
-    void* pListNode; // r3
+    s32 iData; // r1+0x8
+    struct __anon_0x575BD* pTask; // r4
 }
 
-// Erased
-static s32 rspGetNumUCodes(struct __anon_0x5845E* pRSP, u32* pNumCodes) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32* pNumCodes; // r1+0x4
-}
-
-// Erased
-static s32 rspSetupUCode(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-
-    // Local variables
-    struct __anon_0x5A89F* pFrame; // r3
-}
-
-// Erased
-static s32 rspPopDL(struct __anon_0x5845E* pRSP) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-}
-
-// Erased
-static s32 rspSetDL(struct __anon_0x5845E* pRSP, s32 nOffsetRDRAM, s32 bPush) {
+// Range: 0x80072D6C -> 0x80072EF4
+static s32 rspLoadYield(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // s32 nOffsetRDRAM; // r1+0xC
-    // s32 bPush; // r31
 
     // Local variables
-    s32 nAddress; // r5
-    s32* pDL; // r1+0x14
+    s32 iData; // r1+0x8
+    struct __anon_0x575BD* pTask; // r3
 }
 
-// Range: 0x800741CC -> 0x80074454
-static s32 rspLoadMatrix(struct __anon_0x5845E* pRSP, s32 nAddress, f32 (*matrix)[4]) {
+// Erased
+static s32 rspParseDisplayLists(struct __anon_0x5845E* pRSP) {
     // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
-    // f32 (* matrix)[4]; // r31
+    // struct __anon_0x5845E* pRSP; // r28
 
     // Local variables
-    s32* pMtx; // r1+0x18
-    s32 nDataA; // r6
-    s32 nDataB; // r7
-    f32 rScale; // f31
-    f32 rUpper; // r1+0x8
-    f32 rLower; // r1+0x8
-    u16 nUpper; // r1+0x16
-    u16 nLower; // r1+0x14
+    s32 bDone; // r1+0xC
+    s32 nStatus; // r3
+    s32* pDL; // r1+0x8
+    u64 nGBI; // r30
+}
+
+// Erased
+static s32 rspTaskComplete(struct __anon_0x5845E* pRSP, s32 bUsedSP, s32 bUsedDP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 bUsedSP; // r1+0xC
+    // s32 bUsedDP; // r31
+}
+
+// Range: 0x80072C10 -> 0x80072D6C
+static s32 rspParseGBI_Setup(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // struct __anon_0x575BD* pTask; // r31
+
+    // Local variables
+    s32 iSegment; // r1+0x8
+}
+
+// Range: 0x80072A5C -> 0x80072C10
+static s32 rspParseGBI(struct __anon_0x5845E* pRSP, s32* pbDone, s32 nCount) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r27
+    // s32* pbDone; // r28
+    // s32 nCount; // r29
+
+    // Local variables
+    s32 bDone; // r1+0x14
+    s32 nStatus; // r3
+    u64* pDL; // r26
+    struct _CPU* pCPU; // r30
+}
+
+// Erased
+static s32 rspSaveUCode() {}
+
+// Range: 0x80072A08 -> 0x80072A5C
+s32 rspPut8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x800729B4 -> 0x80072A08
+s32 rspPut16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x80072384 -> 0x800729B4
+s32 rspPut32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r1+0x10
+
+    // Local variables
+    struct __anon_0x575BD* pTask; // r4
+    s32 nData; // r31
+    s32 nSize; // r1+0x24
+    void* pTarget; // r1+0x20
+    void* pSource; // r4
+    s32 nLength; // r5
+}
+
+// Range: 0x80072318 -> 0x80072384
+s32 rspPut64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x800722C4 -> 0x80072318
+s32 rspGet8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x80072270 -> 0x800722C4
+s32 rspGet16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x80072124 -> 0x80072270
+s32 rspGet32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x800720B8 -> 0x80072124
+s32 rspGet64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x80071FE0 -> 0x800720B8
+s32 rspInvalidateCache(struct __anon_0x5845E* pRSP, s32 nOffset0, s32 nOffset1) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r28
+    // s32 nOffset0; // r29
+    // s32 nOffset1; // r30
+
+    // Local variables
+    struct __anon_0x5B8F2* pUCode; // r1+0x14
+    void* pListNode; // r31
+    s32 nOffsetUCode0; // r3
+    s32 nOffsetUCode1; // r1+0x8
+}
+
+// Range: 0x80071FC0 -> 0x80071FE0
+s32 rspEnableABI(struct __anon_0x5845E* pRSP, s32 bFlag) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s32 bFlag; // r1+0x4
+}
+
+// Range: 0x80071F6C -> 0x80071FC0
+s32 rspFrameComplete(struct __anon_0x5845E* pRSP) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r31
+}
+
+// Range: 0x80071D8C -> 0x80071F6C
+s32 rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r29
+    // enum __anon_0x5943B eMode; // r30
+
+    // Local variables
+    struct __anon_0x575BD* pTask; // r4
+    s32 bDone; // r1+0x10
+    s32 nCount; // r31
+    struct __anon_0x5A89F* pFrame; // r28
+
+    // References
+    // -> s32 gNoSwapBuffer;
+}
+
+// Range: 0x80071BB8 -> 0x80071D8C
+s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/rspASM.c
+++ b/debug/Fire/rspASM.c
@@ -8,836 +8,38 @@
 #include "types.h"
 
 // Erased
-static s32 rspDisassemble(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r22
-    // struct __anon_0x575BD* pTask; // r19
-
-    // Local variables
-    struct tXL_FILE* pIMEMFile; // r1+0x105C
-    s32 i; // r27
-    s32 h; // r20
-    s32 nCodeAddress; // r7
-    s32 nDataAddress; // r9
-    s32 nFound; // r24
-    u32 nOutData; // r31
-    void* pCode; // r1+0x1058
-    void* pData; // r1+0x1054
-    u32 nRS; // r7
-    u32 nRT; // r20
-    u32 nRD; // r21
-    u32 nSA; // r19
-    u32 nOffset; // r6
-    u32 nTarget; // r5
-    u32 nE; // r7
-    u32 nVT; // r7
-    u32 nVS; // r6
-    u32 nVD; // r5
-    u32 nDE; // r6
-    u32 nBase; // r7
-    u32 nElement; // r6
-    u32 nSize; // r1+0x1048
-    s32 nImmediate; // r7
-    s32 nCount; // r29
-    char acOp[8]; // r1+0x1040
-    char acTemp[8]; // r1+0x1038
-    char acOpString[8]; // r1+0x1030
-    char acTempString[128]; // r1+0xFB0
-    char acOpList[500][8]; // r1+0x10
-    s32 nFirst; // r23
-}
-
-// Erased
-static s32 rspDMAWrite(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nDMEMAddress; // r1+0xC
-    // s32 nRDRAMAddress; // r1+0x10
-    // s32 nLength; // r31
-
-    // Local variables
-    s32 i; // r5
-    s32 nAddress; // r5
-    s16* pDMEM; // r30
-    s16* pRDRAM; // r6
-    void* pData; // r1+0x1C
-}
-
-// Erased
-static s32 rspDMARead(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nDMEMAddress; // r1+0xC
-    // s32 nRDRAMAddress; // r1+0x10
-    // s32 nLength; // r30
-
-    // Local variables
-    s32 i; // r5
-    s32 nAddress; // r5
-    s16* pDMEM; // r31
-    s16* pRDRAM; // r6
-    void* pData; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0x4
-    // s16 nE; // r1+0xA
-
-    // Local variables
-    s16 i; // r6
-}
-
-// Erased
-static s32 rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x40
-    // s16 nVD; // r1+0x44
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r26
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x38
-    // s16 nVD; // r1+0x3C
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x38
-    // s16 nVD; // r1+0x3C
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x38
-    // s16 nVD; // r1+0x3C
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x38
-    // s16 nVD; // r1+0x3C
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r25
-    s64 product; // r1+0x8
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x38
-    // s16 nVD; // r1+0x3C
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r28
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x40
-    // s16 nVD; // r1+0x44
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r26
-    s32 j; // r25
-    s64 product; // r1+0x8
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x40
-    // s16 nVD; // r1+0x44
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r26
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x40
-    // s16 nVD; // r1+0x44
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r26
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x40
-    // s16 nVD; // r1+0x44
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s32 i; // r26
-    s32 j; // r25
-    s64 product; // r30
-    s16 buffer[8]; // r1+0x1C
-}
-
-// Erased
-static s32 rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r22
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 nLE; // r27
-    s16 nGE; // r26
-    s16 nEQ; // r25
-    s16 nCarry; // r21
-    s16 i; // r24
-    s16 j; // r23
-    s16 nDI; // r25
-}
-
-// Erased
-static s32 rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r28
-    s16 j; // r27
-    s32 nResult; // r24
-}
-
-// Erased
-static s32 rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r30
-    s16 j; // r29
-    s32 nResult; // r25
-}
-
-// Erased
-static s32 rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r30
-    s16 j; // r29
-    s32 nResult; // r24
-}
-
-// Erased
-static s32 rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r30
-    s16 j; // r29
-    s32 nResult; // r27
-}
-
-// Erased
-static s32 rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r30
-    s16 j; // r29
-    s32 nResult; // r24
-}
-
-// Erased
-static s32 rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r28
-    s16 j; // r1+0x8
-    s32 nResult; // r4
-}
-
-// Erased
-static s32 rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r3
-    // s16 nVD; // r1+0xC
-    // s16 nVS; // r1+0xE
-    // s16 nVT; // r1+0x10
-    // s16 nE; // r1+0x12
-
-    // Local variables
-    s16 i; // r28
-    s16 j; // r1+0x8
-    s32 nResult; // r4
-}
-
-// Erased
-static s32 rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r8
-    s16 i; // r7
-    s16 nStartAddress; // r8
-}
-
-// Erased
-static s32 rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r9
-    s16 i; // r8
-}
-
-// Erased
-static s32 rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    s32 nAddress; // r5
-}
-
-// Erased
-static s32 rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVReg; // r4
-    char* pDMEM; // r7
-}
-
-// Erased
-static s32 rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-}
-
-// Erased
-static s32 rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r4
-    s16 i; // r3
-}
-
-// Erased
-static s32 rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r5
-    char* pDMEM; // r4
-}
-
-// Erased
-static s32 rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r5
-    char* pDMEM; // r4
-}
-
-// Erased
-static s32 rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 nVT; // r1+0x4
-    // s16 nElement; // r1+0x6
-    // s16 nOffset; // r1+0x8
-    // s16 nBase; // r1+0xA
-
-    // Local variables
-    char* pVT; // r4
-}
-
-// Erased
-static s32 rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 nBase; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 rt; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rt; // r1+0x6
-    // s16 rs; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rt; // r1+0x6
-    // s16 sa; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rt; // r1+0x6
-    // s16 sa; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 immediate; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 rt; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmNOP() {}
-
-// Erased
-static s32 rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 vd; // r1+0x6
-    // s16 e; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 rd; // r1+0x6
-}
-
-// Erased
-static s32 rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 rd; // r1+0x6
-}
-
-// Erased
-static s32 rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 immediate; // r1+0x6
-}
-
-// Erased
-static s32 rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 offset; // r1+0x6
-    // s16 base; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 immediate; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 rt; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rt; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 immediate; // r1+0x8
-}
-
-// Erased
-static s32 rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
-    // Parameters
-    // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s16 rd; // r1+0x4
-    // s16 rs; // r1+0x6
-    // s16 rt; // r1+0x8
-}
-
-// Erased
-static s32 rspVSAW(s16* pResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pResult; // r4
-    // u32 nElement; // r1+0x10
-    // s32* pAcc; // r6
-
-    // Local variables
-    s32 i; // r29
-    s32 element; // r28
-    u16 ri; // r1+0x8
-}
-
-// Erased
-static s32 rspVCL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static s32 rspVMULF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
     // Parameters
     // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
+    // s16* pVec2; // r30
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
+    // u32 nElement; // r31
     // s32* pAcc; // r8
 
     // Local variables
-    u16 sf; // r30
-    u16 tf; // r29
-    s32 di; // r1+0x8
-    s32 i; // r28
-    s32 ge; // r11
-    s32 le; // r27
-    s32 vce; // r26
-    s32 eq; // r25
-    s32 carry; // r24
-
-    // References
-    // -> static u8 rsp_VCE;
-    // -> static u16 rsp_VCO;
-    // -> static u16 rsp_VCC;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVGE(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
-    // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r12
-    s16 si; // r1+0x8
-    s16 ti; // r1+0x8
-
-    // References
-    // -> static u16 rsp_VCO;
-    // -> static u16 rsp_VCC;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-    // -> static u8 vco_carry[8];
-    // -> static u8 vco_equal[8];
-}
-
-// Erased
-static s32 rspVSUBC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
-    // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r10
-    s32 di; // r29
-
-    // References
-    // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVADDC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
-    // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r10
-    u32 di; // r27
-
-    // References
-    // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVSUB(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
-    // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r10
-    s32 borrow; // r28
-    s32 di; // r29
-
-    // References
-    // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVADD(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r1+0x10
-    // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r10
-    s32 carry; // r28
-    s32 di; // r28
-
-    // References
-    // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r18
-    // s16* pVecResult; // r6
-    // u32 nElement; // r19
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r24
+    s32 i; // r20
     u16 du; // r1+0x8
-    s64 taccum; // r23
+    s64 taccum; // r19
+    s64 clampMask; // r17
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r19
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r22
+    u16 du; // r1+0x8
+    s64 taccum; // r3
     s64 clampMask; // r21
 
     // References
@@ -845,8 +47,28 @@ static s32 rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* 
     // -> s32 emask_tab[8];
 }
 
-// Range: 0x8008CF0C -> 0x8008D0B0
-static s32 rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+// Erased
+static s32 rspVMUDM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r17
+    // s16* pVecResult; // r6
+    // u32 nElement; // r18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r23
+    u16 du; // r1+0x8
+    s64 taccum; // r22
+    s64 clampMask; // r20
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Range: 0x8008D0B0 -> 0x8008D248
+static s32 rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
@@ -866,7 +88,27 @@ static s32 rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* 
 }
 
 // Erased
-static s32 rspVMADM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static s32 rspVMUDH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r30
+    // s16* pVecResult; // r6
+    // u32 nElement; // r31
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r22
+    u16 du; // r1+0x8
+    s64 taccum; // r21
+    s64 clampMask; // r19
+
+    // References
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r17
@@ -906,7 +148,7 @@ static s32 rspVMADL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* 
 }
 
 // Erased
-static s32 rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static s32 rspVMADM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r17
@@ -925,28 +167,8 @@ static s32 rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* 
     // -> s32 emask_tab[8];
 }
 
-// Erased
-static s32 rspVMUDH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r30
-    // s16* pVecResult; // r6
-    // u32 nElement; // r31
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r22
-    u16 du; // r1+0x8
-    s64 taccum; // r21
-    s64 clampMask; // r19
-
-    // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Range: 0x8008D0B0 -> 0x8008D248
-static s32 rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+// Range: 0x8008CF0C -> 0x8008D0B0
+static s32 rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
@@ -966,38 +188,18 @@ static s32 rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* 
 }
 
 // Erased
-static s32 rspVMUDM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static s32 rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
     // Parameters
     // s16* pVec1; // r4
-    // s16* pVec2; // r17
+    // s16* pVec2; // r18
     // s16* pVecResult; // r6
-    // u32 nElement; // r18
+    // u32 nElement; // r19
     // s32* pAcc; // r8
 
     // Local variables
-    s32 i; // r23
+    s32 i; // r24
     u16 du; // r1+0x8
-    s64 taccum; // r22
-    s64 clampMask; // r20
-
-    // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
-}
-
-// Erased
-static s32 rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
-    // Parameters
-    // s16* pVec1; // r4
-    // s16* pVec2; // r19
-    // s16* pVecResult; // r6
-    // u32 nElement; // r31
-    // s32* pAcc; // r8
-
-    // Local variables
-    s32 i; // r22
-    u16 du; // r1+0x8
-    s64 taccum; // r3
+    s64 taccum; // r23
     s64 clampMask; // r21
 
     // References
@@ -1006,21 +208,819 @@ static s32 rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* 
 }
 
 // Erased
-static s32 rspVMULF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static s32 rspVADD(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
     // Parameters
     // s16* pVec1; // r4
-    // s16* pVec2; // r30
+    // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
+    // u32 nElement; // r1+0x18
     // s32* pAcc; // r8
 
     // Local variables
-    s32 i; // r20
-    u16 du; // r1+0x8
-    s64 taccum; // r19
-    s64 clampMask; // r17
+    s32 i; // r10
+    s32 carry; // r28
+    s32 di; // r28
 
     // References
+    // -> static u16 rsp_VCO;
     // -> s32 cmask_tab[8];
     // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVSUB(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    s32 borrow; // r28
+    s32 di; // r29
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVADDC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    u32 di; // r27
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVSUBC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r10
+    s32 di; // r29
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVGE(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    s32 i; // r12
+    s16 si; // r1+0x8
+    s16 ti; // r1+0x8
+
+    // References
+    // -> static u16 rsp_VCO;
+    // -> static u16 rsp_VCC;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+    // -> static u8 vco_carry[8];
+    // -> static u8 vco_equal[8];
+}
+
+// Erased
+static s32 rspVCL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pVec1; // r4
+    // s16* pVec2; // r1+0x10
+    // s16* pVecResult; // r6
+    // u32 nElement; // r1+0x18
+    // s32* pAcc; // r8
+
+    // Local variables
+    u16 sf; // r30
+    u16 tf; // r29
+    s32 di; // r1+0x8
+    s32 i; // r28
+    s32 ge; // r11
+    s32 le; // r27
+    s32 vce; // r26
+    s32 eq; // r25
+    s32 carry; // r24
+
+    // References
+    // -> static u8 rsp_VCE;
+    // -> static u16 rsp_VCO;
+    // -> static u16 rsp_VCC;
+    // -> s32 cmask_tab[8];
+    // -> s32 emask_tab[8];
+}
+
+// Erased
+static s32 rspVSAW(s16* pResult, u32 nElement, s32* pAcc) {
+    // Parameters
+    // s16* pResult; // r4
+    // u32 nElement; // r1+0x10
+    // s32* pAcc; // r6
+
+    // Local variables
+    s32 i; // r29
+    s32 element; // r28
+    u16 ri; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 immediate; // r1+0x6
+}
+
+// Erased
+static s32 rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rd; // r1+0x6
+}
+
+// Erased
+static s32 rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rd; // r1+0x6
+}
+
+// Erased
+static s32 rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 vd; // r1+0x6
+    // s16 e; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmNOP() {}
+
+// Erased
+static s32 rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 immediate; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 base; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 sa; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 sa; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rt; // r1+0x6
+    // s16 rs; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rd; // r1+0x4
+    // s16 rs; // r1+0x6
+    // s16 rt; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 rt; // r1+0x4
+    // s16 offset; // r1+0x6
+    // s16 nBase; // r1+0x8
+}
+
+// Erased
+static s32 rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r4
+}
+
+// Erased
+static s32 rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r5
+    char* pDMEM; // r4
+}
+
+// Erased
+static s32 rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r5
+    char* pDMEM; // r4
+}
+
+// Erased
+static s32 rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r4
+    s16 i; // r3
+}
+
+// Erased
+static s32 rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+}
+
+// Erased
+static s32 rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVReg; // r4
+    char* pDMEM; // r7
+}
+
+// Erased
+static s32 rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    s32 nAddress; // r5
+}
+
+// Erased
+static s32 rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r9
+    s16 i; // r8
+}
+
+// Erased
+static s32 rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x0
+    // s16 nVT; // r1+0x4
+    // s16 nElement; // r1+0x6
+    // s16 nOffset; // r1+0x8
+    // s16 nBase; // r1+0xA
+
+    // Local variables
+    char* pVT; // r8
+    s16 i; // r7
+    s16 nStartAddress; // r8
+}
+
+// Erased
+static s32 rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r1+0x8
+    s32 nResult; // r4
+}
+
+// Erased
+static s32 rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r1+0x8
+    s32 nResult; // r4
+}
+
+// Erased
+static s32 rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r24
+}
+
+// Erased
+static s32 rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r27
+}
+
+// Erased
+static s32 rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r24
+}
+
+// Erased
+static s32 rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r30
+    s16 j; // r29
+    s32 nResult; // r25
+}
+
+// Erased
+static s32 rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 i; // r28
+    s16 j; // r27
+    s32 nResult; // r24
+}
+
+// Erased
+static s32 rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r22
+    // s16 nVD; // r1+0xC
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s16 nLE; // r27
+    s16 nGE; // r26
+    s16 nEQ; // r25
+    s16 nCarry; // r21
+    s16 i; // r24
+    s16 j; // r23
+    s16 nDI; // r25
+}
+
+// Erased
+static s32 rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r1+0x8
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r1+0x8
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x38
+    // s16 nVD; // r1+0x3C
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r28
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x40
+    // s16 nVD; // r1+0x44
+    // s16 nVS; // r1+0xE
+    // s16 nVT; // r1+0x10
+    // s16 nE; // r1+0x12
+
+    // Local variables
+    s32 i; // r26
+    s32 j; // r25
+    s64 product; // r30
+    s16 buffer[8]; // r1+0x1C
+}
+
+// Erased
+static s32 rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r3
+    // s16 nVD; // r1+0x4
+    // s16 nE; // r1+0xA
+
+    // Local variables
+    s16 i; // r6
+}
+
+// Erased
+static s32 rspDMARead(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nDMEMAddress; // r1+0xC
+    // s32 nRDRAMAddress; // r1+0x10
+    // s32 nLength; // r30
+
+    // Local variables
+    s32 i; // r5
+    s32 nAddress; // r5
+    s16* pDMEM; // r31
+    s16* pRDRAM; // r6
+    void* pData; // r1+0x1C
+}
+
+// Erased
+static s32 rspDMAWrite(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r1+0x8
+    // s32 nDMEMAddress; // r1+0xC
+    // s32 nRDRAMAddress; // r1+0x10
+    // s32 nLength; // r31
+
+    // Local variables
+    s32 i; // r5
+    s32 nAddress; // r5
+    s16* pDMEM; // r30
+    s16* pRDRAM; // r6
+    void* pData; // r1+0x1C
+}
+
+// Erased
+static s32 rspDisassemble(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+    // Parameters
+    // struct __anon_0x5845E* pRSP; // r22
+    // struct __anon_0x575BD* pTask; // r19
+
+    // Local variables
+    struct tXL_FILE* pIMEMFile; // r1+0x105C
+    s32 i; // r27
+    s32 h; // r20
+    s32 nCodeAddress; // r7
+    s32 nDataAddress; // r9
+    s32 nFound; // r24
+    u32 nOutData; // r31
+    void* pCode; // r1+0x1058
+    void* pData; // r1+0x1054
+    u32 nRS; // r7
+    u32 nRT; // r20
+    u32 nRD; // r21
+    u32 nSA; // r19
+    u32 nOffset; // r6
+    u32 nTarget; // r5
+    u32 nE; // r7
+    u32 nVT; // r7
+    u32 nVS; // r6
+    u32 nVD; // r5
+    u32 nDE; // r6
+    u32 nBase; // r7
+    u32 nElement; // r6
+    u32 nSize; // r1+0x1048
+    s32 nImmediate; // r7
+    s32 nCount; // r29
+    char acOp[8]; // r1+0x1040
+    char acTemp[8]; // r1+0x1038
+    char acOpString[8]; // r1+0x1030
+    char acTempString[128]; // r1+0xFB0
+    char acOpList[500][8]; // r1+0x10
+    s32 nFirst; // r23
 }

--- a/debug/Fire/serial.c
+++ b/debug/Fire/serial.c
@@ -22,33 +22,11 @@ typedef struct __anon_0x78791 {
     /* 0x4 */ s32 nAddress;
 } __anon_0x78791; // size = 0x8
 
-// Range: 0x8008EE20 -> 0x8008EF20
-s32 serialEvent(struct __anon_0x78791* pSerial, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x78791* pSerial; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
+// Range: 0x8008F0EC -> 0x8008F0F4
+s32 serialPut8() {}
 
-// Range: 0x8008EF20 -> 0x8008EF28
-s32 serialGet64() {}
-
-// Range: 0x8008EF28 -> 0x8008EF8C
-s32 serialGet32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x78791* pSerial; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8008EF8C -> 0x8008EF94
-s32 serialGet16() {}
-
-// Range: 0x8008EF94 -> 0x8008EF9C
-s32 serialGet8() {}
-
-// Range: 0x8008EF9C -> 0x8008EFA4
-s32 serialPut64() {}
+// Range: 0x8008F0E4 -> 0x8008F0EC
+s32 serialPut16() {}
 
 // Range: 0x8008EFA4 -> 0x8008F0E4
 s32 serialPut32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
@@ -62,8 +40,30 @@ s32 serialPut32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
     void* aData; // r1+0x14
 }
 
-// Range: 0x8008F0E4 -> 0x8008F0EC
-s32 serialPut16() {}
+// Range: 0x8008EF9C -> 0x8008EFA4
+s32 serialPut64() {}
 
-// Range: 0x8008F0EC -> 0x8008F0F4
-s32 serialPut8() {}
+// Range: 0x8008EF94 -> 0x8008EF9C
+s32 serialGet8() {}
+
+// Range: 0x8008EF8C -> 0x8008EF94
+s32 serialGet16() {}
+
+// Range: 0x8008EF28 -> 0x8008EF8C
+s32 serialGet32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x78791* pSerial; // r1+0x0
+    // u32 nAddress; // r1+0x4
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8008EF20 -> 0x8008EF28
+s32 serialGet64() {}
+
+// Range: 0x8008EE20 -> 0x8008EF20
+s32 serialEvent(struct __anon_0x78791* pSerial, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x78791* pSerial; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}

--- a/debug/Fire/simGCN.c
+++ b/debug/Fire/simGCN.c
@@ -806,51 +806,6 @@ typedef enum __anon_0xA6E7 {
     SM_STOPPED = 1,
 } __anon_0xA6E7;
 
-// Range: 0x80007F80 -> 0x80008538
-s32 xlMain() {
-    // Local variables
-    struct _GXColor color; // r1+0x3C
-    enum __anon_0xA6E7 eMode; // r1+0x38
-    s32 nSize0; // r1+0x34
-    s32 nSize1; // r1+0x30
-    s32 iName; // r5
-    char* szNameROM; // r1+0x2C
-    char acNameROM[32]; // r1+0xC
-    s32 rumbleYes; // r1+0x8
-
-    // References
-    // -> static struct __anon_0x57A1* gpCode;
-    // -> struct __anon_0x87F6* gpFrame;
-    // -> struct __anon_0x7181* gpSound;
-    // -> struct __anon_0x6EA4* gpSystem;
-    // -> struct _XL_OBJECTTYPE gClassSystem;
-    // -> struct _XL_OBJECTTYPE gClassSound;
-    // -> struct _XL_OBJECTTYPE gClassFrame;
-    // -> struct _XL_OBJECTTYPE gClassCode;
-    // -> static char* gaszArgument[8];
-    // -> struct _MCARD mCard;
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
-    // -> u8 gmesgOK[833];
-    // -> u8 gno[1473];
-    // -> u8 gyes[1473];
-    // -> u8 gbar[1857];
-    // -> u8 greadingDisk[3137];
-    // -> u8 gwrongDisk[7937];
-    // -> u8 gfatalErr[13025];
-    // -> u8 gretryErr[9281];
-    // -> u8 gnoDisk[7937];
-    // -> u8 gcoverOpen[10433];
-    // -> void* DemoFrameBuffer1;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> u8 DemoStatEnable;
-    // -> s32 gResetBeginFlag;
-    // -> s32 gButtonDownToggle;
-    // -> s32 gbDisplayedError;
-    // -> s32 gDVDResetToggle;
-}
-
 typedef enum __anon_0xA982 {
     SAT_NONE = -1,
     SAT_NAME = 0,
@@ -863,27 +818,6 @@ typedef enum __anon_0xA982 {
     SAT_RESET = 7,
     SAT_COUNT_ = 8,
 } __anon_0xA982;
-
-// Range: 0x80008538 -> 0x80008578
-s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
-    // Parameters
-    // enum __anon_0xA982 eType; // r1+0x0
-    // char** pszArgument; // r1+0x4
-
-    // References
-    // -> static char* gaszArgument[8];
-}
-
-// Range: 0x80008578 -> 0x800086DC
-static s32 simulatorParseArguments() {
-    // Local variables
-    s32 iArgument; // r23
-    char* szText; // r1+0x14
-    char* szValue; // r1+0x10
-
-    // References
-    // -> static char* gaszArgument[8];
-}
 
 typedef struct PADStatus {
     /* 0x0 */ u16 button;
@@ -914,254 +848,6 @@ typedef struct __anon_0xAD2F {
 // size = 0x78, address = 0x80132758
 struct __anon_0xAD2F DemoPad[4];
 
-// Erased
-static s32 editSoundMenu() {
-    // Local variables
-    s32* menuValues[3]; // r1+0x94
-    s32 menuMinMax[3][2]; // r1+0x7C
-    char* menuNames[3]; // r1+0x70
-    char* menuHelp[3]; // r1+0x64
-    char str[32]; // r1+0x44
-    s32 curItem; // r24
-    s32 bDone; // r1+0xA0
-    s32 i; // r6
-    u32 heldButtons; // r7
-    u32 buttons; // r8
-    u32 downButtons; // r1+0x8
-    u8 holdCount[16]; // r1+0x34
-    struct _GXColor color[3]; // r1+0x28
-    s32 step; // r20
-    u32 bit; // r1+0x8
-    struct _GXColor* colorP; // r31
-
-    // References
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-}
-
-// Erased
-static void MyGXInit() {
-    // Local variables
-    s32 i; // r31
-    f32 identity_mtx[3][4]; // r1+0x50
-}
-
-// Erased
-static s32 simulatorMenu() {}
-
-// Erased
-static s32 simulatorPickROM() {}
-
-// Erased
-static s32 simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
-    // Parameters
-    // char* line1; // r22
-    // char* line2; // r23
-    // char* line3; // r24
-
-    // Local variables
-    s32 nCount; // r25
-
-    // References
-    // -> s32 gButtonDownToggle;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-}
-
-// Erased
-static s32 simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, s32* yes) {
-    // Parameters
-    // char* line1; // r21
-    // char* line2; // r22
-    // char* line3; // r23
-    // s32* yes; // r24
-
-    // Local variables
-    s32 nCount; // r25
-
-    // References
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-}
-
-// Range: 0x800086DC -> 0x800088E4
-static s32 simulatorDrawCursor(s32 nX, s32 nY) {
-    // Parameters
-    // s32 nX; // r30
-    // s32 nY; // r31
-
-    // Local variables
-    struct _GXColor color; // r1+0x18
-    s32 nTick; // r4
-}
-
-// Range: 0x800088E4 -> 0x80008A14
-s32 simulatorMCardPollDrawFormatBar() {
-    // Local variables
-    f32 rate; // r1+0x8
-    s32 nBytes; // r1+0x8
-
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008A14 -> 0x80008B44
-s32 simulatorMCardPollDrawBar() {
-    // Local variables
-    f32 rate; // r1+0x8
-    s32 nBytes; // r1+0x8
-
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008B44 -> 0x80008BDC
-s32 simulatorDrawMCardText() {
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-}
-
-// Erased
-static s32 simulatorDrawText(s32 nX, s32 nY, char* szText, s32 nColorR, s32 nColorG, s32 nColorB) {
-    // Parameters
-    // s32 nX; // r26
-    // s32 nY; // r27
-    // char* szText; // r28
-    // s32 nColorR; // r29
-    // s32 nColorG; // r30
-    // s32 nColorB; // r31
-
-    // Local variables
-    struct _GXColor color; // r1+0x24
-}
-
-// Range: 0x80008BDC -> 0x80008DBC
-s32 simulatorTestReset(s32 IPL, s32 forceMenu, s32 allowReset, s32 usePreviousSettings) {
-    // Parameters
-    // s32 IPL; // r24
-    // s32 forceMenu; // r25
-    // s32 allowReset; // r26
-    // s32 usePreviousSettings; // r27
-
-    // Local variables
-    u32 bFlag; // r1+0x8
-    u32 nTick; // r1+0x8
-    s32 prevIPLSetting; // r28
-    s32 prevForceMenuSetting; // r27
-    s32 prevAllowResetSetting; // r1+0x8
-
-    // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gResetBeginFlag;
-    // -> s32 gPreviousAllowResetSetting;
-    // -> s32 gPreviousForceMenuSetting;
-    // -> s32 gPreviousIPLSetting;
-}
-
-// Erased
-static void sScreenshotFree() {}
-
-// Erased
-static void* sScreenshotAlloc() {}
-
-// Range: 0x80008DBC -> 0x80008DE4
-s32 simulatorRumbleStop(s32 channel) {
-    // Parameters
-    // s32 channel; // r3
-}
-
-// Range: 0x80008DE4 -> 0x80008E0C
-s32 simulatorRumbleStart(s32 channel) {
-    // Parameters
-    // s32 channel; // r3
-}
-
-// Range: 0x80008E0C -> 0x80008E40
-s32 simulatorWriteFLASH(u32 address, u8* data, s32 size) {
-    // Parameters
-    // u32 address; // r4
-    // u8* data; // r6
-    // s32 size; // r5
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008E40 -> 0x80008E74
-s32 simulatorReadFLASH(u32 address, u8* data, s32 size) {
-    // Parameters
-    // u32 address; // r4
-    // u8* data; // r6
-    // s32 size; // r5
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008E74 -> 0x80008EA8
-s32 simulatorWriteSRAM(u32 address, u8* data, s32 size) {
-    // Parameters
-    // u32 address; // r4
-    // u8* data; // r6
-    // s32 size; // r5
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008EA8 -> 0x80008EDC
-s32 simulatorReadSRAM(u32 address, u8* data, s32 size) {
-    // Parameters
-    // u32 address; // r4
-    // u8* data; // r6
-    // s32 size; // r5
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80008EDC -> 0x80008F4C
-s32 simulatorWriteEEPROM(u8 address, u8* data) {
-    // Parameters
-    // u8 address; // r30
-    // u8* data; // r31
-
-    // Local variables
-    s32 size; // r1+0x10
-
-    // References
-    // -> struct _MCARD mCard;
-    // -> struct __anon_0x6EA4* gpSystem;
-}
-
-// Range: 0x80008F4C -> 0x80008FBC
-s32 simulatorReadEEPROM(u8 address, u8* data) {
-    // Parameters
-    // u8 address; // r30
-    // u8* data; // r31
-
-    // Local variables
-    s32 size; // r1+0x10
-
-    // References
-    // -> struct _MCARD mCard;
-    // -> struct __anon_0x6EA4* gpSystem;
-}
-
 typedef enum __anon_0xC003 {
     CT_NONE = 0,
     CT_CONTROLLER = 1,
@@ -1174,84 +860,6 @@ typedef enum __anon_0xC003 {
     CT_COUNT = 8,
 } __anon_0xC003;
 
-// Range: 0x80008FBC -> 0x80009038
-s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
-    // Parameters
-    // s32 channel; // r29
-    // u16 address; // r30
-    // u8* data; // r31
-
-    // Local variables
-    enum __anon_0xC003 type; // r1+0x14
-
-    // References
-    // -> struct __anon_0x6EA4* gpSystem;
-}
-
-// Range: 0x80009038 -> 0x800090B4
-s32 simulatorReadPak(s32 channel, u16 address, u8* data) {
-    // Parameters
-    // s32 channel; // r29
-    // u16 address; // r30
-    // u8* data; // r31
-
-    // Local variables
-    enum __anon_0xC003 type; // r1+0x14
-
-    // References
-    // -> struct __anon_0x6EA4* gpSystem;
-}
-
-// Range: 0x800090B4 -> 0x80009108
-s32 simulatorDetectController(s32 channel) {
-    // Parameters
-    // s32 channel; // r31
-
-    // Local variables
-    struct PADStatus status[4]; // r1+0xC
-}
-
-// Erased
-static s32 simulatorResetController() {}
-
-// Range: 0x80009108 -> 0x80009110
-s32 simulatorShowLoad() {}
-
-// Erased
-static void DEMOInitWindow(s32 nSizeX, s32 nSizeY, s32 nColorR, s32 nColorG, s32 nColorB) {
-    // Parameters
-    // s32 nSizeX; // r3
-    // s32 nSizeY; // r1+0xC
-    // s32 nColorR; // r29
-    // s32 nColorG; // r30
-    // s32 nColorB; // r31
-
-    // Local variables
-    struct _GXColor color; // r1+0x20
-}
-
-// Range: 0x80009110 -> 0x80009684
-s32 simulatorReadController(s32 channel, u32* anData) {
-    // Parameters
-    // s32 channel; // r29
-    // u32* anData; // r30
-
-    // Local variables
-    f32 subStickTest; // f1
-    s32 stickX; // r1+0x8
-    s32 stickY; // r1+0x8
-    s32 subStickX; // r6
-    s32 subStickY; // r7
-    s32 nDirButton; // r3
-
-    // References
-    // -> static u32 gContMap[4][20];
-    // -> static u32 nCurrButton$702;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
-    // -> static u32 nPrevButton$701;
-}
-
 typedef struct __anon_0xC654 {
     /* 0x000 */ char rom[36];
     /* 0x024 */ s32 controllerConfiguration[4][20];
@@ -1261,73 +869,11 @@ typedef struct __anon_0xC654 {
     /* 0x170 */ s32 currentControllerConfig;
 } __anon_0xC654; // size = 0x174
 
-// Erased
-static s32 simulatorChangeControllerConfig(s32 channel, s32 nCurrButton) {
-    // Parameters
-    // s32 channel; // r31
-    // s32 nCurrButton; // r1+0xC
-
-    // References
-    // -> static u32 gContMap[4][20];
-    // -> static struct __anon_0xC654 gSystemRomConfigurationList[1];
-    // -> struct __anon_0x6EA4* gpSystem;
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80009684 -> 0x8000974C
-s32 simulatorCopyControllerMap(u32* mapDataOutput, u32* mapDataInput) {
-    // Parameters
-    // u32* mapDataOutput; // r1+0x0
-    // u32* mapDataInput; // r1+0x4
-
-    // Local variables
-    s32 i; // r7
-}
-
-// Range: 0x8000974C -> 0x80009824
-s32 simulatorSetControllerMap(u32* mapData, s32 channel) {
-    // Parameters
-    // u32* mapData; // r1+0x0
-    // s32 channel; // r1+0x4
-
-    // Local variables
-    s32 i; // r7
-
-    // References
-    // -> static u32 gContMap[4][20];
-}
-
 typedef enum __anon_0xC9F9 {
     SV_NONE = 0,
     SV_CODE = 1,
     SV_FRAME = 2,
 } __anon_0xC9F9;
-
-// Erased
-static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
-    // Parameters
-    // enum __anon_0xC9F9 eView; // r1+0x8
-
-    // References
-    // -> static struct __anon_0x57A1* gpCode;
-    // -> struct __anon_0x87F6* gpFrame;
-}
-
-// Erased
-static enum __anon_0xC9F9 simulatorGetView() {
-    // References
-    // -> static struct __anon_0x57A1* gpCode;
-    // -> struct __anon_0x87F6* gpFrame;
-}
-
-// Erased
-static s32 simulatorShowParts() {}
-
-// Erased
-static s32 simulatorAddXtraTime() {}
-
-// Erased
-static s32 simulatorSetPart() {}
 
 typedef enum __anon_0xCB82 {
     VI_TVMODE_NTSC_INT = 0,
@@ -1371,32 +917,6 @@ struct _GXRenderModeObj* rmode;
 // size = 0x4, address = 0x80135644
 s32 gMovieErrorToggle;
 
-// Range: 0x80009824 -> 0x80009980
-void simulatorResetAndPlayMovie() {
-    // Local variables
-    struct _GXColor color; // r1+0x14
-    struct _GXRenderModeObj* simrmode; // r31
-
-    // References
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-    // -> s32 gMovieErrorToggle;
-    // -> struct _GXRenderModeObj* rmode;
-    // -> struct _MCARD mCard;
-}
-
-// Range: 0x80009980 -> 0x80009A30
-void simulatorReset(s32 IPL, s32 forceMenu) {
-    // Parameters
-    // s32 IPL; // r30
-    // s32 forceMenu; // r31
-
-    // References
-    // -> struct _MCARD mCard;
-}
-
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
     /* 0x4 */ char company[2];
@@ -1428,53 +948,6 @@ typedef struct DVDFileInfo {
     /* 0x34 */ u32 length;
     /* 0x38 */ void (*callback)(s32, struct DVDFileInfo*);
 } __anon_0xD50B; // size = 0x3C
-
-// Range: 0x80009A30 -> 0x8000CB7C
-s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
-    // Parameters
-    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
-
-    // Local variables
-    struct DVDFileInfo fileInfo; // r1+0x80
-
-    // References
-    // -> s32 gButtonDownToggle;
-    // -> struct __anon_0x6EA4* gpSystem;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> u8 gmesgOK[833];
-    // -> char gpErrorMessageBuffer[20480];
-    // -> u8 gyes[1473];
-    // -> u32 gmsg_sv_shareSize;
-    // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv12Size;
-    // -> u32 gmsg_sv11Size;
-    // -> u32 gmsg_sv10Size;
-    // -> u32 gmsg_sv07Size;
-    // -> u32 gmsg_sv06_3Size;
-    // -> u32 gmsg_sv06_2Size;
-    // -> u32 gmsg_sv06_1Size;
-    // -> u32 gmsg_sv05_1Size;
-    // -> u32 gmsg_sv04Size;
-    // -> u32 gmsg_sv03Size;
-    // -> u32 gmsg_sv02Size;
-    // -> u32 gmsg_sv01_2Size;
-    // -> u32 gmsg_sv01Size;
-    // -> u32 gmsg_in05Size;
-    // -> u32 gmsg_in04Size;
-    // -> u32 gmsg_in03Size;
-    // -> u32 gmsg_gf06Size;
-    // -> u32 gmsg_gf05Size;
-    // -> u32 gmsg_gf04Size;
-    // -> u32 gmsg_gf03Size;
-    // -> u32 gmsg_ld06_3Size;
-    // -> u32 gmsg_ld06_2Size;
-    // -> u32 gmsg_ld06_1Size;
-    // -> u32 gmsg_ld05_1Size;
-    // -> u32 gmsg_ld04Size;
-    // -> u32 gmsg_ld03Size;
-    // -> u32 gmsg_ld02Size;
-    // -> u32 gmsg_ld01Size;
-}
 
 typedef enum _GXTexFilter {
     GX_NEAR = 0,
@@ -1527,120 +1000,50 @@ typedef struct __anon_0xDB69 {
     /* 0x8 */ struct __anon_0xDAF8* descriptorArray;
 } __anon_0xDB69; // size = 0xC
 
-// Erased
-static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
-    // Parameters
-    // struct __anon_0xDB69* simulatorMessage; // r27
-
-    // References
-    // -> s32 gButtonDownToggle;
-    // -> struct __anon_0x6EA4* gpSystem;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> u8 gmesgOK[833];
-    // -> u8 gyes[1473];
-}
-
-// Range: 0x8000CB7C -> 0x8000CF24
-s32 simulatorDrawYesNoMessage(enum __anon_0x61D7 simulatorMessage, s32* yes) {
-    // Parameters
-    // enum __anon_0x61D7 simulatorMessage; // r1+0x8
-    // s32* yes; // r30
-
-    // Local variables
-    struct DVDFileInfo fileInfo; // r1+0x10
-
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-    // -> u32 gmsg_sv08Size;
-    // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv06_5Size;
-    // -> u32 gmsg_sv06_4Size;
-    // -> u32 gmsg_in01Size;
-    // -> u32 gmsg_gf01Size;
-    // -> u32 gmsg_ld07Size;
-    // -> u32 gmsg_ld06_4Size;
-    // -> u32 gmsg_ld05_2Size;
-}
-
-// Range: 0x8000CF24 -> 0x8000D1F0
-s32 simulatorDrawYesNoMessageLoop(struct __anon_0xDB69* simulatorQuestion, s32* yes) {
-    // Parameters
-    // struct __anon_0xDB69* simulatorQuestion; // r26
-    // s32* yes; // r27
-
-    // References
-    // -> struct __anon_0x6EA4* gpSystem;
-    // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
-    // -> u8 gno[1473];
-    // -> u8 gyes[1473];
-    // -> s32 gHighlightChoice;
-}
-
-// Erased
-static s32 simulatorDrawErrorMessageFromDVD(s32 drawBar, s32 percent) {
-    // Parameters
-    // s32 drawBar; // r29
-    // s32 percent; // r30
-
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-}
-
-// Range: 0x8000D1F0 -> 0x8000D35C
-s32 simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
-    // Parameters
-    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
-
-    // Local variables
-    struct DVDFileInfo fileInfo; // r1+0xC
-
-    // References
-    // -> char gpErrorMessageBuffer[20480];
-    // -> u32 gmsg_gf02Size;
-    // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv09Size;
-    // -> u32 gmsg_in02Size;
-}
-
-// Range: 0x8000D35C -> 0x8000D58C
-s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 drawBar, s32 percent) {
-    // Parameters
-    // enum __anon_0x61D7 simulatorErrorMessage; // r28
-    // s32 drawBar; // r29
-    // s32 percent; // r31
-
-    // References
-    // -> s32 gbDisplayedError;
-    // -> u8 gfatalErr[13025];
-    // -> u8 gnoDisk[7937];
-    // -> u8 gretryErr[9281];
-    // -> u8 greadingDisk[3137];
-    // -> u8 gwrongDisk[7937];
-    // -> u8 gcoverOpen[10433];
-}
-
 typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
 } __anon_0xE08E; // size = 0x20
 
-// Range: 0x8000D58C -> 0x8000DBB4
-s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message, struct __anon_0xDB69* tplOK,
-                         s32 nX0OK, s32 nY0OK) {
+// Range: 0x8000F0FC -> 0x8000F7CC
+s32 simulatorGXInit() {
+    // Local variables
+    s32 i; // r31
+    struct _GXColor GX_DEFAULT_BG; // r1+0x58
+    struct _GXColor BLACK; // r1+0x54
+    struct _GXColor WHITE; // r1+0x50
+    f32 identity_mtx[3][4]; // r1+0x20
+}
+
+// Range: 0x8000F020 -> 0x8000F0FC
+void simulatorUnpackTexPalette(struct __anon_0xDB69* pal) {
     // Parameters
-    // struct __anon_0xDB69* tplMessage; // r29
-    // s32 nX0Message; // r28
-    // s32 nY0Message; // r27
-    // struct __anon_0xDB69* tplOK; // r23
-    // s32 nX0OK; // r24
-    // s32 nY0OK; // r25
+    // struct __anon_0xDB69* pal; // r1+0x0
 
     // Local variables
-    struct _GXTexObj texObj; // r1+0x98
-    struct _GXColor color0; // r1+0x94
-    struct _GXColor color1; // r1+0x90
-    f32 identity_mtx[3][4]; // r1+0x5C
-    f32 g2DviewMtx[3][4]; // r1+0x2C
+    u16 i; // r4
+}
+
+// Erased
+static void simulatorDEMOSwapBuffers() {
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+}
+
+// Erased
+static void simulatorDEMODoneRender() {
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Erased
+static s32 simulatorDrawBlack() {
+    // Local variables
+    struct _GXColor color; // r1+0x6C
 
     // References
     // -> struct __anon_0x87F6* gpFrame;
@@ -1648,9 +1051,78 @@ s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 n
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
     // -> u8 DemoStatEnable;
+}
+
+// Range: 0x8000EE18 -> 0x8000F020
+s32 simulatorDVDShowError(s32 nStatus) {
+    // Parameters
+    // s32 nStatus; // r26
+
+    // Local variables
+    s32 continueToggle; // r28
+    enum __anon_0x61D7 nMessage; // r27
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> s32 gDVDResetToggle;
+    // -> static s32 toggle$192;
+}
+
+// Range: 0x8000EDA8 -> 0x8000EE18
+s32 simulatorDVDOpen(char* szNameFile, struct DVDFileInfo* pFileInfo) {
+    // Parameters
+    // char* szNameFile; // r30
+    // struct DVDFileInfo* pFileInfo; // r31
+
+    // Local variables
+    s32 nStatus; // r3
+}
+
+// Range: 0x8000ECC4 -> 0x8000EDA8
+s32 simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset,
+                     void (*callback)(s32, struct DVDFileInfo*)) {
+    // Parameters
+    // struct DVDFileInfo* pFileInfo; // r26
+    // void* anData; // r27
+    // s32 nSizeRead; // r28
+    // s32 nOffset; // r29
+    // void (* callback)(s32, struct DVDFileInfo*); // r7
+
+    // Local variables
+    s32 nStatus; // r31
+    s32 bRetry; // r30
+}
+
+// Range: 0x8000ECA0 -> 0x8000ECC4
+s32 simulatorPlayMovie() {}
+
+// Range: 0x8000E484 -> 0x8000ECA0
+s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
+    // Parameters
+    // struct __anon_0xDB69* tpl; // r22
+    // s32 nX0; // r30
+    // s32 nY0; // r23
+    // s32 drawBar; // r24
+    // s32 percent; // r25
+
+    // Local variables
+    struct _GXTexObj texObj; // r1+0xDC
+    struct _GXTexObj texObj2; // r1+0xBC
+    struct _GXColor color; // r1+0xB4
+    f32 identity_mtx[3][4]; // r1+0x84
+    f32 g2DviewMtx[3][4]; // r1+0x54
+    f32 g2[3][4]; // r1+0x24
+
+    // References
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> u8 gbar[1857];
     // -> u8 TexCoords_u8[8];
     // -> u32 Colors_u32[3];
-    // -> s16 VertYes_s16[12];
+    // -> s16 Vert_s16Bar[12];
     // -> s16 Vert_s16[12];
     // -> static f32 gOrthoMtx[4][4];
 }
@@ -1692,22 +1164,23 @@ s32 simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s3
     // -> static f32 gOrthoMtx[4][4];
 }
 
-// Range: 0x8000E484 -> 0x8000ECA0
-s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
+// Range: 0x8000D58C -> 0x8000DBB4
+s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message, struct __anon_0xDB69* tplOK,
+                         s32 nX0OK, s32 nY0OK) {
     // Parameters
-    // struct __anon_0xDB69* tpl; // r22
-    // s32 nX0; // r30
-    // s32 nY0; // r23
-    // s32 drawBar; // r24
-    // s32 percent; // r25
+    // struct __anon_0xDB69* tplMessage; // r29
+    // s32 nX0Message; // r28
+    // s32 nY0Message; // r27
+    // struct __anon_0xDB69* tplOK; // r23
+    // s32 nX0OK; // r24
+    // s32 nY0OK; // r25
 
     // Local variables
-    struct _GXTexObj texObj; // r1+0xDC
-    struct _GXTexObj texObj2; // r1+0xBC
-    struct _GXColor color; // r1+0xB4
-    f32 identity_mtx[3][4]; // r1+0x84
-    f32 g2DviewMtx[3][4]; // r1+0x54
-    f32 g2[3][4]; // r1+0x24
+    struct _GXTexObj texObj; // r1+0x98
+    struct _GXColor color0; // r1+0x94
+    struct _GXColor color1; // r1+0x90
+    f32 identity_mtx[3][4]; // r1+0x5C
+    f32 g2DviewMtx[3][4]; // r1+0x2C
 
     // References
     // -> struct __anon_0x87F6* gpFrame;
@@ -1715,102 +1188,629 @@ s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar,
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
     // -> u8 DemoStatEnable;
-    // -> u8 gbar[1857];
     // -> u8 TexCoords_u8[8];
     // -> u32 Colors_u32[3];
-    // -> s16 Vert_s16Bar[12];
+    // -> s16 VertYes_s16[12];
     // -> s16 Vert_s16[12];
     // -> static f32 gOrthoMtx[4][4];
 }
 
-// Range: 0x8000ECA0 -> 0x8000ECC4
-s32 simulatorPlayMovie() {}
-
-// Range: 0x8000ECC4 -> 0x8000EDA8
-s32 simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset,
-                     void (*callback)(s32, struct DVDFileInfo*)) {
+// Range: 0x8000D35C -> 0x8000D58C
+s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 drawBar, s32 percent) {
     // Parameters
-    // struct DVDFileInfo* pFileInfo; // r26
-    // void* anData; // r27
-    // s32 nSizeRead; // r28
-    // s32 nOffset; // r29
-    // void (* callback)(s32, struct DVDFileInfo*); // r7
+    // enum __anon_0x61D7 simulatorErrorMessage; // r28
+    // s32 drawBar; // r29
+    // s32 percent; // r31
 
-    // Local variables
-    s32 nStatus; // r31
-    s32 bRetry; // r30
+    // References
+    // -> s32 gbDisplayedError;
+    // -> u8 gfatalErr[13025];
+    // -> u8 gnoDisk[7937];
+    // -> u8 gretryErr[9281];
+    // -> u8 greadingDisk[3137];
+    // -> u8 gwrongDisk[7937];
+    // -> u8 gcoverOpen[10433];
 }
 
-// Range: 0x8000EDA8 -> 0x8000EE18
-s32 simulatorDVDOpen(char* szNameFile, struct DVDFileInfo* pFileInfo) {
+// Range: 0x8000D1F0 -> 0x8000D35C
+s32 simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
     // Parameters
-    // char* szNameFile; // r30
-    // struct DVDFileInfo* pFileInfo; // r31
+    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
 
     // Local variables
-    s32 nStatus; // r3
+    struct DVDFileInfo fileInfo; // r1+0xC
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u32 gmsg_gf02Size;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv09Size;
+    // -> u32 gmsg_in02Size;
 }
 
-// Range: 0x8000EE18 -> 0x8000F020
-s32 simulatorDVDShowError(s32 nStatus) {
+// Erased
+static s32 simulatorDrawErrorMessageFromDVD(s32 drawBar, s32 percent) {
     // Parameters
-    // s32 nStatus; // r26
+    // s32 drawBar; // r29
+    // s32 percent; // r30
 
-    // Local variables
-    s32 continueToggle; // r28
-    enum __anon_0x61D7 nMessage; // r27
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+}
+
+// Range: 0x8000CF24 -> 0x8000D1F0
+s32 simulatorDrawYesNoMessageLoop(struct __anon_0xDB69* simulatorQuestion, s32* yes) {
+    // Parameters
+    // struct __anon_0xDB69* simulatorQuestion; // r26
+    // s32* yes; // r27
 
     // References
     // -> struct __anon_0x6EA4* gpSystem;
-    // -> s32 gDVDResetToggle;
-    // -> static s32 toggle$192;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> u8 gno[1473];
+    // -> u8 gyes[1473];
+    // -> s32 gHighlightChoice;
 }
 
-// Erased
-static s32 simulatorDrawBlack() {
-    // Local variables
-    struct _GXColor color; // r1+0x6C
-
-    // References
-    // -> struct __anon_0x87F6* gpFrame;
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-}
-
-// Erased
-static void simulatorDEMODoneRender() {
-    // References
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-    // -> u8 DemoStatEnable;
-}
-
-// Erased
-static void simulatorDEMOSwapBuffers() {
-    // References
-    // -> void* DemoCurrentBuffer;
-    // -> void* DemoFrameBuffer2;
-    // -> void* DemoFrameBuffer1;
-}
-
-// Range: 0x8000F020 -> 0x8000F0FC
-void simulatorUnpackTexPalette(struct __anon_0xDB69* pal) {
+// Range: 0x8000CB7C -> 0x8000CF24
+s32 simulatorDrawYesNoMessage(enum __anon_0x61D7 simulatorMessage, s32* yes) {
     // Parameters
-    // struct __anon_0xDB69* pal; // r1+0x0
+    // enum __anon_0x61D7 simulatorMessage; // r1+0x8
+    // s32* yes; // r30
 
     // Local variables
-    u16 i; // r4
+    struct DVDFileInfo fileInfo; // r1+0x10
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u32 gmsg_sv08Size;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv06_5Size;
+    // -> u32 gmsg_sv06_4Size;
+    // -> u32 gmsg_in01Size;
+    // -> u32 gmsg_gf01Size;
+    // -> u32 gmsg_ld07Size;
+    // -> u32 gmsg_ld06_4Size;
+    // -> u32 gmsg_ld05_2Size;
 }
 
-// Range: 0x8000F0FC -> 0x8000F7CC
-s32 simulatorGXInit() {
+// Erased
+static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
+    // Parameters
+    // struct __anon_0xDB69* simulatorMessage; // r27
+
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> u8 gmesgOK[833];
+    // -> u8 gyes[1473];
+}
+
+// Range: 0x80009A30 -> 0x8000CB7C
+s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
+    // Parameters
+    // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
+
+    // Local variables
+    struct DVDFileInfo fileInfo; // r1+0x80
+
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> u8 gmesgOK[833];
+    // -> char gpErrorMessageBuffer[20480];
+    // -> u8 gyes[1473];
+    // -> u32 gmsg_sv_shareSize;
+    // -> enum __anon_0x61D7 simulatorMessageCurrent;
+    // -> u32 gmsg_sv12Size;
+    // -> u32 gmsg_sv11Size;
+    // -> u32 gmsg_sv10Size;
+    // -> u32 gmsg_sv07Size;
+    // -> u32 gmsg_sv06_3Size;
+    // -> u32 gmsg_sv06_2Size;
+    // -> u32 gmsg_sv06_1Size;
+    // -> u32 gmsg_sv05_1Size;
+    // -> u32 gmsg_sv04Size;
+    // -> u32 gmsg_sv03Size;
+    // -> u32 gmsg_sv02Size;
+    // -> u32 gmsg_sv01_2Size;
+    // -> u32 gmsg_sv01Size;
+    // -> u32 gmsg_in05Size;
+    // -> u32 gmsg_in04Size;
+    // -> u32 gmsg_in03Size;
+    // -> u32 gmsg_gf06Size;
+    // -> u32 gmsg_gf05Size;
+    // -> u32 gmsg_gf04Size;
+    // -> u32 gmsg_gf03Size;
+    // -> u32 gmsg_ld06_3Size;
+    // -> u32 gmsg_ld06_2Size;
+    // -> u32 gmsg_ld06_1Size;
+    // -> u32 gmsg_ld05_1Size;
+    // -> u32 gmsg_ld04Size;
+    // -> u32 gmsg_ld03Size;
+    // -> u32 gmsg_ld02Size;
+    // -> u32 gmsg_ld01Size;
+}
+
+// Range: 0x80009980 -> 0x80009A30
+void simulatorReset(s32 IPL, s32 forceMenu) {
+    // Parameters
+    // s32 IPL; // r30
+    // s32 forceMenu; // r31
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80009824 -> 0x80009980
+void simulatorResetAndPlayMovie() {
+    // Local variables
+    struct _GXColor color; // r1+0x14
+    struct _GXRenderModeObj* simrmode; // r31
+
+    // References
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+    // -> s32 gMovieErrorToggle;
+    // -> struct _GXRenderModeObj* rmode;
+    // -> struct _MCARD mCard;
+}
+
+// Erased
+static s32 simulatorSetPart() {}
+
+// Erased
+static s32 simulatorAddXtraTime() {}
+
+// Erased
+static s32 simulatorShowParts() {}
+
+// Erased
+static enum __anon_0xC9F9 simulatorGetView() {
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
+}
+
+// Erased
+static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
+    // Parameters
+    // enum __anon_0xC9F9 eView; // r1+0x8
+
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
+}
+
+// Range: 0x8000974C -> 0x80009824
+s32 simulatorSetControllerMap(u32* mapData, s32 channel) {
+    // Parameters
+    // u32* mapData; // r1+0x0
+    // s32 channel; // r1+0x4
+
+    // Local variables
+    s32 i; // r7
+
+    // References
+    // -> static u32 gContMap[4][20];
+}
+
+// Range: 0x80009684 -> 0x8000974C
+s32 simulatorCopyControllerMap(u32* mapDataOutput, u32* mapDataInput) {
+    // Parameters
+    // u32* mapDataOutput; // r1+0x0
+    // u32* mapDataInput; // r1+0x4
+
+    // Local variables
+    s32 i; // r7
+}
+
+// Erased
+static s32 simulatorChangeControllerConfig(s32 channel, s32 nCurrButton) {
+    // Parameters
+    // s32 channel; // r31
+    // s32 nCurrButton; // r1+0xC
+
+    // References
+    // -> static u32 gContMap[4][20];
+    // -> static struct __anon_0xC654 gSystemRomConfigurationList[1];
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80009110 -> 0x80009684
+s32 simulatorReadController(s32 channel, u32* anData) {
+    // Parameters
+    // s32 channel; // r29
+    // u32* anData; // r30
+
+    // Local variables
+    f32 subStickTest; // f1
+    s32 stickX; // r1+0x8
+    s32 stickY; // r1+0x8
+    s32 subStickX; // r6
+    s32 subStickY; // r7
+    s32 nDirButton; // r3
+
+    // References
+    // -> static u32 gContMap[4][20];
+    // -> static u32 nCurrButton$702;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> static u32 nPrevButton$701;
+}
+
+// Erased
+static void DEMOInitWindow(s32 nSizeX, s32 nSizeY, s32 nColorR, s32 nColorG, s32 nColorB) {
+    // Parameters
+    // s32 nSizeX; // r3
+    // s32 nSizeY; // r1+0xC
+    // s32 nColorR; // r29
+    // s32 nColorG; // r30
+    // s32 nColorB; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x20
+}
+
+// Range: 0x80009108 -> 0x80009110
+s32 simulatorShowLoad() {}
+
+// Erased
+static s32 simulatorResetController() {}
+
+// Range: 0x800090B4 -> 0x80009108
+s32 simulatorDetectController(s32 channel) {
+    // Parameters
+    // s32 channel; // r31
+
+    // Local variables
+    struct PADStatus status[4]; // r1+0xC
+}
+
+// Range: 0x80009038 -> 0x800090B4
+s32 simulatorReadPak(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r29
+    // u16 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    enum __anon_0xC003 type; // r1+0x14
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80008FBC -> 0x80009038
+s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
+    // Parameters
+    // s32 channel; // r29
+    // u16 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    enum __anon_0xC003 type; // r1+0x14
+
+    // References
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80008F4C -> 0x80008FBC
+s32 simulatorReadEEPROM(u8 address, u8* data) {
+    // Parameters
+    // u8 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    s32 size; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80008EDC -> 0x80008F4C
+s32 simulatorWriteEEPROM(u8 address, u8* data) {
+    // Parameters
+    // u8 address; // r30
+    // u8* data; // r31
+
+    // Local variables
+    s32 size; // r1+0x10
+
+    // References
+    // -> struct _MCARD mCard;
+    // -> struct __anon_0x6EA4* gpSystem;
+}
+
+// Range: 0x80008EA8 -> 0x80008EDC
+s32 simulatorReadSRAM(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008E74 -> 0x80008EA8
+s32 simulatorWriteSRAM(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008E40 -> 0x80008E74
+s32 simulatorReadFLASH(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008E0C -> 0x80008E40
+s32 simulatorWriteFLASH(u32 address, u8* data, s32 size) {
+    // Parameters
+    // u32 address; // r4
+    // u8* data; // r6
+    // s32 size; // r5
+
+    // References
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x80008DE4 -> 0x80008E0C
+s32 simulatorRumbleStart(s32 channel) {
+    // Parameters
+    // s32 channel; // r3
+}
+
+// Range: 0x80008DBC -> 0x80008DE4
+s32 simulatorRumbleStop(s32 channel) {
+    // Parameters
+    // s32 channel; // r3
+}
+
+// Erased
+static void* sScreenshotAlloc() {}
+
+// Erased
+static void sScreenshotFree() {}
+
+// Range: 0x80008BDC -> 0x80008DBC
+s32 simulatorTestReset(s32 IPL, s32 forceMenu, s32 allowReset, s32 usePreviousSettings) {
+    // Parameters
+    // s32 IPL; // r24
+    // s32 forceMenu; // r25
+    // s32 allowReset; // r26
+    // s32 usePreviousSettings; // r27
+
+    // Local variables
+    u32 bFlag; // r1+0x8
+    u32 nTick; // r1+0x8
+    s32 prevIPLSetting; // r28
+    s32 prevForceMenuSetting; // r27
+    s32 prevAllowResetSetting; // r1+0x8
+
+    // References
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gResetBeginFlag;
+    // -> s32 gPreviousAllowResetSetting;
+    // -> s32 gPreviousForceMenuSetting;
+    // -> s32 gPreviousIPLSetting;
+}
+
+// Erased
+static s32 simulatorDrawText(s32 nX, s32 nY, char* szText, s32 nColorR, s32 nColorG, s32 nColorB) {
+    // Parameters
+    // s32 nX; // r26
+    // s32 nY; // r27
+    // char* szText; // r28
+    // s32 nColorR; // r29
+    // s32 nColorG; // r30
+    // s32 nColorB; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x24
+}
+
+// Range: 0x80008B44 -> 0x80008BDC
+s32 simulatorDrawMCardText() {
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+}
+
+// Range: 0x80008A14 -> 0x80008B44
+s32 simulatorMCardPollDrawBar() {
+    // Local variables
+    f32 rate; // r1+0x8
+    s32 nBytes; // r1+0x8
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x800088E4 -> 0x80008A14
+s32 simulatorMCardPollDrawFormatBar() {
+    // Local variables
+    f32 rate; // r1+0x8
+    s32 nBytes; // r1+0x8
+
+    // References
+    // -> char gpErrorMessageBuffer[20480];
+    // -> struct _MCARD mCard;
+}
+
+// Range: 0x800086DC -> 0x800088E4
+static s32 simulatorDrawCursor(s32 nX, s32 nY) {
+    // Parameters
+    // s32 nX; // r30
+    // s32 nY; // r31
+
+    // Local variables
+    struct _GXColor color; // r1+0x18
+    s32 nTick; // r4
+}
+
+// Erased
+static s32 simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, s32* yes) {
+    // Parameters
+    // char* line1; // r21
+    // char* line2; // r22
+    // char* line3; // r23
+    // s32* yes; // r24
+
+    // Local variables
+    s32 nCount; // r25
+
+    // References
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> s32 gButtonDownToggle;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Erased
+static s32 simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
+    // Parameters
+    // char* line1; // r22
+    // char* line2; // r23
+    // char* line3; // r24
+
+    // Local variables
+    s32 nCount; // r25
+
+    // References
+    // -> s32 gButtonDownToggle;
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Erased
+static s32 simulatorPickROM() {}
+
+// Erased
+static s32 simulatorMenu() {}
+
+// Erased
+static void MyGXInit() {
     // Local variables
     s32 i; // r31
-    struct _GXColor GX_DEFAULT_BG; // r1+0x58
-    struct _GXColor BLACK; // r1+0x54
-    struct _GXColor WHITE; // r1+0x50
-    f32 identity_mtx[3][4]; // r1+0x20
+    f32 identity_mtx[3][4]; // r1+0x50
+}
+
+// Erased
+static s32 editSoundMenu() {
+    // Local variables
+    s32* menuValues[3]; // r1+0x94
+    s32 menuMinMax[3][2]; // r1+0x7C
+    char* menuNames[3]; // r1+0x70
+    char* menuHelp[3]; // r1+0x64
+    char str[32]; // r1+0x44
+    s32 curItem; // r24
+    s32 bDone; // r1+0xA0
+    s32 i; // r6
+    u32 heldButtons; // r7
+    u32 buttons; // r8
+    u32 downButtons; // r1+0x8
+    u8 holdCount[16]; // r1+0x34
+    struct _GXColor color[3]; // r1+0x28
+    s32 step; // r20
+    u32 bit; // r1+0x8
+    struct _GXColor* colorP; // r31
+
+    // References
+    // -> struct __anon_0xAD2F DemoPad[4];
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> void* DemoFrameBuffer1;
+    // -> u8 DemoStatEnable;
+}
+
+// Range: 0x80008578 -> 0x800086DC
+static s32 simulatorParseArguments() {
+    // Local variables
+    s32 iArgument; // r23
+    char* szText; // r1+0x14
+    char* szValue; // r1+0x10
+
+    // References
+    // -> static char* gaszArgument[8];
+}
+
+// Range: 0x80008538 -> 0x80008578
+s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
+    // Parameters
+    // enum __anon_0xA982 eType; // r1+0x0
+    // char** pszArgument; // r1+0x4
+
+    // References
+    // -> static char* gaszArgument[8];
+}
+
+// Range: 0x80007F80 -> 0x80008538
+s32 xlMain() {
+    // Local variables
+    struct _GXColor color; // r1+0x3C
+    enum __anon_0xA6E7 eMode; // r1+0x38
+    s32 nSize0; // r1+0x34
+    s32 nSize1; // r1+0x30
+    s32 iName; // r5
+    char* szNameROM; // r1+0x2C
+    char acNameROM[32]; // r1+0xC
+    s32 rumbleYes; // r1+0x8
+
+    // References
+    // -> static struct __anon_0x57A1* gpCode;
+    // -> struct __anon_0x87F6* gpFrame;
+    // -> struct __anon_0x7181* gpSound;
+    // -> struct __anon_0x6EA4* gpSystem;
+    // -> struct _XL_OBJECTTYPE gClassSystem;
+    // -> struct _XL_OBJECTTYPE gClassSound;
+    // -> struct _XL_OBJECTTYPE gClassFrame;
+    // -> struct _XL_OBJECTTYPE gClassCode;
+    // -> static char* gaszArgument[8];
+    // -> struct _MCARD mCard;
+    // -> static u32 gnTickReset;
+    // -> static s32 gbReset;
+    // -> u8 gmesgOK[833];
+    // -> u8 gno[1473];
+    // -> u8 gyes[1473];
+    // -> u8 gbar[1857];
+    // -> u8 greadingDisk[3137];
+    // -> u8 gwrongDisk[7937];
+    // -> u8 gfatalErr[13025];
+    // -> u8 gretryErr[9281];
+    // -> u8 gnoDisk[7937];
+    // -> u8 gcoverOpen[10433];
+    // -> void* DemoFrameBuffer1;
+    // -> void* DemoCurrentBuffer;
+    // -> void* DemoFrameBuffer2;
+    // -> u8 DemoStatEnable;
+    // -> s32 gResetBeginFlag;
+    // -> s32 gButtonDownToggle;
+    // -> s32 gbDisplayedError;
+    // -> s32 gDVDResetToggle;
 }

--- a/debug/Fire/soundGCN.c
+++ b/debug/Fire/soundGCN.c
@@ -50,39 +50,12 @@ typedef struct __anon_0x208BA {
     /* 0xD4 */ s32 nSizeRamp;
 } __anon_0x208BA; // size = 0xD8
 
-// Range: 0x8001C498 -> 0x8001C690
-s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r3
-    // s32 nEvent; // r1+0xC
-
-    // Local variables
-    s32 iBuffer; // r1+0x8
-
-    // References
-    // -> s32 gVolumeCurve[257];
-}
-
 typedef enum __anon_0x20C8D {
     SOUND_BEEP_ACCEPT = 0,
     SOUND_BEEP_DECLINE = 1,
     SOUND_BEEP_SELECT = 2,
     SOUND_BEEP_COUNT = 3,
 } __anon_0x20C8D;
-
-// Erased
-static s32 soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r5
-    // enum __anon_0x20C8D iBeep; // r1+0xC
-}
-
-// Range: 0x8001C690 -> 0x8001C70C
-s32 soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r29
-    // enum __anon_0x20C8D iBeep; // r1+0xC
-}
 
 typedef enum __anon_0x20E13 {
     XLFT_NONE = -1,
@@ -132,17 +105,6 @@ typedef struct tXL_FILE {
     /* 0x18 */ enum __anon_0x20E13 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x2131A; // size = 0x58
-
-// Range: 0x8001C70C -> 0x8001C824
-s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r28
-    // enum __anon_0x20C8D iBeep; // r1+0xC
-    // char* szNameFile; // r5
-
-    // Local variables
-    struct tXL_FILE* pFile; // r1+0x14
-}
 
 typedef enum __anon_0x2152F {
     SM_NONE = -1,
@@ -212,62 +174,69 @@ typedef struct __anon_0x218B8 {
 // size = 0x4, address = 0x80135600
 struct __anon_0x218B8* gpSystem;
 
-// Range: 0x8001C824 -> 0x8001C880
-static void soundCallbackBeep() {
-    // Local variables
-    struct __anon_0x208BA* pSound; // r31
+typedef enum __anon_0x221A3 {
+    SR_NONE = -1,
+    SR_DECREASE = 0,
+    SR_INCREASE = 1,
+} __anon_0x221A3;
 
-    // References
-    // -> struct __anon_0x218B8* gpSystem;
-}
-
-// Erased
-static void InitVolumeCurve() {
-    // Local variables
-    s32 i; // r29
-
-    // References
-    // -> s32 gVolumeCurve[257];
-}
-
-// Range: 0x8001C880 -> 0x8001CA20
-s32 soundSetBufferSize(struct __anon_0x208BA* pSound, s32 nSize) {
+// Range: 0x8001D250 -> 0x8001D34C
+s32 soundWipeBuffers(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r31
-    // s32 nSize; // r29
 
     // Local variables
-    s32 iBuffer; // r29
+    s32 iBuffer; // r30
 }
 
-// Range: 0x8001CA20 -> 0x8001CA54
-s32 soundGetDMABuffer(u32* pnSize) {
+// Range: 0x8001CD8C -> 0x8001D250
+static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon_0x221A3 eRamp) {
     // Parameters
-    // u32* pnSize; // r31
-}
+    // struct __anon_0x208BA* pSound; // r1+0x8
+    // s32 iBuffer; // r1+0xC
+    // enum __anon_0x221A3 eRamp; // r1+0x10
 
-// Range: 0x8001CA54 -> 0x8001CA60
-s32 soundSetAddress(struct __anon_0x208BA* pSound, void* pData) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r1+0x0
-    // void* pData; // r1+0x4
+    // Local variables
+    s32 bFlag; // r8
+    s32 iData; // r1+0x8
+    s16* anData; // r9
+    s16 nData0; // r10
+    s16 nData1; // r11
+    s16 nGoal0; // r12
+    s16 nGoal1; // r31
+    s16 nStep0; // r5
+    s16 nStep1; // r4
+    s16 nLast0; // r27
+    s16 nLast1; // r27
 }
 
 // Erased
-static s32 soundSetBitRate() {}
-
-// Range: 0x8001CA60 -> 0x8001CA80
-s32 soundSetDACRate(struct __anon_0x208BA* pSound, s32 nDacRate) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r1+0x0
-    // s32 nDacRate; // r1+0x4
-}
-
-// Range: 0x8001CA80 -> 0x8001CAB8
-s32 soundSetLength(struct __anon_0x208BA* pSound, s32 nSize) {
+static s32 soundMakeZero(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r3
-    // s32 nSize; // r1+0xC
+
+    // Local variables
+    s32 iData; // r7
+}
+
+// Erased
+static s32 soundMakeHold() {}
+
+// Range: 0x8001CCCC -> 0x8001CD8C
+static s32 soundPlayBuffer(struct __anon_0x208BA* pSound) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x8
+
+    // Local variables
+    void* pData; // r6
+    s32 iBuffer; // r4
+    s32 nSize; // r4
+}
+
+// Range: 0x8001CCA4 -> 0x8001CCCC
+static void soundCallbackDMA() {
+    // References
+    // -> struct __anon_0x218B8* gpSystem;
 }
 
 // Range: 0x8001CAB8 -> 0x8001CCA4
@@ -293,67 +262,98 @@ static s32 soundMakeBuffer(struct __anon_0x208BA* pSound) {
     // -> s32 gVolumeCurve[257];
 }
 
-// Range: 0x8001CCA4 -> 0x8001CCCC
-static void soundCallbackDMA() {
+// Range: 0x8001CA80 -> 0x8001CAB8
+s32 soundSetLength(struct __anon_0x208BA* pSound, s32 nSize) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r3
+    // s32 nSize; // r1+0xC
+}
+
+// Range: 0x8001CA60 -> 0x8001CA80
+s32 soundSetDACRate(struct __anon_0x208BA* pSound, s32 nDacRate) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x0
+    // s32 nDacRate; // r1+0x4
+}
+
+// Erased
+static s32 soundSetBitRate() {}
+
+// Range: 0x8001CA54 -> 0x8001CA60
+s32 soundSetAddress(struct __anon_0x208BA* pSound, void* pData) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r1+0x0
+    // void* pData; // r1+0x4
+}
+
+// Range: 0x8001CA20 -> 0x8001CA54
+s32 soundGetDMABuffer(u32* pnSize) {
+    // Parameters
+    // u32* pnSize; // r31
+}
+
+// Range: 0x8001C880 -> 0x8001CA20
+s32 soundSetBufferSize(struct __anon_0x208BA* pSound, s32 nSize) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r31
+    // s32 nSize; // r29
+
+    // Local variables
+    s32 iBuffer; // r29
+}
+
+// Erased
+static void InitVolumeCurve() {
+    // Local variables
+    s32 i; // r29
+
+    // References
+    // -> s32 gVolumeCurve[257];
+}
+
+// Range: 0x8001C824 -> 0x8001C880
+static void soundCallbackBeep() {
+    // Local variables
+    struct __anon_0x208BA* pSound; // r31
+
     // References
     // -> struct __anon_0x218B8* gpSystem;
 }
 
-// Range: 0x8001CCCC -> 0x8001CD8C
-static s32 soundPlayBuffer(struct __anon_0x208BA* pSound) {
+// Range: 0x8001C70C -> 0x8001C824
+s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
     // Parameters
-    // struct __anon_0x208BA* pSound; // r1+0x8
+    // struct __anon_0x208BA* pSound; // r28
+    // enum __anon_0x20C8D iBeep; // r1+0xC
+    // char* szNameFile; // r5
 
     // Local variables
-    void* pData; // r6
-    s32 iBuffer; // r4
-    s32 nSize; // r4
+    struct tXL_FILE* pFile; // r1+0x14
+}
+
+// Range: 0x8001C690 -> 0x8001C70C
+s32 soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r29
+    // enum __anon_0x20C8D iBeep; // r1+0xC
 }
 
 // Erased
-static s32 soundMakeHold() {}
+static s32 soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+    // Parameters
+    // struct __anon_0x208BA* pSound; // r5
+    // enum __anon_0x20C8D iBeep; // r1+0xC
+}
 
-// Erased
-static s32 soundMakeZero(struct __anon_0x208BA* pSound) {
+// Range: 0x8001C498 -> 0x8001C690
+s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r3
+    // s32 nEvent; // r1+0xC
 
     // Local variables
-    s32 iData; // r7
-}
+    s32 iBuffer; // r1+0x8
 
-typedef enum __anon_0x221A3 {
-    SR_NONE = -1,
-    SR_DECREASE = 0,
-    SR_INCREASE = 1,
-} __anon_0x221A3;
-
-// Range: 0x8001CD8C -> 0x8001D250
-static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon_0x221A3 eRamp) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r1+0x8
-    // s32 iBuffer; // r1+0xC
-    // enum __anon_0x221A3 eRamp; // r1+0x10
-
-    // Local variables
-    s32 bFlag; // r8
-    s32 iData; // r1+0x8
-    s16* anData; // r9
-    s16 nData0; // r10
-    s16 nData1; // r11
-    s16 nGoal0; // r12
-    s16 nGoal1; // r31
-    s16 nStep0; // r5
-    s16 nStep1; // r4
-    s16 nLast0; // r27
-    s16 nLast1; // r27
-}
-
-// Range: 0x8001D250 -> 0x8001D34C
-s32 soundWipeBuffers(struct __anon_0x208BA* pSound) {
-    // Parameters
-    // struct __anon_0x208BA* pSound; // r31
-
-    // Local variables
-    s32 iBuffer; // r30
+    // References
+    // -> s32 gVolumeCurve[257];
 }

--- a/debug/Fire/sram.c
+++ b/debug/Fire/sram.c
@@ -21,68 +21,16 @@ typedef struct __anon_0x74AB9 {
     /* 0x0 */ void* pHost;
 } __anon_0x74AB9; // size = 0x4
 
-// Range: 0x8008E138 -> 0x8008E238
-s32 sramEvent(struct __anon_0x74AB9* pSram, s32 nEvent, void* pArgument) {
+// Range: 0x8008E430 -> 0x8008E4A8
+s32 sramCopySRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
     // Parameters
-    // struct __anon_0x74AB9* pSram; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
+    // struct __anon_0x74AB9* pSRAM; // r1+0x8
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetSRAM; // r31
+    // s32 nSize; // r1+0x14
 
-// Range: 0x8008E238 -> 0x8008E268
-static s32 sramGet64(u32 nAddress, s64* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s64* pData; // r5
-}
-
-// Range: 0x8008E268 -> 0x8008E298
-static s32 sramGet32(u32 nAddress, s32* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r5
-}
-
-// Range: 0x8008E298 -> 0x8008E2C8
-static s32 sramGet16(u32 nAddress, s16* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s16* pData; // r5
-}
-
-// Range: 0x8008E2C8 -> 0x8008E2F8
-static s32 sramGet8(u32 nAddress, char* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // char* pData; // r5
-}
-
-// Range: 0x8008E2F8 -> 0x8008E328
-static s32 sramPut64(u32 nAddress, s64* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s64* pData; // r5
-}
-
-// Range: 0x8008E328 -> 0x8008E358
-static s32 sramPut32(u32 nAddress, s32* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r5
-}
-
-// Range: 0x8008E358 -> 0x8008E388
-static s32 sramPut16(u32 nAddress, s16* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // s16* pData; // r5
-}
-
-// Range: 0x8008E388 -> 0x8008E3B8
-static s32 sramPut8(u32 nAddress, char* pData) {
-    // Parameters
-    // u32 nAddress; // r1+0xC
-    // char* pData; // r5
+    // Local variables
+    void* pTarget; // r1+0x18
 }
 
 // Range: 0x8008E3B8 -> 0x8008E430
@@ -97,14 +45,66 @@ s32 sramTransferSRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSR
     void* pTarget; // r1+0x18
 }
 
-// Range: 0x8008E430 -> 0x8008E4A8
-s32 sramCopySRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
+// Range: 0x8008E388 -> 0x8008E3B8
+static s32 sramPut8(u32 nAddress, char* pData) {
     // Parameters
-    // struct __anon_0x74AB9* pSRAM; // r1+0x8
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetSRAM; // r31
-    // s32 nSize; // r1+0x14
+    // u32 nAddress; // r1+0xC
+    // char* pData; // r5
+}
 
-    // Local variables
-    void* pTarget; // r1+0x18
+// Range: 0x8008E358 -> 0x8008E388
+static s32 sramPut16(u32 nAddress, s16* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s16* pData; // r5
+}
+
+// Range: 0x8008E328 -> 0x8008E358
+static s32 sramPut32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r5
+}
+
+// Range: 0x8008E2F8 -> 0x8008E328
+static s32 sramPut64(u32 nAddress, s64* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s64* pData; // r5
+}
+
+// Range: 0x8008E2C8 -> 0x8008E2F8
+static s32 sramGet8(u32 nAddress, char* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // char* pData; // r5
+}
+
+// Range: 0x8008E298 -> 0x8008E2C8
+static s32 sramGet16(u32 nAddress, s16* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s16* pData; // r5
+}
+
+// Range: 0x8008E268 -> 0x8008E298
+static s32 sramGet32(u32 nAddress, s32* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r5
+}
+
+// Range: 0x8008E238 -> 0x8008E268
+static s32 sramGet64(u32 nAddress, s64* pData) {
+    // Parameters
+    // u32 nAddress; // r1+0xC
+    // s64* pData; // r5
+}
+
+// Range: 0x8008E138 -> 0x8008E238
+s32 sramEvent(struct __anon_0x74AB9* pSram, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x74AB9* pSram; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
 }

--- a/debug/Fire/system.c
+++ b/debug/Fire/system.c
@@ -672,38 +672,6 @@ typedef enum __anon_0x394CD {
     SOT_COUNT = 16,
 } __anon_0x394CD;
 
-// Range: 0x8002CA14 -> 0x8002D2EC
-s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r31
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r26
-
-    // Local variables
-    struct _CPU* pCPU; // r30
-    struct __anon_0x393FF exception; // r1+0x1C
-    enum __anon_0x394CD eObject; // r1+0x8
-    enum __anon_0x394CD storageDevice; // r1+0x8
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassRdb;
-    // -> struct _XL_OBJECTTYPE gClassPeripheral;
-    // -> struct _XL_OBJECTTYPE gClassLibrary;
-    // -> struct _XL_OBJECTTYPE gClassSerial;
-    // -> struct _XL_OBJECTTYPE gClassVideo;
-    // -> struct _XL_OBJECTTYPE gClassAudio;
-    // -> struct _XL_OBJECTTYPE gClassDisk;
-    // -> struct _XL_OBJECTTYPE gClassMips;
-    // -> struct _XL_OBJECTTYPE gClassRDP;
-    // -> struct _XL_OBJECTTYPE gClassRSP;
-    // -> struct _XL_OBJECTTYPE gClassROM;
-    // -> struct _XL_OBJECTTYPE gClassRAM;
-    // -> struct _XL_OBJECTTYPE gClassPIF;
-    // -> struct _XL_OBJECTTYPE gClassCPU;
-    // -> struct __anon_0x36AAA* gpSound;
-    // -> struct __anon_0x35B4C* gpFrame;
-}
-
 typedef enum __anon_0x3979C {
     SIT_NONE = -1,
     SIT_SW0 = 0,
@@ -724,13 +692,6 @@ typedef enum __anon_0x3979C {
     SIT_PRENMI = 15,
     SIT_COUNT_ = 16,
 } __anon_0x3979C;
-
-// Range: 0x8002D2EC -> 0x8002D324
-s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r1+0x0
-    // enum __anon_0x3979C eType; // r1+0x4
-}
 
 typedef enum __anon_0x3994B {
     CEC_NONE = -1,
@@ -769,74 +730,11 @@ typedef enum __anon_0x3994B {
     CEC_COUNT = 32,
 } __anon_0x3994B;
 
-// Range: 0x8002D324 -> 0x8002D47C
-s32 systemCheckInterrupts(struct __anon_0x37240* pSystem) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r25
-
-    // Local variables
-    s32 iException; // r30
-    s32 nMaskFinal; // r29
-    s32 bUsed; // r28
-    s32 bDone; // r27
-    struct __anon_0x393FF exception; // r1+0xC
-    enum __anon_0x3994B eCodeFinal; // r26
-}
-
-// Range: 0x8002D47C -> 0x8002D578
-s32 systemExecute(struct __anon_0x37240* pSystem, s32 nCount) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r31
-    // s32 nCount; // r4
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassSystem;
-}
-
-// Range: 0x8002D578 -> 0x8002D730
-s32 systemReset(struct __anon_0x37240* pSystem) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r29
-
-    // Local variables
-    s64 nPC; // r1+0x10
-    s32 nOffsetRAM; // r4
-    enum __anon_0x394CD eObject; // r30
-}
-
-// Range: 0x8002D730 -> 0x8002D740
-s32 systemGetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD* pStorageDevice) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r1+0x0
-    // enum __anon_0x394CD* pStorageDevice; // r1+0x4
-}
-
 // size = 0x10, address = 0x800EE758
 struct _XL_OBJECTTYPE gClassFlash;
 
 // size = 0x10, address = 0x800EE768
 struct _XL_OBJECTTYPE gClassSram;
-
-// Range: 0x8002D740 -> 0x8002D82C
-s32 systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD storageDevice) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r30
-    // enum __anon_0x394CD storageDevice; // r31
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassSram;
-    // -> struct _XL_OBJECTTYPE gClassFlash;
-}
-
-// Range: 0x8002D82C -> 0x8002D894
-s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r30
-    // enum __anon_0x3A085* peMode; // r31
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassSystem;
-}
 
 typedef enum __anon_0x3A085 {
     SM_NONE = -1,
@@ -844,109 +742,8 @@ typedef enum __anon_0x3A085 {
     SM_STOPPED = 1,
 } __anon_0x3A085;
 
-// Range: 0x8002D894 -> 0x8002D904
-s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r30
-    // enum __anon_0x3A085 eMode; // r31
-
-    // References
-    // -> struct _XL_OBJECTTYPE gClassSystem;
-}
-
-// Erased
-static s32 systemClearBreak(struct __anon_0x37240* pSystem) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r1+0x0
-}
-
-// Erased
-static s32 systemSetBreak(struct __anon_0x37240* pSystem, s64 nAddress) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r1+0x0
-    // s64 nAddress; // r1+0x8
-}
-
-// Range: 0x8002D904 -> 0x8002D9F8
-s32 systemCopyROM(struct __anon_0x37240* pSystem, s32 nOffsetRAM, s32 nOffsetROM, s32 nSize, s32 (*pCallback)()) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r29
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetROM; // r30
-    // s32 nSize; // r1+0x14
-    // s32 (* pCallback)(); // r31
-
-    // Local variables
-    void* pTarget; // r1+0x1C
-}
-
 // size = 0x4, address = 0x80135600
 struct __anon_0x37240* gpSystem;
-
-// Range: 0x8002D9F8 -> 0x8002DB30
-static s32 __systemCopyROM_Complete() {
-    // Local variables
-    s32 iAddress; // r30
-    s32 nCount; // r1+0x88
-    u32 nAddress0; // r30
-    u32 nAddress1; // r31
-    u32 anAddress[32]; // r1+0x8
-
-    // References
-    // -> struct __anon_0x37240* gpSystem;
-}
-
-// Range: 0x8002DB30 -> 0x8002DB38
-static s32 systemPut64() {}
-
-// Range: 0x8002DB38 -> 0x8002DB40
-static s32 systemPut32() {}
-
-// Range: 0x8002DB40 -> 0x8002DB48
-static s32 systemPut16() {}
-
-// Range: 0x8002DB48 -> 0x8002DB50
-static s32 systemPut8() {}
-
-// Range: 0x8002DB50 -> 0x8002DB64
-static s32 systemGet64(s64* pData) {
-    // Parameters
-    // s64* pData; // r1+0x8
-}
-
-// Range: 0x8002DB64 -> 0x8002DB74
-static s32 systemGet32(s32* pData) {
-    // Parameters
-    // s32* pData; // r1+0x8
-}
-
-// Range: 0x8002DB74 -> 0x8002DB84
-static s32 systemGet16(s16* pData) {
-    // Parameters
-    // s16* pData; // r1+0x8
-}
-
-// Range: 0x8002DB84 -> 0x8002DB94
-static s32 systemGet8(char* pData) {
-    // Parameters
-    // char* pData; // r1+0x8
-}
-
-// Range: 0x8002DB94 -> 0x8002DD70
-static s32 systemGetException(enum __anon_0x3979C eType, struct __anon_0x393FF* pException) {
-    // Parameters
-    // enum __anon_0x3979C eType; // r1+0x4
-    // struct __anon_0x393FF* pException; // r1+0x8
-}
-
-// Erased
-static s32 systemClearExceptions(struct __anon_0x37240* pSystem) {
-    // Parameters
-    // struct __anon_0x37240* pSystem; // r1+0x0
-
-    // Local variables
-    s32 iException; // r1+0x0
-}
 
 typedef struct __anon_0x3A807 {
     /* 0x00 */ s32 configuration;
@@ -1178,6 +975,54 @@ typedef struct __anon_0x3C350 {
     /* 0x1C */ enum __anon_0x3C277 eControllerType[5];
 } __anon_0x3C350; // size = 0x30
 
+// Range: 0x80030B38 -> 0x80030E70
+static s32 systemSetupGameRAM(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r27
+
+    // Local variables
+    char* szExtra; // r1+0x414
+    s32 bExpansion; // r30
+    s32 nSizeRAM; // r28
+    s32 nSizeCacheROM; // r29
+    s32 nSizeExtra; // r3
+    struct __anon_0x3BEE8* pROM; // r29
+    u32 nCode; // r28
+    u32 iCode; // r1+0x8
+    u32 anCode[256]; // r1+0x14
+
+    // References
+    // -> u32 gnFlagZelda;
+}
+
+// Erased
+static s32 systemMapControllerIndex(s32 gameIndex, s32 configIndex) {
+    // Parameters
+    // s32 gameIndex; // r1+0xC
+    // s32 configIndex; // r30
+
+    // Local variables
+    s32 i; // r31
+
+    // References
+    // -> static u32 contMap[4][20];
+    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+}
+
+// Range: 0x80030364 -> 0x80030B38
+s32 systemGetInitialConfiguration(struct __anon_0x3BEE8* pROM, s32 index) {
+    // Parameters
+    // struct __anon_0x3BEE8* pROM; // r24
+    // s32 index; // r1+0x10
+
+    // Local variables
+    char* szText; // r1+0x14
+
+    // References
+    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+    // -> static u32 contMap[4][20];
+}
+
 // Range: 0x8002DD70 -> 0x80030364
 static s32 systemSetupGameALL(struct __anon_0x37240* pSystem) {
     // Parameters
@@ -1209,50 +1054,205 @@ static s32 systemSetupGameALL(struct __anon_0x37240* pSystem) {
     // -> f32 fTickScale;
 }
 
-// Range: 0x80030364 -> 0x80030B38
-s32 systemGetInitialConfiguration(struct __anon_0x3BEE8* pROM, s32 index) {
+// Erased
+static s32 systemClearExceptions(struct __anon_0x37240* pSystem) {
     // Parameters
-    // struct __anon_0x3BEE8* pROM; // r24
-    // s32 index; // r1+0x10
+    // struct __anon_0x37240* pSystem; // r1+0x0
 
     // Local variables
-    char* szText; // r1+0x14
+    s32 iException; // r1+0x0
+}
+
+// Range: 0x8002DB94 -> 0x8002DD70
+static s32 systemGetException(enum __anon_0x3979C eType, struct __anon_0x393FF* pException) {
+    // Parameters
+    // enum __anon_0x3979C eType; // r1+0x4
+    // struct __anon_0x393FF* pException; // r1+0x8
+}
+
+// Range: 0x8002DB84 -> 0x8002DB94
+static s32 systemGet8(char* pData) {
+    // Parameters
+    // char* pData; // r1+0x8
+}
+
+// Range: 0x8002DB74 -> 0x8002DB84
+static s32 systemGet16(s16* pData) {
+    // Parameters
+    // s16* pData; // r1+0x8
+}
+
+// Range: 0x8002DB64 -> 0x8002DB74
+static s32 systemGet32(s32* pData) {
+    // Parameters
+    // s32* pData; // r1+0x8
+}
+
+// Range: 0x8002DB50 -> 0x8002DB64
+static s32 systemGet64(s64* pData) {
+    // Parameters
+    // s64* pData; // r1+0x8
+}
+
+// Range: 0x8002DB48 -> 0x8002DB50
+static s32 systemPut8() {}
+
+// Range: 0x8002DB40 -> 0x8002DB48
+static s32 systemPut16() {}
+
+// Range: 0x8002DB38 -> 0x8002DB40
+static s32 systemPut32() {}
+
+// Range: 0x8002DB30 -> 0x8002DB38
+static s32 systemPut64() {}
+
+// Range: 0x8002D9F8 -> 0x8002DB30
+static s32 __systemCopyROM_Complete() {
+    // Local variables
+    s32 iAddress; // r30
+    s32 nCount; // r1+0x88
+    u32 nAddress0; // r30
+    u32 nAddress1; // r31
+    u32 anAddress[32]; // r1+0x8
 
     // References
-    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
-    // -> static u32 contMap[4][20];
+    // -> struct __anon_0x37240* gpSystem;
+}
+
+// Range: 0x8002D904 -> 0x8002D9F8
+s32 systemCopyROM(struct __anon_0x37240* pSystem, s32 nOffsetRAM, s32 nOffsetROM, s32 nSize, s32 (*pCallback)()) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r29
+    // s32 nOffsetRAM; // r4
+    // s32 nOffsetROM; // r30
+    // s32 nSize; // r1+0x14
+    // s32 (* pCallback)(); // r31
+
+    // Local variables
+    void* pTarget; // r1+0x1C
 }
 
 // Erased
-static s32 systemMapControllerIndex(s32 gameIndex, s32 configIndex) {
+static s32 systemSetBreak(struct __anon_0x37240* pSystem, s64 nAddress) {
     // Parameters
-    // s32 gameIndex; // r1+0xC
-    // s32 configIndex; // r30
-
-    // Local variables
-    s32 i; // r31
-
-    // References
-    // -> static u32 contMap[4][20];
-    // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // s64 nAddress; // r1+0x8
 }
 
-// Range: 0x80030B38 -> 0x80030E70
-static s32 systemSetupGameRAM(struct __anon_0x37240* pSystem) {
+// Erased
+static s32 systemClearBreak(struct __anon_0x37240* pSystem) {
     // Parameters
-    // struct __anon_0x37240* pSystem; // r27
+    // struct __anon_0x37240* pSystem; // r1+0x0
+}
 
-    // Local variables
-    char* szExtra; // r1+0x414
-    s32 bExpansion; // r30
-    s32 nSizeRAM; // r28
-    s32 nSizeCacheROM; // r29
-    s32 nSizeExtra; // r3
-    struct __anon_0x3BEE8* pROM; // r29
-    u32 nCode; // r28
-    u32 iCode; // r1+0x8
-    u32 anCode[256]; // r1+0x14
+// Range: 0x8002D894 -> 0x8002D904
+s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x3A085 eMode; // r31
 
     // References
-    // -> u32 gnFlagZelda;
+    // -> struct _XL_OBJECTTYPE gClassSystem;
+}
+
+// Range: 0x8002D82C -> 0x8002D894
+s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x3A085* peMode; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSystem;
+}
+
+// Range: 0x8002D740 -> 0x8002D82C
+s32 systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD storageDevice) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r30
+    // enum __anon_0x394CD storageDevice; // r31
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSram;
+    // -> struct _XL_OBJECTTYPE gClassFlash;
+}
+
+// Range: 0x8002D730 -> 0x8002D740
+s32 systemGetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD* pStorageDevice) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // enum __anon_0x394CD* pStorageDevice; // r1+0x4
+}
+
+// Range: 0x8002D578 -> 0x8002D730
+s32 systemReset(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r29
+
+    // Local variables
+    s64 nPC; // r1+0x10
+    s32 nOffsetRAM; // r4
+    enum __anon_0x394CD eObject; // r30
+}
+
+// Range: 0x8002D47C -> 0x8002D578
+s32 systemExecute(struct __anon_0x37240* pSystem, s32 nCount) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r31
+    // s32 nCount; // r4
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassSystem;
+}
+
+// Range: 0x8002D324 -> 0x8002D47C
+s32 systemCheckInterrupts(struct __anon_0x37240* pSystem) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r25
+
+    // Local variables
+    s32 iException; // r30
+    s32 nMaskFinal; // r29
+    s32 bUsed; // r28
+    s32 bDone; // r27
+    struct __anon_0x393FF exception; // r1+0xC
+    enum __anon_0x3994B eCodeFinal; // r26
+}
+
+// Range: 0x8002D2EC -> 0x8002D324
+s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r1+0x0
+    // enum __anon_0x3979C eType; // r1+0x4
+}
+
+// Range: 0x8002CA14 -> 0x8002D2EC
+s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x37240* pSystem; // r31
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r26
+
+    // Local variables
+    struct _CPU* pCPU; // r30
+    struct __anon_0x393FF exception; // r1+0x1C
+    enum __anon_0x394CD eObject; // r1+0x8
+    enum __anon_0x394CD storageDevice; // r1+0x8
+
+    // References
+    // -> struct _XL_OBJECTTYPE gClassRdb;
+    // -> struct _XL_OBJECTTYPE gClassPeripheral;
+    // -> struct _XL_OBJECTTYPE gClassLibrary;
+    // -> struct _XL_OBJECTTYPE gClassSerial;
+    // -> struct _XL_OBJECTTYPE gClassVideo;
+    // -> struct _XL_OBJECTTYPE gClassAudio;
+    // -> struct _XL_OBJECTTYPE gClassDisk;
+    // -> struct _XL_OBJECTTYPE gClassMips;
+    // -> struct _XL_OBJECTTYPE gClassRDP;
+    // -> struct _XL_OBJECTTYPE gClassRSP;
+    // -> struct _XL_OBJECTTYPE gClassROM;
+    // -> struct _XL_OBJECTTYPE gClassRAM;
+    // -> struct _XL_OBJECTTYPE gClassPIF;
+    // -> struct _XL_OBJECTTYPE gClassCPU;
+    // -> struct __anon_0x36AAA* gpSound;
+    // -> struct __anon_0x35B4C* gpFrame;
 }

--- a/debug/Fire/video.c
+++ b/debug/Fire/video.c
@@ -36,56 +36,6 @@ typedef struct __anon_0x75B37 {
     /* 0x3C */ s32 nSyncLeap;
 } __anon_0x75B37; // size = 0x40
 
-// Range: 0x8008E8A0 -> 0x8008E9F4
-s32 videoEvent(struct __anon_0x75B37* pVideo, s32 nEvent, void* pArgument) {
-    // Parameters
-    // struct __anon_0x75B37* pVideo; // r30
-    // s32 nEvent; // r1+0xC
-    // void* pArgument; // r31
-}
-
-// Erased
-static s32 videoGetMode(struct __anon_0x75B37* pVideo, s32* pbBlack, s32* pnSizeX, s32* pnSizeY) {
-    // Parameters
-    // struct __anon_0x75B37* pVideo; // r1+0x8
-    // s32* pbBlack; // r1+0xC
-    // s32* pnSizeX; // r1+0x10
-    // s32* pnSizeY; // r1+0x14
-
-    // Local variables
-    s32 nSizeX; // r1+0x8
-    s32 nSizeY; // r3
-}
-
-// Range: 0x8008E9F4 -> 0x8008EA60
-s32 videoForceRetrace(struct __anon_0x75B37* pVideo) {
-    // Parameters
-    // struct __anon_0x75B37* pVideo; // r31
-}
-
-// Erased
-static s32 videoTickScan() {}
-
-// Range: 0x8008EA60 -> 0x8008EA68
-s32 videoGet64() {}
-
-// Range: 0x8008EA68 -> 0x8008EB84
-s32 videoGet32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
-    // Parameters
-    // struct __anon_0x75B37* pVideo; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r31
-}
-
-// Range: 0x8008EB84 -> 0x8008EB8C
-s32 videoGet16() {}
-
-// Range: 0x8008EB8C -> 0x8008EB94
-s32 videoGet8() {}
-
-// Range: 0x8008EB94 -> 0x8008EB9C
-s32 videoPut64() {}
-
 typedef struct __anon_0x76165 {
     /* 0x0 */ f32 rX;
     /* 0x4 */ f32 rY;
@@ -354,6 +304,12 @@ typedef struct __anon_0x77548 {
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x77548; // size = 0x3D150
 
+// Range: 0x8008EE18 -> 0x8008EE20
+s32 videoPut8() {}
+
+// Range: 0x8008EE10 -> 0x8008EE18
+s32 videoPut16() {}
+
 // Range: 0x8008EB9C -> 0x8008EE10
 s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
     // Parameters
@@ -367,8 +323,52 @@ s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
     struct __anon_0x761FF* pBuffer; // r29
 }
 
-// Range: 0x8008EE10 -> 0x8008EE18
-s32 videoPut16() {}
+// Range: 0x8008EB94 -> 0x8008EB9C
+s32 videoPut64() {}
 
-// Range: 0x8008EE18 -> 0x8008EE20
-s32 videoPut8() {}
+// Range: 0x8008EB8C -> 0x8008EB94
+s32 videoGet8() {}
+
+// Range: 0x8008EB84 -> 0x8008EB8C
+s32 videoGet16() {}
+
+// Range: 0x8008EA68 -> 0x8008EB84
+s32 videoGet32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r30
+    // u32 nAddress; // r1+0xC
+    // s32* pData; // r31
+}
+
+// Range: 0x8008EA60 -> 0x8008EA68
+s32 videoGet64() {}
+
+// Erased
+static s32 videoTickScan() {}
+
+// Range: 0x8008E9F4 -> 0x8008EA60
+s32 videoForceRetrace(struct __anon_0x75B37* pVideo) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r31
+}
+
+// Erased
+static s32 videoGetMode(struct __anon_0x75B37* pVideo, s32* pbBlack, s32* pnSizeX, s32* pnSizeY) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r1+0x8
+    // s32* pbBlack; // r1+0xC
+    // s32* pnSizeX; // r1+0x10
+    // s32* pnSizeY; // r1+0x14
+
+    // Local variables
+    s32 nSizeX; // r1+0x8
+    s32 nSizeY; // r3
+}
+
+// Range: 0x8008E8A0 -> 0x8008E9F4
+s32 videoEvent(struct __anon_0x75B37* pVideo, s32 nEvent, void* pArgument) {
+    // Parameters
+    // struct __anon_0x75B37* pVideo; // r30
+    // s32 nEvent; // r1+0xC
+    // void* pArgument; // r31
+}


### PR DESCRIPTION
This should hopefully make it easier to compare with the source code, since the order in the compiled objects is reversed due to `-inline deferred`