### PR TITLE
Match some RSP audio functions

### DIFF
--- a/include/emulator/rsp.h
+++ b/include/emulator/rsp.h
@@ -35,14 +35,14 @@
 #define AUDIO_SEGMENT_ADDRESS(pRSP, nOffsetRDRAM) \
     (pRSP->anAudioBaseSegment[((nOffsetRDRAM) >> 24) & 0xF] + ((nOffsetRDRAM) & 0xFFFFFF))
 
-typedef enum __anon_0x581E7 {
+typedef enum RspAudioUCodeType {
     RUT_NOCODE = -1,
     RUT_ABI1 = 0,
     RUT_ABI2 = 1,
     RUT_ABI3 = 2,
     RUT_ABI4 = 3,
     RUT_UNKNOWN = 4,
-} __anon_0x581E7;
+} RspAudioUCodeType;
 
 typedef enum RspUCodeType {
     RUT_NONE = -1,
@@ -227,7 +227,7 @@ typedef struct Rsp {
     /* 0x38C8 */ s16 nVCC;
     /* 0x38CA */ s16 nVC0;
     /* 0x38CC */ char nVCE;
-    /* 0x38D0 */ __anon_0x581E7 eTypeAudioUCode;
+    /* 0x38D0 */ RspAudioUCodeType eTypeAudioUCode;
     /* 0x38D4 */ u16 nAudioMemOffset;
     /* 0x38D6 */ u16 nAudioADPCMOffset;
     /* 0x38D8 */ u16 nAudioScratchOffset;

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -1305,7 +1305,35 @@ static bool rspASetBuffer1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     return true;
 }
 
-#pragma GLOBAL_ASM("asm/non_matchings/rsp/rspASetVolume1.s")
+static bool rspASetVolume1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    u16 nFlags = (nCommandHi >> 16) & 0xFF;
+    u16 v = nCommandHi & 0xFFFF;
+    u16 t = (nCommandLo >> 16) & 0xFFFF;
+    u16 r = nCommandLo & 0xFFFF;
+
+    if (nFlags & 8) {
+        pRSP->anAudioBuffer[0x1BE] = v;
+        pRSP->anAudioBuffer[0x1BF] = r;
+    } else if (nFlags & 4) {
+        if (nFlags & 2) {
+            pRSP->anAudioBuffer[0x1B3] = v;
+        } else {
+            pRSP->anAudioBuffer[0x1B4] = v;
+        }
+    } else {
+        if (nFlags & 2) {
+            pRSP->anAudioBuffer[0x1B8] = v;
+            pRSP->anAudioBuffer[0x1B9] = t;
+            pRSP->anAudioBuffer[0x1BA] = r;
+        } else {
+            pRSP->anAudioBuffer[0x1BB] = v;
+            pRSP->anAudioBuffer[0x1BC] = t;
+            pRSP->anAudioBuffer[0x1BD] = r;
+        }
+    }
+
+    return true;
+}
 
 static bool rspParseABI(Rsp* pRSP, RspTask* pTask) {
     u8* pFUCode;

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -1275,7 +1275,35 @@ static bool rspAPoleFilter1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
 
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspAResample1.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/rsp/rspASetBuffer1.s")
+static bool rspASetBuffer1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    u16 nDMEMIn = nCommandHi & 0xFFFF;
+    u16 nDMEMOut = (nCommandLo >> 16) & 0xFFFF;
+    u16 nCount = nCommandLo & 0xFFFF;
+
+    if ((nCommandHi >> 16) & 8) {
+        pRSP->nAudioDMauxR[1] = nCount + pRSP->nAudioMemOffset;
+        pRSP->nAudioDMauxR[0] = (u16)((s32)pRSP->nAudioDMauxR[1] / 2);
+        pRSP->anAudioBuffer[0x1B7] = (s16)pRSP->nAudioDMauxR[1];
+        pRSP->nAudioDMOutR[1] = nDMEMIn + pRSP->nAudioMemOffset;
+        pRSP->nAudioDMOutR[0] = (u16)((s32)pRSP->nAudioDMOutR[1] / 2);
+        pRSP->anAudioBuffer[0x1B5] = (s16)pRSP->nAudioDMOutR[1];
+        pRSP->nAudioDMauxL[1] = nDMEMOut + pRSP->nAudioMemOffset;
+        pRSP->nAudioDMauxL[0] = (u16)((s32)pRSP->nAudioDMauxL[1] / 2);
+        pRSP->anAudioBuffer[0x1B6] = (s16)pRSP->nAudioDMauxL[1];
+    } else {
+        pRSP->nAudioCount[1] = nCount;
+        pRSP->nAudioCount[0] = (u16)((s32)pRSP->nAudioCount[1] / 2);
+        pRSP->anAudioBuffer[0x1B2] = (s16)pRSP->nAudioCount[1];
+        pRSP->nAudioDMEMIn[1] = nDMEMIn + pRSP->nAudioMemOffset;
+        pRSP->nAudioDMEMIn[0] = (u16)((s32)pRSP->nAudioDMEMIn[1] / 2);
+        pRSP->anAudioBuffer[0x1B0] = (s16)pRSP->nAudioDMEMIn[1];
+        pRSP->nAudioDMEMOut[1] = nDMEMOut + pRSP->nAudioMemOffset;
+        pRSP->nAudioDMEMOut[0] = (u16)((s32)pRSP->nAudioDMEMOut[1] / 2);
+        pRSP->anAudioBuffer[0x1B1] = (s16)pRSP->nAudioDMEMOut[1];
+    }
+
+    return true;
+}
 
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspASetVolume1.s")
 

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -1754,8 +1754,35 @@ static inline bool rspALoadADPCM2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
 static bool rspAMix2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi);
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspAMix2.s")
 
