### PR TITLE
Declare non-static functions and add non-matching compatibility on ``mcardGCN.c``

### DIFF
--- a/include/emulator/mcardGCN.h
+++ b/include/emulator/mcardGCN.h
@@ -3,6 +3,17 @@
 
 #include "dolphin.h"
 
+// __anon_0x1BD8E
+typedef enum MemCardCommand {
+    MC_C_NONE = 0,
+    MC_C_CONTINUE = 1,
+    MC_C_IPL = 2,
+    MC_C_GO_TO_GAME = 3,
+    MC_C_CREATE_GAME = 4,
+    MC_C_DELETE_GAME = 5,
+    MC_C_FORMAT_CARD = 6,
+} MemCardCommand;
+
 // __anon_0x1B0CB
 typedef enum MemCardError {
     MC_E_NONE = 0,
@@ -146,11 +157,27 @@ typedef struct _MCARD {
 
 extern MemCard mCard;
 
+s32 mcardReadGameData(MemCard* pMCard);
 s32 mcardWriteGameDataReset(MemCard* pMCard);
-s32 mcardWrite(MemCard* pMCard, s32 address, s32 size, char* data);
-s32 mcardRead(MemCard* pMCard, s32 address, s32 size, char* data);
+s32 mcardReInit(MemCard* pMCard);
 s32 mcardInit(MemCard* pMCard);
+s32 mcardFileSet(MemCard* pMCard, char* name);
+s32 mcardGameSet(MemCard* pMCard, char* name);
+s32 mcardFileCreate(MemCard* pMCard, char* name, char* comment, char* icon, char* banner, s32 size);
+s32 mcardGameCreate(MemCard* pMCard, char* name, s32 defaultConfiguration, s32 size);
+s32 mcardCardErase(MemCard* pMCard);
+s32 mcardFileErase(MemCard* pMCard);
+s32 mcardGameErase(MemCard* pMCard, s32 index);
+s32 mcardGameRelease(MemCard* pMCard);
+s32 mcardRead(MemCard* pMCard, s32 address, s32 size, char* data);
+s32 mcardMenu(MemCard* pMCard, __anon_0x1A5F0 menuEntry, MemCardCommand* pCommand);
+s32 mcardOpenError(MemCard* pMCard, MemCardCommand* pCommand);
+s32 mcardOpenDuringGameError(MemCard* pMCard, MemCardCommand* pCommand);
+s32 mcardWrite(MemCard* pMCard, s32 address, s32 size, char* data);
 s32 mcardOpen(MemCard* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
               s32* defaultConfiguration, s32 fileSize, s32 gameSize);
+s32 mcardOpenDuringGame(MemCard* pMCard);
+s32 mcardStore(MemCard* pMCard);
+s32 mcardUpdate(MemCard* pMCard);
 
 #endif

--- a/include/emulator/mcardGCN.h
+++ b/include/emulator/mcardGCN.h
@@ -178,6 +178,6 @@ s32 mcardOpen(MemCard* pMCard, char* fileName, char* comment, char* icon, char* 
               s32* defaultConfiguration, s32 fileSize, s32 gameSize);
 s32 mcardOpenDuringGame(MemCard* pMCard);
 s32 mcardStore(MemCard* pMCard);
-s32 mcardUpdate(MemCard* pMCard);
+s32 mcardUpdate(void);
 
 #endif

--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -19,18 +19,13 @@ void* jtbl_800EA5A8[24] = {
 void* jtbl_800EA5A8[24] = {0};
 #endif
 
-#ifndef NON_MATCHING
 void* jtbl_800EA608[24] = {
     &lbl_80016E54, &lbl_80016E54, &lbl_80016DE8, &lbl_80016DC8, &lbl_80016E28, &lbl_80016DD8,
     &lbl_80016E08, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54,
     &lbl_80016E54, &lbl_80016E08, &lbl_80016E54, &lbl_80016E54, &lbl_80016DF8, &lbl_80016E54,
     &lbl_80016E44, &lbl_80016E18, &lbl_80016E18, &lbl_80016E54, &lbl_80016E54, &lbl_80016E34,
 };
-#else
-void* jtbl_800EA608[24] = {0};
-#endif
 
-#ifndef NON_MATCHING
 void* jtbl_800EA668[50] = {
     &lbl_800177EC, &lbl_80016EF8, &lbl_80016F24, &lbl_80016F54, &lbl_80016F80, &lbl_80016FAC, &lbl_80016FD8,
     &lbl_80017020, &lbl_80017054, &lbl_80017074, &lbl_8001709C, &lbl_800170E8, &lbl_80017134, &lbl_80017158,
@@ -41,9 +36,6 @@ void* jtbl_800EA668[50] = {
     &lbl_8001769C, &lbl_800176B4, &lbl_800177EC, &lbl_800176FC, &lbl_80017734, &lbl_80017768, &lbl_8001779C,
     &lbl_800177C4,
 };
-#else
-void* jtbl_800EA668[50] = {0};
-#endif
 
 char D_800EA730[] = "Accessing Card";
 char D_800EA740[] = "Writing Game Data";

--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -8,20 +8,29 @@ char D_800EA548[] =
 char D_800EA564[] = "Invalid Memory Card Command %d - Assuming Go To Game";
 char D_800EA59C[] = "mcardGCN.c";
 
+#ifndef NON_MATCHING
 void* jtbl_800EA5A8[24] = {
     &lbl_80016D74, &lbl_80016D74, &lbl_80016D08, &lbl_80016CE8, &lbl_80016D48, &lbl_80016CF8,
     &lbl_80016D28, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74,
     &lbl_80016D74, &lbl_80016D28, &lbl_80016D74, &lbl_80016D74, &lbl_80016D18, &lbl_80016D74,
     &lbl_80016D54, &lbl_80016D38, &lbl_80016D38, &lbl_80016D74, &lbl_80016D74, &lbl_80016D64,
 };
+#else
+void* jtbl_800EA5A8[24] = {0};
+#endif
 
+#ifndef NON_MATCHING
 void* jtbl_800EA608[24] = {
     &lbl_80016E54, &lbl_80016E54, &lbl_80016DE8, &lbl_80016DC8, &lbl_80016E28, &lbl_80016DD8,
     &lbl_80016E08, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54, &lbl_80016E54,
     &lbl_80016E54, &lbl_80016E08, &lbl_80016E54, &lbl_80016E54, &lbl_80016DF8, &lbl_80016E54,
     &lbl_80016E44, &lbl_80016E18, &lbl_80016E18, &lbl_80016E54, &lbl_80016E54, &lbl_80016E34,
 };
+#else
+void* jtbl_800EA608[24] = {0};
+#endif
 
+#ifndef NON_MATCHING
 void* jtbl_800EA668[50] = {
     &lbl_800177EC, &lbl_80016EF8, &lbl_80016F24, &lbl_80016F54, &lbl_80016F80, &lbl_80016FAC, &lbl_80016FD8,
     &lbl_80017020, &lbl_80017054, &lbl_80017074, &lbl_8001709C, &lbl_800170E8, &lbl_80017134, &lbl_80017158,
@@ -32,6 +41,9 @@ void* jtbl_800EA668[50] = {
     &lbl_8001769C, &lbl_800176B4, &lbl_800177EC, &lbl_800176FC, &lbl_80017734, &lbl_80017768, &lbl_8001779C,
     &lbl_800177C4,
 };
+#else
+void* jtbl_800EA668[50] = {0};
+#endif
 
 char D_800EA730[] = "Accessing Card";
 char D_800EA740[] = "Writing Game Data";

--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -8,16 +8,12 @@ char D_800EA548[] =
 char D_800EA564[] = "Invalid Memory Card Command %d - Assuming Go To Game";
 char D_800EA59C[] = "mcardGCN.c";
 
-#ifndef NON_MATCHING
 void* jtbl_800EA5A8[24] = {
     &lbl_80016D74, &lbl_80016D74, &lbl_80016D08, &lbl_80016CE8, &lbl_80016D48, &lbl_80016CF8,
     &lbl_80016D28, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74, &lbl_80016D74,
     &lbl_80016D74, &lbl_80016D28, &lbl_80016D74, &lbl_80016D74, &lbl_80016D18, &lbl_80016D74,
     &lbl_80016D54, &lbl_80016D38, &lbl_80016D38, &lbl_80016D74, &lbl_80016D74, &lbl_80016D64,
 };
-#else
-void* jtbl_800EA5A8[24] = {0};
-#endif
 
 void* jtbl_800EA608[24] = {
     &lbl_80016E54, &lbl_80016E54, &lbl_80016DE8, &lbl_80016DC8, &lbl_80016E28, &lbl_80016DD8,


### PR DESCRIPTION
I was thinking it might be good for matching the functions, also I passed ``pMCard`` as a parameter for ``mcardUpdate``, based on the other functions I'd say it's an unused parameter but decomp will tell us for sure, let me know if I should revert this to ``void`` instead

also I think ``__anon_0x1A5F0`` is probably ``MemCardMessage`` but the usage confused me a bit so I didn't name it