### PR TITLE
Remove Ptr typedefs

### DIFF
--- a/include/dolphin/mtx.h
+++ b/include/dolphin/mtx.h
@@ -5,15 +5,7 @@
 
 typedef struct Vec {
     f32 x, y, z;
-} Vec, *VecPtr, Point3d, *Point3dPtr;
-
-typedef struct S16Vec {
-    s16 x, y, z;
-} S16Vec, *S16VecPtr;
-
-typedef struct Quaternion {
-    f32 x, y, z, w;
-} Quaternion, *QuaternionPtr, Qtrn, *QtrnPtr;
+} Vec;
 
 typedef f32 Mtx[3][4];
 typedef f32 Mtx44[4][4];

--- a/include/dolphin/tex.h
+++ b/include/dolphin/tex.h
@@ -18,7 +18,7 @@ typedef struct {
     /* 0x21 */ u8 minLOD;
     /* 0x22 */ u8 maxLOD;
     /* 0x23 */ u8 unpacked;
-} TEXHeader, *TEXHeaderPtr; // size = 0x24
+} TEXHeader; // size = 0x24
 
 typedef struct {
     /* 0x0 */ u16 numEntries;
@@ -26,20 +26,20 @@ typedef struct {
     /* 0x3 */ u8 pad8;
     /* 0x4 */ GXTlutFmt format;
     /* 0x8 */ char* data;
-} CLUTHeader, *CLUTHeaderPtr; // size = 0xC
+} CLUTHeader; // size = 0xC
 
 typedef struct {
-    /* 0x0 */ TEXHeaderPtr textureHeader;
-    /* 0x4 */ CLUTHeaderPtr CLUTHeader;
-} TEXDescriptor, *TEXDescriptorPtr; // size = 0x8
+    /* 0x0 */ TEXHeader* textureHeader;
+    /* 0x4 */ CLUTHeader* CLUTHeader;
+} TEXDescriptor; // size = 0x8
 
 typedef struct {
     /* 0x0 */ u32 versionNumber;
     /* 0x4 */ u32 numDescriptors;
-    /* 0x8 */ TEXDescriptorPtr descriptorArray;
-} TEXPalette, *TEXPalettePtr; // size = 0xC
+    /* 0x8 */ TEXDescriptor* descriptorArray;
+} TEXPalette; // size = 0xC
 
-TEXDescriptorPtr TEXGet(TEXPalettePtr pal, u32 id);
-void TEXGetGXTexObjFromPalette(TEXPalettePtr pal, GXTexObj* to, u32 id);
+TEXDescriptor* TEXGet(TEXPalette* pal, u32 id);
+void TEXGetGXTexObjFromPalette(TEXPalette* pal, GXTexObj* to, u32 id);
 
 #endif

--- a/include/emulator/THPRead.h
+++ b/include/emulator/THPRead.h
@@ -17,7 +17,7 @@ typedef enum MovieMessage {
 extern bool gMovieErrorToggle;
 
 bool movieGXInit(void);
-bool movieDrawImage(TEXPalettePtr tpl, s16 nX0, s16 nY0);
+bool movieDrawImage(TEXPalette* tpl, s16 nX0, s16 nY0);
 bool movieDrawErrorMessage(MovieMessage movieMessage);
 bool movieDVDShowError(s32 nStatus, void*, s32, u32);
 bool movieDVDRead(DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset);

--- a/include/emulator/simGCN.h
+++ b/include/emulator/simGCN.h
@@ -97,7 +97,7 @@ extern u8 TexCoords_u8[];
 
 extern char gpErrorMessageBuffer[20480];
 
-void simulatorUnpackTexPalette(TEXPalettePtr pal);
+void simulatorUnpackTexPalette(TEXPalette* pal);
 bool simulatorDVDOpen(char* szNameFile, DVDFileInfo* pFileInfo);
 bool simulatorDVDRead(DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset, DVDCallback callback);
 bool simulatorShowLoad(s32 unknown, char* szNameFile, f32 rProgress);

--- a/src/emulator/THPRead.c
+++ b/src/emulator/THPRead.c
@@ -152,7 +152,7 @@ bool movieGXInit(void) {
     return true;
 }
 
-bool movieDrawImage(TEXPalettePtr tpl, s16 nX0, s16 nY0) {
+bool movieDrawImage(TEXPalette* tpl, s16 nX0, s16 nY0) {
     GXTexObj texObj;
     s32 pad2;
     GXColor color;
@@ -259,39 +259,39 @@ bool movieDrawImage(TEXPalettePtr tpl, s16 nX0, s16 nY0) {
 bool movieDrawErrorMessage(MovieMessage movieMessage) {
     switch (movieMessage) {
         case M_M_DISK_COVER_OPEN:
-            movieDrawImage((TEXPalettePtr)(u8*)gcoverOpen,
-                           160 - ((TEXPalettePtr)(u8*)gcoverOpen)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gcoverOpen)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gcoverOpen,
+                           160 - ((TEXPalette*)(u8*)gcoverOpen)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gcoverOpen)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_WRONG_DISK:
-            movieDrawImage((TEXPalettePtr)(u8*)gwrongDisk,
-                           160 - ((TEXPalettePtr)(u8*)gwrongDisk)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gwrongDisk)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gwrongDisk,
+                           160 - ((TEXPalette*)(u8*)gwrongDisk)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gwrongDisk)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_READING_DISK:
-            movieDrawImage((TEXPalettePtr)(u8*)greadingDisk,
-                           160 - ((TEXPalettePtr)(u8*)greadingDisk)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)greadingDisk)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)greadingDisk,
+                           160 - ((TEXPalette*)(u8*)greadingDisk)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)greadingDisk)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_RETRY_ERROR:
-            movieDrawImage((TEXPalettePtr)(u8*)gretryErr,
-                           160 - ((TEXPalettePtr)(u8*)gretryErr)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gretryErr)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gretryErr,
+                           160 - ((TEXPalette*)(u8*)gretryErr)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gretryErr)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_FATAL_ERROR:
-            movieDrawImage((TEXPalettePtr)(u8*)gfatalErr,
-                           160 - ((TEXPalettePtr)(u8*)gfatalErr)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gfatalErr)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gfatalErr,
+                           160 - ((TEXPalette*)(u8*)gfatalErr)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gfatalErr)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_NO_DISK:
-            movieDrawImage((TEXPalettePtr)(u8*)gnoDisk,
-                           160 - ((TEXPalettePtr)(u8*)gnoDisk)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gnoDisk)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gnoDisk,
+                           160 - ((TEXPalette*)(u8*)gnoDisk)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gnoDisk)->descriptorArray->textureHeader->height / 2);
             break;
         case M_M_DISK_DEFAULT_ERROR:
