### PR TITLE
Clean up remaining extern variable declarations in .c files

### DIFF
--- a/include/simGCN.h
+++ b/include/simGCN.h
@@ -112,6 +112,9 @@ extern void* gpFrame;
 extern void* gpSound;
 extern System* gpSystem;
 
+extern s32 gz_bnrSize;
+extern s32 gz_iconSize;
+
 void simulatorUnpackTexPalette(__anon_0xDB69* pal);
 s32 simulatorDVDOpen(char* szNameFile, DVDFileInfo* pFileInfo);
 s32 simulatorDVDRead(DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset, DVDCallback callback);

--- a/include/simGCN.h
+++ b/include/simGCN.h
@@ -112,8 +112,8 @@ extern void* gpFrame;
 extern void* gpSound;
 extern System* gpSystem;
 
-extern s32 gz_bnrSize;
-extern s32 gz_iconSize;
+extern u32 gz_bnrSize;
+extern u32 gz_iconSize;
 
 void simulatorUnpackTexPalette(__anon_0xDB69* pal);
 s32 simulatorDVDOpen(char* szNameFile, DVDFileInfo* pFileInfo);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1,8 +1,8 @@
 #include "dolphin.h"
 #include "simGCN.h"
 #include "system.h"
+#include "xlCoreGCN.h"
 
-extern GXRenderModeObj* rmode;
 void* gBufferP;
 
 void MovieInit(void) {

--- a/src/system.c
+++ b/src/system.c
@@ -22,14 +22,6 @@
 #include "sram.h"
 #include "video.h"
 
-extern void* gpFrame;
-extern void* gpSound;
-
-extern s32 gz_bnrSize;
-extern s32 gz_iconSize;
-
-extern MemCard mCard;
-
 //! TODO: import MSL headers
 extern int atoi(const char* str);
 


### PR DESCRIPTION
I don't think these should be necessary going forward, now that our headers are in better shape