### PR TITLE
Handle more preprocessor directives in decompme script

### DIFF
--- a/include/dolphin/types.h
+++ b/include/dolphin/types.h
@@ -18,15 +18,6 @@ typedef int BOOL;
 #define FALSE 0
 #define TRUE 1
 
-#if defined(__MWERKS__)
-#define AT_ADDRESS(addr) : (addr)
-#elif defined(__GNUC__)
-// #define AT_ADDRESS(addr) __attribute__((address((addr))))
-#define AT_ADDRESS(addr) // was removed in GCC. define in linker script instead.
-#else
-#error unknown compiler
-#endif
-
 #define ATTRIBUTE_ALIGN(num) __attribute__((aligned(num)))
 
 #define INT_MAX 2147483647

--- a/src/simGCN.c
+++ b/src/simGCN.c
@@ -34,44 +34,44 @@ const f32 D_800D30A0[] = {1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
 const f32 D_800D30D0[] = {1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0};
 const f32 D_800D3100[] = {1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0};
 
-u8 gcoverOpen[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000D8880, 0x000028C1)
+u8 gcoverOpen[0x28C1] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000D8880, 0x28C1)
 };
 
-u8 gnoDisk[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000DB160, 0x00001F01)
+u8 gnoDisk[0x1F01] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000DB160, 0x1F01)
 };
 
-u8 gretryErr[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000DD080, 0x00002441)
+u8 gretryErr[0x2441] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000DD080, 0x2441)
 };
 
-u8 gfatalErr[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000DF4E0, 0x000032E1)
+u8 gfatalErr[0x32E1] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000DF4E0, 0x32E1)
 };
 
-u8 gwrongDisk[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E27E0, 0x00001F01)
+u8 gwrongDisk[0x1F01] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E27E0, 0x1F01)
 };
 
-u8 greadingDisk[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E4700, 0x00000C41)
+u8 greadingDisk[0x0C41] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E4700, 0x0C41)
 };
 
-u8 gbar[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E5360, 0x00000741)
+u8 gbar[0x0741] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E5360, 0x0741)
 };
 
-u8 gyes[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E5AC0, 0x000005C1)
+u8 gyes[0x05C1] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E5AC0, 0x05C1)
 };
 
-u8 gno[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E60A0, 0x000005C1)
+u8 gno[0x05C1] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E60A0, 0x05C1)
 };
 
