### PR TITLE
Kinda fix decompme.py

### DIFF
--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import platform
 import re
 import subprocess
+import sys
 import urllib.parse
 import urllib.request
 
@@ -82,7 +83,7 @@ def main():
         ).encode("ascii")
         with urllib.request.urlopen("https://decomp.me/api/scratch", post_data) as f:
             resp = f.read()
-            json_data: Dict[str, str] = json.loads(resp)
+            json_data: dict[str, str] = json.loads(resp)
             if "slug" in json_data:
                 slug = json_data["slug"]
                 token = json_data.get("claim_token")

--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -34,7 +34,8 @@ CPP_ARGS = [
 
 
 def homebrew_gcc_cpp() -> str:
-    for lookup_path in ["/usr/local/bin", "/opt/homebrew/bin"]:
+    lookup_paths = ["/usr/local/bin", "/opt/homebrew/bin"]
+    for lookup_path in lookup_paths:
         try:
             return max(f for f in os.listdir(lookup_path) if f.startswith("cpp-"))
         except ValueError:


### PR DESCRIPTION
We now run the actual preprocessor so at least the context will compile correctly. The downside is that macros are not preserved in the context, and decomp.me's automatic m2c decompilation doesn't work.