### PR TITLE
Match paired-single/quantization (`psq`) functions

### DIFF
--- a/include/dolphin/os/OSFastCast.h
+++ b/include/dolphin/os/OSFastCast.h
@@ -13,12 +13,13 @@ extern "C" {
 
 #define OS_FASTCAST_U8 2
 #define OS_FASTCAST_U16 3
+#define OS_FASTCAST_S8 4
 #define OS_FASTCAST_S16 5
-// clang-format off
+
 static inline void OSInitFastCast(void) {
 #ifdef __MWERKS__
-  asm
-  {
+    // clang-format off
+    asm {
         li      r3, OS_GQR_U8
         oris    r3, r3, OS_GQR_U8
         mtspr   GQR2, r3
@@ -34,12 +35,160 @@ static inline void OSInitFastCast(void) {
         li      r3, OS_GQR_S16
         oris    r3, r3, OS_GQR_S16
         mtspr   GQR5, r3
-  }
-#else
-
+    }
+    // clang-format off
 #endif
 }
-// clang-format off
+
+static inline f32 __OSu8tof32(register u8* arg) {
+    register f32 ret;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_l ret, 0(arg), 1, OS_FASTCAST_U8
+    }
+    // clang-format on
+#else
+    ret = (f32)*arg;
+#endif
+
+    return ret;
+}
+
+static inline f32 __OSu16tof32(register u16* arg) {
+    register f32 ret;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_l ret, 0(arg), 1, OS_FASTCAST_U16
+    }
+    // clang-format on
+#else
+    ret = (f32)*arg;
+#endif
+
+    return ret;
+}
+
+static inline f32 __OSs8tof32(register s8* arg) {
+    register f32 ret;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_l ret, 0(arg), 1, OS_FASTCAST_S8
+    }
+    // clang-format on
+#else
+    ret = (f32)*arg;
+#endif
+
+    return ret;
+}
+
+static inline f32 __OSs16tof32(register s16* arg) {
+    register f32 ret;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_l ret, 0(arg), 1, OS_FASTCAST_S16
+    }
+    // clang-format on
+#else
+    ret = (f32)*arg;
+#endif
+
+    return ret;
+}
+
+static inline void OSu8tof32(u8* in, f32* out) { *out = __OSu8tof32(in); }
+static inline void OSu16tof32(u16* in, f32* out) { *out = __OSu16tof32(in); }
+static inline void OSs8tof32(s8* in, f32* out) { *out = __OSs8tof32(in); }
+static inline void OSs16tof32(s16* in, f32* out) { *out = __OSs16tof32(in); }
+
+static inline u8 __OSf32tou8(register f32 arg) {
+    f32 a;
+    register f32* ptr = &a;
+    u8 r;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_st arg, 0(ptr), 1, OS_FASTCAST_U8
+    }
+    // clang-format on
+    r = *(u8*)ptr;
+#else
+    r = (u8)arg;
+#endif
+
+    return r;
+}
+
+static inline u16 __OSf32tou16(register f32 arg) {
+    f32 a;
+    register f32* ptr = &a;
+    u16 r;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_st arg, 0(ptr), 1, OS_FASTCAST_U16
+    }
+    // clang-format on
+    r = *(u16*)ptr;
+#else
+    r = (u16)arg;
+#endif
+
+    return r;
+}
+
+static inline s8 __OSf32tos8(register f32 arg) {
+    f32 a;
+    register f32* ptr = &a;
+    s8 r;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_st arg, 0(ptr), 1, OS_FASTCAST_S8
+    }
+    // clang-format on
+    r = *(s8*)ptr;
+#else
+    r = (s8)arg;
+#endif
+
+    return r;
+}
+
+static inline s16 __OSf32tos16(register f32 arg) {
+    f32 a;
+    register f32* ptr = &a;
+    s16 r;
+
+#ifdef __MWERKS__
+    // clang-format off
+    asm {
+        psq_st arg, 0(ptr), 1, OS_FASTCAST_S16
+    }
+    // clang-format on
+    r = *(s16*)ptr;
+#else
+    r = (s16)arg;
+#endif
+
+    return r;
+}
+
+static inline void OSf32tou8(f32* in, u8* out) { *out = __OSf32tou8(*in); }
+static inline void OSf32tou16(f32* in, u16* out) { *out = __OSf32tou16(*in); }
+static inline void OSf32tos8(f32* in, s8* out) { *out = __OSf32tos8(*in); }
+static inline void OSf32tos16(f32* in, s16* out) { *out = __OSf32tos16(*in); }
 
 #ifdef __cplusplus
 }

