### PR TITLE
Simplify setup using auto-extract feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ __pycache__/
 
 # Permuter artifacts
 nonmatchings/
+
+# Original files
+orig/*/*
+!orig/*/.gitkeep

--- a/README.md
+++ b/README.md
@@ -79,26 +79,13 @@ To get objdiff to work properly you also need to add the path to the folder cont
 
 1. Clone the repo using `git clone https://github.com/zeldaret/oot-gc`.
 
-2. Extract the following TGC archive containing the N64 emulator from the disc of the version you want to build:
-
-  * `mq-j`: `zlj_f.tgc`
-  * `mq-u`: `zlj_f.tgc`
-  * `mq-e`: `zlj_f.tgc`
-  * `ce-j`: `120903_zelda.tgc`
-  * `ce-u`: `zelda_ENG_090903.tgc`
-  * `ce-e`: `zelda_PAL_093003.tgc`
-
-  Then, extract the DOL file from the TGC archive and place it in the repo as `orig/<version>/main.dol`.
-
-  You can use [Dolphin](https://dolphin-emu.org) to perform both of these extraction steps:
-  first, right click on the `.iso` file, select "Properties", go to the "Filesystem" tab, find the correct
-  `.tgc` file, then right-click and select "Extract File..." and extract it to your games folder.
-  Then, right-click the extracted `.tgc` file in Dolphin, select "Properties", go to the "Filesystem" tab,
-  right-click the "Disc" and select "Extract System Data..." to extract the DOL file.
+2. Copy the disc image of the version you want to decompile into the appropriate `orig/*` directory. _(Supported formats: ISO (GCM), RVZ, WIA, WBFS, CISO, NFS, GCZ, TGC)_
 
 3. Run `python3 configure.py` to generate the build. (Note: on Windows you might need to run ``python configure.py``.)
 
 4. Run `ninja` to build the `ce-j` version, or run `ninja <version>` to build another version.
+
+5. After the initial build, you can delete the disc image(s) from the `orig/*` directories.
 
 ## Development Tools
 

--- a/config/ce-e/config.yml
+++ b/config/ce-e/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/ce-e/main.dol
+object_base: orig/ce-e
+object: files/tgc/zelda_PAL_093003.tgc:sys/main.dol
 hash: 8c5c365ae2df34c4cb27e86eb1cf30f2a2e4cd1b
 symbols: config/ce-e/symbols.txt
 splits: config/ce-e/splits.txt

--- a/config/ce-j/config.yml
+++ b/config/ce-j/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/ce-j/main.dol
+object_base: orig/ce-j
+object: files/tgc/120903_zelda.tgc:sys/main.dol
 hash: aed1c15af4d667a3cffd8621a6bb3fd08b4c3b04
 symbols: config/ce-j/symbols.txt
 splits: config/ce-j/splits.txt

--- a/config/ce-u/config.yml
+++ b/config/ce-u/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/ce-u/main.dol
+object_base: orig/ce-u
+object: files/tgc/zelda_ENG_090903.tgc:sys/main.dol
 hash: eaec2d80639095b751c68d9371f7aac7e5c7dbc7
 symbols: config/ce-u/symbols.txt
 splits: config/ce-u/splits.txt

--- a/config/mq-e/config.yml
+++ b/config/mq-e/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/mq-e/main.dol
+object_base: orig/mq-e
+object: files/zlj_f.tgc:sys/main.dol
 hash: 9155899e1ed86fc2b25113c77d49396c77d24138
 symbols: config/mq-e/symbols.txt
 splits: config/mq-e/splits.txt

--- a/config/mq-j/config.yml
+++ b/config/mq-j/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/mq-j/main.dol
+object_base: orig/mq-j
+object: files/zlj_f.tgc:sys/main.dol
 hash: 7bfa2acdf675b5c5442890688d1e0293817ad63f
 symbols: config/mq-j/symbols.txt
 splits: config/mq-j/splits.txt

--- a/config/mq-u/config.yml
+++ b/config/mq-u/config.yml
@@ -1,6 +1,7 @@
 # See config.example.yml for documentation.
 name: oot-gc
-object: orig/mq-u/main.dol
+object_base: orig/mq-u
+object: files/zlj_f.tgc:sys/main.dol
 hash: 1bd1d5e7c13dc94c2090d458c9e6706932e611a8
 symbols: config/mq-u/symbols.txt
 splits: config/mq-u/splits.txt

--- a/configure.py
+++ b/configure.py
@@ -14,6 +14,7 @@
 
 import argparse
 import sys
+import glob
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -112,7 +113,12 @@ args = parser.parse_args()
 
 config = ProjectConfig()
 
-# Only configure versions for which main.dol exists
+
+# Only configure versions for which an orig file exists
+def version_exists(version: str) -> bool:
+    return glob.glob(str(Path("orig") / version / "*")) != []
+
+
 ALL_VERSIONS = [
     "mq-j",
     "mq-u",
@@ -124,11 +130,11 @@ ALL_VERSIONS = [
 config.versions = [
     version
     for version in ALL_VERSIONS
-    if (Path("orig") / version / "main.dol").exists()
+    if version_exists(version)
 ]
 
 if not config.versions:
-    sys.exit("Error: no main.dol found for any version")
+    sys.exit("Error: no orig files found for any version")
 
 if "ce-j" in config.versions:
     config.default_version = "ce-j"
@@ -160,8 +166,8 @@ if args.no_asm:
 
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20231018"
-config.dtk_tag = "v0.8.3"
-config.objdiff_tag = "v2.0.0-beta.5"
+config.dtk_tag = "v1.1.3"
+config.objdiff_tag = "v2.3.2"
 config.sjiswrap_tag = "v1.1.1"
 config.wibo_tag = "0.6.11"
 config.linker_version = "GC/1.1"


### PR DESCRIPTION
This updates to the latest decomp-toolkit version and enables support for auto-extracting the orig file(s) from a disc image.

The new structure of the `orig` directory after extraction:
```
orig/ce-e/files/tgc/zelda_PAL_093003/sys/main.dol
orig/ce-j/files/tgc/120903_zelda/sys/main.dol
orig/ce-u/files/tgc/zelda_ENG_090903/sys/main.dol
orig/mq-e/files/zlj_f/sys/main.dol
orig/mq-j/files/zlj_f/sys/main.dol
orig/mq-u/files/zlj_f/sys/main.dol
```