### PR TITLE
Add support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ brew install git ninja python3
 brew install --cask --no-quarantine gcenx/wine/wine-crossover
 ```
 
+#### Windows
+
+You will need the following dependencies:
+- [ninja.exe](https://github.com/ninja-build/ninja/releases/latest)
+- Python (make sure to add it to your PATH during the installation)
+- [Git for Windows](https://www.git-scm.com/downloads)
+
+You need to add ``C:\Program Files\Git\bin`` to your system's PATH (not the user one) in order to execute bash scripts properly.
+
+To get objdiff to work properly you also need to add the path to the folder containing ``ninja.exe`` to the system's PATH.
+
 ### Instructions
 
 1. Clone the repo using `git clone https://github.com/zeldaret/oot-gc`.
@@ -61,7 +72,7 @@ brew install --cask --no-quarantine gcenx/wine/wine-crossover
   You can use [Dolphin](https://dolphin-emu.org) to perform both of these extraction steps:
   right click on the file you want to extract from, select `Properties`, and go to the `Filesystem` tab.
 
-3. Run `python3 configure.py`.
+3. Run `python3 configure.py`. (Note: on Windows you might need to run ``python configure.py``.)
 
 4. Run `ninja` to build the `ce-j` version, or run `ninja <version>` to build another version.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ You need to add ``C:\Program Files\Git\bin`` to your system's PATH (not the user
 
 To get objdiff to work properly you also need to add the path to the folder containing ``ninja.exe`` to the system's PATH.
 
+If you git shows ``splits.txt`` and/or ``symbols.txt`` are modified for no reasons you might need to turn off CRLF. You can do that with ``git config --global core.autocrlf false``
+
 ### Instructions
 
 1. Clone the repo using `git clone https://github.com/zeldaret/oot-gc`.

--- a/tools/asm_processor/compile.sh
+++ b/tools/asm_processor/compile.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+# bash scripts are executed with sh.exe, installed with Git for Windows, which is using MSYS
+OS=$(uname -o)
+PYTHON="python3"
+if [ "$OS" == "Msys" ]
+then 
+    PYTHON="python"
+fi
+
 CC="$1"
 shift
 AS="$1"
@@ -18,9 +26,9 @@ trap "rm -rf $TEMP" EXIT
 STEM=$(basename "$IN")
 STEM="${STEM%.*}"
 
-tools/asm_processor/asm_processor.py "$IN" > "$TEMP/$STEM.c"
+$PYTHON tools/asm_processor/asm_processor.py "$IN" > "$TEMP/$STEM.c"
 $CC "$TEMP/$STEM.c" -c -o "$TEMP"
-tools/asm_processor/asm_processor.py "$IN" --post-process "$TEMP/$STEM.o" --assembler "$AS" --asm-prelude include/macros.inc
+$PYTHON tools/asm_processor/asm_processor.py "$IN" --post-process "$TEMP/$STEM.o" --assembler "$AS" --asm-prelude include/macros.inc
 # Remove sections that don't work with our reloc hacks
 build/binutils/powerpc-eabi-objcopy --remove-section .mwcats.text --remove-section .comment "$TEMP/$STEM.o" "$OUT"
 # Copy depfile, replacing the first line with the correct input/output files

--- a/tools/project.py
+++ b/tools/project.py
@@ -422,6 +422,8 @@ def generate_build_ninja(
         mwcc_implicit.append(transform_dep)
         mwcc_sjis_implicit.append(transform_dep)
         mwcc_asm_processor_implicit.append(transform_dep)
+    else:
+        mwcc_asm_processor_cmd = "sh " + mwcc_asm_processor_cmd
 
     n.comment("Link ELF file")
     n.rule(


### PR DESCRIPTION
on Linux running the compile.sh script with ``sh`` fails, on windows using ``sh.exe`` works, using ``bash`` works on Linux but ``bash.exe`` doesn't work on Windows, hence that ``else`` I added in ``project.py``

also I'm not a bash expert so let me know if anything needs to be changed in ``compile.sh``