--- a/include/emulator/frame.h
+++ b/include/emulator/frame.h
@@ -133,16 +133,16 @@ typedef struct FrameBuffer {
 } FrameBuffer; // size = 0x14
 
 // __anon_0x274AD
-typedef struct Vect3F {
+typedef struct Vec3f {
     /* 0x0 */ f32 x;
     /* 0x4 */ f32 y;
     /* 0x8 */ f32 z;
-} Vect3F; // size = 0xC
+} Vec3f; // size = 0xC
 
 // __anon_0x23CAB
 typedef struct Light {
     /* 0x00 */ bool bTransformed;
-    /* 0x04 */ Vect3F rVecOrigTowards;
+    /* 0x04 */ Vec3f rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
     /* 0x18 */ f32 rColorB;
@@ -160,10 +160,10 @@ typedef struct Light {
 // __anon_0x23EDB
 typedef struct LookAt {
     /* 0x00 */ bool bTransformed;
-    /* 0x04 */ Vect3F rS;
-    /* 0x10 */ Vect3F rT;
-    /* 0x1C */ Vect3F rSRaw;
-    /* 0x28 */ Vect3F rTRaw;
+    /* 0x04 */ Vec3f rS;
+    /* 0x10 */ Vec3f rT;
+    /* 0x1C */ Vec3f rSRaw;
+    /* 0x28 */ Vec3f rTRaw;
 } LookAt; // size = 0x34
 
 // __anon_0x23FC4
@@ -171,7 +171,7 @@ typedef struct Vertex {
     /* 0x00 */ f32 rSum;
     /* 0x04 */ f32 rS;
     /* 0x08 */ f32 rT;
-    /* 0x0C */ Vect3F vec;
+    /* 0x0C */ Vec3f vec;
     /* 0x18 */ u8 anColor[4];
 } Vertex; // size = 0x1C
 

--- a/include/emulator/rsp.h
+++ b/include/emulator/rsp.h
@@ -64,7 +64,7 @@ typedef struct __anon_0x575BD {
 
 typedef struct __anon_0x57890 {
     /* 0x00 */ s32 iDL;
-    /* 0x04 */ s32 bValid;
+    /* 0x04 */ bool bValid;
     /* 0x08 */ struct __anon_0x575BD task;
     /* 0x48 */ s32 nCountVertex;
     /* 0x4C */ __anon_0x60B3F eTypeUCode;
@@ -107,9 +107,9 @@ typedef struct __anon_0x57E56 {
     /* 0x0 */ u8 nRed;
     /* 0x1 */ u8 nGreen;
     /* 0x2 */ u8 nBlue;
-    /* 0x3 */ char rVectorX;
-    /* 0x4 */ char rVectorY;
-    /* 0x5 */ char rVectorZ;
+    /* 0x3 */ s8 rVectorX;
+    /* 0x4 */ s8 rVectorY;
+    /* 0x5 */ s8 rVectorZ;
 } __anon_0x57E56; // size = 0x6
 
 typedef struct __anon_0x58107 {
@@ -215,11 +215,11 @@ typedef struct Rsp {
     /* 0x39C8 */ s32* dctBuf;
 } Rsp; // size = 0x39CC
 
-s32 rspInvalidateCache(Rsp* pRSP, s32 nOffset0, s32 nOffset1);
-s32 rspEnableABI(Rsp* pRSP, s32 bFlag);
-s32 rspFrameComplete(Rsp* pRSP);
-s32 rspUpdate(Rsp* pRSP, RspUpdateMode eMode);
-s32 rspEvent(Rsp* pRSP, s32 nEvent, void* pArgument);
+bool rspInvalidateCache(Rsp* pRSP, s32 nOffset0, s32 nOffset1);
+bool rspEnableABI(Rsp* pRSP, bool bFlag);
+bool rspFrameComplete(Rsp* pRSP);
+bool rspUpdate(Rsp* pRSP, RspUpdateMode eMode);
+bool rspEvent(Rsp* pRSP, s32 nEvent, void* pArgument);
 
 extern _XL_OBJECTTYPE gClassRSP;
 

--- a/include/macros.h
+++ b/include/macros.h
@@ -10,6 +10,8 @@
 
 #define OFFSETOF(p, field) ((u8*)&(p)->field - (u8*)(p))
 
+#define SQ(x) ((x) * (x))
+
 // Adds no-ops to increase a function's size, preventing automatic inlining
 #define NO_INLINE() \
     (void)0;        \

--- a/libc/math.h
+++ b/libc/math.h
@@ -121,6 +121,8 @@ _MATH_INLINE float powf(float __x, float __y) { return pow(__x, __y); }
 #define FP_NORMAL 4
 #define FP_SUBNORMAL 5
 
+double __frsqrte(double x);
+
 static inline int __fpclassifyf(float x) {
   switch ((*(_INT32*)&x) & 0x7f800000) {
   case 0x7f800000: {
@@ -174,13 +176,10 @@ extern inline float sqrtf(float x) {
   volatile float y;
 
   if (x > 0.0f) {
-    double guess = __frsqrte((double)x);                  /* returns an approximation to	*/
-    guess = _half * guess * (_three - guess * guess * x); /* now have 12 sig bits
-                                                           */
-    guess = _half * guess * (_three - guess * guess * x); /* now have 24 sig bits
-                                                           */
-    guess = _half * guess * (_three - guess * guess * x); /* now have 32 sig bits
-                                                           */
+    double guess = __frsqrte((double)x);                  /* returns an approximation to  */
+    guess = _half * guess * (_three - guess * guess * x); /* now have 12 sig bits         */
+    guess = _half * guess * (_three - guess * guess * x); /* now have 24 sig bits         */
+    guess = _half * guess * (_three - guess * guess * x); /* now have 32 sig bits         */
     y = (float)(x * guess);
     return y;
   }
@@ -197,6 +196,22 @@ _MATH_INLINE double sqrt(double x) {
     return x * guess;
   } else if (x == 0.0) {
     return 0;
+  } else if (x) {
+    return NAN;
+  }
+  return INFINITY;
+}
+
+_MATH_INLINE float _inv_sqrtf(float x) {
+  const float _half = .5f;
+  const float _three = 3.0f;
+
+  if (x > 0.0f) {
+    float guess = __frsqrte((double)x);                   /* returns an approximation to  */
+    guess = _half * guess * (_three - guess * guess * x); /* now have 8  sig bits         */
+    guess = _half * guess * (_three - guess * guess * x); /* now have 16 sig bits         */
+    guess = _half * guess * (_three - guess * guess * x); /* now have >24 sig bits        */
+    return guess;
   } else if (x) {
     return NAN;
   }

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -2138,9 +2138,7 @@ bool frameGetMatrix(Frame* pFrame, Mtx44 matrix, FrameMatrixType eType, bool bPu
 
 // TODO: move these paired-single/quantization functions to a separate header
 // along with the GQR initialization in xlMain()?
-inline void s16tof32(register s16* in, register f32* out) {
-    OSs16tof32(in, out);
-}
+inline void s16tof32(register s16* in, register f32* out) { OSs16tof32(in, out); }
 
 inline void s16tof32Pair(register s16* in, register f32* out) {
 #ifdef __MWERKS__
@@ -2595,7 +2593,7 @@ bool frameSetMatrixHint(Frame* pFrame, FrameMatrixProjection eProjection, s32 nA
     }
 
     if (eProjection == 1) {
-        rScale = 0.0f;
+        rNear = 0.0f;
     }
 
     pFrame->aMatrixHint[iHint].nCount = 4;

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -2388,11 +2388,11 @@ bool frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
                      arNormal[2] * pFrame->lookAt.rT.z;
                 if (nTexGen & 0x100) {
                     colorS = rS * rS * rS;
-                    colorS = (D_80135E50 * colorS) + colorS;
-                    rS = (D_80135E54 * rS) + colorS;
+                    colorS = (0.22673f * colorS) + colorS;
+                    rS = ((1.0f / (f32)M_PI) * rS) + colorS;
                     colorT = rT * rT * rT;
-                    colorT = (D_80135E50 * colorT) + colorT;
-                    rT = (D_80135E54 * rT) + colorT;
+                    colorT = (0.22673f * colorT) + colorT;
+                    rT = ((1.0f / (f32)M_PI) * rT) + colorT;
                 } else {
                     rS *= 0.5f;
                     rT *= 0.5f;
@@ -2417,11 +2417,11 @@ bool frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
 
                 if (nTexGen & 0x100) {
                     colorS = rS * rS * rS;
-                    colorS = (D_80135E50 * colorS) + colorS;
-                    rS = (D_80135E54 * rS) + colorS;
+                    colorS = (0.22673f * colorS) + colorS;
+                    rS = ((1.0f / (f32)M_PI) * rS) + colorS;
                     colorT = rT * rT * rT;
-                    colorT = (D_80135E50 * colorT) + colorT;
-                    rT = (D_80135E54 * rT) + colorT;
+                    colorT = (0.22673f * colorT) + colorT;
+                    rT = ((1.0f / (f32)M_PI) * rT) + colorT;
                 } else {
                     rS *= 0.5f;
                     rT *= 0.5f;

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -2163,7 +2163,41 @@ bool frameSetLightCount(Frame* pFrame, s32 nCount) {
     return true;
 }
 
+// Matches but data doesn't
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameSetLight.s")
+#else
+bool frameSetLight(Frame* pFrame, s32 iLight, s8* pData) {
+    Light* pLight;
+
+    if (iLight >= 0 && iLight < 8) {
+        pLight = &pFrame->aLight[iLight];
+        pLight->bTransformed = false;
+
+        if (pData[3] != 0) {
+            pLight->kc = (u8)pData[3] * 0.0078125f + 0.0625f;
+            pLight->kl = (u8)pData[7] / 4096.0f;
+            pLight->kq = (u8)pData[14] / 4194304.0f;
+            pLight->coordX = *(s16*)&pData[8];
+            pLight->coordY = *(s16*)&pData[10];
+            pLight->coordZ = *(s16*)&pData[12];
+        } else {
+            pLight->kc = 0.0f;
+        }
+
+        OSu8tof32((u8*)&pData[0], &pLight->rColorR);
+        OSu8tof32((u8*)&pData[1], &pLight->rColorG);
+        OSu8tof32((u8*)&pData[2], &pLight->rColorB);
+
+        s8tof32Scaled(&pData[8], &pLight->rVecOrigTowards.x);
+        s8tof32Scaled(&pData[9], &pLight->rVecOrigTowards.y);
+        s8tof32Scaled(&pData[10], &pLight->rVecOrigTowards.z);
+        return true;
+    } else {
+        return false;
+    }
+}
+#endif
 
 bool frameSetLookAt(Frame* pFrame, s32 iLookAt, s8* pData) {
     switch (iLookAt) {

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -2199,7 +2199,7 @@ inline void s16tof32Scaled32Pair(register s16* src, register f32* dst) {
 #ifndef NON_MATCHING
 #pragma GLOBAL_ASM("asm/non_matchings/frame/frameLoadVertex.s")
 #else
-s32 frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
+bool frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
     f32 mag;
     s32 iLight;
     s32 nLight;
@@ -2234,7 +2234,7 @@ s32 frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
     pnData16 = pBuffer;
     iVertex1 = iVertex0 + nCount - 1;
     if (iVertex0 < 0 || iVertex0 >= 80 || iVertex1 < 0 || iVertex1 >= 80) {
-        return 0;
+        return false;
     }
 
     matrixModel = pFrame->aMatrixModel[pFrame->iMatrixModel];
@@ -2254,7 +2254,7 @@ s32 frameLoadVertex(Frame* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
         // TODO: volatile hacks
     } else if (!(*(volatile u32*)&pFrame->nMode & 0x400000) && pFrame->iHintProjection != -1) {
         if (!frameScaleMatrix(pFrame->matrixView, matrixModel, pFrame->aMatrixHint[pFrame->iHintProjection].rScale)) {
-            return 0;
+            return false;
         }
         pFrame->nMode |= 0x400000;
         matrixView = pFrame->matrixView;

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -3,6 +3,7 @@
 #include "emulator/ram.h"
 #include "emulator/rdp.h"
 #include "emulator/rsp_jumptables.h"
+#include "emulator/system.h"
 
 _XL_OBJECTTYPE gClassRSP = {
     "RSP",

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -1,4 +1,7 @@
 #include "emulator/rsp.h"
+#include "emulator/cpu.h"
+#include "emulator/ram.h"
+#include "emulator/rdp.h"
 #include "emulator/rsp_jumptables.h"
 
 _XL_OBJECTTYPE gClassRSP = {
@@ -315,7 +318,132 @@ const f32 D_80136074 = 1.52587890625e-05;
 
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspParseGBI_F3DEX2.s")
 
+// Matches but data doesn't
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspLoadMatrix.s")
+#else
+static bool rspLoadMatrix(Rsp* pRSP, s32 nAddress, Mtx44 matrix) {
+    s32* pMtx;
+    s32 nDataA;
+    s32 nDataB;
+    f32 rScale;
+    f32 rUpper;
+    f32 rLower;
+    u16 nUpper;
+    u16 nLower;
+
+    rScale = 1.0f / 65536.0f;
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pMtx, nAddress, NULL)) {
+        return false;
+    }
+
+    nDataA = pMtx[0];
+    nDataB = pMtx[8];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[0][0] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[0][1] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[1];
+    nDataB = pMtx[9];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[0][2] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[0][3] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[2];
+    nDataB = pMtx[10];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[1][0] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[1][1] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[3];
+    nDataB = pMtx[11];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[1][2] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[1][3] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[4];
+    nDataB = pMtx[12];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[2][0] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[2][1] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[5];
+    nDataB = pMtx[13];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[2][2] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[2][3] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[6];
+    nDataB = pMtx[14];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[3][0] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[3][1] = rUpper + rLower * rScale;
+
+    nDataA = pMtx[7];
+    nDataB = pMtx[15];
+    nUpper = nDataA >> 16;
+    nLower = nDataB >> 16;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[3][2] = rUpper + rLower * rScale;
+    nUpper = nDataA & 0xFFFF;
+    nLower = nDataB & 0xFFFF;
+    OSs16tof32((s16*)&nUpper, &rUpper);
+    OSu16tof32(&nLower, &rLower);
+    matrix[3][3] = rUpper + rLower * rScale;
+
+    return true;
+}
+#endif
 
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspFindUCode.s")
 

--- a/src/emulator/xlCoreGCN.c
+++ b/src/emulator/xlCoreGCN.c
@@ -155,23 +155,7 @@ int main(int nCount, char** aszArgument) {
 
     __PADDisableRecalibration(true);
     OSInitAlarm();
-
-#ifdef __MWERKS__
-    asm {
-        li      r3, 4
-        oris    r3, r3, 4
-        mtspr   GQR2, r3
-        li      r3, 5
-        oris    r3, r3, 5
-        mtspr   GQR3, r3
-        li      r3, 6
-        oris    r3, r3, 6
-        mtspr   GQR4, r3
-        li      r3, 7
-        oris    r3, r3, 7
-        mtspr   GQR5, r3
-    }
-#endif
+    OSInitFastCast();
 
     nSizeHeap = 0;
 


### PR DESCRIPTION
Background on the GameCube CPU's unique `psq` instructions: https://mariokartwii.com/showthread.php?tid=1870

GQRs 2-5 are from OSFastCast.h. I tried a couple versions but ultimately the ones from the [open_rvl](https://github.com/kiwi515/open_rvl/blob/main/include/revolution/OS/OSFastCast.h) repo worked the best.

GQRs 6-7 appear to be custom, for decoding 1.7 and 11.5 fixed-point numbers used by the GBI. They're initialized in `xlMain()` and only used in frame.c. I'm not sure what to call them or where to put them so I left a TODO to think about it later.

Finally, `PSMTX44MultVecNoW` looks to be handwritten and it's probably the cause of `peephole off` in frame.c