### PR TITLE
Allow building without a default version (ce-j)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -121,8 +121,15 @@ config.versions = [
     for version in ALL_VERSIONS
     if (Path("orig") / version / "main.dol").exists()
 ]
+
+if not config.versions:
+    sys.exit("Error: no main.dol found for any version")
+
 if "ce-j" in config.versions:
     config.default_version = "ce-j"
+else:
+    # Use the earliest version as default
+    config.default_version = config.versions[0]
 
 config.warn_missing_config = True
 config.warn_missing_source = False

--- a/tools/project.py
+++ b/tools/project.py
@@ -177,6 +177,7 @@ class ProjectConfig:
             "ldflags",
             "linker_version",
             "libs",
+            "default_version",
         ]
         for attr in required_attrs:
             if getattr(self, attr) is None:

--- a/tools/project.py
+++ b/tools/project.py
@@ -177,7 +177,6 @@ class ProjectConfig:
             "ldflags",
             "linker_version",
             "libs",
-            "default_version",
         ]
         for attr in required_attrs:
             if getattr(self, attr) is None:


### PR DESCRIPTION
Currently if try to set up only mq-j, you can't, because project.py requires that `default_version` exists even though nothing relies on this (the default target for ninja is only generated if `default_version is not None`).