-            movieDrawImage((TEXPalettePtr)(u8*)gfatalErr,
-                           160 - ((TEXPalettePtr)(u8*)gfatalErr)->descriptorArray->textureHeader->width / 2,
-                           120 - ((TEXPalettePtr)(u8*)gfatalErr)->descriptorArray->textureHeader->height / 2);
+            movieDrawImage((TEXPalette*)(u8*)gfatalErr,
+                           160 - ((TEXPalette*)(u8*)gfatalErr)->descriptorArray->textureHeader->width / 2,
+                           120 - ((TEXPalette*)(u8*)gfatalErr)->descriptorArray->textureHeader->height / 2);
             break;
     }
 

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -282,14 +282,14 @@ bool simulatorGXInit(void) {
     return true;
 }
 
-void simulatorUnpackTexPalette(TEXPalettePtr pal) {
+void simulatorUnpackTexPalette(TEXPalette* pal) {
     u16 i;
 
-    pal->descriptorArray = (TEXDescriptorPtr)((char*)pal->descriptorArray + (u32)pal);
+    pal->descriptorArray = (TEXDescriptor*)((char*)pal->descriptorArray + (u32)pal);
     for (i = 0; i < pal->numDescriptors; i++) {
         if (pal->descriptorArray[i].textureHeader) {
             pal->descriptorArray[i].textureHeader =
-                (TEXHeaderPtr)((char*)pal + (u32)pal->descriptorArray[i].textureHeader);
+                (TEXHeader*)((char*)pal + (u32)pal->descriptorArray[i].textureHeader);
             if (!pal->descriptorArray[i].textureHeader->unpacked) {
                 pal->descriptorArray[i].textureHeader->data =
                     (char*)pal + (u32)pal->descriptorArray[i].textureHeader->data;
@@ -297,7 +297,7 @@ void simulatorUnpackTexPalette(TEXPalettePtr pal) {
             }
         }
         if (pal->descriptorArray[i].CLUTHeader) {
-            pal->descriptorArray[i].CLUTHeader = (CLUTHeaderPtr)((u8*)pal + (u32)pal->descriptorArray[i].CLUTHeader);
+            pal->descriptorArray[i].CLUTHeader = (CLUTHeader*)((u8*)pal + (u32)pal->descriptorArray[i].CLUTHeader);
             if (!pal->descriptorArray[i].CLUTHeader->unpacked) {
                 pal->descriptorArray[i].CLUTHeader->data = (char*)pal + (u32)pal->descriptorArray[i].CLUTHeader->data;
                 pal->descriptorArray[i].CLUTHeader->unpacked = true;
@@ -431,7 +431,7 @@ bool simulatorPlayMovie(void) {
     return true;
 }
 
-s32 simulatorDrawImage(TEXPalettePtr tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
+s32 simulatorDrawImage(TEXPalette* tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
     GXTexObj texObj;
     GXTexObj texObj2;
     u32 pad2;
@@ -545,18 +545,18 @@ s32 simulatorDrawImage(TEXPalettePtr tpl, s32 nX0, s32 nY0, s32 drawBar, s32 per
     if (drawBar == true) {
         GXLoadPosMtxImm(g2DviewMtx, false);
 
-        Vert_s16Bar[0] = N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width / 2;
+        Vert_s16Bar[0] = N64_FRAME_WIDTH / 2 - ((TEXPalette*)gbar)->descriptorArray->textureHeader->width / 2;
         Vert_s16Bar[1] = (nY0 + tpl->descriptorArray->textureHeader->height);
-        Vert_s16Bar[3] = ((N64_FRAME_WIDTH / 2 - (((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width / 2)) +
-                          ((((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width * percent) / 100));
+        Vert_s16Bar[3] = ((N64_FRAME_WIDTH / 2 - (((TEXPalette*)gbar)->descriptorArray->textureHeader->width / 2)) +
+                          ((((TEXPalette*)gbar)->descriptorArray->textureHeader->width * percent) / 100));
         Vert_s16Bar[4] = (nY0 + tpl->descriptorArray->textureHeader->height);
-        Vert_s16Bar[6] = ((N64_FRAME_WIDTH / 2 - (((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width / 2)) +
-                          ((((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width * percent) / 100));
+        Vert_s16Bar[6] = ((N64_FRAME_WIDTH / 2 - (((TEXPalette*)gbar)->descriptorArray->textureHeader->width / 2)) +
+                          ((((TEXPalette*)gbar)->descriptorArray->textureHeader->width * percent) / 100));
         Vert_s16Bar[7] = (nY0 + tpl->descriptorArray->textureHeader->height +
-                          ((TEXPalettePtr)gbar)->descriptorArray->textureHeader->height);
-        Vert_s16Bar[9] = N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gbar)->descriptorArray->textureHeader->width / 2;
+                          ((TEXPalette*)gbar)->descriptorArray->textureHeader->height);
+        Vert_s16Bar[9] = N64_FRAME_WIDTH / 2 - ((TEXPalette*)gbar)->descriptorArray->textureHeader->width / 2;
         Vert_s16Bar[10] = (nY0 + tpl->descriptorArray->textureHeader->height +
-                           ((TEXPalettePtr)gbar)->descriptorArray->textureHeader->height);
+                           ((TEXPalette*)gbar)->descriptorArray->textureHeader->height);
 
         DCStoreRange(Vert_s16Bar, sizeof(Vert_s16Bar));
         GXClearVtxDesc();
@@ -569,7 +569,7 @@ s32 simulatorDrawImage(TEXPalettePtr tpl, s32 nX0, s32 nY0, s32 drawBar, s32 per
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_S16, 0);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_CLR_RGBA, GX_RGB8, 0);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_U8, 0);
-        TEXGetGXTexObjFromPalette((TEXPalettePtr)gbar, &texObj2, 0);
+        TEXGetGXTexObjFromPalette((TEXPalette*)gbar, &texObj2, 0);
         GXLoadTexObj(&texObj2, GX_TEXMAP0);
 
         GXBegin(GX_QUADS, GX_VTXFMT0, 4);
@@ -613,8 +613,8 @@ s32 simulatorDrawImage(TEXPalettePtr tpl, s32 nX0, s32 nY0, s32 drawBar, s32 per
     return 1;
 }
 
-s32 simulatorDrawYesNoImage(TEXPalettePtr tplMessage, s32 nX0Message, s32 nY0Message, TEXPalettePtr tplYes, s32 nX0Yes,
-                            s32 nY0Yes, TEXPalettePtr tplNo, s32 nX0No, s32 nY0No) {
+s32 simulatorDrawYesNoImage(TEXPalette* tplMessage, s32 nX0Message, s32 nY0Message, TEXPalette* tplYes, s32 nX0Yes,
+                            s32 nY0Yes, TEXPalette* tplNo, s32 nX0No, s32 nY0No) {
 
     GXTexObj texObj;
     u32 pad;
@@ -844,7 +844,7 @@ s32 simulatorDrawYesNoImage(TEXPalettePtr tplMessage, s32 nX0Message, s32 nY0Mes
     return 1;
 }
 
-s32 simulatorDrawOKImage(TEXPalettePtr tplMessage, s32 nX0Message, s32 nY0Message, TEXPalettePtr tplOK, s32 nX0OK,
+s32 simulatorDrawOKImage(TEXPalette* tplMessage, s32 nX0Message, s32 nY0Message, TEXPalette* tplOK, s32 nX0OK,
                          s32 nY0OK) {
     GXTexObj texObj;
     GXColor color0;
@@ -1009,51 +1009,51 @@ bool simulatorDrawErrorMessage(__anon_0x61D7 simulatorErrorMessage, s32 drawBar,
     switch (simulatorErrorMessage) {
         case S_M_DISK_COVER_OPEN:
             simulatorDrawImage(
-                (TEXPalettePtr)gcoverOpen,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gcoverOpen)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gcoverOpen)->descriptorArray->textureHeader->height / 2, drawBar,
+                (TEXPalette*)gcoverOpen,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)gcoverOpen)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gcoverOpen)->descriptorArray->textureHeader->height / 2, drawBar,
                 percent);
             break;
         case S_M_DISK_WRONG_DISK:
             simulatorDrawImage(
-                (TEXPalettePtr)gwrongDisk,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gwrongDisk)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gwrongDisk)->descriptorArray->textureHeader->height / 2, drawBar,
+                (TEXPalette*)gwrongDisk,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)gwrongDisk)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gwrongDisk)->descriptorArray->textureHeader->height / 2, drawBar,
                 percent);
             break;
         case S_M_DISK_READING_DISK:
             simulatorDrawImage(
-                (TEXPalettePtr)greadingDisk,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)greadingDisk)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)greadingDisk)->descriptorArray->textureHeader->height / 2,
-                drawBar, percent);
+                (TEXPalette*)greadingDisk,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)greadingDisk)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)greadingDisk)->descriptorArray->textureHeader->height / 2, drawBar,
+                percent);
             break;
         case S_M_DISK_RETRY_ERROR:
             simulatorDrawImage(
-                (TEXPalettePtr)gretryErr,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gretryErr)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gretryErr)->descriptorArray->textureHeader->height / 2, drawBar,
+                (TEXPalette*)gretryErr,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)gretryErr)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gretryErr)->descriptorArray->textureHeader->height / 2, drawBar,
                 percent);
             break;
         case S_M_DISK_FATAL_ERROR:
             simulatorDrawImage(
-                (TEXPalettePtr)gfatalErr,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gfatalErr)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gfatalErr)->descriptorArray->textureHeader->height / 2, drawBar,
+                (TEXPalette*)gfatalErr,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)gfatalErr)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gfatalErr)->descriptorArray->textureHeader->height / 2, drawBar,
                 percent);
             break;
         case S_M_DISK_NO_DISK:
