### PR TITLE
Match more ``frame.c`` functions

### DIFF
--- a/include/dolphin/mtx.h
+++ b/include/dolphin/mtx.h
@@ -17,6 +17,7 @@ typedef struct Quaternion {
 
 typedef f32 Mtx[3][4];
 typedef f32 Mtx44[4][4];
+typedef f32 (*Mtx44Ptr)[4];
 
 void PSMTXIdentity(Mtx m);
 void SMTXConcat(const Mtx a, const Mtx b, Mtx ab);

--- a/include/emulator/frame.h
+++ b/include/emulator/frame.h
@@ -67,6 +67,17 @@ typedef enum FrameMatrixProjection {
     FMP_ORTHOGRAPHIC = 1,
 } FrameMatrixProjection;
 
+// __anon_0x2D223
+typedef enum FrameColorType {
+    FCT_NONE = -1,
+    FCT_FOG,
+    FCT_FILL,
+    FCT_BLEND,
+    FCT_PRIMITIVE,
+    FCT_ENVIRONMENT,
+    FCT_COUNT
+} FrameColorType;
+
 // __anon_0x2D45B
 typedef struct Primitive {
     /* 0x0 */ s32 nCount;
@@ -80,6 +91,20 @@ typedef struct Viewport {
     /* 0x8 */ f32 rSizeX;
     /* 0xC */ f32 rSizeY;
 } Viewport; // size = 0x10
+
+// __anon_0x2D2B6
+typedef struct Scissor {
+    /* 0x00 */ s32 bFlip;
+    /* 0x04 */ s32 iTile;
+    /* 0x08 */ s32 nX0;
+    /* 0x0C */ s32 nY0;
+    /* 0x10 */ s32 nX1;
+    /* 0x14 */ s32 nY1;
+    /* 0x18 */ f32 rS;
+    /* 0x1C */ f32 rT;
+    /* 0x20 */ f32 rDeltaS;
+    /* 0x24 */ f32 rDeltaT;
+} Scissor; // size = 0x28
 
 // __anon_0x23B9E
 typedef struct FrameBuffer {

--- a/include/emulator/frame.h
+++ b/include/emulator/frame.h
@@ -4,6 +4,23 @@
 #include "dolphin.h"
 #include "emulator/xlObject.h"
 
+#define FRAME_SYNC_TOKEN 0x7D00
+
+// N64 frame buffer dimensions
+#define N64_FRAME_WIDTH 320
+#define N64_FRAME_HEIGHT 240
+
+// GC is rendered at double the resolution
+#define GC_FRAME_WIDTH (N64_FRAME_WIDTH * 2)
+#define GC_FRAME_HEIGHT (N64_FRAME_HEIGHT * 2)
+
+// Dimensions of the player preview on the equipment menu of the Zelda pause screen
+#define ZELDA_PAUSE_EQUIP_PLAYER_WIDTH 64
+#define ZELDA_PAUSE_EQUIP_PLAYER_HEIGHT 112
+
+#define ZELDA2_CAMERA_WIDTH 160
+#define ZELDA2_CAMERA_HEIGHT 128
+
 typedef s32 (*FrameDrawFunc)(void*, void*);
 
 // __anon_0x27B8C
@@ -354,7 +371,7 @@ typedef struct Frame {
     /* 0x01C30 */ s32 nBlocksTexture;
     /* 0x01C34 */ s32 nBlocksMaxTexture;
     /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
+    /* 0x01CF8 */ u32 anPackColor[N64_FRAME_WIDTH];
     /* 0x021F8 */ u32 nAddressLoad;
     /* 0x021FC */ u32 nCodePixel;
     /* 0x02200 */ u32 nTlutCode[16];

--- a/include/emulator/frame.h
+++ b/include/emulator/frame.h
@@ -146,6 +146,12 @@ typedef struct TextureMemory {
     /* 0x0 */ TMEM_Block data;
 } TextureMemory; // size = 0x1000
 
+// __anon_0x25A82
+typedef struct TextureInfo {
+    /* 0x0 */ s32 nSizeTextures;
+    /* 0x4 */ s32 nCountTextures;
+} TextureInfo; // size = 0x8
+
 // _FRAME_TEXTURE
 // __anon_0x24462
 typedef struct FrameTexture FrameTexture;

--- a/include/emulator/frame.h
+++ b/include/emulator/frame.h
@@ -330,7 +330,7 @@ typedef struct Frame {
     /* 0x00084 */ f32 rScaleY;
     /* 0x00088 */ u32 nCountFrames;
     /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00090 */ u32 aMode[FMT_COUNT];
     /* 0x000B8 */ Viewport viewport;
     /* 0x000C8 */ FrameBuffer aBuffer[4];
     /* 0x00118 */ u32 nOffsetDepth0;

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -246,10 +246,10 @@ extern void* lbl_8001D45C;
 extern void* lbl_8001D3FC;
 extern void* lbl_8001D418;
 
-void* jtbl_800EB168[] = {&lbl_8001D3FC, &lbl_8001D418, &lbl_8001D418, &lbl_8001D42C, &lbl_8001D42C,
-                         &lbl_8001D42C, &lbl_8001D444, &lbl_8001D45C, &lbl_8001D3FC, &lbl_8001D418};
+void* jtbl_800EB168[10] = {&lbl_8001D3FC, &lbl_8001D418, &lbl_8001D418, &lbl_8001D42C, &lbl_8001D42C,
+                           &lbl_8001D42C, &lbl_8001D444, &lbl_8001D45C, &lbl_8001D3FC, &lbl_8001D418};
 #else
-void* jtbl_800EB168[] = {0};
+void* jtbl_800EB168[10] = {0};
 #endif
 
 #ifndef NON_MATCHING
@@ -264,10 +264,10 @@ extern void* lbl_80020144;
 extern void* lbl_80020144;
 extern void* lbl_80020144;
 
-void* jtbl_800EB190[] = {&lbl_80020074, &lbl_80020084, &lbl_800200C8, &lbl_800200D8, &lbl_800200E8,
-                         &lbl_80020134, &lbl_80020144, &lbl_80020144, &lbl_80020144, &lbl_80020144};
+void* jtbl_800EB190[10] = {&lbl_80020074, &lbl_80020084, &lbl_800200C8, &lbl_800200D8, &lbl_800200E8,
+                           &lbl_80020134, &lbl_80020144, &lbl_80020144, &lbl_80020144, &lbl_80020144};
 #else
-void* jtbl_800EB190[] = {0};
+void* jtbl_800EB190[10] = {0};
 #endif
 
 char D_800EB1B8[] = "frameEnd: INTERNAL ERROR: Called when 'gbFrameBegin' is TRUE!\n";
@@ -283,12 +283,12 @@ extern void* lbl_80029818;
 extern void* lbl_80029824;
 extern void* lbl_80029830;
 
-void* jtbl_800EB20C[] = {
+void* jtbl_800EB20C[8] = {
     &lbl_800297DC, &lbl_800297E8, &lbl_800297F4, &lbl_80029800,
     &lbl_8002980C, &lbl_80029818, &lbl_80029824, &lbl_80029830,
 };
 #else
-void* jtbl_800EB20C[] = {0};
+void* jtbl_800EB20C[8] = {0};
 #endif
 
 #ifndef NON_MATCHING
@@ -325,7 +325,7 @@ extern void* lbl_80029938;
 extern void* lbl_80029938;
 extern void* lbl_8002992C;
 
-void* jtbl_800EB22C[] = {
+void* jtbl_800EB22C[32] = {
     &lbl_8002986C, &lbl_80029878, &lbl_80029884, &lbl_80029890, &lbl_8002989C, &lbl_800298A8, &lbl_80029920,
     &lbl_800298B4, &lbl_800298C0, &lbl_800298CC, &lbl_800298D8, &lbl_800298E4, &lbl_800298F0, &lbl_800298FC,
     &lbl_80029908, &lbl_80029914, &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938,
@@ -333,7 +333,7 @@ void* jtbl_800EB22C[] = {
     &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_8002992C,
 };
 #else
-void* jtbl_800EB22C[] = {0};
+void* jtbl_800EB22C[32] = {0};
 #endif
 
 char D_800EB2AC[] = "LoadTexture: Unknown FILTER mode (%d)\n";
@@ -638,8 +638,8 @@ s32 frameDrawTriangle_C3T3(Frame* pFrame, Primitive* pPrimitive) {
         f32(*pMatrix)[4] = pFrame->aMatrixModel[pFrame->iMatrixModel];
         Vertex* vtx = &pFrame->aVertex[pPrimitive->anData[0]];
         if ((vtx->rSum == 53.0f && pMatrix[3][0] == -3080.0f && pMatrix[3][2] == 6067.0f) ||
-            (pMatrix[2][4] == -31.0f && pMatrix[3][2] == 1669.0f)) {
-            if (pMatrix[2][4] == -31.0f && pMatrix[3][2] == 1669.0f) {
+            (pMatrix[3][0] == -31.0f && pMatrix[3][2] == 1669.0f)) {
+            if (pMatrix[3][0] == -31.0f && pMatrix[3][2] == 1669.0f) {
                 gHackCreditsColor = 1;
             }
             return 1;
@@ -1809,7 +1809,7 @@ s32 frameSetMode(Frame* pFrame, FrameModeType eType, u32 nMode) {
     u32 nFlag;
     u32 nModeChanged;
 
-    if ((pFrame->nMode & (1 << eType))) {
+    if (pFrame->nMode & (1 << eType)) {
         nModeChanged = pFrame->aMode[eType] ^ nMode;
     } else {
         nModeChanged = 0xFFFFFFFF;
@@ -2151,12 +2151,12 @@ s32 frameGetTextureInfo(Frame* pFrame, TextureInfo* pInfo) {
             nCount++;
             switch (pTexture->eFormat) {
                 case GX_TF_I4:
-                case 8:
-                    nSize += (s32)((pTexture->nSizeX * pTexture->nSizeY) + 1) >> 1;
+                case 8: // GX_TF_CI4?
+                    nSize += ((pTexture->nSizeX * pTexture->nSizeY) + 1) >> 1;
                     break;
                 case GX_TF_I8:
                 case GX_TF_IA4:
-                case 9:
+                case 9: // GX_TF_CI8?
                     nSize += pTexture->nSizeX * pTexture->nSizeY;
                     break;
                 case GX_TF_IA8:
@@ -2175,7 +2175,7 @@ s32 frameGetTextureInfo(Frame* pFrame, TextureInfo* pInfo) {
         }
     }
 
-    pInfo->nSizeTextures = nSize + (nCount * 0x6C);
+    pInfo->nSizeTextures = nSize + (nCount * sizeof(FrameTexture));
     pInfo->nCountTextures = nCount;
     return 1;
 }

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -10,23 +10,6 @@
 #include "emulator/xlObject.h"
 #include "macros.h"
 
-#define FRAME_SYNC_TOKEN 0x7D00
-
-// N64 frame buffer dimensions
-#define N64_FRAME_WIDTH 320
-#define N64_FRAME_HEIGHT 240
-
-// GC is rendered at double the resolution
-#define GC_FRAME_WIDTH (N64_FRAME_WIDTH * 2)
-#define GC_FRAME_HEIGHT (N64_FRAME_HEIGHT * 2)
-
-// Dimensions of the player preview on the equipment menu of the Zelda pause screen
-#define ZELDA_PAUSE_EQUIP_PLAYER_WIDTH 64
-#define ZELDA_PAUSE_EQUIP_PLAYER_HEIGHT 112
-
-#define ZELDA2_CAMERA_WIDTH 160
-#define ZELDA2_CAMERA_HEIGHT 128
-
 const s32 D_800D31C0[] = {
     0x00000006, 0x00000000, 0x00000005, 0x00020000, 0x00000004, 0x00030000, 0x00000003, 0x00038000,
     0x00000002, 0x0003C000, 0x00000001, 0x0003E000, 0x00000000, 0x0003F000, 0x00000000, 0x0003F800,
@@ -635,7 +618,7 @@ s32 frameDrawTriangle_C3T3(Frame* pFrame, Primitive* pPrimitive) {
     u32 pad[20];
 
     if (gpSystem->eTypeROM == SRT_ZELDA1 && pPrimitive->nCount == 3 && (pFrame->aMode[4] & 0xC00) == 0xC00) {
-        f32(*pMatrix)[4] = pFrame->aMatrixModel[pFrame->iMatrixModel];
+        Mtx44Ptr pMatrix = pFrame->aMatrixModel[pFrame->iMatrixModel];
         Vertex* vtx = &pFrame->aVertex[pPrimitive->anData[0]];
         if ((vtx->rSum == 53.0f && pMatrix[3][0] == -3080.0f && pMatrix[3][2] == 6067.0f) ||
             (pMatrix[3][0] == -31.0f && pMatrix[3][2] == 1669.0f)) {
@@ -1898,7 +1881,7 @@ s32 frameGetMode(Frame* pFrame, FrameModeType eType, u32* pnMode) {
 s32 frameSetMatrix(Frame* pFrame, Mtx44 matrix, FrameMatrixType eType, s32 bLoad, s32 bPush, s32 nAddressN64) {
     s32 pad1;
     s32 bFlag;
-    f32(*matrixTarget)[4];
+    Mtx44Ptr matrixTarget;
     Mtx44 matrixResult;
     s32 pad2[9];
 

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -91,14 +91,20 @@ char* gaszNameAlpha[] = {
     "APREV", "A0", "A1", "A2", "TEXA", "RASA", "KONST", "ZERO", "KONST",
 };
 
-s32 (*gapfDrawTriangle[8])(Frame*, Primitive*) = {
-    frameDrawTriangle_C0T0, frameDrawTriangle_C1T0, 0x00000000, frameDrawTriangle_C3T0,
-    frameDrawTriangle_C0T3, frameDrawTriangle_C1T3, 0x00000000, frameDrawTriangle_C3T3,
+FrameDrawFunc gapfDrawTriangle[8] = {
+    (FrameDrawFunc)frameDrawTriangle_C0T0,
+    (FrameDrawFunc)frameDrawTriangle_C1T0,
+    NULL,
+    (FrameDrawFunc)frameDrawTriangle_C3T0,
+    (FrameDrawFunc)frameDrawTriangle_C0T3,
+    (FrameDrawFunc)frameDrawTriangle_C1T3,
+    NULL,
+    (FrameDrawFunc)frameDrawTriangle_C3T3,
 };
 
-s32 (*gapfDrawLine[6])(Frame*, Primitive*) = {
-    frameDrawLine_C0T0, frameDrawLine_C1T0, frameDrawLine_C2T0,
-    frameDrawLine_C0T2, frameDrawLine_C1T2, frameDrawLine_C2T2,
+FrameDrawFunc gapfDrawLine[6] = {
+    (FrameDrawFunc)frameDrawLine_C0T0, (FrameDrawFunc)frameDrawLine_C1T0, (FrameDrawFunc)frameDrawLine_C2T0,
+    (FrameDrawFunc)frameDrawLine_C0T2, (FrameDrawFunc)frameDrawLine_C1T2, (FrameDrawFunc)frameDrawLine_C2T2,
 };
 
 s32 nCopyFrame;
@@ -642,12 +648,12 @@ s32 frameDrawTriangle_C3T3(Frame* pFrame, Primitive* pPrimitive) {
 
     if (pFrame->nModeVtx != 0x17) {
         GXClearVtxDesc();
-        GXSetVtxDesc(9, 1);
-        GXSetVtxDesc(0xB, 1);
-        GXSetVtxDesc(0xD, 1);
-        GXSetVtxAttrFmt(0, 9, 1, 4, 0);
-        GXSetVtxAttrFmt(0, 0xB, 1, 5, 0);
-        GXSetVtxAttrFmt(0, 0xD, 1, 4, 0);
+        GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+        GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+        GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+        GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_RGBA6, 0);
+        GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+        GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_RGBA6, 0);
         pFrame->nModeVtx = 0x17;
     }
 

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -77,11 +77,10 @@ GXTexCoordID ganNameTexCoord[] = {
 char D_800EA8D8[] = "TEXRRR (obsolete)";
 char D_800EA8EC[] = "TEXGGG (obsolete)";
 char D_800EA900[] = "TEXBBB (obsolete)";
-char D_800EA914[] = "GX_CC_KONST";
 
 char* gaszNameColor[] = {
     "CPREV", "APREV", "C0",  "A0",   "C1",    "A1",   "C2",       "A2",       "TEXC",     "TEXA",
-    "RASC",  "RASA",  "ONE", "HALF", "KONST", "ZERO", D_800EA8D8, D_800EA8EC, D_800EA900, D_800EA914,
+    "RASC",  "RASA",  "ONE", "HALF", "KONST", "ZERO", D_800EA8D8, D_800EA8EC, D_800EA900, "GX_CC_KONST",
 };
 
 char* gaszNameAlpha[] = {
@@ -111,10 +110,8 @@ s32 sZBufShift[] = {
     0x00038000, 0x00000003, 0x00030000, 0x00000004, 0x00020000, 0x00000005, 0x00000000, 0x00000006,
 };
 
-char D_800EAA0C[] = "PRIMITIVE";
-char D_800EAA18[] = "ENVIRONMENT";
 char* gaszNameColorType[] = {
-    "FOG", "FILL", "BLEND", D_800EAA0C, D_800EAA18,
+    "FOG", "FILL", "BLEND", "PRIMITIVE", "ENVIRONMENT",
 };
 
 static GXTexObj sFrameObj1;
@@ -227,6 +224,7 @@ s32 anRenderModeDatabaseCycle1[] = {
 
 char D_800EB13C[] = "GetTextureInfo: Unknown texture-format: %d\n";
 
+#ifndef NON_MATCHING
 extern void* lbl_8001D3FC;
 extern void* lbl_8001D418;
 extern void* lbl_8001D418;
@@ -240,7 +238,11 @@ extern void* lbl_8001D418;
 
 void* jtbl_800EB168[] = {&lbl_8001D3FC, &lbl_8001D418, &lbl_8001D418, &lbl_8001D42C, &lbl_8001D42C,
                          &lbl_8001D42C, &lbl_8001D444, &lbl_8001D45C, &lbl_8001D3FC, &lbl_8001D418};
+#else
+void* jtbl_800EB168[] = {0};
+#endif
 
+#ifndef NON_MATCHING
 extern void* lbl_80020074;
 extern void* lbl_80020084;
 extern void* lbl_800200C8;
@@ -254,9 +256,14 @@ extern void* lbl_80020144;
 
 void* jtbl_800EB190[] = {&lbl_80020074, &lbl_80020084, &lbl_800200C8, &lbl_800200D8, &lbl_800200E8,
                          &lbl_80020134, &lbl_80020144, &lbl_80020144, &lbl_80020144, &lbl_80020144};
+#else
+void* jtbl_800EB190[] = {0};
+#endif
+
 char D_800EB1B8[] = "frameEnd: INTERNAL ERROR: Called when 'gbFrameBegin' is TRUE!\n";
 char D_800EB1F8[] = "Waiting for valid?\n";
 
+#ifndef NON_MATCHING
 extern void* lbl_800297DC;
 extern void* lbl_800297E8;
 extern void* lbl_800297F4;
@@ -266,13 +273,15 @@ extern void* lbl_80029818;
 extern void* lbl_80029824;
 extern void* lbl_80029830;
 
-#ifndef NON_MATCHING
 void* jtbl_800EB20C[] = {
     &lbl_800297DC, &lbl_800297E8, &lbl_800297F4, &lbl_80029800,
     &lbl_8002980C, &lbl_80029818, &lbl_80029824, &lbl_80029830,
 };
+#else
+void* jtbl_800EB20C[] = {0};
 #endif
 
+#ifndef NON_MATCHING
 extern void* lbl_8002986C;
 extern void* lbl_80029878;
 extern void* lbl_80029884;
@@ -306,7 +315,6 @@ extern void* lbl_80029938;
 extern void* lbl_80029938;
 extern void* lbl_8002992C;
 
-#ifndef NON_MATCHING
 void* jtbl_800EB22C[] = {
     &lbl_8002986C, &lbl_80029878, &lbl_80029884, &lbl_80029890, &lbl_8002989C, &lbl_800298A8, &lbl_80029920,
     &lbl_800298B4, &lbl_800298C0, &lbl_800298CC, &lbl_800298D8, &lbl_800298E4, &lbl_800298F0, &lbl_800298FC,
@@ -314,6 +322,8 @@ void* jtbl_800EB22C[] = {
     &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_80029938,
     &lbl_80029938, &lbl_80029938, &lbl_80029938, &lbl_8002992C,
 };
+#else
+void* jtbl_800EB22C[] = {0};
 #endif
 
 char D_800EB2AC[] = "LoadTexture: Unknown FILTER mode (%d)\n";
@@ -597,7 +607,40 @@ static s32 frameGetCombineAlpha(Frame* pFrame, GXTevAlphaArg* pnAlphaTEV, s32 nA
 
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameCheckTriangleDivide.s")
 
+#ifndef NON_MATCHING
+// matches but data doesn't
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameDrawTriangle_C3T3.s")
+#else
+s32 frameDrawTriangle_C3T3(Frame* pFrame, Primitive* pPrimitive) {
+    u32 pad[20];
+
+    if (gpSystem->eTypeROM == SRT_ZELDA1 && pPrimitive->nCount == 3 && (pFrame->aMode[4] & 0xC00) == 0xC00) {
+        f32(*pMatrix)[4] = pFrame->aMatrixModel[pFrame->iMatrixModel];
+        Vertex* vtx = &pFrame->aVertex[pPrimitive->anData[0]];
+        if ((vtx->rSum == 53.0f && pMatrix[3][0] == -3080.0f && pMatrix[3][2] == 6067.0f) ||
+            (pMatrix[2][4] == -31.0f && pMatrix[3][2] == 1669.0f)) {
+            if (pMatrix[2][4] == -31.0f && pMatrix[3][2] == 1669.0f) {
+                gHackCreditsColor = 1;
+            }
+            return 1;
+        }
+    }
+
+    if (pFrame->nModeVtx != 0x17) {
+        GXClearVtxDesc();
+        GXSetVtxDesc(9, 1);
+        GXSetVtxDesc(0xB, 1);
+        GXSetVtxDesc(0xD, 1);
+        GXSetVtxAttrFmt(0, 9, 1, 4, 0);
+        GXSetVtxAttrFmt(0, 0xB, 1, 5, 0);
+        GXSetVtxAttrFmt(0, 0xD, 1, 4, 0);
+        pFrame->nModeVtx = 0x17;
+    }
+
+    frameCheckTriangleDivide(pFrame, pPrimitive);
+    return 1;
+}
+#endif
 
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameDrawTriangle_Setup.s")
 
@@ -1117,7 +1160,90 @@ s32 frameSetFill(Frame* pFrame, s32 bFill) {
 
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameSetSize.s")
 
+#ifndef NON_MATCHING
+// matches but data doesn't
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameSetMode.s")
+#else
+s32 frameSetMode(Frame* pFrame, FrameModeType eType, u32 nMode) {
+    u32 nFlag;
+    u32 nModeChanged;
+
+    if ((pFrame->nMode & (1 << eType))) {
+        nModeChanged = pFrame->aMode[eType] ^ nMode;
+    } else {
+        nModeChanged = 0xFFFFFFFF;
+        *((volatile u32*)&pFrame->nMode) |= (1 << eType);
+    }
+
+    nFlag = 0;
+    switch (eType) {
+        case FMT_FOG:
+            if (nModeChanged != 0) {
+                nFlag |= 0x20;
+            }
+            break;
+        case FMT_GEOMETRY:
+            if ((nModeChanged & 0x10) != 0) {
+                nFlag |= 0x20;
+            }
+            if ((nModeChanged & 1) != 0) {
+                nFlag |= 4;
+            }
+            if ((nModeChanged & 0xC) != 0) {
+                nFlag |= 8;
+            }
+            if ((nModeChanged & 0x180) != 0) {
+                nFlag |= 2;
+            }
+            break;
+        case FMT_TEXTURE1:
+            if (nModeChanged != 0) {
+                nFlag |= 0x7C01;
+            }
+            break;
+        case FMT_TEXTURE2:
+            if (nModeChanged != 0) {
+                nFlag |= 0x7D01;
+            }
+            break;
+        case FMT_OTHER0:
+            nFlag |= 0x200;
+            if ((nModeChanged & 3) != 0) {
+                nFlag |= 0x7C00;
+            }
+            if ((nModeChanged & 0xF0) != 0) {
+                nFlag |= 4;
+            }
+            if ((nModeChanged & 0xC00) != 0) {
+                nFlag |= 0x40000 | 4;
+            }
+            if ((nModeChanged & 0xFFFF0000) != 0) {
+                nFlag |= 0x7C00;
+            }
+            break;
+        case FMT_OTHER1:
+            if (nModeChanged != 0) {
+                nFlag |= 0x7F01;
+            }
+            break;
+        case FMT_COMBINE_COLOR1:
+        case FMT_COMBINE_COLOR2:
+        case FMT_COMBINE_ALPHA1:
+        case FMT_COMBINE_ALPHA2:
+            if (nModeChanged != 0) {
+                nFlag |= 0x7D00;
+            }
+            break;
+    }
+
+    if (nFlag != 0) {
+        frameDrawReset(pFrame, nFlag);
+    }
+
+    pFrame->aMode[eType] = nMode;
+    return 1;
+}
+#endif
 
 s32 frameGetMode(Frame* pFrame, FrameModeType eType, u32* pnMode) {
     *pnMode = pFrame->aMode[eType];
@@ -1363,6 +1489,55 @@ s32 frameSetMatrixHint(Frame* pFrame, FrameMatrixProjection eProjection, s32 nAd
 
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameInvalidateCache.s")
 
+#ifndef NON_MATCHING
+// matches but data doesn't
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameGetTextureInfo.s")
+#else
+s32 frameGetTextureInfo(Frame* pFrame, TextureInfo* pInfo) {
+    FrameTexture* pTexture;
+    s32 iTexture;
+    s32 nCount;
+    s32 nSize;
+
+    nSize = 0;
+    nCount = 0;
+    iTexture = 0;
+
+    for (iTexture = 0; iTexture < ARRAY_COUNT(pFrame->apTextureCached); iTexture++) {
+        pTexture = pFrame->apTextureCached[iTexture];
+
+        while (pTexture != NULL) {
+            nCount++;
+            switch (pTexture->eFormat) {
+                case GX_TF_I4:
+                case 8:
+                    nSize += (s32)((pTexture->nSizeX * pTexture->nSizeY) + 1) >> 1;
+                    break;
+                case GX_TF_I8:
+                case GX_TF_IA4:
+                case 9:
+                    nSize += pTexture->nSizeX * pTexture->nSizeY;
+                    break;
+                case GX_TF_IA8:
+                case GX_TF_RGB565:
+                case GX_TF_RGB5A3:
+                    nSize += pTexture->nSizeX * pTexture->nSizeY * 2;
+                    break;
+                case GX_TF_RGBA8:
+                    nSize += pTexture->nSizeX * pTexture->nSizeY * 4;
+                    break;
+                default:
+                    OSReport("GetTextureInfo: Unknown texture-format: %d\n", pTexture->eFormat);
+                    return 0;
+            }
+            pTexture = pTexture->pTextureNext;
+        }
+    }
+
+    pInfo->nSizeTextures = nSize + (nCount * 0x6C);
+    pInfo->nCountTextures = nCount;
+    return 1;
+}
+#endif
 
 #pragma GLOBAL_ASM("asm/non_matchings/frame/PSMTX44MultVecNoW.s")


### PR DESCRIPTION
functions done:
- frameDrawTriangle_C3T3
- frameSetScissor
- frameSetColor
- ZeldaDrawFrameNoBlend
- ZeldaDrawFrame
- frameSetMode
- frameGetTextureInfo

also I was able to clean up slightly the data, and I was able to use the N64 height/width macros to set some floats that are most likely using these values