### PR TITLE
Remove C preprocessor requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ format:
 	find include src -name '*.h' -o -name '*.c' | xargs clang-format -i
 
 # Note: this is meant for testing/modding purposes as a dol is easier to package and run than the original elf
-dol: $(DOL) compare
+dol: all $(DOL)
 
 .PHONY: all setup clean format dol distclean
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ MWCC_DIR := tools/mwcc_compiler/$(MWCC_VERSION)
 CC := $(WINE) $(MWCC_DIR)/mwcceppc.exe
 LD := $(WINE) $(MWCC_DIR)/mwldeppc.exe
 
-CPP := cpp
 SHA1SUM := sha1sum
 PYTHON := python3
 ELF2DOL := tools/elf2dol/elf2dol
@@ -92,9 +91,7 @@ SBSS_PDHR 	:= 10
 default: all
 
 # Compare to the checksum of a stripped original
-all: $(ELF) compare
-
-compare:
+all: $(ELF)
 ifneq ($(NON_MATCHING),1)
 	@md5sum $(COMPARE_TO)
 	@md5sum -c checksum.md5
@@ -131,12 +128,9 @@ ALL_DIRS := build $(BUILD_DIR) $(addprefix $(BUILD_DIR)/,$(SRC_DIRS) $(ASM_DIRS)
 # Make sure build directory exists before compiling anything
 DUMMY != mkdir -p $(ALL_DIRS)
 
-$(LDSCRIPT): ldscript.lcf
-	$(CPP) -P -MMD -MP -MT $@ -MF $@.d -I include/ -I . -DBUILD_DIR=$(BUILD_DIR) -o $@ $<
-
-$(ELF): $(O_FILES) $(LDSCRIPT)
+$(ELF): $(O_FILES) ldscript.lcf
 	$(RM) -rf $(ASM_PROCESSOR_DIR)/tmp
-	$(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) $(O_FILES)
+	$(LD) $(LDFLAGS) -o $@ -lcf ldscript.lcf $(O_FILES)
 	$(OBJCOPY) $(ELF) $(COMPARE_TO) -S
 
 $(DOL): $(ELF)

--- a/ldscript.lcf
+++ b/ldscript.lcf
@@ -23,33 +23,3 @@ SECTIONS {
     __ArenaLo = (_db_stack_addr + 0x1f) & ~0x1f;
     __ArenaHi = 0x81700000 ;
 }
-/*
-.init   80003100 - 80005598 : 002498
-.text   800055A0 - 800D2F8C : 0CD9EC
-.ctors  800D2FA0 - 800D2FA8 : 000008
-.dtors  800D2FC0 - 800D2FC8 : 000008
-.rodata 800D2FE0 - 800D3710 : 000730
-.data   800D3720 - 800F3ED8 : 0207B8
-.bss    800F3EE0 - 80134CD8 : 040DF8
-.sdata  80134CE0 - 80135579 : 000899
-.sbss   80135580 - 80135CFD : 00077D
-.sdata2 80135D00 - 80136420 : 000720
-.sbss2  80136420 - 80136420 : 000000
-
-_f_sbss2        80136420
-_stack_addr     80146420
-_stack_end      80136420
-_db_stack_addr  80148420
-
-__ArenaLo       80148420
-__ArenaHi       81700000
-
-_rom_copy_info  80005514
-_bss_init_info  80005580
-
-_SDA_BASE_      8013CCE0
-_SDA2_BASE_     8013DD00
-
-_ctors          800D2FA0 
-_dtors          800D2FC0 
-*/


### PR DESCRIPTION
The C preprocessor was only used to strip some comments from the linker script, which can be gotten from the linker map file instead. This makes it a bit easier to build on macOS, where the default C preprocessor is clang, not gcc.