### PR TITLE
Match cpuExecuteOpcode and some MIPS-related functions

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -1,0 +1,34 @@
+#ifndef _MATH_H
+#define _MATH_H
+
+#include "dolphin.h"
+
+extern u32 __float_nan[];
+extern u32 __float_huge[];
+
+#define NAN (*(f32*)__float_nan)
+#define INFINITY (*(f32*)__float_huge)
+
+f64 floor(f64);
+f64 ceil(f64);
+
+inline f64 fabs(f64 x) { return __fabs(x); }
+
+inline f64 sqrt(f64 x) {
+    if (x > 0.0) {
+        f64 guess = __frsqrte(x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        return x * guess;
+    } else if (x == 0.0) {
+        return 0.0;
+    } else if (x) {
+        return NAN;
+    }
+
+    return INFINITY;
+}
+
+#endif

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -3616,11 +3616,11 @@ static s32 cpuExecuteOpcode(Cpu* pCPU, s32 nCount0, s32 nAddressN64, s32 nAddres
             nAddress = pCPU->aGPR[MIPS_RS(nOpcode)].s32 + MIPS_IMM_S16(nOpcode);
             if (CPU_DEVICE(nAddress)->pfGet32(CPU_DEVICE(nAddress)->pObject,
                                               nAddress + CPU_DEVICE(nAddress)->nOffsetAddress, &nData32)) {
-                if (MIPS_FT(nOpcode) & 1) {
-                    pCPU->aFPR[MIPS_FT(nOpcode) - 1].u64 &= 0xFFFFFFFF;
-                    pCPU->aFPR[MIPS_FT(nOpcode) - 1].u64 |= (s64)nData32 << 32;
+                if (MIPS_RT(nOpcode) & 1) {
+                    pCPU->aFPR[MIPS_RT(nOpcode) - 1].u64 &= 0xFFFFFFFF;
+                    pCPU->aFPR[MIPS_RT(nOpcode) - 1].u64 |= (s64)nData32 << 32;
                 } else {
-                    pCPU->aFPR[MIPS_FT(nOpcode)].s32 = nData32;
+                    pCPU->aFPR[MIPS_RT(nOpcode)].s32 = nData32;
                 }
             }
             break;
@@ -3635,7 +3635,7 @@ static s32 cpuExecuteOpcode(Cpu* pCPU, s32 nCount0, s32 nAddressN64, s32 nAddres
             nAddress = pCPU->aGPR[MIPS_RS(nOpcode)].s32 + MIPS_IMM_S16(nOpcode);
             if (CPU_DEVICE(nAddress)->pfGet64(CPU_DEVICE(nAddress)->pObject,
                                               nAddress + CPU_DEVICE(nAddress)->nOffsetAddress, &nData64)) {
-                pCPU->aFPR[MIPS_FT(nOpcode)].s64 = nData64;
+                pCPU->aFPR[MIPS_RT(nOpcode)].s64 = nData64;
             }
             break;
         case 0x37: // ld

--- a/src/simGCN.c
+++ b/src/simGCN.c
@@ -108,6 +108,7 @@ char D_800E9B80[] = "       Please reduce memory-size to 24MB (using 'setsmemsiz
 char D_800E9BD0[] = "zlj_f.n64";
 char D_800E9BDC[] = "cursor.raw";
 
+#ifndef NON_MATCHING
 extern void *lbl_80008684, *lbl_800086B8, *lbl_800086B8, *lbl_800086B8, *lbl_80008678, *lbl_800086B8, *lbl_800086B8,
     *lbl_800086B8, *lbl_800086B8, *lbl_800086B8, *lbl_80008690, *lbl_800086B8, *lbl_800086B8, *lbl_8000866C,
     *lbl_800086B8, *lbl_8000869C, *lbl_800086B8, *lbl_800086B8, *lbl_800086B8, *lbl_80008660, *lbl_800086B8,
@@ -117,6 +118,7 @@ extern void *lbl_80008684, *lbl_800086B8, *lbl_800086B8, *lbl_800086B8, *lbl_800
     *lbl_80008690, *lbl_800086B8, *lbl_800086B8, *lbl_8000866C, *lbl_800086B8, *lbl_8000869C, *lbl_800086B8,
     *lbl_800086B8, *lbl_800086B8, *lbl_80008660, *lbl_800086B8, *lbl_800086A8;
 
+// simulatorParseArguments
 void* jtbl_800E9BE8[] = {
     &lbl_80008684, &lbl_800086B8, &lbl_800086B8, &lbl_800086B8, &lbl_80008678, &lbl_800086B8, &lbl_800086B8,
     &lbl_800086B8, &lbl_800086B8, &lbl_800086B8, &lbl_80008690, &lbl_800086B8, &lbl_800086B8, &lbl_8000866C,
@@ -130,9 +132,11 @@ void* jtbl_800E9BE8[] = {
 
 extern void *lbl_8000882C, *lbl_80008834, *lbl_8000883C, *lbl_80008844, *lbl_80008850, *lbl_8000885C, *lbl_80008868;
 
+// simulatorDrawCursor
 void* jtbl_800E9CC0[] = {
     &lbl_8000882C, &lbl_80008834, &lbl_8000883C, &lbl_80008844, &lbl_80008850, &lbl_8000885C, &lbl_80008868,
 };
+#endif
 
 char D_800E9CDC[] = "Invalid Message Image Data - Assuming SV09";
 char D_800E9D08[] = "simGCN.c";


### PR DESCRIPTION
`cpuExecuteOpcode` is the main MIPS interpreter if the MIPS code is not recompiled. The most interesting thing I found was a hack for `frameGetDepth` when interpreting `lhu`