### PR TITLE
Remove InsertBraces from .clang-format (for old clang-format versions)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,4 +23,3 @@ AllowShortEnumsOnASingleLine: false
 AlignEscapedNewlines: Left
 AlignTrailingComments: false
 SortIncludes: true
-InsertBraces: true


### PR DESCRIPTION
I don't think it adds too much so maybe it's not worth making users upgrade for this (some projects, like oot, require an old clang-format version). Lmk if you disagree though