### PR TITLE
Fix asm processor still using the devkit env variable

### DIFF
--- a/tools/asm_processor/compile.sh
+++ b/tools/asm_processor/compile.sh
@@ -12,4 +12,4 @@ temp="$(mktemp -d tools/asm_processor/tmp/XXXXXX)"
 tools/asm_processor/asm_processor.py "$2" --assembler "$AS" > "$temp.c" &&
 $CC "$temp.c" -c -o "$temp.o" &&
 tools/asm_processor/asm_processor.py "$2" --post-process "$temp.o" --assembler "$AS" --asm-prelude include/macros.inc
-$DEVKITPPC/bin/powerpc-eabi-objcopy --remove-section .mwcats.text --remove-section .comment "$temp.o" "$1"
+tools/binutils/powerpc-eabi-objcopy --remove-section .mwcats.text --remove-section .comment "$temp.o" "$1"


### PR DESCRIPTION
sorry I missed this during the review (I have this defined so it built properly when I tested)
also it builds properly on debian (but I had to run make with sudo lol, I love wine)