### PR TITLE
Document ``contMap`` configurations

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -24,7 +24,7 @@
 typedef s32 (*SystemCopyCallbackFunc)(void);
 
 // note: each stick direction count as an input
-typedef enum GcnButtons {
+typedef enum GcnButton {
     GCN_BTN_A = 0,
     GCN_BTN_B = 1,
     GCN_BTN_X = 2,
@@ -46,7 +46,7 @@ typedef enum GcnButtons {
     GCN_BTN_CSTICK_LEFT = 18,
     GCN_BTN_CSTICK_RIGHT = 19,
     GCN_BTN_COUNT = 20,
-} GcnButtons;
+} GcnButton;
 
 // __anon_0x394CD
 typedef enum SystemMode {

--- a/include/system.h
+++ b/include/system.h
@@ -5,7 +5,48 @@
 #include "dolphin.h"
 #include "mips.h"
 
+#define N64_BTN_A (1 << 31)
+#define N64_BTN_B (1 << 30)
+#define N64_BTN_Z (1 << 29)
+#define N64_BTN_START (1 << 28)
+#define N64_BTN_DUP (1 << 27)
+#define N64_BTN_DDOWN (1 << 26)
+#define N64_BTN_DLEFT (1 << 25)
+#define N64_BTN_DRIGHT (1 << 24)
+#define N64_BTN_L (1 << 21)
+#define N64_BTN_R (1 << 20)
+#define N64_BTN_CUP (1 << 19)
+#define N64_BTN_CDOWN (1 << 18)
+#define N64_BTN_CLEFT (1 << 17)
+#define N64_BTN_CRIGHT (1 << 16)
+#define N64_BTN_UNSET 0
+
 typedef s32 (*SystemCopyCallbackFunc)(void);
+
+// note: each stick direction count as an input
+typedef enum GcnButtons {
+    GCN_BTN_A = 0,
+    GCN_BTN_B = 1,
+    GCN_BTN_X = 2,
+    GCN_BTN_Y = 3,
+    GCN_BTN_L = 4,
+    GCN_BTN_R = 5,
+    GCN_BTN_Z = 6,
+    GCN_BTN_START = 7,
+    GCN_BTN_UNK8 = 8,
+    GCN_BTN_UNK9 = 9,
+    GCN_BTN_UNK10 = 10,
+    GCN_BTN_UNK11 = 11,
+    GCN_BTN_DPAD_UP = 12,
+    GCN_BTN_DPAD_DOWN = 13,
+    GCN_BTN_DPAD_LEFT = 14,
+    GCN_BTN_DPAD_RIGHT = 15,
+    GCN_BTN_CSTICK_UP = 16,
+    GCN_BTN_CSTICK_DOWN = 17,
+    GCN_BTN_CSTICK_LEFT = 18,
+    GCN_BTN_CSTICK_RIGHT = 19,
+    GCN_BTN_COUNT = 20,
+} GcnButtons;
 
 // __anon_0x394CD
 typedef enum SystemMode {
@@ -111,7 +152,7 @@ typedef struct System {
 // __anon_0x3459E
 typedef struct SystemRomConfig {
     /* 0x0000 */ char rom[36];
-    /* 0x0024 */ s32 controllerConfiguration[4][20];
+    /* 0x0024 */ s32 controllerConfiguration[4][GCN_BTN_COUNT];
     /* 0x0164 */ s32 rumbleConfiguration;
     /* 0x0168 */ SystemObjectType storageDevice;
     /* 0x016C */ s32 normalControllerConfig;

--- a/src/simGCN.c
+++ b/src/simGCN.c
@@ -233,7 +233,7 @@ void* jtbl_800EA194[] = {
 };
 
 static f32 gOrthoMtx[4][4] ALIGNAS(32);
-static u32 gContMap[4][20];
+static u32 gContMap[4][GCN_BTN_COUNT];
 static char* gaszArgument[8];
 
 u32 gmsg_ld01Size = 0x00003E20;

--- a/src/system.c
+++ b/src/system.c
@@ -62,36 +62,102 @@ _XL_OBJECTTYPE gClassSystem = {
     (EventFunc)systemEvent,
 }; // size = 0x10
 
-static u32 contMap[4][20] = {
-    // Controller 1
+// clang-format off
+static u32 contMap[4][GCN_BTN_COUNT] = {
+    // Controller Configuration No. 1
     {
-        0x80000000, 0x40000000, 0x00000000, 0x00000000, 0x00200000, 0x00100000, 0x20000000,
-        0x10000000, 0x08000000, 0x04000000, 0x02000000, 0x01000000, 0x08000000, 0x04000000,
-        0x02000000, 0x01000000, 0x00080000, 0x00040000, 0x00020000, 0x00010000,
-
+        N64_BTN_A,      // GCN_BTN_A
+        N64_BTN_B,      // GCN_BTN_B
+        N64_BTN_UNSET,  // GCN_BTN_X
+        N64_BTN_UNSET,  // GCN_BTN_Y
+        N64_BTN_L,      // GCN_BTN_L
+        N64_BTN_R,      // GCN_BTN_R
+        N64_BTN_Z,      // GCN_BTN_Z
+        N64_BTN_START,  // GCN_BTN_START
+        0x08000000,     // GCN_BTN_UNK8
+        0x04000000,     // GCN_BTN_UNK9
+        0x02000000,     // GCN_BTN_UNK10
+        0x01000000,     // GCN_BTN_UNK11
+        N64_BTN_DUP,    // GCN_BTN_DPAD_UP
+        N64_BTN_DDOWN,  // GCN_BTN_DPAD_DOWN
+        N64_BTN_DLEFT,  // GCN_BTN_DPAD_LEFT
+        N64_BTN_DRIGHT, // GCN_BTN_DPAD_RIGHT
+        N64_BTN_CUP,    // GCN_BTN_CSTICK_UP
+        N64_BTN_CDOWN,  // GCN_BTN_CSTICK_DOWN
+        N64_BTN_CLEFT,  // GCN_BTN_CSTICK_LEFT
+        N64_BTN_CRIGHT, // GCN_BTN_CSTICK_RIGHT
     },
-    // Controller 2
+    // Controller Configuration No. 2
     {
-        0x80000000, 0x40000000, 0x00000000, 0x00000000, 0x20000000, 0x00100000, 0x20000000,
-        0x10000000, 0x08000000, 0x04000000, 0x02000000, 0x01000000, 0x08000000, 0x04000000,
-        0x02000000, 0x01000000, 0x00080000, 0x00040000, 0x00020000, 0x00010000,
-
+        N64_BTN_A,      // GCN_BTN_A
+        N64_BTN_B,      // GCN_BTN_B
+        N64_BTN_UNSET,  // GCN_BTN_X
+        N64_BTN_UNSET,  // GCN_BTN_Y
+        N64_BTN_Z,      // GCN_BTN_L
+        N64_BTN_R,      // GCN_BTN_R
+        N64_BTN_Z,      // GCN_BTN_Z
+        N64_BTN_START,  // GCN_BTN_START
+        0x08000000,     // GCN_BTN_UNK8
+        0x04000000,     // GCN_BTN_UNK9
+        0x02000000,     // GCN_BTN_UNK10
+        0x01000000,     // GCN_BTN_UNK11
+        N64_BTN_DUP,    // GCN_BTN_DPAD_UP
+        N64_BTN_DDOWN,  // GCN_BTN_DPAD_DOWN
+        N64_BTN_DLEFT,  // GCN_BTN_DPAD_LEFT
+        N64_BTN_DRIGHT, // GCN_BTN_DPAD_RIGHT
+        N64_BTN_CUP,    // GCN_BTN_CSTICK_UP
+        N64_BTN_CDOWN,  // GCN_BTN_CSTICK_DOWN
+        N64_BTN_CLEFT,  // GCN_BTN_CSTICK_LEFT
+        N64_BTN_CRIGHT, // GCN_BTN_CSTICK_RIGHT
     },
-    // Controller 3
+    // Controller Configuration No. 3
     {
-        0x80000000, 0x40000000, 0x00010000, 0x00020000, 0x20000000, 0x00100000, 0x00040000,
-        0x10000000, 0x08000000, 0x04000000, 0x02000000, 0x01000000, 0x00200000, 0x00200000,
-        0x00200000, 0x00200000, 0x00080000, 0x00040000, 0x00020000, 0x00010000,
-
+        N64_BTN_A,      // GCN_BTN_A
+        N64_BTN_B,      // GCN_BTN_B
+        N64_BTN_CRIGHT, // GCN_BTN_X
+        N64_BTN_CLEFT,  // GCN_BTN_Y
+        N64_BTN_Z,      // GCN_BTN_L
+        N64_BTN_R,      // GCN_BTN_R
+        N64_BTN_CDOWN,  // GCN_BTN_Z
+        N64_BTN_START,  // GCN_BTN_START
+        0x08000000,     // GCN_BTN_UNK8
+        0x04000000,     // GCN_BTN_UNK9
+        0x02000000,     // GCN_BTN_UNK10
+        0x01000000,     // GCN_BTN_UNK11
+        N64_BTN_L,      // GCN_BTN_DPAD_UP
+        N64_BTN_L,      // GCN_BTN_DPAD_DOWN
+        N64_BTN_L,      // GCN_BTN_DPAD_LEFT
+        N64_BTN_L,      // GCN_BTN_DPAD_RIGHT
+        N64_BTN_CUP,    // GCN_BTN_CSTICK_UP
+        N64_BTN_CDOWN,  // GCN_BTN_CSTICK_DOWN
+        N64_BTN_CLEFT,  // GCN_BTN_CSTICK_LEFT
+        N64_BTN_CRIGHT, // GCN_BTN_CSTICK_RIGHT
     },
-    // Controller 4
+    // Controller Configuration No. 4
     {
-        0x80000000, 0x40000000, 0x00200000, 0x00000000, 0x20000000, 0x00100000, 0x20000000,
-        0x10000000, 0x08000000, 0x04000000, 0x02000000, 0x01000000, 0x08000000, 0x04000000,
-        0x02000000, 0x01000000, 0x00080000, 0x00040000, 0x00020000, 0x00010000,
+        N64_BTN_A,      // GCN_BTN_A
+        N64_BTN_B,      // GCN_BTN_B
+        N64_BTN_L,      // GCN_BTN_X
+        N64_BTN_UNSET,  // GCN_BTN_Y
+        N64_BTN_Z,      // GCN_BTN_L
+        N64_BTN_R,      // GCN_BTN_R
+        N64_BTN_Z,      // GCN_BTN_Z
+        N64_BTN_START,  // GCN_BTN_START
+        0x08000000,     // GCN_BTN_UNK8
+        0x04000000,     // GCN_BTN_UNK9
+        0x02000000,     // GCN_BTN_UNK10
+        0x01000000,     // GCN_BTN_UNK11
+        N64_BTN_DUP,    // GCN_BTN_DPAD_UP
+        N64_BTN_DDOWN,  // GCN_BTN_DPAD_DOWN
+        N64_BTN_DLEFT,  // GCN_BTN_DPAD_LEFT
+        N64_BTN_DRIGHT, // GCN_BTN_DPAD_RIGHT
+        N64_BTN_CUP,    // GCN_BTN_CSTICK_UP
+        N64_BTN_CDOWN,  // GCN_BTN_CSTICK_DOWN
+        N64_BTN_CLEFT,  // GCN_BTN_CSTICK_LEFT
+        N64_BTN_CRIGHT, // GCN_BTN_CSTICK_RIGHT
     },
-
 }; // size = 0x140
+// clang-format on
 
 SystemRomConfig gSystemRomConfigurationList[1];
 u32 nTickMultiplier = 2;


### PR DESCRIPTION
This adds an enum to know which gamecube controller button it is in the array and there's macros for n64 buttons, which are used as the elements of the second array, some values are still in hex because I think they should be the left stick mappings but they don't do anything (at least it was the same behavior) when you map a button (note that they share the same mappings as the D-Pad)

I tried using clang's ``AlignTrailingComments`` option but it was doing strange things in functions.h so I decided to manually disable the formatting on the array for now (I think the comments looks more readable when aligned)