-u8 gmesgOK[] ALIGNAS(32) = {
-#pragma INCBIN("SIM_original.elf", 0x000E6680, 0x00000341)
+u8 gmesgOK[0x0341] ALIGNAS(32) = {
+#pragma INCBIN("SIM_original.elf", 0x000E6680, 0x0341)
 };
 
 s16 Vert_s16[12] ALIGNAS(32) = {

--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -21,16 +21,14 @@ COMPILER_NAME = "mwcc_233_159"
 # We don't set -inline deferred because otherwise the reversed function order
 # would require manually deleting all previous function definitions from the
 # context.
-COMPILER_FLAGS = (
-    "-Cpp_exceptions off -proc gekko -fp hard -fp_contract on -enum int -O4,p -inline auto -nodefaults -msgstyle gcc"
-)
+COMPILER_FLAGS = "-Cpp_exceptions off -proc gekko -fp hard -fp_contract on -enum int -O4,p -inline auto -nodefaults -msgstyle gcc"
 
 INCLUDE_PATTERN = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-DEFINE_PATTERN = re.compile(r'^#define\s+(\w+)(?:\s+(.*))?$')
-IF_PATTERN = re.compile(r'^#if(n)?(?:def)?\s+(.*)$')
-ELSE_PATTERN = re.compile(r'^#else$')
-ENDIF_PATTERN = re.compile(r'^#endif$')
-INCBIN_PATTERN = re.compile(r'^#pragma INCBIN\(.*\)$')
+DEFINE_PATTERN = re.compile(r"^#define\s+(\w+)(?:\s+(.*))?$")
+IF_PATTERN = re.compile(r"^#if(n)?(?:def)?\s+(.*)$")
+ELSE_PATTERN = re.compile(r"^#else$")
+ENDIF_PATTERN = re.compile(r"^#endif$")
+INCBIN_PATTERN = re.compile(r"^#pragma INCBIN\(.*\)$")
 
 # Defined preprocessor macros
 defines = {"__MWERKS__"}
@@ -42,7 +40,7 @@ def process_file(path: Path) -> str:
     lines = path.read_text().splitlines()
     out_text = ""
     for i, line in enumerate(lines):
-        if (match := IF_PATTERN.match(line.strip())):
+        if match := IF_PATTERN.match(line.strip()):
             condition = match[2] in defines
             if match[1] == "n":
                 condition = not condition
@@ -55,11 +53,11 @@ def process_file(path: Path) -> str:
             if not all(condition_stack):
                 continue
 
-            if (match := DEFINE_PATTERN.match(line.strip())):
+            if match := DEFINE_PATTERN.match(line.strip()):
                 defines.add(match[1])
                 out_text += line
                 out_text += "\n"
-            elif (match := INCLUDE_PATTERN.match(line.strip())):
+            elif match := INCLUDE_PATTERN.match(line.strip()):
                 out_text += f'/* "{path}" line {i + 1} "{match[1]}" */\n'
                 out_text += process_file(INCLUDE_DIR / match[1])
                 out_text += f'/* end "{match[1]}" */\n'
@@ -77,7 +75,9 @@ def main():
     parser = argparse.ArgumentParser(description="Create a decomp.me scratch")
     parser.add_argument("c_file", metavar="C_FILE", type=Path, help="Input .c file")
     parser.add_argument("asm_file", metavar="ASM_FILE", type=Path, help="Input .s file")
-    parser.add_argument("--print-context", action="store_true", help="Print the context and exit")
+    parser.add_argument(
+        "--print-context", action="store_true", help="Print the context and exit"
+    )
 
     args = parser.parse_args()
 

--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -17,8 +17,11 @@ import urllib.parse
 import urllib.request
 
 COMPILER_NAME = "mwcc_233_159"
+# We don't set -inline deferred because otherwise the reversed function order
+# would require manually deleting all previous function definitions from the
+# context.
 COMPILER_FLAGS = (
-    "-Cpp_exceptions off -proc gekko -fp hard -enum int -O4,p -nodefaults -msgstyle gcc"
+    "-Cpp_exceptions off -proc gekko -fp hard -fp_contract on -enum int -O4,p -inline auto -nodefaults -msgstyle gcc"
 )
 INCLUDE_PATTERN = re.compile(r'^#include\s*[<"](.+?)[>"]$')
 GUARD_PATTERN = re.compile(r'^#ifndef\s+(.*)$')

--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -105,7 +105,7 @@ def main():
         ).encode("ascii")
         with urllib.request.urlopen("https://decomp.me/api/scratch", post_data) as f:
             resp = f.read()
-            json_data: Dict[str, str] = json.loads(resp)
+            json_data: dict[str, str] = json.loads(resp)
             if "slug" in json_data:
                 slug = json_data["slug"]
                 token = json_data.get("claim_token")

--- a/tools/decompme.py
+++ b/tools/decompme.py
@@ -16,6 +16,7 @@ import re
 import urllib.parse
 import urllib.request
 
+INCLUDE_DIR = Path("include")
 COMPILER_NAME = "mwcc_233_159"
 # We don't set -inline deferred because otherwise the reversed function order
 # would require manually deleting all previous function definitions from the
@@ -23,35 +24,51 @@ COMPILER_NAME = "mwcc_233_159"
 COMPILER_FLAGS = (
     "-Cpp_exceptions off -proc gekko -fp hard -fp_contract on -enum int -O4,p -inline auto -nodefaults -msgstyle gcc"
 )
-INCLUDE_PATTERN = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-GUARD_PATTERN = re.compile(r'^#ifndef\s+(.*)$')
-INCLUDE_DIR = Path("include")
 
-defines = set()
+INCLUDE_PATTERN = re.compile(r'^#include\s*[<"](.+?)[>"]$')
+DEFINE_PATTERN = re.compile(r'^#define\s+(\w+)(?:\s+(.*))?$')
+IF_PATTERN = re.compile(r'^#if(n)?(?:def)?\s+(.*)$')
+ELSE_PATTERN = re.compile(r'^#else$')
+ENDIF_PATTERN = re.compile(r'^#endif$')
+INCBIN_PATTERN = re.compile(r'^#pragma INCBIN\(.*\)$')
+
+# Defined preprocessor macros
+defines = {"__MWERKS__"}
+# Stack of preprocessor conditions
+condition_stack = [True]
 
 
 def process_file(path: Path) -> str:
     lines = path.read_text().splitlines()
     out_text = ""
     for i, line in enumerate(lines):
-        guard_match = GUARD_PATTERN.match(line.strip())
-        if i == 0 and guard_match:
-            if guard_match[1] in defines:
-                break
-            defines.add(guard_match[1])
-            continue
-
-        if line.startswith("#if") or line.startswith("#endif"):
-            continue
-
-        include_match = INCLUDE_PATTERN.match(line.strip())
-        if include_match:
-            out_text += f'/* "{path}" line {i + 1} "{include_match[1]}" */\n'
-            out_text += process_file(INCLUDE_DIR / include_match[1])
-            out_text += f'/* end "{include_match[1]}" */\n'
+        if (match := IF_PATTERN.match(line.strip())):
+            condition = match[2] in defines
+            if match[1] == "n":
+                condition = not condition
+            condition_stack.append(condition)
+        elif ELSE_PATTERN.match(line.strip()):
+            condition_stack[-1] = not condition_stack[-1]
+        elif ENDIF_PATTERN.match(line.strip()):
+            condition_stack.pop()
         else:
-            out_text += line
-            out_text += "\n"
+            if not all(condition_stack):
+                continue
+
+            if (match := DEFINE_PATTERN.match(line.strip())):
+                defines.add(match[1])
+                out_text += line
+                out_text += "\n"
+            elif (match := INCLUDE_PATTERN.match(line.strip())):
+                out_text += f'/* "{path}" line {i + 1} "{match[1]}" */\n'
+                out_text += process_file(INCLUDE_DIR / match[1])
+                out_text += f'/* end "{match[1]}" */\n'
+            elif INCBIN_PATTERN.match(line.strip()):
+                out_text += "    0"
+                out_text += "\n"
+            else:
+                out_text += line
+                out_text += "\n"
 
     return out_text
 
@@ -60,6 +77,7 @@ def main():
     parser = argparse.ArgumentParser(description="Create a decomp.me scratch")
     parser.add_argument("c_file", metavar="C_FILE", type=Path, help="Input .c file")
     parser.add_argument("asm_file", metavar="ASM_FILE", type=Path, help="Input .s file")
+    parser.add_argument("--print-context", action="store_true", help="Print the context and exit")
 
     args = parser.parse_args()
 
@@ -67,6 +85,10 @@ def main():
     asm_cont = args.asm_file.read_text()
     context = process_file(args.c_file)
     source_code = ""  # TODO: separate source code from context automatically
+
+    if args.print_context:
+        print(context)
+        return
 
     print("Uploading...")
     try:


### PR DESCRIPTION
Also INCBIN and sync compiler flags. Unfortunately you still have to do a lot of manual fixing of the context (but at least you now don't have to delete all previous function definitions like in my first attempt).

Tested with a cpu.c function and a simGCN.c function, but there could be weirder stuff in other files