### PR TITLE
Set up permuter import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 
 # IDE artifacts
 .vscode/
+
+# Permuter artifacts
+nonmatchings/

--- a/README.md
+++ b/README.md
@@ -77,10 +77,16 @@ Run `tools/decompme.py <c-file> <asm-file>` (e.g. `tools/decompme.py src/emulato
 
 ### Permuter
 
-To import a function for [decomp-permuter](https://github.com/simonlindholm/decomp-permuter), ensure `powerpc-eabi-objdump` binary is on your `PATH`
-(for instance by adding `tools/binutils` from this project) and run `path/to/permuter/import.py <c-file> <asm-file>`
-(e.g. `path/to/permuter/import.py src/emulator/cpu.c asm/non_matchings/cpu/cpuExecute.s`). Sometimes you may need to tweak the source in
-order for things to import correctly, for example by explicitly marking auto-inlined functions as `inline`.
+To import a function for [decomp-permuter](https://github.com/simonlindholm/decomp-permuter), ensure `powerpc-eabi-objdump` binary
+is on your `PATH` (for instance by adding `tools/binutils` from this project) and run something like
+
+```sh
+path/to/permuter/import.py src/emulator/THPRead.c asm/non_matchings/THPRead/Reader.s
+path/to/permuter/permuter.py nonmatchings/Reader -j 8
+```
+
+Sometimes you may need to tweak the source in order for things to import
+correctly, for example by explicitly marking auto-inlined functions as `inline`.
 
 ### Debug Info
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ For locally diffing the current build against the expected build:
 Run `tools/decompme.py <c-file> <asm-file>` (e.g. `tools/decompme.py src/emulator/cpu.c asm/non_matchings/cpu/cpuExecute.s`) to create a
 [decomp.me](https://decomp.me/) scratch for a function. The C file and all of its included headers will be used as the context.
 
+### Permuter
+
+To import a function for [decomp-permuter](https://github.com/simonlindholm/decomp-permuter), ensure `powerpc-eabi-objdump` binary is on your `PATH`
+(for instance by adding `tools/binutils` from this project) and run `path/to/permuter/import.py <c-file> <asm-file>`
+(e.g. `path/to/permuter/import.py src/emulator/cpu.c asm/non_matchings/cpu/cpuExecute.s`). Sometimes you may need to tweak the source in
+order for things to import correctly, for example by explicitly marking auto-inlined functions as `inline`.
+
 ### Debug Info
 
 The files in the `debug/` directory contain a dump of the DWARF debugging information in the original ELF. Functions marked as `// Erased`

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -1,0 +1,14 @@
+compiler_type = "mwcc"
+compiler_command = "wibo tools/mwcc_compiler/GC/1.1/mwcceppc.exe -Cpp_exceptions off -proc gekko -fp hardware -fp_contract on -enum int -align powerpc -nosyspath -RTTI off -str reuse -multibyte -O4,p -inline auto,deferred -nodefaults -msgstyle gcc -Iinclude -Ilibc -c"
+assembler_command = "tools/binutils/powerpc-eabi-as -mgekko"
+asm_prelude_file = "include/macros.inc"
+
+[preserve_macros]
+"NULL" = "void*"
+"true" = "int"
+"false" = "int"
+"ALIGN_PREV" = "int"
+"ALIGN_NEXT" = "int"
+"ARRAY_COUNT" = "int"
+"ARRAY_COUNTU" = "unsigned int"
+"OFFSETOF" = "int"


### PR DESCRIPTION
This assumes `wibo` because with `wine` it's kind of uselessly slow and crashy, at least on mac.

Testing:
```
# edit THPRead.c to mark movieDVDRead as inline
decomp-permuter/import.py src/emulator/THPRead.c asm/non_matchings/THPRead/Reader.s
decomp-permuter/permuter.py nonmatchings/Reader -j 8
```

Note you need a recent decomp-permuter to pick up https://github.com/simonlindholm/decomp-permuter/pull/170