### PR TITLE
Use bool everywhere in mcard

### DIFF
--- a/include/emulator/mcardGCN.h
+++ b/include/emulator/mcardGCN.h
@@ -3,7 +3,6 @@
 
 #include "dolphin.h"
 
-// __anon_0x1BD8E
 typedef enum MemCardCommand {
     MC_C_NONE = 0,
     MC_C_CONTINUE = 1,
@@ -14,7 +13,6 @@ typedef enum MemCardCommand {
     MC_C_FORMAT_CARD = 6,
 } MemCardCommand;
 
-// __anon_0x1B0CB
 typedef enum MemCardError {
     MC_E_NONE = 0,
     MC_E_BUSY = 1,
@@ -97,50 +95,49 @@ typedef enum MemCardMessage {
     MC_M_GF06 = 49,
 } MemCardMessage;
 
-// __anon_0x1AC1A
-typedef struct __anon_0x1AC1A {
+typedef struct MemCardGameInfo {
     /* 0x00 */ s32 configuration;
     /* 0x04 */ s32 size;
     /* 0x08 */ s32 offset;
     /* 0x0C */ char* buffer;
-    /* 0x10 */ s32* writtenBlocks;
-    /* 0x14 */ s32 writtenConfig;
-} __anon_0x1AC1A; // size = 0x18
+    /* 0x10 */ bool* writtenBlocks;
+    /* 0x14 */ bool writtenConfig;
+} MemCardGameInfo; // size = 0x18
 
-typedef struct __anon_0x1AEB5 {
+typedef struct MemCardFileInfo {
     /* 0x000 */ s32 currentGame;
     /* 0x004 */ s32 fileSize;
     /* 0x008 */ char name[33];
     /* 0x02C */ s32 numberOfGames;
-    /* 0x030 */ __anon_0x1AC1A game;
-    /* 0x048 */ s32 changedDate;
-    /* 0x04C */ s32 changedChecksum;
+    /* 0x030 */ MemCardGameInfo game;
+    /* 0x048 */ bool changedDate;
+    /* 0x04C */ bool changedChecksum;
     /* 0x050 */ s32 gameSize[16];
     /* 0x090 */ s32 gameOffset[16];
     /* 0x0D0 */ s32 gameConfigIndex[16];
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ OSCalendarTime time;
     /* 0x348 */ CARDFileInfo fileInfo;
-} __anon_0x1AEB5; // size = 0x35C
+} MemCardFileInfo; // size = 0x35C
 
 // __anon_0x1B36F
 typedef struct _MCARD {
-    /* 0x000 */ __anon_0x1AEB5 file;
+    /* 0x000 */ MemCardFileInfo file;
     /* 0x35C */ MemCardError error;
     /* 0x360 */ s32 slot;
     /* 0x364 */ bool (*pPollFunction)(void);
     /* 0x368 */ s32 pollPrevBytes;
     /* 0x36C */ s32 pollSize;
     /* 0x370 */ char pollMessage[256];
-    /* 0x470 */ s32 saveToggle;
+    /* 0x470 */ bool saveToggle;
     /* 0x474 */ char* writeBuffer;
     /* 0x478 */ char* readBuffer;
-    /* 0x47C */ s32 writeToggle;
-    /* 0x480 */ s32 soundToggle;
+    /* 0x47C */ bool writeToggle;
+    /* 0x480 */ bool soundToggle;
     /* 0x484 */ s32 writeStatus;
     /* 0x488 */ s32 writeIndex;
     /* 0x48C */ s32 accessType;
-    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x490 */ bool gameIsLoaded;
     /* 0x494 */ char saveFileName[256];
     /* 0x594 */ char saveComment[256];
     /* 0x694 */ char* saveIcon;
@@ -148,10 +145,10 @@ typedef struct _MCARD {
     /* 0x69C */ char saveGameName[256];
     /* 0x79C */ s32 saveFileSize;
     /* 0x7A0 */ s32 saveGameSize;
-    /* 0x7A4 */ s32 bufferCreated;
+    /* 0x7A4 */ bool bufferCreated;
     /* 0x7A8 */ s32 cardSize;
-    /* 0x7AC */ s32 wait;
-    /* 0x7B0 */ s32 isBroken;
+    /* 0x7AC */ bool wait;
+    /* 0x7B0 */ bool isBroken;
     /* 0x7B4 */ s32 saveConfiguration;
 } MemCard; // size = 0x7B8
 

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -1953,7 +1953,7 @@ bool simulatorReadEEPROM(u8 address, u8* data) {
         return false;
     }
 
-    mcardRead(&mCard, (address * 8) & 0x7F8, 8, (char*)data);
+    mcardRead(&mCard, address * 8, 8, (char*)data);
     return true;
 }
 
@@ -1964,7 +1964,7 @@ bool simulatorWriteEEPROM(u8 address, u8* data) {
         return false;
     }
 
-    mcardWrite(&mCard, (address * 8) & 0x7F8, 8, (char*)data);
+    mcardWrite(&mCard, address * 8, 8, (char*)data);
     return true;
 }
 
@@ -2483,9 +2483,9 @@ bool xlMain(void) {
         return false;
     }
 
-    mCard.bufferCreated = 0;
+    mCard.bufferCreated = false;
 #if VERSION != MQ_J
-    mCard.isBroken = 0;
+    mCard.isBroken = false;
 #endif
     mcardInit(&mCard);
 

--- a/src/emulator/system.c
+++ b/src/emulator/system.c
@@ -1538,7 +1538,7 @@ static bool systemSetupGameALL(System* pSystem) {
         }
     }
 
-    if (mCard.saveToggle == 1) {
+    if (mCard.saveToggle == true) {
         systemSetControllerConfiguration(&gSystemRomConfigurationList[0], mCard.file.game.configuration, false);
     }
 


### PR DESCRIPTION
Part 1 of mcard cleanups. For things named `toggle` I'm not sure whether to use `true/false` or `0/1` (like an enum, I guess), since they do `toggle == 1` a lot. Then again, the also do `someFunctionReturningABool() == true` a lot too so maybe that's just the style in this file.