### PR TITLE
Fix permuter tool paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Run `tools/decompme.py <c-file> <asm-file>` (e.g. `tools/decompme.py src/emulato
 ### Permuter
 
 To import a function for [decomp-permuter](https://github.com/simonlindholm/decomp-permuter), ensure `powerpc-eabi-objdump` binary
-is on your `PATH` (for instance by adding `tools/binutils` from this project) and run something like
+is on your `PATH` (for instance by adding `build/binutils` from this project) and run something like
 
 ```sh
 path/to/permuter/import.py src/emulator/THPRead.c asm/non_matchings/THPRead/Reader.s

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -1,6 +1,6 @@
 compiler_type = "mwcc"
-compiler_command = "wibo tools/mwcc_compiler/GC/1.1/mwcceppc.exe -Cpp_exceptions off -proc gekko -fp hardware -fp_contract on -enum int -align powerpc -nosyspath -RTTI off -str reuse -multibyte -O4,p -inline auto,deferred -nodefaults -msgstyle gcc -Iinclude -Ilibc -c"
-assembler_command = "tools/binutils/powerpc-eabi-as -mgekko"
+compiler_command = "build/tools/wibo build/compilers/GC/1.1/mwcceppc.exe -Cpp_exceptions off -proc gekko -fp hardware -fp_contract on -enum int -align powerpc -nosyspath -RTTI off -str reuse -multibyte -O4,p -inline auto,deferred -nodefaults -msgstyle gcc -Iinclude -Ilibc -c"
+assembler_command = "build/binutils/powerpc-eabi-as -mgekko"
 asm_prelude_file = "include/macros.inc"
 
 [preserve_macros]


### PR DESCRIPTION
Stuff has moved around since the dtk migration