### PR TITLE
Document memory card format, add macros for offsets + sizes

### DIFF
--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -33,6 +33,7 @@
 // Checksums are a simple sum of all 32-bit words in the block, with the exception of the checksum field itself.
 // If the checksum is 0, it is replaced with 1 to avoid having a valid block with all 0s.
 
+// Same as CARD_SYSTEM_BLOCK_SIZE (but signed instead of unsigned)
 #define BLOCK_SIZE 0x2000
 #define HEADER_SIZE (3 * BLOCK_SIZE)
 


### PR DESCRIPTION
I considered computing the sizes of everything (e.g. `sizeof(OSCalendarTime)` instead of 0x28) but it got weird since the size of the game names section is wrong in the format.