-static bool rspAInterleave2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi);
-#pragma GLOBAL_ASM("asm/non_matchings/rsp/rspAInterleave2.s")
+static bool rspAInterleave2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
+    s32 outp;
+    s32 inpr;
+    s32 inpl;
+    s32 count;
+    s32 i;
+
+    outp = (s32)(nCommandHi & 0xFFFF) >> 1;
+    inpr = (s32)(nCommandLo & 0xFFFF) >> 1;
+    inpl = (s32)(nCommandLo >> 16) >> 1;
+    count = (nCommandHi >> 12) & 0xFF0;
+
+    outp += 8;
+    for (i = 0; i < count; i += 8) {
+        pRSP->anAudioBuffer[outp - 8] = pRSP->anAudioBuffer[inpl + 0];
+        pRSP->anAudioBuffer[outp - 7] = pRSP->anAudioBuffer[inpr + 0];
+        pRSP->anAudioBuffer[outp - 6] = pRSP->anAudioBuffer[inpl + 1];
+        pRSP->anAudioBuffer[outp - 5] = pRSP->anAudioBuffer[inpr + 1];
+        pRSP->anAudioBuffer[outp - 4] = pRSP->anAudioBuffer[inpl + 2];
+        pRSP->anAudioBuffer[outp - 3] = pRSP->anAudioBuffer[inpr + 2];
+        pRSP->anAudioBuffer[outp - 2] = pRSP->anAudioBuffer[inpl + 3];
+        pRSP->anAudioBuffer[outp - 1] = pRSP->anAudioBuffer[inpr + 3];
+        outp += 8;
+        inpl += 4;
+        inpr += 4;
+    }
+
+    return true;
+}
 
 static bool rspADistFilter2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi);
 #pragma GLOBAL_ASM("asm/non_matchings/rsp/rspADistFilter2.s")


### PR DESCRIPTION
Mainly `rspParseABI[1-4]` and some of its helper functions. I mostly gave up on documenting because I'm not sure which ABI corresponds to which games (although I think ABI1 is sm64 and ABI2 is oot at least)