### PR TITLE
Fix permission issue and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,18 @@ SIM_S is a version of the build with stripped symbols which when diffed against 
 
 ### Requirements
 
-You will need the following packages:
+You will need the following dependencies:
 * build-essential
 * git
 * python3
-* wine32
+* 32-bits wine
+* clang-format (optional)
+
+If not installed by default, you will also need:
+* wget
+* unzip
+
+### Ubuntu/Debian
 
 In order to install the 32-bits version of Wine, you will need to run:
 
@@ -30,10 +37,8 @@ Under a Debian/Ubuntu, you can install them with the following commands:
 
 ```
 sudo apt-get update
-sudo apt-get install build-essential git python3 wine32:i386
+sudo apt-get install build-essential git python3 wine32:i386 wget unzip
 ```
-
-Note: some Linux distributions may not have ``wget`` and ``unzip``, which are required too.
 
 ### Instructions
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,16 @@ SIM_S is a version of the build with stripped symbols which when diffed against 
 ### Requirements
 
 You will need the following dependencies:
-* build-essential
+* gcc or clang
+* make
 * git
 * python3
 * 32-bits wine
-* clang-format (optional)
-
-If not installed by default, you will also need:
 * wget
 * unzip
+* clang-format (optional)
 
-### Ubuntu/Debian
+#### Ubuntu/Debian
 
 In order to install the 32-bits version of Wine, you will need to run:
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,29 @@ SIM_S is a version of the build with stripped symbols which when diffed against 
 
 ## Building
 
-### Required tools
+### Requirements
 
+You will need the following packages:
+* build-essential
+* git
 * python3
+* wine32
+
+In order to install the 32-bits version of Wine, you will need to run:
+
+```
+sudo dpkg --add-architecture i386
+sudo apt-get update
+```
+
+Under a Debian/Ubuntu, you can install them with the following commands:
+
+```
+sudo apt-get update
+sudo apt-get install build-essential git python3 wine32:i386
+```
+
+Note: some Linux distributions may not have ``wget`` and ``unzip``, which are required too.
 
 ### Instructions
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -36,4 +36,4 @@ mwcc_compiler:
 	wget https://files.decomp.dev/compilers_$(COMPILERS_TAG).zip -O mwcc_compiler/compilers_$(COMPILERS_TAG).zip
 	unzip mwcc_compiler/compilers_$(COMPILERS_TAG).zip -d mwcc_compiler
 	rm mwcc_compiler/compilers_$(COMPILERS_TAG).zip
-	chmod -R +x mwcc_compiler/
+	find mwcc_compiler/ -name '*.exe' -exec chmod +x {} \;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -36,3 +36,4 @@ mwcc_compiler:
 	wget https://files.decomp.dev/compilers_$(COMPILERS_TAG).zip -O mwcc_compiler/compilers_$(COMPILERS_TAG).zip
 	unzip mwcc_compiler/compilers_$(COMPILERS_TAG).zip -d mwcc_compiler
 	rm mwcc_compiler/compilers_$(COMPILERS_TAG).zip
+	chmod -R +x mwcc_compiler/


### PR DESCRIPTION
This updates the readme to make the requirements more explicit (python isn't the only requirement here) and also it's fixing a permission issue related to the mwcc compilers

Though I don't have enough knowledge about linux permissions so I just used the same command used by the powerpc binaries, I'm open to suggestions