### PR TITLE
Use -inline deferred on libc and runtime files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -192,11 +192,11 @@ def DolphinLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
         "objects": objects,
     }
 
-def GenericLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
+def GenericLib(lib_name: str, cflags: List[str], objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
         "mw_version": "GC/1.2.5",
-        "cflags": cflags_base,
+        "cflags": cflags,
         "host": False,
         "objects": objects,
     }
@@ -427,6 +427,7 @@ config.libs = [
     ),
     GenericLib(
         "metrotrk",
+        cflags_base,
         [
             Object(NonMatching, "metrotrk/mainloop.c"),
             Object(NonMatching, "metrotrk/nubevent.c"),
@@ -453,6 +454,7 @@ config.libs = [
     ),
     GenericLib(
         "runtime",
+        [*cflags_base, "-inline deferred"],
         [
             Object(MatchingFor("mq-j", "ce-j", "ce-u"), "runtime/__mem.c"),
             Object(MatchingFor("mq-j", "ce-j", "ce-u"), "runtime/__va_arg.c"),
@@ -462,6 +464,7 @@ config.libs = [
     ),
     GenericLib(
         "libc",
+        [*cflags_base, "-inline deferred"],
         [
             Object(MatchingFor("mq-j", "ce-j", "ce-u"), "libc/abort_exit.c"),
             Object(MatchingFor("mq-j", "ce-j", "ce-u"), "libc/ansi_files.c"),
@@ -500,6 +503,7 @@ config.libs = [
     ),
     GenericLib(
         "debugger",
+        cflags_base,
         [
             Object(MatchingFor("mq-j", "ce-j", "ce-u"), "debugger/AmcExi2Stubs.c"),
             Object(NonMatching, "debugger/DebuggerDriver.c"),

--- a/libc/ctype.h
+++ b/libc/ctype.h
@@ -40,7 +40,7 @@ static inline int isupper(int c) { return __ctype_map[__zero_fill(c)] & __upper_
 static inline int isxdigit(int c) { return __ctype_map[__zero_fill(c)] & __hex_digit; }
 static inline int iswblank(int c) { return ((c == (int)L' ') || (c == (int)L'\t')); }
 
-int toupper(int c);
 int tolower(int c);
+int toupper(int c);
 
 #endif

--- a/src/libc/buffer_io.c
+++ b/src/libc/buffer_io.c
@@ -1,5 +1,12 @@
 #include "buffer_io.h"
 
+void __prep_buffer(FILE* file) {
+    file->buffer_ptr = file->buffer;
+    file->buffer_len = file->buffer_size;
+    file->buffer_len -= file->position & file->buffer_alignment;
+    file->buffer_pos = file->position;
+}
+
 int __flush_buffer(FILE* file, size_t* bytes_flushed) {
     size_t len;
     int res;
@@ -20,16 +27,6 @@ int __flush_buffer(FILE* file, size_t* bytes_flushed) {
         file->position += file->buffer_len;
     }
 
-    file->buffer_ptr = file->buffer;
-    file->buffer_len = file->buffer_size;
-    file->buffer_len -= file->position & file->buffer_alignment;
-    file->buffer_pos = file->position;
+    __prep_buffer(file);
     return 0;
-}
-
-void __prep_buffer(FILE* file) {
-    file->buffer_ptr = file->buffer;
-    file->buffer_len = file->buffer_size;
-    file->buffer_len -= file->position & file->buffer_alignment;
-    file->buffer_pos = file->position;
 }

--- a/src/libc/ctype.c
+++ b/src/libc/ctype.c
@@ -166,16 +166,16 @@ const u8 __upper_map[256] = {
     0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
 };
 
-int toupper(int c) {
-    if (c == EOF) {
-        return EOF;
-    }
-    return __upper_map[c & 0xFF];
-}
-
 int tolower(int c) {
     if (c == EOF) {
         return EOF;
     }
     return __lower_map[c & 0xFF];
+}
+
+int toupper(int c) {
+    if (c == EOF) {
+        return EOF;
+    }
+    return __upper_map[c & 0xFF];
 }

--- a/src/libc/e_pow.c
+++ b/src/libc/e_pow.c
@@ -40,6 +40,10 @@ static const f64 ivln2 = 1.44269504088896338700e+00; /* 0x3FF71547, 0x652B82FE =
 static const f64 ivln2_h = 1.44269502162933349609e+00; /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
 static const f64 ivln2_l = 1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
 
+#pragma dont_inline on
+f64 scalbn(f64 x, int n) { return ldexp(x, n); }
+#pragma dont_inline reset
+
 f64 __ieee754_pow(f64 x, f64 y) {
     f64 z, ax, z_h, z_l, p_h, p_l;
     f64 y1, t1, t2, r, s, t, u, v, w;
@@ -299,5 +303,3 @@ f64 __ieee754_pow(f64 x, f64 y) {
     }
     return s * z;
 }
-
-f64 scalbn(f64 x, int n) { return ldexp(x, n); }

--- a/src/libc/trigf.c
+++ b/src/libc/trigf.c
@@ -8,45 +8,16 @@ extern f32 __sincos_poly[];
 const f32 tmp_float[] = {0.25f, 0.0232393741608f, 1.70555722434e-7f, 1.86736494323e-11f};
 f32 __four_over_pi_m1[] = {0.0f, 0.0f, 0.0f, 0.0f};
 
-f32 tanf(f32 x) { return sin__Ff(x) / cos__Ff(x); }
-
-f32 cos__Ff(f32 x) { return cosf(x); }
-
-f32 sin__Ff(f32 x) { return sinf(x); }
-
-f32 cosf(f32 x) {
-    int n;
-    f32 y;
-    f32 ysq;
-    f32 z;
-
-    z = (2.0f / (f32)M_PI) * x;
-    n = (__HI(x) & 0x80000000) ? (int)(z - 0.5f) : (int)(z + 0.5f);
-
-    y = x - n * 2 + __four_over_pi_m1[0] * x + __four_over_pi_m1[1] * x + __four_over_pi_m1[2] * x +
-        __four_over_pi_m1[3] * x;
-    n &= 3;
-    if (fabsf__Ff(y) < __epsilon) {
-        n <<= 1;
-        return __sincos_on_quadrant[n + 1] - y * __sincos_on_quadrant[n];
-    }
-
-    ysq = y * y;
-    if (n & 1) {
-        n <<= 1;
-        z = -((((__sincos_poly[1] * ysq + __sincos_poly[3]) * ysq + __sincos_poly[5]) * ysq + __sincos_poly[7]) * ysq +
-              __sincos_poly[9]) *
-            y;
-        return z * __sincos_on_quadrant[n];
-    } else {
-        n <<= 1;
-        z = (((__sincos_poly[0] * ysq + __sincos_poly[2]) * ysq + __sincos_poly[4]) * ysq + __sincos_poly[6]) * ysq +
-            __sincos_poly[8];
-        return z * __sincos_on_quadrant[n + 1];
-    }
+void __sinit_trigf_c(void) {
+    __four_over_pi_m1[0] = tmp_float[0];
+    __four_over_pi_m1[1] = tmp_float[1];
+    __four_over_pi_m1[2] = tmp_float[2];
+    __four_over_pi_m1[3] = tmp_float[3];
 }
 
-float sinf(float x) {
+CTORS void* const __sinit_trigf_c_reference = __sinit_trigf_c;
+
+f32 sinf(f32 x) {
     int n;
     f32 y;
     f32 ysq;
@@ -80,11 +51,44 @@ float sinf(float x) {
     }
 }
 
-void __sinit_trigf_c(void) {
-    __four_over_pi_m1[0] = tmp_float[0];
-    __four_over_pi_m1[1] = tmp_float[1];
-    __four_over_pi_m1[2] = tmp_float[2];
-    __four_over_pi_m1[3] = tmp_float[3];
+f32 cosf(f32 x) {
+    int n;
+    f32 y;
+    f32 ysq;
+    f32 z;
+
+    z = (2.0f / (f32)M_PI) * x;
+    n = (__HI(x) & 0x80000000) ? (int)(z - 0.5f) : (int)(z + 0.5f);
+
+    y = x - n * 2 + __four_over_pi_m1[0] * x + __four_over_pi_m1[1] * x + __four_over_pi_m1[2] * x +
+        __four_over_pi_m1[3] * x;
+    n &= 3;
+    if (fabsf__Ff(y) < __epsilon) {
+        n <<= 1;
+        return __sincos_on_quadrant[n + 1] - y * __sincos_on_quadrant[n];
+    }
+
+    ysq = y * y;
+    if (n & 1) {
+        n <<= 1;
+        z = -((((__sincos_poly[1] * ysq + __sincos_poly[3]) * ysq + __sincos_poly[5]) * ysq + __sincos_poly[7]) * ysq +
+              __sincos_poly[9]) *
+            y;
+        return z * __sincos_on_quadrant[n];
+    } else {
+        n <<= 1;
+        z = (((__sincos_poly[0] * ysq + __sincos_poly[2]) * ysq + __sincos_poly[4]) * ysq + __sincos_poly[6]) * ysq +
+            __sincos_poly[8];
+        return z * __sincos_on_quadrant[n + 1];
+    }
 }
 
-CTORS void* const __sinit_trigf_c_reference = __sinit_trigf_c;
+#pragma dont_inline on
+
+f32 sin__Ff(f32 x) { return sinf(x); }
+
+f32 cos__Ff(f32 x) { return cosf(x); }
+
+#pragma dont_inline reset
+
+f32 tanf(f32 x) { return sin__Ff(x) / cos__Ff(x); }

--- a/src/libc/uart_console_io.c
+++ b/src/libc/uart_console_io.c
@@ -2,7 +2,7 @@
 #include "dolphin/exi.h"
 #include "dolphin/types.h"
 
-int __init_console(void) {
+static inline int __init_console(void) {
     static bool initialized;
     int res = 0;
 
@@ -13,21 +13,6 @@ int __init_console(void) {
         }
     }
     return res;
-}
-
-int __close_console(__file_handle file) { return 0; }
-
-int __write_console(__file_handle handle, unsigned char* buffer, size_t* count, __idle_proc idle_proc) {
-    if (__init_console() != 0) {
-        return 1;
-    }
-
-    if (WriteUARTN(buffer, *count) != 0) {
-        *count = 0;
-        return 1;
-    }
-
-    return 0;
 }
 
 int __read_console(__file_handle handle, unsigned char* buffer, size_t* count, __idle_proc idle_proc) {
@@ -52,3 +37,18 @@ int __read_console(__file_handle handle, unsigned char* buffer, size_t* count, _
 
     return (res == 0 ? 0 : 1) & 0xFF;
 }
+
+int __write_console(__file_handle handle, unsigned char* buffer, size_t* count, __idle_proc idle_proc) {
+    if (__init_console() != 0) {
+        return 1;
+    }
+
+    if (WriteUARTN(buffer, *count) != 0) {
+        *count = 0;
+        return 1;
+    }
+
+    return 0;
+}
+
+int __close_console(__file_handle file) { return 0; }

--- a/src/runtime/__mem.c
+++ b/src/runtime/__mem.c
@@ -1,9 +1,22 @@
 #include "dolphin/types.h"
 #include "mem_funcs.h"
 
-INIT void* memset(void* dst, int val, size_t n) {
-    __fill_mem(dst, val, n);
+INIT void* memcpy(void* dst, const void* src, size_t n) {
+    const char* p;
+    char* q;
+    int rev = ((u32)src < (u32)dst);
 
+    if (!rev) {
+
+        for (p = (const char*)src - 1, q = (char*)dst - 1, n++; --n;) {
+            *++q = *++p;
+        }
+
+    } else {
+        for (p = (const char*)src + n, q = (char*)dst + n, n++; --n;) {
+            *--q = *--p;
+        }
+    }
     return (dst);
 }
 
@@ -66,21 +79,8 @@ INIT void __fill_mem(void* dst, int val, size_t n) {
     }
 }
 
-INIT void* memcpy(void* dst, const void* src, size_t n) {
-    const char* p;
-    char* q;
-    int rev = ((u32)src < (u32)dst);
+INIT void* memset(void* dst, int val, size_t n) {
+    __fill_mem(dst, val, n);
 
-    if (!rev) {
-
-        for (p = (const char*)src - 1, q = (char*)dst - 1, n++; --n;) {
-            *++q = *++p;
-        }
-
-    } else {
-        for (p = (const char*)src + n, q = (char*)dst + n, n++; --n;) {
-            *--q = *--p;
-        }
-    }
     return (dst);
 }


### PR DESCRIPTION
Things make more sense with the reverse function order, although I had to add `#pragma dont_inline` in a few places. Debugger stubs don't seem to use it, and I haven't looked a metrotrk.