### PR TITLE
Rework make setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ SIM_S is a version of the build with stripped symbols which when diffed against 
 
 ### Required tools
 
-* [devkitPro](https://devkitpro.org/wiki/Getting_Started)
 * python3
 
 ### Instructions
 
 1. Obtain the original ELF executable found in the `120903_zelda.tgc` file on the Japanese Collector's Edition disk and place it in the base working directory and name it `SIM_original.elf`
-2. Obtain a copy of the MWCC for embedded PowerPC and place it in the `tools/mwcc_compiler/1.1/` folder.
-(NOTE: This compiler's executables [mwcceppc.exe mwasmeppc.exe and mwldeppc.exe] can be installed with Codewarrior 1.1 for Gamecube, but no license or crack is provided with this project. Please obtain access to the compiler on your own.)
-3. Run `make setup` and `make`
+2. Run `make setup` and `make`

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+binutils/**
+mwcc_compiler/**

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,38 @@
+
+ifeq ($(OS),Windows_NT)
+    BINUTILS_ZIP=windows-x86_64
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)
+        BINUTILS_ZIP=linux-x86_64
+    endif
+    ifeq ($(UNAME_S),Darwin)
+        BINUTILS_ZIP=macos-universal
+    endif
+endif
+
+BINUTILS_TAG := 2.42-1
+COMPILERS_TAG := 20231018
+
+.PHONY: all clean
+
+all: binutils mwcc_compiler
+	$(MAKE) -C elf2dol
+
+clean:
+	rm -rf binutils
+	rm -rf mwcc_compiler
+	$(MAKE) -C elf2dol clean
+
+binutils:
+	mkdir -p binutils
+	wget https://github.com/encounter/gc-wii-binutils/releases/download/$(BINUTILS_TAG)/$(BINUTILS_ZIP).zip -O binutils/$(BINUTILS_ZIP).zip
+	unzip binutils/$(BINUTILS_ZIP).zip -d binutils
+	rm binutils/$(BINUTILS_ZIP).zip
+	chmod +x binutils/powerpc-eabi-*
+
+mwcc_compiler:
+	mkdir -p mwcc_compiler
+	wget https://files.decomp.dev/compilers_$(COMPILERS_TAG).zip -O mwcc_compiler/compilers_$(COMPILERS_TAG).zip
+	unzip mwcc_compiler/compilers_$(COMPILERS_TAG).zip -d mwcc_compiler
+	rm mwcc_compiler/compilers_$(COMPILERS_TAG).zip

--- a/tools/elf2dol/Makefile
+++ b/tools/elf2dol/Makefile
@@ -5,10 +5,9 @@ ELF2DOL_CFLAGS := -O3 -Wall -s
 all: $(ELF2DOL)
 
 clean:
-	rm -r elf2dol
+	$(RM) elf2dol
 
 .PHONY: all clean
 
 $(ELF2DOL):
-	@echo [tools] building elf2dol 
-	@$(ELF2DOL_CC) $(ELF2DOL_CFLAGS) -o $(ELF2DOL) elf2dol.c
+	$(ELF2DOL_CC) $(ELF2DOL_CFLAGS) -o $(ELF2DOL) elf2dol.c


### PR DESCRIPTION
- Remove dependence on devkitpro, instead downloads a suitable binutils release from https://github.com/encounter/gc-wii-binutils
- Download compilers on setup