-            simulatorDrawImage(
-                (TEXPalettePtr)gnoDisk,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gnoDisk)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gnoDisk)->descriptorArray->textureHeader->height / 2, drawBar,
-                percent);
+            simulatorDrawImage((TEXPalette*)gnoDisk,
+                               N64_FRAME_WIDTH / 2 - ((TEXPalette*)gnoDisk)->descriptorArray->textureHeader->width / 2,
+                               N64_FRAME_HEIGHT / 2 -
+                                   ((TEXPalette*)gnoDisk)->descriptorArray->textureHeader->height / 2,
+                               drawBar, percent);
             break;
         case S_M_DISK_DEFAULT_ERROR:
             simulatorDrawImage(
-                (TEXPalettePtr)gfatalErr,
-                N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gfatalErr)->descriptorArray->textureHeader->width / 2,
-                N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gfatalErr)->descriptorArray->textureHeader->height / 2, drawBar,
+                (TEXPalette*)gfatalErr,
+                N64_FRAME_WIDTH / 2 - ((TEXPalette*)gfatalErr)->descriptorArray->textureHeader->width / 2,
+                N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gfatalErr)->descriptorArray->textureHeader->height / 2, drawBar,
                 percent);
             break;
 
@@ -1075,7 +1075,7 @@ s32 simulatorPrepareMessage(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_in02Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
             break;
 
@@ -1086,7 +1086,7 @@ s32 simulatorPrepareMessage(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv09Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
             break;
 
@@ -1097,7 +1097,7 @@ s32 simulatorPrepareMessage(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf02Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
             break;
@@ -1108,10 +1108,10 @@ s32 simulatorPrepareMessage(__anon_0x61D7 simulatorErrorMessage) {
     return true;
 }
 
-bool simulatorDrawYesNoMessageLoop(TEXPalettePtr simulatorQuestion, s32* yes) {
-    TEXDescriptorPtr* pNo;
-    TEXDescriptorPtr* pYes;
-    TEXDescriptorPtr* pQuestion;
+bool simulatorDrawYesNoMessageLoop(TEXPalette* simulatorQuestion, s32* yes) {
+    TEXDescriptor** pNo;
+    TEXDescriptor** pYes;
+    TEXDescriptor** pQuestion;
     s32 pad[2];
 
     if (*yes == 1) {
@@ -1120,13 +1120,13 @@ bool simulatorDrawYesNoMessageLoop(TEXPalettePtr simulatorQuestion, s32* yes) {
         gHighlightChoice = false;
     }
 
-    pNo = &((TEXPalettePtr)gno)->descriptorArray;
-    pYes = &((TEXPalettePtr)gyes)->descriptorArray;
+    pNo = &((TEXPalette*)gno)->descriptorArray;
+    pYes = &((TEXPalette*)gyes)->descriptorArray;
     pQuestion = &simulatorQuestion->descriptorArray;
     simulatorDrawYesNoImage(simulatorQuestion, N64_FRAME_WIDTH / 2 - (*pQuestion)->textureHeader->width / 2,
-                            N64_FRAME_HEIGHT / 2 - (*pQuestion)->textureHeader->height / 2, (TEXPalettePtr)gyes,
+                            N64_FRAME_HEIGHT / 2 - (*pQuestion)->textureHeader->height / 2, (TEXPalette*)gyes,
                             120 - (*pYes)->textureHeader->width / 2, 180 - (*pYes)->textureHeader->height / 2,
-                            (TEXPalettePtr)gno, 200 - (*pNo)->textureHeader->width / 2,
+                            (TEXPalette*)gno, 200 - (*pNo)->textureHeader->width / 2,
                             180 - (*pNo)->textureHeader->height / 2);
 
     if (gButtonDownToggle == true) {
@@ -1145,9 +1145,9 @@ bool simulatorDrawYesNoMessageLoop(TEXPalettePtr simulatorQuestion, s32* yes) {
     }
 
     simulatorDrawYesNoImage(simulatorQuestion, N64_FRAME_WIDTH / 2 - (*pQuestion)->textureHeader->width / 2,
-                            N64_FRAME_HEIGHT / 2 - (*pQuestion)->textureHeader->height / 2, (TEXPalettePtr)gyes,
+                            N64_FRAME_HEIGHT / 2 - (*pQuestion)->textureHeader->height / 2, (TEXPalette*)gyes,
                             120 - (*pYes)->textureHeader->width / 2, 180 - (*pYes)->textureHeader->height / 2,
-                            (TEXPalettePtr)gno, 200 - (*pNo)->textureHeader->width / 2,
+                            (TEXPalette*)gno, 200 - (*pNo)->textureHeader->width / 2,
                             180 - (*pNo)->textureHeader->height / 2);
 
     if (DemoPad->pst.err == 0) {
@@ -1188,9 +1188,9 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld05_2Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
 
         case S_M_CARD_LD06_4:
             if (simulatorMessageCurrent != simulatorMessage) {
@@ -1199,9 +1199,9 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld06_4Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
 
         case S_M_CARD_LD07:
             if (simulatorMessageCurrent != simulatorMessage) {
@@ -1210,10 +1210,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld07Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
         case S_M_CARD_GF01:
             if (simulatorMessageCurrent != simulatorMessage) {
                 simulatorMessageCurrent = simulatorMessage;
@@ -1221,10 +1221,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf01Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
 
         case S_M_CARD_IN01:
             if (simulatorMessageCurrent != simulatorMessage) {
@@ -1233,10 +1233,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_in01Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
 
         case S_M_CARD_SV06_4:
             if (simulatorMessageCurrent != simulatorMessage) {
@@ -1245,10 +1245,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv06_4Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
         case S_M_CARD_SV06_5:
             if (simulatorMessageCurrent != simulatorMessage) {
                 simulatorMessageCurrent = simulatorMessage;
@@ -1256,10 +1256,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv06_5Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
         case S_M_CARD_SV08:
             if (simulatorMessageCurrent != simulatorMessage) {
                 simulatorMessageCurrent = simulatorMessage;
@@ -1267,10 +1267,10 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv08Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
 
-            return simulatorDrawYesNoMessageLoop((TEXPalettePtr)gpErrorMessageBuffer, yes);
+            return simulatorDrawYesNoMessageLoop((TEXPalette*)gpErrorMessageBuffer, yes);
 
         default:
             break;
@@ -1279,13 +1279,13 @@ bool simulatorDrawYesNoMessage(__anon_0x61D7 simulatorMessage, s32* yes) {
     return false;
 }
 
-static inline bool simulatorDrawOKMessageLoop(TEXPalettePtr simulatorMessage) {
+static inline bool simulatorDrawOKMessageLoop(TEXPalette* simulatorMessage) {
     simulatorDrawOKImage(
-        (TEXPalettePtr)gpErrorMessageBuffer,
-        N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2,
-        N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2,
+        (TEXPalette*)gpErrorMessageBuffer,
+        N64_FRAME_WIDTH / 2 - ((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2,
+        N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2,
         simulatorMessage, N64_FRAME_WIDTH / 2 - simulatorMessage->descriptorArray->textureHeader->width / 2,
-        180 - ((TEXPalettePtr)gyes)->descriptorArray->textureHeader->height / 2); // bug, copy paste error?
+        180 - ((TEXPalette*)gyes)->descriptorArray->textureHeader->height / 2); // bug, copy paste error?
 
     if (gButtonDownToggle == true) {
         DEMOPadRead();
@@ -1298,11 +1298,11 @@ static inline bool simulatorDrawOKMessageLoop(TEXPalettePtr simulatorMessage) {
     DEMOPadRead();
 
     simulatorDrawOKImage(
-        (TEXPalettePtr)gpErrorMessageBuffer,
-        N64_FRAME_WIDTH / 2 - ((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2,
-        N64_FRAME_HEIGHT / 2 - ((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2,
+        (TEXPalette*)gpErrorMessageBuffer,
+        N64_FRAME_WIDTH / 2 - ((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2,
+        N64_FRAME_HEIGHT / 2 - ((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2,
         simulatorMessage, N64_FRAME_WIDTH / 2 - simulatorMessage->descriptorArray->textureHeader->width / 2,
-        180 - ((TEXPalettePtr)gyes)->descriptorArray->textureHeader->height / 2); // bug, copy paste error?
+        180 - ((TEXPalette*)gyes)->descriptorArray->textureHeader->height / 2); // bug, copy paste error?
 
     if ((DemoPad->pst.err == PAD_ERR_NONE) && (DemoPad->pst.button & (PAD_BUTTON_START | PAD_BUTTON_A))) {
         soundPlayBeep(SYSTEM_SOUND(gpSystem), SOUND_BEEP_ACCEPT);
@@ -1325,9 +1325,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld01Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD02:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1335,9 +1335,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld02Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD03:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1345,9 +1345,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld03Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD04:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1355,9 +1355,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld04Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD05_1:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1365,9 +1365,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld05_1Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD06_1:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1375,9 +1375,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld06_1Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD06_2:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1385,9 +1385,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld06_2Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_LD06_3:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1395,9 +1395,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_ld06_3Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_GF03:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1405,9 +1405,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf03Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_GF04:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1415,9 +1415,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf04Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_GF05:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1425,9 +1425,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf05Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_GF06:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1435,9 +1435,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_gf06Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_IN03:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1445,9 +1445,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_in03Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_IN04:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1455,9 +1455,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_in04Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_IN05:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1465,9 +1465,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_in05Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV01:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1475,9 +1475,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv01Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV01_2:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1485,9 +1485,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv01_2Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV02:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1495,9 +1495,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv02Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV03:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1505,9 +1505,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv03Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV04:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1515,9 +1515,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv04Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV05_1:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1525,9 +1525,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv05_1Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV06_1:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1535,9 +1535,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv06_1Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV06_2:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1545,9 +1545,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv06_2Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV06_3:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1555,9 +1555,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv06_3Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV07:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1565,9 +1565,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv07Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV10:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1575,9 +1575,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv10Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV11:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1585,9 +1585,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv11Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV12:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1595,9 +1595,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv12Size), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         case S_M_CARD_SV_SHARE:
             if (simulatorMessageCurrent != simulatorErrorMessage) {
                 simulatorMessageCurrent = simulatorErrorMessage;
@@ -1605,9 +1605,9 @@ bool simulatorDrawErrorMessageWait(__anon_0x61D7 simulatorErrorMessage) {
                     simulatorDVDRead(&fileInfo, gpErrorMessageBuffer, OSRoundUp32B(gmsg_sv_shareSize), 0, NULL);
                 }
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)gpErrorMessageBuffer);
+                simulatorUnpackTexPalette((TEXPalette*)gpErrorMessageBuffer);
             }
-            return simulatorDrawOKMessageLoop((TEXPalettePtr)gmesgOK);
+            return simulatorDrawOKMessageLoop((TEXPalette*)gmesgOK);
         default:
             break;
     }
@@ -2004,13 +2004,13 @@ bool simulatorTestReset(bool IPL, bool forceMenu, bool allowReset, bool usePrevi
 }
 
 bool simulatorDrawMCardText(void) {
-    if ((s32)(((TEXPalettePtr)gpErrorMessageBuffer)->versionNumber) == 0) {
+    if ((s32)(((TEXPalette*)gpErrorMessageBuffer)->versionNumber) == 0) {
         xlPostText("Invalid Message Image Data - Assuming SV09", "simGCN.c", 1623);
         simulatorPrepareMessage(S_M_CARD_SV09);
     }
-    simulatorDrawImage((TEXPalettePtr)gpErrorMessageBuffer,
-                       160 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
-                       120 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 0, 0);
+    simulatorDrawImage((TEXPalette*)gpErrorMessageBuffer,
+                       160 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
+                       120 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 0, 0);
     return true;
 }
 
@@ -2025,13 +2025,13 @@ s32 simulatorMCardPollDrawBar(void) {
 
     rate = (rate < 0.0f) ? 0.0f : rate;
 
-    if ((s32)(((TEXPalettePtr)gpErrorMessageBuffer)->versionNumber) == 0) {
+    if ((s32)(((TEXPalette*)gpErrorMessageBuffer)->versionNumber) == 0) {
         xlPostText("Invalid Message Image Data - Assuming SV09", "simGCN.c", 1623);
         simulatorPrepareMessage(S_M_CARD_SV09);
     }
-    simulatorDrawImage((TEXPalettePtr)gpErrorMessageBuffer,
-                       160 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
-                       120 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 1,
+    simulatorDrawImage((TEXPalette*)gpErrorMessageBuffer,
+                       160 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
+                       120 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 1,
                        100.0f * rate);
     return true;
 }
@@ -2047,13 +2047,13 @@ s32 simulatorMCardPollDrawFormatBar(void) {
 
     rate = (rate < 0.0f) ? 0.0f : rate;
 
-    if ((s32)(((TEXPalettePtr)gpErrorMessageBuffer)->versionNumber) == 0) {
+    if ((s32)(((TEXPalette*)gpErrorMessageBuffer)->versionNumber) == 0) {
         xlPostText("Invalid Message Image Data - Assuming SV09", "simGCN.c", 1623);
         simulatorPrepareMessage(S_M_CARD_SV09);
     }
-    simulatorDrawImage((TEXPalettePtr)gpErrorMessageBuffer,
-                       160 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
-                       120 - (((TEXPalettePtr)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 0,
+    simulatorDrawImage((TEXPalette*)gpErrorMessageBuffer,
+                       160 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->width / 2),
+                       120 - (((TEXPalette*)gpErrorMessageBuffer)->descriptorArray->textureHeader->height / 2), 0,
                        100.0f * rate);
     return true;
 }
@@ -2280,16 +2280,16 @@ bool xlMain(void) {
     VISetBlack(false);
     VIFlush();
 
-    simulatorUnpackTexPalette((TEXPalettePtr)gcoverOpen);
-    simulatorUnpackTexPalette((TEXPalettePtr)gnoDisk);
-    simulatorUnpackTexPalette((TEXPalettePtr)gretryErr);
-    simulatorUnpackTexPalette((TEXPalettePtr)gfatalErr);
-    simulatorUnpackTexPalette((TEXPalettePtr)gwrongDisk);
-    simulatorUnpackTexPalette((TEXPalettePtr)greadingDisk);
-    simulatorUnpackTexPalette((TEXPalettePtr)gbar);
-    simulatorUnpackTexPalette((TEXPalettePtr)gyes);
-    simulatorUnpackTexPalette((TEXPalettePtr)gno);
-    simulatorUnpackTexPalette((TEXPalettePtr)gmesgOK);
+    simulatorUnpackTexPalette((TEXPalette*)gcoverOpen);
+    simulatorUnpackTexPalette((TEXPalette*)gnoDisk);
+    simulatorUnpackTexPalette((TEXPalette*)gretryErr);
+    simulatorUnpackTexPalette((TEXPalette*)gfatalErr);
+    simulatorUnpackTexPalette((TEXPalette*)gwrongDisk);
+    simulatorUnpackTexPalette((TEXPalette*)greadingDisk);
+    simulatorUnpackTexPalette((TEXPalette*)gbar);
+    simulatorUnpackTexPalette((TEXPalette*)gyes);
+    simulatorUnpackTexPalette((TEXPalette*)gno);
+    simulatorUnpackTexPalette((TEXPalette*)gmesgOK);
 
     gbReset = false;
     gnTickReset = OSGetTick();

--- a/src/emulator/system.c
+++ b/src/emulator/system.c
@@ -447,7 +447,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
         if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
             !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -455,7 +455,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
         mcardOpen(&mCard, "MARIO", "Mario 64", mCard.saveIcon, mCard.saveBanner, "MARIO",
                   &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
 
@@ -514,7 +514,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -522,7 +522,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 // "ゼルダコレクション"
                 mcardOpen(&mCard, "ZELDA1", "\x83\x5b\x83\x8b\x83\x5f\x83\x52\x83\x8c\x83\x4e\x83\x56\x83\x87\x83\x93",
                           mCard.saveIcon, mCard.saveBanner, "ZELDAX",
@@ -534,7 +534,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -542,7 +542,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 // "ゼルダコレクション"
                 mcardOpen(&mCard, "ZELDA1", "\x83\x5b\x83\x8b\x83\x5f\x83\x52\x83\x8c\x83\x4e\x83\x56\x83\x87\x83\x93",
                           mCard.saveIcon, mCard.saveBanner, "ZELDA",
@@ -556,7 +556,7 @@ static bool systemSetupGameALL(System* pSystem) {
             }
 
             DVDClose(&fileInfo);
-            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+            simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
             if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                 !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -564,7 +564,7 @@ static bool systemSetupGameALL(System* pSystem) {
             }
 
             DVDClose(&fileInfo);
-            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+            simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
             mcardOpen(&mCard, "ZELDAD", "The Legend of Zelda Debug", mCard.saveIcon, mCard.saveBanner, "ZELDAD",
                       &gSystemRomConfigurationList[i].currentControllerConfig, 0xC000, 0x8000);
         }
@@ -596,7 +596,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
         if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
             !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -604,7 +604,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
         mcardOpen(&mCard, "ZELDA3", "Legend of Zelda", mCard.saveIcon, mCard.saveBanner, "ZELDA3",
                   &gSystemRomConfigurationList[i].currentControllerConfig, 0x24000, 0x20000);
 
@@ -675,7 +675,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
         if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
             !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -683,7 +683,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
         mcardOpen(&mCard, "PILOT", "Pilotwings", mCard.saveIcon, mCard.saveBanner, "PILOT",
                   &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
     } else if (romTestCode(pROM, "NAFJ")) {
@@ -694,7 +694,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
         if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
             !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -702,7 +702,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
 
         DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
         mcardOpen(&mCard, "AF", "Animal Forest", mCard.saveIcon, mCard.saveBanner, "AF",
                   &gSystemRomConfigurationList[i].currentControllerConfig, 0x24000, 0x20000);
     } else if (romTestCode(pROM, "NBCE")) {
@@ -724,7 +724,7 @@ static bool systemSetupGameALL(System* pSystem) {
             }
 
             DVDClose(&fileInfo);
-            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+            simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
             if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
                 !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -732,7 +732,7 @@ static bool systemSetupGameALL(System* pSystem) {
             }
 
             DVDClose(&fileInfo);
-            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+            simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
             mcardOpen(&mCard, "CRUISE", "Cruise 'n USA", mCard.saveIcon, mCard.saveBanner, "CRUISE",
                       &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
 
@@ -781,7 +781,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -789,7 +789,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 mcardOpen(&mCard, "DRMARIO", "Dr. Mario", mCard.saveIcon, mCard.saveBanner, "DRMARIO",
                           &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
                 gpSystem->eTypeROM = SRT_DRMARIO;
@@ -837,7 +837,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -845,7 +845,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 mcardOpen(&mCard, "KART", "Mario Kart", mCard.saveIcon, mCard.saveBanner, "KART",
                           &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
                 pCPU->nCompileFlag |= 0x10;
@@ -870,7 +870,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -878,7 +878,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 mcardOpen(&mCard, "MP1", "Mario Party 1", mCard.saveIcon, mCard.saveBanner, "MP1",
                           &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
             } else if (romTestCode(pROM, "NMWE")) {
@@ -891,7 +891,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -899,7 +899,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 mcardOpen(&mCard, "MP2", "Mario Party 2", mCard.saveIcon, mCard.saveBanner, "MP2",
                           &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
             } else if (romTestCode(pROM, "NMVE")) {
@@ -912,7 +912,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                 if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                     !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -920,7 +920,7 @@ static bool systemSetupGameALL(System* pSystem) {
                 }
 
                 DVDClose(&fileInfo);
-                simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                 mcardOpen(&mCard, "MP3", "Mario Party 3", mCard.saveIcon, mCard.saveBanner, "MP3",
                           &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x800);
             } else if (!romTestCode(pROM, "NM3E") && !romTestCode(pROM, "NRIE")) {
@@ -932,7 +932,7 @@ static bool systemSetupGameALL(System* pSystem) {
                     }
 
                     DVDClose(&fileInfo);
-                    simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                    simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                     if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                         !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -940,7 +940,7 @@ static bool systemSetupGameALL(System* pSystem) {
                     }
 
                     DVDClose(&fileInfo);
-                    simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                    simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
 
                     mcardOpen(&mCard, "PaperMario", "Paper Mario", mCard.saveIcon, mCard.saveBanner, "PAPERMARIO",
                               &gSystemRomConfigurationList[i].currentControllerConfig, 0x24000, 0x20000);
@@ -951,7 +951,7 @@ static bool systemSetupGameALL(System* pSystem) {
                     }
 
                     DVDClose(&fileInfo);
-                    simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                    simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                     if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
                         !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -959,7 +959,7 @@ static bool systemSetupGameALL(System* pSystem) {
                     }
 
                     DVDClose(&fileInfo);
-                    simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                    simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                     mcardOpen(&mCard, "PokemonStadium", "Pokemon Stadium", mCard.saveIcon, mCard.saveBanner,
                               "POKEMONSTADIUM", &gSystemRomConfigurationList[i].currentControllerConfig, 0x24000,
@@ -990,7 +990,7 @@ static bool systemSetupGameALL(System* pSystem) {
                         }
 
                         DVDClose(&fileInfo);
-                        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                         if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                             !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -998,7 +998,7 @@ static bool systemSetupGameALL(System* pSystem) {
                         }
 
                         DVDClose(&fileInfo);
-                        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                        simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                         mcardOpen(&mCard, "STARFOX", "Starfox", mCard.saveIcon, mCard.saveBanner, "STARFOX",
                                   &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000, 0x200);
                         pCPU->nCompileFlag |= 0x110;
@@ -1051,7 +1051,7 @@ static bool systemSetupGameALL(System* pSystem) {
                         }
 
                         DVDClose(&fileInfo);
-                        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                        simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                         if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                             !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0, NULL)) {
@@ -1059,7 +1059,7 @@ static bool systemSetupGameALL(System* pSystem) {
                         }
 
                         DVDClose(&fileInfo);
-                        simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                        simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                         mcardOpen(&mCard, "1080", "1080", mCard.saveIcon, mCard.saveBanner, "1080",
                                   &gSystemRomConfigurationList[i].currentControllerConfig, 0xC000, 0x8000);
                     } else if (!romTestCode(pROM, "NTPE") && !romTestCode(pROM, "NEPE")) {
@@ -1080,7 +1080,7 @@ static bool systemSetupGameALL(System* pSystem) {
                             }
 
                             DVDClose(&fileInfo);
-                            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                            simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                             if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                                 !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0,
@@ -1089,7 +1089,7 @@ static bool systemSetupGameALL(System* pSystem) {
                             }
 
                             DVDClose(&fileInfo);
-                            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                            simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
 
                             mcardOpen(&mCard, "PANEL", "Panel de Pon", mCard.saveIcon, mCard.saveBanner, "PANEL",
                                       &gSystemRomConfigurationList[i].currentControllerConfig, 0xC000, 0x8000);
@@ -1118,7 +1118,7 @@ static bool systemSetupGameALL(System* pSystem) {
                             }
 
                             DVDClose(&fileInfo);
-                            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveIcon);
+                            simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
 
                             if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
                                 !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & 0xFFFFFFE0, 0,
@@ -1127,7 +1127,7 @@ static bool systemSetupGameALL(System* pSystem) {
                             }
 
                             DVDClose(&fileInfo);
-                            simulatorUnpackTexPalette((TEXPalettePtr)mCard.saveBanner);
+                            simulatorUnpackTexPalette((TEXPalette*)mCard.saveBanner);
                             mcardOpen(&mCard, "YoshiStory", "YoshiStory", mCard.saveIcon, mCard.saveBanner,
                                       "YoshiStory", &gSystemRomConfigurationList[i].currentControllerConfig, 0x4000,
                                       0x800);

--- a/src/emulator/xlCoreGCN.c
+++ b/src/emulator/xlCoreGCN.c
@@ -149,7 +149,7 @@ bool xlCoreHiResolution(void) { return true; }
 int main(int nCount, char** aszArgument) {
     void* pHeap;
     u32 i;
-    TEXDescriptorPtr tdp;
+    TEXDescriptor* tdp;
     GXColor black;
     s32 nSizeHeap;
     s32 nSize;
@@ -183,11 +183,11 @@ int main(int nCount, char** aszArgument) {
         VIWaitForRetrace();
     }
 
-    simulatorUnpackTexPalette((TEXPalettePtr)gTgPcTPL);
+    simulatorUnpackTexPalette((TEXPalette*)gTgPcTPL);
 
     black = D_80135D00;
     for (i = 0; i < 2; i++) {
-        tdp = TEXGet((TEXPalettePtr)gTgPcTPL, i);
+        tdp = TEXGet((TEXPalette*)gTgPcTPL, i);
         GXInitTexObj(&g_texMap[i], tdp->textureHeader->data, tdp->textureHeader->width, tdp->textureHeader->height,
                      tdp->textureHeader->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
     }


### PR DESCRIPTION
The permuter import doesn't handle
```
typedef struct Foo {
   ...
} Foo, Bar;
```
correctly, it turns it into
```
typedef struct Foo {
   ...
} Foo;
typedef struct Foo {
   ...
} Bar;
```
which is an error since now `struct Foo` is defined twice. I never liked these typedefs anyway, `TexPalettePtr` is both longer and less explicit than `TexPalette*`.