### PR TITLE
Move gpErrorMessageBuffer to simGCN.c

### DIFF
--- a/asm/THPPlayer.s
+++ b/asm/THPPlayer.s
@@ -1570,10 +1570,6 @@ D_800EA458:
 
 .balign 4
 
-/* 000F1760 800F46E0 5000 */
-glabel gpErrorMessageBuffer
-    .skip 20480
-
 /* 000F6760 800F96E0 0040 */
 WorkBuffer:
     .skip 64

--- a/asm/simGCN.s
+++ b/asm/simGCN.s
@@ -8776,6 +8776,10 @@ gContMap:
 gaszArgument:
     .skip 32
 
+/* 000F1760 800F46E0 5000 */
+glabel gpErrorMessageBuffer
+    .skip 20480
+
 .section .sdata, "wa"
 
 .balign 8

--- a/include/emulator/THPPlayer.h
+++ b/include/emulator/THPPlayer.h
@@ -93,6 +93,4 @@ typedef struct __anon_0x10B6F {
     /* 0x1A8 */ __anon_0x109FA audioBuffer[3];
 } __anon_0x10B6F; // size = 0x1D0
 
-extern char gpErrorMessageBuffer[20480];
-
 #endif

--- a/src/emulator/THPPlayer.c
+++ b/src/emulator/THPPlayer.c
@@ -25,8 +25,6 @@ char D_800EA3F8[] = "This thp file doesn't have the offset data\n";
 char D_800EA424[] = "Specified frame number is over total frame number\n";
 char D_800EA458[] = "Specified audio track number is invalid\n";
 
-static char gpErrorMessageBuffer[20480];
-
 static s32 WorkBuffer[16];
 static OSMessageQueue PrepareReadyQueue;
 static OSMessageQueue UsedTextureSetQueue;

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -295,6 +295,7 @@ void* gpFrame;
 void* gpSound;
 System* gpSystem;
 
+static char gpErrorMessageBuffer[20480];
 s32 gbDisplayedError;
 s32 gPreviousAllowResetSetting;
 s32 gPreviousForceMenuSetting;


### PR DESCRIPTION
This makes more sense logically and is required for matching simGCN.c