### PR TITLE
Add explicit casts to void**

### DIFF
--- a/src/emulator/cpu.c
+++ b/src/emulator/cpu.c
@@ -669,7 +669,7 @@ static bool cpuCompile_DSLLV(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 16;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -703,7 +703,7 @@ static bool cpuCompile_DSRLV(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 16;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -737,7 +737,7 @@ static bool cpuCompile_DSRAV(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 17;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -772,7 +772,7 @@ static bool cpuCompile_DMULT(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 53;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -843,7 +843,7 @@ static bool cpuCompile_DMULTU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 28;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -889,7 +889,7 @@ static bool cpuCompile_DDIV(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 64;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -971,7 +971,7 @@ static bool cpuCompile_DDIVU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 43;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1032,7 +1032,7 @@ static inline bool cpuCompile_DADD(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1053,7 +1053,7 @@ static inline bool cpuCompile_DADDU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1074,7 +1074,7 @@ static inline bool cpuCompile_DSUB(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1095,7 +1095,7 @@ static inline bool cpuCompile_DSUBU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1116,7 +1116,7 @@ static bool cpuCompile_S_SQRT(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 36;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1170,7 +1170,7 @@ static bool cpuCompile_D_SQRT(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 48;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1236,7 +1236,7 @@ static bool cpuCompile_W_CVT_SD(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 14;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1268,7 +1268,7 @@ static bool cpuCompile_L_CVT_SD(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 56;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1342,7 +1342,7 @@ static bool cpuCompile_CEIL_W(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 13;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1373,7 +1373,7 @@ static bool cpuCompile_FLOOR_W(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 13;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1404,7 +1404,7 @@ static inline bool cpuCompile_ROUND_W(s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1425,7 +1425,7 @@ static inline bool cpuCompile_TRUNC_W(s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 3;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1446,7 +1446,7 @@ static bool cpuCompile_LB(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 11;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1474,7 +1474,7 @@ static bool cpuCompile_LH(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 11;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1502,7 +1502,7 @@ static bool cpuCompile_LW(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1529,7 +1529,7 @@ static bool cpuCompile_LBU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1556,7 +1556,7 @@ static bool cpuCompile_LHU(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1583,7 +1583,7 @@ static bool cpuCompile_SB(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1610,7 +1610,7 @@ static bool cpuCompile_SH(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1637,7 +1637,7 @@ static bool cpuCompile_SW(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 10;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1664,7 +1664,7 @@ static bool cpuCompile_LDC(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 12;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1693,7 +1693,7 @@ static bool cpuCompile_SDC(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 12;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1722,7 +1722,7 @@ static bool cpuCompile_LWL(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 12;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -1752,7 +1752,7 @@ static bool cpuCompile_LWR(Cpu* pCPU, s32* addressGCN) {
     s32 count = 0;
     s32 nSize = 12;
 
-    if (!xlHeapTake(&compile, (nSize * sizeof(s32)) | 0x30000000)) {
+    if (!xlHeapTake((void**)&compile, (nSize * sizeof(s32)) | 0x30000000)) {
         return false;
     }
     *addressGCN = (s32)compile;
@@ -4392,7 +4392,7 @@ static bool cpuMakeLink(Cpu* pCPU, CpuExecuteFunc* ppfLink, CpuExecuteFunc pfFun
     s32 nData;
     s32 pad;
 
-    if (!xlHeapTake(&pnCode, 0x200 | 0x30000000)) {
+    if (!xlHeapTake((void**)&pnCode, 0x200 | 0x30000000)) {
         return false;
     }
     *ppfLink = (CpuExecuteFunc)pnCode;
@@ -4439,7 +4439,7 @@ static bool cpuMakeLink(Cpu* pCPU, CpuExecuteFunc* ppfLink, CpuExecuteFunc pfFun
 }
 
 static inline bool cpuFreeLink(Cpu* pCPU, CpuExecuteFunc* ppfLink) {
-    if (!xlHeapFree(&ppfLink)) {
+    if (!xlHeapFree((void**)&ppfLink)) {
         return false;
     } else {
         *ppfLink = NULL;
@@ -4512,7 +4512,7 @@ bool cpuExecute(Cpu* pCPU, u64 nAddressBreak) {
     cpuCompile_LWR(pCPU, &cpuCompile_LWR_function);
 
     if (cpuMakeFunction(pCPU, &pFunction, pCPU->nPC)) {
-        if (!xlHeapTake(&pnCode, 0x100 | 0x30000000)) {
+        if (!xlHeapTake((void**)&pnCode, 0x100 | 0x30000000)) {
             return false;
         }
 
@@ -4553,7 +4553,7 @@ bool cpuExecute(Cpu* pCPU, u64 nAddressBreak) {
 
         pfCode();
 
-        if (!xlHeapFree(&pfCode)) {
+        if (!xlHeapFree((void**)&pfCode)) {
             return false;
         }
 
@@ -4684,7 +4684,8 @@ static bool cpuHackHandler(Cpu* pCPU) {
 
     iSave1 = iSave2 = iLoad = 0;
 
-    if (xlObjectTest(SYSTEM_RAM(pCPU->pHost), &gClassRAM) && ramGetBuffer(SYSTEM_RAM(pCPU->pHost), &pnCode, 0, NULL)) {
+    if (xlObjectTest(SYSTEM_RAM(pCPU->pHost), &gClassRAM) &&
+        ramGetBuffer(SYSTEM_RAM(pCPU->pHost), (void**)&pnCode, 0, NULL)) {
         if (!ramGetSize(SYSTEM_RAM(pCPU->pHost), (s32*)&nSize)) {
             return false;
         }
@@ -4902,7 +4903,7 @@ static bool cpuMakeDevice(Cpu* pCPU, s32* piDevice, void* pObject, s32 nOffset, 
     }
 
     *piDevice = iDevice;
-    if (!xlHeapTake(&pDevice, sizeof(CpuDevice))) {
+    if (!xlHeapTake((void**)&pDevice, sizeof(CpuDevice))) {
         return false;
     }
 
@@ -6441,7 +6442,7 @@ static bool treeKill(Cpu* pCPU) {
     }
 
     root->total -= count;
-    if (!xlHeapFree(&pCPU->gTree)) {
+    if (!xlHeapFree((void**)&pCPU->gTree)) {
         return false;
     }
 

--- a/src/emulator/flash.c
+++ b/src/emulator/flash.c
@@ -162,10 +162,10 @@ bool flashEvent(Flash* pFLASH, s32 nEvent, void* pArgument) {
         case 2:
             pFLASH->pHost = pArgument;
             pFLASH->flashCommand = 0;
-            xlHeapTake(&pFLASH->flashBuffer, 128);
+            xlHeapTake((void**)&pFLASH->flashBuffer, 128);
             break;
         case 3:
-            xlHeapFree(&pFLASH->flashBuffer);
+            xlHeapFree((void**)&pFLASH->flashBuffer);
             break;
         case 0x1002:
             if (!cpuSetDevicePut(SYSTEM_CPU(pFLASH->pHost), pArgument, (Put8Func)flashPut8, (Put16Func)flashPut16,

--- a/src/emulator/frame.c
+++ b/src/emulator/frame.c
@@ -3176,7 +3176,7 @@ bool frameHackCIMG_Zelda(Frame* pFrame, FrameBuffer* pBuffer, u64* pnGBI, u32 nC
         high2 = pnGBI[1] >> 32;
         if (high2 == 0xFD10013F) {
             low2 = SYSTEM_RSP(gpSystem)->anBaseSegment[(low2 >> 24) & 0xF] + (low2 & 0xFFFFFF);
-            if (!ramGetBuffer(SYSTEM_RAM(gpSystem), &srcP, low2, NULL)) {
+            if (!ramGetBuffer(SYSTEM_RAM(gpSystem), (void**)&srcP, low2, NULL)) {
                 return false;
             }
             sDestinationBuffer = low2;

--- a/src/emulator/library.c
+++ b/src/emulator/library.c
@@ -175,7 +175,7 @@ static bool __osException(Cpu* pCPU) {
     }
 
     CPU_DEVICE_GET32(apDevice, aiDevice, pLibrary->anAddress[8], &pCPU->aGPR[26].u32);
-    if (!cpuGetAddressBuffer(pCPU, &__osRunningThread, pCPU->aGPR[26].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&__osRunningThread, pCPU->aGPR[26].u32)) {
         return false;
     }
 
@@ -536,7 +536,7 @@ static bool __osEnqueueAndYield(Cpu* pCPU) {
     __OSGlobalIntMask = *(u32*)pLibrary->apData[3];
     CPU_DEVICE_GET32(apDevice, aiDevice, pLibrary->anAddress[8], &pCPU->aGPR[5].u32);
 
-    if (!cpuGetAddressBuffer(pCPU, &__osRunningThread, pCPU->aGPR[5].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&__osRunningThread, pCPU->aGPR[5].u32)) {
         return false;
     }
 
@@ -653,7 +653,7 @@ static bool __osDispatchThread(Cpu* pCPU) {
     nAddress = pCPU->aGPR[2].u32;
     *(u32*)pLibrary->apData[8] = nAddress;
 
-    if (!cpuGetAddressBuffer(pCPU, &__osRunningThread, nAddress)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&__osRunningThread, nAddress)) {
         return false;
     }
 
@@ -873,9 +873,9 @@ void guMtxCatF(Cpu* pCPU) {
     u32* nf;
     u32* res;
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &nf, pCPU->aGPR[5].u32);
-    cpuGetAddressBuffer(pCPU, &res, pCPU->aGPR[6].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&nf, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&res, pCPU->aGPR[6].u32);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
@@ -908,8 +908,8 @@ void guMtxF2L(Cpu* pCPU) {
     s32* af;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[5].u32);
     frameFixMatrixHint(SYSTEM_FRAME(pCPU->pHost), pCPU->aGPR[4].u32, pCPU->aGPR[5].u32);
 
     ai = &m[0];
@@ -937,7 +937,7 @@ void guMtxIdentF(Cpu* pCPU) {
 
     *((volatile f32*)&data0.f32) = 0.0f;
     *((volatile f32*)&data1.f32) = 1.0f;
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
 
     float1 = data1.f32;
     float0 = data0.f32;
@@ -955,7 +955,7 @@ void guMtxIdentF(Cpu* pCPU) {
 void guMtxIdent(Cpu* pCPU) {
     s32* m;
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
     m[0] = 0x10000;
     m[1] = 0;
     m[2] = 1;
@@ -990,8 +990,8 @@ void guOrthoF(Cpu* pCPU) {
     CpuFpr data1;
     CpuFpr data;
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     l = data.f32;
@@ -1070,8 +1070,8 @@ void guOrtho(Cpu* pCPU) {
     f32 scale;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     l = data.f32;
@@ -1149,9 +1149,9 @@ void guPerspectiveF(Cpu* pCPU) {
     f32 rFar;
     f32 scale;
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
-    cpuGetAddressBuffer(pCPU, &perspNorm, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&perspNorm, pCPU->aGPR[5].u32);
 
     data.u32 = pCPU->aGPR[6].u32;
     fovy = data.f32;
@@ -1224,8 +1224,8 @@ void guPerspective(Cpu* pCPU) {
     s32* af;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[6].u32;
     fovy = data.f32;
@@ -1294,8 +1294,8 @@ void GenPerspective_1080(Cpu* pCPU) {
     f32 rFar;
     Frame* pFrame = SYSTEM_FRAME(pCPU->pHost);
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     fovy = data.f32;
@@ -1322,7 +1322,7 @@ void guScaleF(Cpu* pCPU) {
 
     data0.f32 = 0.0f;
     data1.f32 = 1.0f;
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
@@ -1352,7 +1352,7 @@ void guScale(Cpu* pCPU) {
     s32* af;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
 
     mf[0][0] = 1.0f;
     mf[0][1] = 0.0f;
@@ -1401,7 +1401,7 @@ void guTranslateF(Cpu* pCPU) {
 
     data0.f32 = 0.0f;
     data1.f32 = 1.0f;
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
@@ -1430,7 +1430,7 @@ void guTranslate(Cpu* pCPU) {
     s32* af;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
 
     mf[0][0] = 1.0f;
     mf[0][1] = 0.0f;
@@ -1491,7 +1491,7 @@ void guRotateF(Cpu* pCPU) {
     f32 t;
     static f32 dtor = (f32)M_PI / 180;
 
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     a = data.f32;
@@ -1522,7 +1522,7 @@ void guRotateF(Cpu* pCPU) {
 
     data0.f32 = 0.0f;
     data1.f32 = 1.0f;
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
@@ -1590,8 +1590,8 @@ void guRotate(Cpu* pCPU) {
     s32 pad[2];
     static f32 dtor = (f32)M_PI / 180;
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     a = data.f32;
@@ -1687,8 +1687,8 @@ void guLookAtF(Cpu* pCPU) {
 
     data0.f32 = 0.0f;
     data1.f32 = 1.0f;
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     xEye = data.f32;
@@ -1812,8 +1812,8 @@ void guLookAt(Cpu* pCPU) {
     f32 zUp;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[5].u32;
     xEye = data.f32;
@@ -1965,10 +1965,10 @@ void guLookAtHiliteF(Cpu* pCPU) {
     s32 twidth;
     s32 theight;
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &l, pCPU->aGPR[5].u32);
-    cpuGetAddressBuffer(pCPU, &h, pCPU->aGPR[6].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&l, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&h, pCPU->aGPR[6].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[7].u32;
     xEye = data.f32;
@@ -2202,10 +2202,10 @@ void guLookAtHilite(Cpu* pCPU) {
     s32 theight;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &l, pCPU->aGPR[5].u32);
-    cpuGetAddressBuffer(pCPU, &h, pCPU->aGPR[6].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&l, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&h, pCPU->aGPR[6].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[7].u32;
     xEye = data.f32;
@@ -2402,9 +2402,9 @@ void guLookAtReflectF(Cpu* pCPU) {
     f32 yRight;
     f32 zRight;
 
-    cpuGetAddressBuffer(pCPU, &mf, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &l, pCPU->aGPR[5].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&mf, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&l, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[6].u32;
     xEye = data.f32;
@@ -2559,9 +2559,9 @@ void guLookAtReflect(Cpu* pCPU) {
     f32 zRight;
     s32 pad[2];
 
-    cpuGetAddressBuffer(pCPU, &m, pCPU->aGPR[4].u32);
-    cpuGetAddressBuffer(pCPU, &l, pCPU->aGPR[5].u32);
-    cpuGetAddressBuffer(pCPU, &sp, pCPU->aGPR[29].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&m, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&l, pCPU->aGPR[5].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&sp, pCPU->aGPR[29].u32);
 
     data.u32 = pCPU->aGPR[6].u32;
     xEye = data.f32;
@@ -2734,7 +2734,7 @@ bool __osEepStatus(Cpu* pCPU) {
     s32 nSize;
     u8* status;
 
-    if (!cpuGetAddressBuffer(pCPU, &status, pCPU->aGPR[5].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&status, pCPU->aGPR[5].u32)) {
         return false;
     }
 
@@ -2762,7 +2762,7 @@ bool osEepromRead(Cpu* pCPU) {
     u8* buffer;
 
     address = pCPU->aGPR[5].u8;
-    if (!cpuGetAddressBuffer(pCPU, &buffer, pCPU->aGPR[6].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&buffer, pCPU->aGPR[6].u32)) {
         return false;
     }
 
@@ -2776,7 +2776,7 @@ bool osEepromWrite(Cpu* pCPU) {
     u8* buffer;
 
     address = pCPU->aGPR[5].u8;
-    if (!cpuGetAddressBuffer(pCPU, &buffer, pCPU->aGPR[6].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&buffer, pCPU->aGPR[6].u32)) {
         return false;
     }
 
@@ -2793,7 +2793,7 @@ bool osEepromLongRead(Cpu* pCPU) {
     ret = 0;
 
     address = pCPU->aGPR[5].u8;
-    if (!cpuGetAddressBuffer(pCPU, &buffer, pCPU->aGPR[6].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&buffer, pCPU->aGPR[6].u32)) {
         return false;
     }
     length = pCPU->aGPR[7].s32;
@@ -2822,7 +2822,7 @@ bool osEepromLongWrite(Cpu* pCPU) {
     ret = 0;
 
     address = pCPU->aGPR[5].u8;
-    if (!cpuGetAddressBuffer(pCPU, &buffer, pCPU->aGPR[6].u32)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&buffer, pCPU->aGPR[6].u32)) {
         return false;
     }
     length = pCPU->aGPR[7].s32;
@@ -2858,7 +2858,7 @@ bool starfoxCopy(Cpu* pCPU) {
     char* target;
 
     A1 = pCPU->aGPR[5].u32;
-    cpuGetAddressBuffer(pCPU, &A0, pCPU->aGPR[4].u32);
+    cpuGetAddressBuffer(pCPU, (void**)&A0, pCPU->aGPR[4].u32);
 
     A3 = A0[2] + pCPU->aGPR[4].u32;
     T9 = A0[3] + pCPU->aGPR[4].u32;
@@ -2884,20 +2884,20 @@ bool starfoxCopy(Cpu* pCPU) {
         }
 
         if (T2 != 0) {
-            cpuGetAddressBuffer(pCPU, &source, T9);
-            cpuGetAddressBuffer(pCPU, &target, A1);
+            cpuGetAddressBuffer(pCPU, (void**)&source, T9);
+            cpuGetAddressBuffer(pCPU, (void**)&target, A1);
             T9 += 1;
             A1 += 1;
             *target = *source;
         } else {
-            cpuGetAddressBuffer(pCPU, &pData16, A3);
+            cpuGetAddressBuffer(pCPU, (void**)&pData16, A3);
             A3 += 2;
             T3 = (((u32)*pData16 >> 12) & 0xF) + 3;
             T1 = A1 - (*pData16 & 0xFFF);
 
             do {
-                cpuGetAddressBuffer(pCPU, &source, T1 - 1);
-                cpuGetAddressBuffer(pCPU, &target, A1);
+                cpuGetAddressBuffer(pCPU, (void**)&source, T1 - 1);
+                cpuGetAddressBuffer(pCPU, (void**)&target, A1);
                 T3 -= 1;
                 A1 += 1;
                 T1 += 1;
@@ -2931,12 +2931,12 @@ bool dmaSoundRomHandler_ZELDA1(Cpu* pCPU) {
     s32 nOffsetROM;
 
     nAddress = pCPU->aGPR[5].u32;
-    if (!cpuGetAddressBuffer(pCPU, &pIOMessage, nAddress)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&pIOMessage, nAddress)) {
         return false;
     }
 
     nAddress = (u32)pIOMessage->hdr.retQueue;
-    if (!cpuGetAddressBuffer(pCPU, &mq, nAddress)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&mq, nAddress)) {
         return false;
     }
 
@@ -2944,7 +2944,7 @@ bool dmaSoundRomHandler_ZELDA1(Cpu* pCPU) {
     first = mq->first;
     msgCount = mq->msgCount;
     validCount = mq->validCount;
-    if (!cpuGetAddressBuffer(pCPU, &msg, nAddress)) {
+    if (!cpuGetAddressBuffer(pCPU, (void**)&msg, nAddress)) {
         return false;
     }
 
@@ -3488,7 +3488,7 @@ static bool libraryFindFunctions(Library* pLibrary) {
             nAddress += 4;
         } while (nOpcode != 0x400A4000);
 
-        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, nAddress + 0x14)) {
+        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, nAddress + 0x14)) {
             return false;
         }
 
@@ -3512,7 +3512,7 @@ static bool libraryFindFunctions(Library* pLibrary) {
         } while (MIPS_OP(nOpcode) != 0x02 && (nOpcode & 0xFFFF0000) != 0x10000000 && MIPS_OP(nOpcode) != 0x00 &&
                  MIPS_FUNCT(nOpcode) != 0x08);
 
-        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, nAddress + 8)) {
+        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, nAddress + 8)) {
             return false;
         }
 
@@ -3523,7 +3523,7 @@ static bool libraryFindFunctions(Library* pLibrary) {
          iFunction < ARRAY_COUNTU(gaFunction) && gaFunction[iFunction].pfLibrary != (LibraryFuncImpl)__osEnqueueThread;
          iFunction++) {}
     if (iFunction < ARRAY_COUNTU(gaFunction) && nAddressEnqueueThread != -1) {
-        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, nAddressEnqueueThread)) {
+        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, nAddressEnqueueThread)) {
             return false;
         }
         *(pnCode++) = 0x7C000000 | iFunction;
@@ -3541,7 +3541,7 @@ static bool libraryFindFunctions(Library* pLibrary) {
             nAddress += 4;
         } while (nOpcode != 0x03E00008);
 
-        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, nAddress + 4)) {
+        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, nAddress + 4)) {
             return false;
         }
 
@@ -3554,7 +3554,7 @@ static bool libraryFindFunctions(Library* pLibrary) {
          iFunction < ARRAY_COUNTU(gaFunction) && gaFunction[iFunction].pfLibrary != (LibraryFuncImpl)__osDispatchThread;
          iFunction++) {}
     if (iFunction < ARRAY_COUNTU(gaFunction) && nAddressDispatchThread != -1) {
-        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, nAddressDispatchThread)) {
+        if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, nAddressDispatchThread)) {
             return false;
         }
 
@@ -3594,7 +3594,7 @@ bool libraryTestFunction(Library* pLibrary, CpuFunction* pFunction) {
             bDone = false;
             bReturn = true;
 
-            if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCode, pFunction->nAddress0)) {
+            if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCode, pFunction->nAddress0)) {
                 return false;
             }
 
@@ -3602,7 +3602,7 @@ bool libraryTestFunction(Library* pLibrary, CpuFunction* pFunction) {
             bFlag = MIPS_OP(nOpcode) == 0x1F ? false : true;
             if (gaFunction[iFunction].pfLibrary == (LibraryFuncImpl)osEepromLongRead && nChecksum == 0x5B919EF9) {
                 nAddress = (pFunction->nAddress0 & 0xF0000000) | (MIPS_TARGET(pnCode[17]) << 2);
-                if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCodeTemp, nAddress)) {
+                if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCodeTemp, nAddress)) {
                     return false;
                 }
                 if (pnCodeTemp[10] != 0xAFA00030) {
@@ -3612,7 +3612,7 @@ bool libraryTestFunction(Library* pLibrary, CpuFunction* pFunction) {
             } else if (gaFunction[iFunction].pfLibrary == (LibraryFuncImpl)osEepromLongWrite &&
                        nChecksum == 0x5B919EF9) {
                 nAddress = (pFunction->nAddress0 & 0xF0000000) | (MIPS_TARGET(pnCode[17]) << 2);
-                if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), &pnCodeTemp, nAddress)) {
+                if (!cpuGetAddressBuffer(SYSTEM_CPU(pLibrary->pHost), (void**)&pnCodeTemp, nAddress)) {
                     return false;
                 }
                 if (pnCodeTemp[10] == 0xAFA00030) {

--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -144,22 +144,22 @@ bool mcardReInit(MemCard* pMCard) {
     pMCard->writeToggle = true;
 
     if (pMCard->writeBuffer != NULL) {
-        if (!xlHeapFree(&pMCard->writeBuffer)) {
+        if (!xlHeapFree((void**)&pMCard->writeBuffer)) {
             return false;
         }
     }
 
     if (pMCard->readBuffer != NULL) {
-        if (!xlHeapFree(&pMCard->readBuffer)) {
+        if (!xlHeapFree((void**)&pMCard->readBuffer)) {
             return false;
         }
     }
 
-    if (!xlHeapTake(&pMCard->writeBuffer, 0x2000 | 0x30000000)) {
+    if (!xlHeapTake((void**)&pMCard->writeBuffer, 0x2000 | 0x30000000)) {
         return false;
     }
 
-    if (!xlHeapTake(&pMCard->readBuffer, 0x2000 | 0x30000000)) {
+    if (!xlHeapTake((void**)&pMCard->readBuffer, 0x2000 | 0x30000000)) {
         return false;
     }
 
@@ -347,7 +347,7 @@ static inline bool mcardFileRelease(MemCard* pMCard) {
 
     if (!pMCard->bufferCreated) {
         if (pMCard->file.game.buffer != NULL) {
-            if (!xlHeapFree(&pMCard->file.game.buffer)) {
+            if (!xlHeapFree((void**)&pMCard->file.game.buffer)) {
                 return false;
             }
         }
@@ -356,7 +356,7 @@ static inline bool mcardFileRelease(MemCard* pMCard) {
         memset(&pMCard->file.game.configuration, 0, sizeof(s32));
     }
 
-    if ((pMCard->file.game.writtenBlocks == NULL) || xlHeapFree(&pMCard->file.game.writtenBlocks)) {
+    if ((pMCard->file.game.writtenBlocks == NULL) || xlHeapFree((void**)&pMCard->file.game.writtenBlocks)) {
         pMCard->file.game.writtenConfig = 0;
         pMCard->file.currentGame = 16;
     }
@@ -367,7 +367,7 @@ static inline bool mcardFileRelease(MemCard* pMCard) {
 bool mcardGameRelease(MemCard* pMCard) {
     if (pMCard->bufferCreated == 0) {
         if (pMCard->file.game.buffer != NULL) {
-            if (!xlHeapFree(&pMCard->file.game.buffer)) {
+            if (!xlHeapFree((void**)&pMCard->file.game.buffer)) {
                 return false;
             }
         }
@@ -377,7 +377,7 @@ bool mcardGameRelease(MemCard* pMCard) {
     }
 
     if (pMCard->file.game.writtenBlocks != NULL) {
-        if (!xlHeapFree(&pMCard->file.game.writtenBlocks)) {
+        if (!xlHeapFree((void**)&pMCard->file.game.writtenBlocks)) {
             return false;
         }
     }

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -985,14 +985,14 @@ static bool rspAADPCMDec1Fast(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     nDMEMOut = pRSP->nAudioDMEMOut[0];
     nCount = pRSP->nAudioCount[0];
     nSrcAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pStateAddress, nSrcAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pStateAddress, nSrcAddress, NULL)) {
         return false;
     }
 
     if (!(nFlags & 1)) {
         pTempStateAddr = pStateAddress;
         if (nFlags & 2) {
-            if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pTempStateAddr, pRSP->nAudioLoopAddress, NULL)) {
+            if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pTempStateAddr, pRSP->nAudioLoopAddress, NULL)) {
                 return false;
             }
         }
@@ -1495,14 +1495,14 @@ static bool rspAADPCMDec2Fast(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     nDMEMOut = pRSP->nAudioDMEMOut[0];
     nCount = pRSP->nAudioCount[0];
     nSrcAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pStateAddress, nSrcAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pStateAddress, nSrcAddress, NULL)) {
         return false;
     }
 
     if (!(nFlags & 1)) {
         pTempStateAddr = pStateAddress;
         if (nFlags & 2) {
-            if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pTempStateAddr, pRSP->nAudioLoopAddress, NULL)) {
+            if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pTempStateAddr, pRSP->nAudioLoopAddress, NULL)) {
                 return false;
             }
         }
@@ -2636,7 +2636,7 @@ inline bool rspSetDL(Rsp* pRSP, s32 nOffsetRDRAM, bool bPush) {
     s32* pDL;
 
     nAddress = SEGMENT_ADDRESS(pRSP, nOffsetRDRAM);
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pDL, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pDL, nAddress, NULL)) {
         return false;
     }
 
@@ -3191,7 +3191,7 @@ bool rspInvalidateCache(Rsp* pRSP, s32 nOffset0, s32 nOffset1) {
 
         if ((nOffsetUCode1 <= offset0 && offset0 <= nOffsetUCode0) ||
             (nOffsetUCode1 <= offset1 && offset1 <= nOffsetUCode0)) {
-            if (!xlListFreeItem(pRSP->pListUCode, &pUCode)) {
+            if (!xlListFreeItem(pRSP->pListUCode, (void**)&pUCode)) {
                 return false;
             }
         }

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -2353,16 +2353,16 @@ bool xlMain(void) {
 
     gpSystem = NULL;
 
-    if (!xlObjectMake(&gpCode, NULL, &gClassCode)) {
+    if (!xlObjectMake((void**)&gpCode, NULL, &gClassCode)) {
         return false;
     }
-    if (!xlObjectMake(&gpFrame, NULL, &gClassFrame)) {
+    if (!xlObjectMake((void**)&gpFrame, NULL, &gClassFrame)) {
         return false;
     }
-    if (!xlObjectMake(&gpSound, NULL, &gClassSound)) {
+    if (!xlObjectMake((void**)&gpSound, NULL, &gClassSound)) {
         return false;
     }
-    if (!xlObjectMake(&gpSystem, NULL, &gClassSystem)) {
+    if (!xlObjectMake((void**)&gpSystem, NULL, &gClassSystem)) {
         return false;
     }
 
@@ -2395,16 +2395,16 @@ bool xlMain(void) {
 
     simulatorRun(&eMode);
 
-    if (!xlObjectFree(&gpSystem)) {
+    if (!xlObjectFree((void**)&gpSystem)) {
         return false;
     }
-    if (!xlObjectFree(&gpSound)) {
+    if (!xlObjectFree((void**)&gpSound)) {
         return false;
     }
-    if (!xlObjectFree(&gpFrame)) {
+    if (!xlObjectFree((void**)&gpFrame)) {
         return false;
     }
-    if (!xlObjectFree(&gpCode)) {
+    if (!xlObjectFree((void**)&gpCode)) {
         return false;
     }
 

--- a/src/emulator/system.c
+++ b/src/emulator/system.c
@@ -462,11 +462,11 @@ static bool systemSetupGameALL(System* pSystem) {
     pROM = SYSTEM_ROM(pSystem);
     pPIF = SYSTEM_PIF(pSystem);
 
-    if (!xlHeapTake(&mCard.saveIcon, gz_iconSize | 0x30000000)) {
+    if (!xlHeapTake((void**)&mCard.saveIcon, gz_iconSize | 0x30000000)) {
         return false;
     }
 
-    if (!xlHeapTake(&mCard.saveBanner, gz_bnrSize | 0x30000000)) {
+    if (!xlHeapTake((void**)&mCard.saveBanner, gz_bnrSize | 0x30000000)) {
         return false;
     }
 
@@ -474,7 +474,7 @@ static bool systemSetupGameALL(System* pSystem) {
     memset(&defaultConfiguration, 0, 4);
     pSystem->eTypeROM = SRT_UNKNOWN;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pSystem), &anMode, 0x300, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pSystem), (void**)&anMode, 0x300, NULL)) {
         return false;
     }
 
@@ -691,7 +691,7 @@ static bool systemSetupGameALL(System* pSystem) {
         nTickMultiplier = 2;
         fTickScale = 1.1f;
 
-        if (!ramGetBuffer(SYSTEM_RAM(pSystem), &anMode, 0x300U, NULL)) {
+        if (!ramGetBuffer(SYSTEM_RAM(pSystem), (void**)&anMode, 0x300U, NULL)) {
             return false;
         }
 
@@ -1136,17 +1136,17 @@ static bool systemSetupGameALL(System* pSystem) {
                     } else if (romTestCode(pROM, "NTEA")) {
                         pSystem->eTypeROM = SRT_1080;
 
-                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), &anMode, 0x300U, NULL)) {
+                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), (void**)&anMode, 0x300U, NULL)) {
                             return false;
                         }
 
                         anMode[4] = 0x17D7;
-                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), &anMode, 0x200U, NULL)) {
+                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), (void**)&anMode, 0x200U, NULL)) {
                             return false;
                         }
 
                         anMode[0] = 0xAC290000;
-                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), &anMode, 0x284U, NULL)) {
+                        if (!ramGetBuffer(SYSTEM_RAM(pSystem), (void**)&anMode, 0x284U, NULL)) {
                             return false;
                         }
 

--- a/src/emulator/xlFileGCN.c
+++ b/src/emulator/xlFileGCN.c
@@ -50,7 +50,7 @@ static inline bool xlFileGetFile(tXL_FILE** ppFile, char* szFileName) {
 }
 
 bool xlFileOpen(tXL_FILE** ppFile, XlFileType eType, char* szFileName) {
-    if (!xlObjectMake(ppFile, NULL, &gTypeFile)) {
+    if (!xlObjectMake((void**)ppFile, NULL, &gTypeFile)) {
         return false;
     }
 
@@ -62,12 +62,12 @@ bool xlFileOpen(tXL_FILE** ppFile, XlFileType eType, char* szFileName) {
         return true;
     }
 
-    xlObjectFree(ppFile);
+    xlObjectFree((void**)ppFile);
     return false;
 }
 
 bool xlFileClose(tXL_FILE** ppFile) {
-    if (!xlObjectFree(ppFile)) {
+    if (!xlObjectFree((void**)ppFile)) {
         return false;
     }
 

--- a/src/emulator/xlList.c
+++ b/src/emulator/xlList.c
@@ -8,7 +8,7 @@ static tXL_LIST gListList;
 bool xlListMake(tXL_LIST** ppList, s32 nItemSize) {
     nItemSize = (nItemSize + 3) & ~3;
 
-    if (xlListMakeItem(&gListList, ppList)) {
+    if (xlListMakeItem(&gListList, (void**)ppList)) {
         (*ppList)->nItemCount = 0;
         (*ppList)->nItemSize = nItemSize;
         (*ppList)->pNodeNext = NULL;

--- a/src/emulator/xlObject.c
+++ b/src/emulator/xlObject.c
@@ -17,7 +17,7 @@ static inline bool xlObjectFindData(__anon_0x5062** ppData, _XL_OBJECTTYPE* pTyp
 }
 
 static inline bool xlObjectMakeData(__anon_0x5062** ppData, _XL_OBJECTTYPE* pType) {
-    if (!xlListMakeItem(gpListData, ppData)) {
+    if (!xlListMakeItem(gpListData, (void**)ppData)) {
         return false;
     }
 


### PR DESCRIPTION
Later MWCC versions don't like the implicit casts. Not relevant for matching but useful for testing since other MWCC versions have been studied more than 1.1