### PR TITLE
Only configure versions if main.dol exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,14 @@ To get objdiff to work properly you also need to add the path to the folder cont
   * `ce-e`: `zelda_PAL_093003.tgc`
 
   Then, extract the DOL file from the TGC archive and place it in the repo as `orig/<version>/main.dol`.
-  You can use [Dolphin](https://dolphin-emu.org) to perform both of these extraction steps:
-  right click on the file you want to extract from, select `Properties`, and go to the `Filesystem` tab.
 
-3. Run `python3 configure.py`. (Note: on Windows you might need to run ``python configure.py``.)
+  You can use [Dolphin](https://dolphin-emu.org) to perform both of these extraction steps:
+  first, right click on the `.iso` file, select "Properties", go to the "Filesystem" tab, find the correct
+  `.tgc` file, then right-click and select "Extract File..." and extract it to your games folder.
+  Then, right-click the extracted `.tgc` file in Dolphin, select "Properties", go to the "Filesystem" tab,
+  right-click the "Disc" and select "Extract System Data..." to extract the DOL file.
+
+3. Run `python3 configure.py` to generate the build. (Note: on Windows you might need to run ``python configure.py``.)
 
 4. Run `ninja` to build the `ce-j` version, or run `ninja <version>` to build another version.
 

--- a/configure.py
+++ b/configure.py
@@ -100,12 +100,21 @@ args = parser.parse_args()
 ### Project configuration
 
 config = ProjectConfig()
-config.versions = [
+
+# Only configure versions for which main.dol exists
+ALL_VERSIONS = [
     "mq-j",
     "ce-j",
     "ce-u",
 ]
-config.default_version = "ce-j"
+config.versions = [
+    version
+    for version in ALL_VERSIONS
+    if (Path("orig") / version / "main.dol").exists()
+]
+if "ce-j" in config.versions:
+    config.default_version = "ce-j"
+
 config.warn_missing_config = True
 config.warn_missing_source = False
 config.progress_all = False


### PR DESCRIPTION
Currently you need to acquire the DOL for all versions in order for any version to be built, which is a pretty big ask. Now configure.py will only generate the build for versions where `orig/VERSION/main.dol` exists. Unfortunately if you want to add more versions you'll have to run `configure.py` again manually because the build won't track it.

Also, I added some more detail in the README about how to extract the DOL