### PR TITLE
Match cpuExecuteLoadStore and cpuExecuteLoadStoreF

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -3832,6 +3832,7 @@ static s32 cpuExecuteCall(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGC
     return nAddressGCN;
 }
 
+// Matches but data doesn't
 #ifndef NON_MATCHING
 static s32 cpuExecuteLoadStore(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN);
 #pragma GLOBAL_ASM("asm/non_matchings/cpu/cpuExecuteLoadStore.s")
@@ -4108,6 +4109,7 @@ static s32 cpuExecuteLoadStore(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddr
 }
 #endif
 
+// Matches but data doesn't
 #ifndef NON_MATCHING
 static s32 cpuExecuteLoadStoreF(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN);
 #pragma GLOBAL_ASM("asm/non_matchings/cpu/cpuExecuteLoadStoreF.s")


### PR DESCRIPTION
These recompile load/store instructions into PowerPC machine code. I've given up on annotating the PPC instructions for now, ideally we'd make macros or inline functions for them but it's not fully clear what those look like yet (e.g. when to use `|` vs `+` for immediates)