### PR TITLE
Use s32 only for long types in debug info

### DIFF
--- a/debug/Core/xlCoreGCN.c
+++ b/debug/Core/xlCoreGCN.c
@@ -11,7 +11,7 @@
 u8 gTgPcTPL[32897];
 
 // size = 0x4, address = 0x80135580
-static s32 gnCountArgument;
+static int gnCountArgument;
 
 // size = 0x4, address = 0x80135584
 static char** gaszArgument;
@@ -85,7 +85,7 @@ struct _GXTexObj g_texMap[4];
 struct _GXRenderModeObj* rmode;
 
 // size = 0x4, address = 0x80135420
-s32 __OSCurrHeap;
+int __OSCurrHeap;
 
 // size = 0x4, address = 0x80135A94
 void* DemoFrameBuffer1;
@@ -184,16 +184,16 @@ static void xlCoreInit(struct _GXRenderModeObj* mode) {
     // -> void* DemoFrameBuffer1;
     // -> static void* DefaultFifo;
     // -> static struct __anon_0x238* DefaultFifoObj;
-    // -> s32 __OSCurrHeap;
+    // -> int __OSCurrHeap;
 }
 
 // Range: 0x80005DC8 -> 0x80005E04
-s32 xlCoreReset() {
+int xlCoreReset() {
     // References
     // -> static void* gArenaHi;
     // -> static void* gArenaLo;
     // -> static void* gpHeap;
-    // -> s32 __OSCurrHeap;
+    // -> int __OSCurrHeap;
 }
 
 // Range: 0x80005C54 -> 0x80005DC8
@@ -203,7 +203,7 @@ static void xlCoreInitRenderMode(struct _GXRenderModeObj* mode) {
 
     // Local variables
     char* szText; // r31
-    s32 iArgument; // r5
+    int iArgument; // r5
 
     // References
     // -> static struct _GXRenderModeObj rmodeobj;
@@ -211,7 +211,7 @@ static void xlCoreInitRenderMode(struct _GXRenderModeObj* mode) {
     // -> struct _GXRenderModeObj GXMpal480IntDf;
     // -> struct _GXRenderModeObj GXPal528IntDf;
     // -> struct _GXRenderModeObj GXNtsc480Prog;
-    // -> static s32 gnCountArgument;
+    // -> static int gnCountArgument;
     // -> static char** gaszArgument;
     // -> struct _GXRenderModeObj GXNtsc480IntDf;
 }
@@ -252,46 +252,46 @@ static void xlCoreInitVI() {
 }
 
 // Range: 0x80005918 -> 0x80005920
-s32 xlCoreGetArgumentCount() {
+int xlCoreGetArgumentCount() {
     // References
-    // -> static s32 gnCountArgument;
+    // -> static int gnCountArgument;
 }
 
 // Range: 0x800058E4 -> 0x80005918
-s32 xlCoreGetArgument(s32 iArgument, char** pszArgument) {
+int xlCoreGetArgument(int iArgument, char** pszArgument) {
     // Parameters
-    // s32 iArgument; // r1+0x0
+    // int iArgument; // r1+0x0
     // char** pszArgument; // r1+0x4
 
     // References
     // -> static char** gaszArgument;
-    // -> static s32 gnCountArgument;
+    // -> static int gnCountArgument;
 }
 
 // Range: 0x800058DC -> 0x800058E4
-s32 xlCoreHiResolution() {}
+int xlCoreHiResolution() {}
 
 // Erased
-static s32 xlCoreEnableFPExceptions() {
+static int xlCoreEnableFPExceptions() {
     // Local variables
     f64 control; // r1+0x8
     union DoubleLongLong d; // r1+0x8
 }
 
 // Erased
-static s32 xlCoreGetUpper24MB(void* ppBuffer) {
+static int xlCoreGetUpper24MB(void* ppBuffer) {
     // Parameters
     // void* ppBuffer; // r1+0x0
 }
 
 // Range: 0x80005674 -> 0x800058DC
-s32 main(s32 nCount, char** aszArgument) {
+int main(int nCount, char** aszArgument) {
     // Parameters
-    // s32 nCount; // r1+0x8
+    // int nCount; // r1+0x8
     // char** aszArgument; // r1+0xC
 
     // Local variables
-    s32 nSize; // r31
+    int nSize; // r31
     void* pHeap; // r27
     s32 nSizeHeap; // r3
     struct __anon_0xD1E* tdp; // r1+0x8
@@ -299,7 +299,7 @@ s32 main(s32 nCount, char** aszArgument) {
     u32 i; // r26
 
     // References
-    // -> s32 __OSCurrHeap;
+    // -> int __OSCurrHeap;
     // -> static void* gpHeap;
     // -> struct _GXTexObj g_texMap[4];
     // -> u8 gTgPcTPL[32897];
@@ -310,7 +310,7 @@ s32 main(s32 nCount, char** aszArgument) {
     // -> static void* DefaultFifo;
     // -> static struct __anon_0x238* DefaultFifoObj;
     // -> static char** gaszArgument;
-    // -> static s32 gnCountArgument;
+    // -> static int gnCountArgument;
 }
 
 // Range: 0x800055A0 -> 0x80005674

--- a/debug/Core/xlFileGCN.c
+++ b/debug/Core/xlFileGCN.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x19EC; // size = 0x10
 
 // size = 0x10, address = 0x800DB7E0
@@ -50,18 +50,18 @@ typedef struct DVDFileInfo {
 } __anon_0x1ED3; // size = 0x3C
 
 // size = 0x4, address = 0x801355A0
-static s32 (*gpfOpen)(char*, struct DVDFileInfo*);
+static int (*gpfOpen)(char*, struct DVDFileInfo*);
 
 // size = 0x4, address = 0x801355A4
-static s32 (*gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+static int (*gpfRead)(struct DVDFileInfo*, void*, int, int, void (*)(s32, struct DVDFileInfo*));
 
 typedef struct tXL_FILE {
-    /* 0x00 */ s32 iBuffer;
+    /* 0x00 */ int iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
-    /* 0x0C */ s32 nAttributes;
-    /* 0x10 */ s32 nSize;
-    /* 0x14 */ s32 nOffset;
+    /* 0x0C */ int nAttributes;
+    /* 0x10 */ int nSize;
+    /* 0x14 */ int nOffset;
     /* 0x18 */ enum __anon_0x2757 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x2085; // size = 0x58
@@ -73,142 +73,142 @@ typedef enum __anon_0x2757 {
 } __anon_0x2757;
 
 // Range: 0x80006274 -> 0x80006280
-s32 xlFileSetOpen(s32 (*pfOpen)(char*, struct DVDFileInfo*)) {
+int xlFileSetOpen(int (*pfOpen)(char*, struct DVDFileInfo*)) {
     // Parameters
-    // s32 (* pfOpen)(char*, struct DVDFileInfo*); // r1+0x0
+    // int (* pfOpen)(char*, struct DVDFileInfo*); // r1+0x0
 
     // References
-    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> static int (* gpfOpen)(char*, struct DVDFileInfo*);
 }
 
 // Range: 0x80006268 -> 0x80006274
-s32 xlFileSetRead(s32 (*pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*))) {
+int xlFileSetRead(int (*pfRead)(struct DVDFileInfo*, void*, int, int, void (*)(s32, struct DVDFileInfo*))) {
     // Parameters
-    // s32 (* pfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*)); // r1+0x0
+    // int (* pfRead)(struct DVDFileInfo*, void*, int, int, void (*)(s32, struct DVDFileInfo*)); // r1+0x0
 
     // References
-    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+    // -> static int (* gpfRead)(struct DVDFileInfo*, void*, int, int, void (*)(s32, struct DVDFileInfo*));
 }
 
 // Range: 0x8000614C -> 0x80006268
-s32 xlFileGetSize(s32* pnSize, char* szFileName) {
+int xlFileGetSize(int* pnSize, char* szFileName) {
     // Parameters
-    // s32* pnSize; // r31
+    // int* pnSize; // r31
     // char* szFileName; // r30
 
     // Local variables
     struct tXL_FILE* pFile; // r1+0x10
 
     // References
-    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> static int (* gpfOpen)(char*, struct DVDFileInfo*);
     // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
 // Erased
-static s32 xlFileLoad(char* szFileName, void* ppBuffer) {
+static int xlFileLoad(char* szFileName, void* ppBuffer) {
     // Parameters
     // char* szFileName; // r30
     // void* ppBuffer; // r31
 
     // Local variables
-    s32 nSize; // r1+0x18
+    int nSize; // r1+0x18
     struct tXL_FILE* pFile; // r1+0x14
 
     // References
-    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> static int (* gpfOpen)(char*, struct DVDFileInfo*);
     // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
 // Range: 0x80006078 -> 0x8000614C
-s32 xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {
+int xlFileOpen(struct tXL_FILE** ppFile, enum __anon_0x2757 eType, char* szFileName) {
     // Parameters
     // struct tXL_FILE** ppFile; // r29
     // enum __anon_0x2757 eType; // r30
     // char* szFileName; // r31
 
     // Local variables
-    s32 nStatus; // r3
+    int nStatus; // r3
 
     // References
-    // -> static s32 (* gpfOpen)(char*, struct DVDFileInfo*);
+    // -> static int (* gpfOpen)(char*, struct DVDFileInfo*);
     // -> struct _XL_OBJECTTYPE gTypeFile;
 }
 
 // Erased
-static s32 xlFileCreate() {}
+static int xlFileCreate() {}
 
 // Range: 0x80006044 -> 0x80006078
-s32 xlFileClose(struct tXL_FILE** ppFile) {
+int xlFileClose(struct tXL_FILE** ppFile) {
     // Parameters
     // struct tXL_FILE** ppFile; // r3
 }
 
 // Range: 0x80005F40 -> 0x80006044
-s32 xlFileGet(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
+int xlFileGet(struct tXL_FILE* pFile, void* pTarget, int nSizeBytes) {
     // Parameters
     // struct tXL_FILE* pFile; // r27
     // void* pTarget; // r28
-    // s32 nSizeBytes; // r29
+    // int nSizeBytes; // r29
 
     // Local variables
-    s32 nOffset; // r6
-    s32 nOffsetExtra; // r1+0x8
-    s32 nSize; // r5
-    s32 nSizeUsed; // r30
+    int nOffset; // r6
+    int nOffsetExtra; // r1+0x8
+    int nSize; // r5
+    int nSizeUsed; // r30
 
     // References
-    // -> static s32 (* gpfRead)(struct DVDFileInfo*, void*, s32, s32, void (*)(s32, struct DVDFileInfo*));
+    // -> static int (* gpfRead)(struct DVDFileInfo*, void*, int, int, void (*)(s32, struct DVDFileInfo*));
 }
 
 // Erased
-static s32 xlFileGetFlip(struct tXL_FILE* pFile, void* pTarget, s32 nSizeBytes) {
+static int xlFileGetFlip(struct tXL_FILE* pFile, void* pTarget, int nSizeBytes) {
     // Parameters
     // struct tXL_FILE* pFile; // r30
     // void* pTarget; // r31
-    // s32 nSizeBytes; // r1+0x10
+    // int nSizeBytes; // r1+0x10
 }
 
 // Erased
-static s32 xlFileGetLine(struct tXL_FILE* pFile, char* acLine, s32 nSizeLine) {
+static int xlFileGetLine(struct tXL_FILE* pFile, char* acLine, int nSizeLine) {
     // Parameters
     // struct tXL_FILE* pFile; // r28
     // char* acLine; // r29
-    // s32 nSizeLine; // r30
+    // int nSizeLine; // r30
 
     // Local variables
-    s32 iCharacter; // r31
+    int iCharacter; // r31
     char nCharacter; // r1+0x14
 }
 
 // Erased
-static s32 xlFilePut() {}
+static int xlFilePut() {}
 
 // Erased
-static s32 xlFilePutFlip(s32 nSizeBytes) {
+static int xlFilePutFlip(int nSizeBytes) {
     // Parameters
-    // s32 nSizeBytes; // r1+0x8
+    // int nSizeBytes; // r1+0x8
 }
 
 // Erased
-static s32 xlFilePutLine() {}
+static int xlFilePutLine() {}
 
 // Range: 0x80005F18 -> 0x80005F40
-s32 xlFileSetPosition(struct tXL_FILE* pFile, s32 nOffset) {
+int xlFileSetPosition(struct tXL_FILE* pFile, int nOffset) {
     // Parameters
     // struct tXL_FILE* pFile; // r1+0x0
-    // s32 nOffset; // r1+0x4
+    // int nOffset; // r1+0x4
 }
 
 // Erased
-static s32 xlFileGetPosition(struct tXL_FILE* pFile, s32* pnOffset) {
+static int xlFileGetPosition(struct tXL_FILE* pFile, int* pnOffset) {
     // Parameters
     // struct tXL_FILE* pFile; // r1+0x0
-    // s32* pnOffset; // r1+0x4
+    // int* pnOffset; // r1+0x4
 }
 
 // Range: 0x80005E68 -> 0x80005F18
-s32 xlFileEvent(struct tXL_FILE* pFile, s32 nEvent) {
+int xlFileEvent(struct tXL_FILE* pFile, int nEvent) {
     // Parameters
     // struct tXL_FILE* pFile; // r31
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
 }

--- a/debug/Core/xlHeap.c
+++ b/debug/Core/xlHeap.c
@@ -8,33 +8,33 @@
 #include "dolphin/types.h"
 
 // size = 0x4, address = 0x801355A8
-static u32* gpHeap;
+static unsigned int* gpHeap;
 
 // size = 0x4, address = 0x801355AC
-static u32* gpHeapBlockFirst;
+static unsigned int* gpHeapBlockFirst;
 
 // size = 0x4, address = 0x801355B0
-static u32* gpHeapBlockLast;
+static unsigned int* gpHeapBlockLast;
 
 // size = 0x4, address = 0x801355B4
-static s32 gnHeapTakeCount;
+static int gnHeapTakeCount;
 
 // size = 0x4, address = 0x801355B8
-static s32 gnHeapFreeCount;
+static int gnHeapFreeCount;
 
 // size = 0x4, address = 0x801355BC
-static s32 gnHeapTakeCacheCount;
+static int gnHeapTakeCacheCount;
 
 // size = 0x580, address = 0x800F3FB0
-static u32* gapHeapBlockCache[11][32];
+static unsigned int* gapHeapBlockCache[11][32];
 
 // size = 0x4, address = 0x801355C0
-s32 gnSizeHeap;
+int gnSizeHeap;
 
 // Erased
-static s32 xlHeapTestBlock(u32 nBlock) {
+static int xlHeapTestBlock(unsigned int nBlock) {
     // Parameters
-    // u32 nBlock; // r1+0x0
+    // unsigned int nBlock; // r1+0x0
 }
 
 // Erased
@@ -43,183 +43,183 @@ static void xlHeapShowStatistics() {}
 // Erased
 static void xlHeapStatisticsReset() {
     // References
-    // -> static s32 gnHeapFreeCount;
-    // -> static s32 gnHeapTakeCount;
-    // -> static s32 gnHeapTakeCacheCount;
+    // -> static int gnHeapFreeCount;
+    // -> static int gnHeapTakeCount;
+    // -> static int gnHeapTakeCacheCount;
 }
 
 // Range: 0x800079C0 -> 0x80007BC0
-static s32 xlHeapBlockCacheGet(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+static int xlHeapBlockCacheGet(int nSize, unsigned int** ppBlock, int* pnBlockSize) {
     // Parameters
-    // s32 nSize; // r1+0x0
-    // u32** ppBlock; // r1+0x4
-    // s32* pnBlockSize; // r1+0x8
+    // int nSize; // r1+0x0
+    // unsigned int** ppBlock; // r1+0x4
+    // int* pnBlockSize; // r1+0x8
 
     // Local variables
-    s32 nBlockCachedSize; // r1+0x0
-    s32 nBlock; // r8
-    s32 nBlockSize; // r9
-    s32 nBlockBest; // r10
-    s32 nBlockBestSize; // r11
-    u32* pBlock; // r12
+    int nBlockCachedSize; // r1+0x0
+    int nBlock; // r8
+    int nBlockSize; // r9
+    int nBlockBest; // r10
+    int nBlockBestSize; // r11
+    unsigned int* pBlock; // r12
 
     // References
-    // -> static s32 gnHeapTakeCacheCount;
-    // -> static u32* gapHeapBlockCache[11][32];
+    // -> static int gnHeapTakeCacheCount;
+    // -> static unsigned int* gapHeapBlockCache[11][32];
 }
 
 // Range: 0x80007758 -> 0x800079C0
-static s32 xlHeapBlockCacheAdd(u32* pBlock) {
+static int xlHeapBlockCacheAdd(unsigned int* pBlock) {
     // Parameters
-    // u32* pBlock; // r1+0x0
+    // unsigned int* pBlock; // r1+0x0
 
     // Local variables
-    s32 nSize; // r6
-    s32 nBlock; // r7
-    s32 nBlockSize; // r1+0x0
-    s32 nBlockCachedSize; // r1+0x0
-    u32* pBlockCached; // r8
+    int nSize; // r6
+    int nBlock; // r7
+    int nBlockSize; // r1+0x0
+    int nBlockCachedSize; // r1+0x0
+    unsigned int* pBlockCached; // r8
 
     // References
-    // -> static u32* gapHeapBlockCache[11][32];
+    // -> static unsigned int* gapHeapBlockCache[11][32];
 }
 
 // Range: 0x8000764C -> 0x80007758
-static s32 xlHeapBlockCacheClear(u32* pBlock) {
+static int xlHeapBlockCacheClear(unsigned int* pBlock) {
     // Parameters
-    // u32* pBlock; // r1+0x0
+    // unsigned int* pBlock; // r1+0x0
 
     // Local variables
-    s32 nSize; // r1+0x0
-    s32 nBlock; // r6
-    s32 nBlockSize; // r1+0x0
+    int nSize; // r1+0x0
+    int nBlock; // r6
+    int nBlockSize; // r1+0x0
 
     // References
-    // -> static u32* gapHeapBlockCache[11][32];
+    // -> static unsigned int* gapHeapBlockCache[11][32];
 }
 
 // Range: 0x80007540 -> 0x8000764C
-static s32 xlHeapBlockCacheReset() {
+static int xlHeapBlockCacheReset() {
     // Local variables
-    s32 nBlockSize; // r1+0x8
-    u32* pBlock; // r30
-    u32 nBlock; // r1+0x8
+    int nBlockSize; // r1+0x8
+    unsigned int* pBlock; // r30
+    unsigned int nBlock; // r1+0x8
 
     // References
-    // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gapHeapBlockCache[11][32];
-    // -> static s32 gnHeapFreeCount;
-    // -> static s32 gnHeapTakeCount;
-    // -> static s32 gnHeapTakeCacheCount;
+    // -> static unsigned int* gpHeapBlockFirst;
+    // -> static unsigned int* gapHeapBlockCache[11][32];
+    // -> static int gnHeapFreeCount;
+    // -> static int gnHeapTakeCount;
+    // -> static int gnHeapTakeCacheCount;
 }
 
 // Range: 0x8000743C -> 0x80007540
-static s32 xlHeapFindUpperBlock(s32 nSize, u32** ppBlock, s32* pnBlockSize) {
+static int xlHeapFindUpperBlock(int nSize, unsigned int** ppBlock, int* pnBlockSize) {
     // Parameters
-    // s32 nSize; // r28
-    // u32** ppBlock; // r29
-    // s32* pnBlockSize; // r30
+    // int nSize; // r28
+    // unsigned int** ppBlock; // r29
+    // int* pnBlockSize; // r30
 
     // Local variables
-    s32 nBlockSize; // r3
-    u32 nBlock; // r4
-    u32* pBlock; // r7
-    u32* pBlockBest; // r31
-    u32* pBlockNext; // r27
+    int nBlockSize; // r3
+    unsigned int nBlock; // r4
+    unsigned int* pBlock; // r7
+    unsigned int* pBlockBest; // r31
+    unsigned int* pBlockNext; // r27
 
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
 }
 
 // Range: 0x800071B4 -> 0x8000743C
-s32 xlHeapTake(void* ppHeap, s32 nByteCount) {
+int xlHeapTake(void* ppHeap, int nByteCount) {
     // Parameters
     // void* ppHeap; // r26
-    // s32 nByteCount; // r1+0xC
+    // int nByteCount; // r1+0xC
 
     // Local variables
-    s32 bValid; // r30
-    u32 nSizeExtra; // r29
-    u32 iTry; // r28
-    s32 nSize; // r27
-    s32 nBlockSize; // r1+0x14
-    s32 nBlockNextSize; // r28
-    s32 nBlockNextNextSize; // r30
-    u32 nBlock; // r6
-    u32* pBlock; // r1+0x10
-    u32* pBlockNext; // r31
-    u32* pBlockNextNext; // r3
+    int bValid; // r30
+    unsigned int nSizeExtra; // r29
+    unsigned int iTry; // r28
+    int nSize; // r27
+    int nBlockSize; // r1+0x14
+    int nBlockNextSize; // r28
+    int nBlockNextNextSize; // r30
+    unsigned int nBlock; // r6
+    unsigned int* pBlock; // r1+0x10
+    unsigned int* pBlockNext; // r31
+    unsigned int* pBlockNextNext; // r3
 
     // References
-    // -> static s32 gnHeapTakeCount;
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
+    // -> static int gnHeapTakeCount;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
 }
 
 // Range: 0x80007098 -> 0x800071B4
-s32 xlHeapFree(void* ppHeap) {
+int xlHeapFree(void* ppHeap) {
     // Parameters
     // void* ppHeap; // r31
 
     // Local variables
-    s32 nBlockSize; // r30
-    s32 nBlockNextSize; // r29
-    u32* pBlock; // r28
-    u32* pBlockNext; // r3
+    int nBlockSize; // r30
+    int nBlockNextSize; // r29
+    unsigned int* pBlock; // r28
+    unsigned int* pBlockNext; // r3
 
     // References
-    // -> static s32 gnHeapFreeCount;
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
+    // -> static int gnHeapFreeCount;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
 }
 
 // Erased
-static s32 xlHeapTest(void* pHeap) {
+static int xlHeapTest(void* pHeap) {
     // Parameters
     // void* pHeap; // r1+0x0
 
     // Local variables
-    u32* pBlock; // r3
+    unsigned int* pBlock; // r3
 }
 
 // Range: 0x80006F68 -> 0x80007098
-s32 xlHeapCompact() {
+int xlHeapCompact() {
     // Local variables
-    s32 nCount; // r1+0x8
-    s32 nBlockLarge; // r1+0x8
-    s32 nBlockSize; // r4
-    s32 nBlockNextSize; // r3
-    s32 anBlockLarge[6]; // r1+0x8
-    u32 nBlock; // r1+0x8
-    u32* pBlock; // r5
-    u32* pBlockPrevious; // r6
-    u32 nBlockNext; // r7
-    u32* pBlockNext; // r8
+    int nCount; // r1+0x8
+    int nBlockLarge; // r1+0x8
+    int nBlockSize; // r4
+    int nBlockNextSize; // r3
+    int anBlockLarge[6]; // r1+0x8
+    unsigned int nBlock; // r1+0x8
+    unsigned int* pBlock; // r5
+    unsigned int* pBlockPrevious; // r6
+    unsigned int nBlockNext; // r7
+    unsigned int* pBlockNext; // r8
 
     // References
-    // -> static u32* gpHeapBlockFirst;
+    // -> static unsigned int* gpHeapBlockFirst;
 }
 
 // Range: 0x80006AF0 -> 0x80006F68
-s32 xlHeapCopy(void* pHeapTarget, void* pHeapSource, s32 nByteCount) {
+int xlHeapCopy(void* pHeapTarget, void* pHeapSource, int nByteCount) {
     // Parameters
     // void* pHeapTarget; // r3
     // void* pHeapSource; // r4
-    // s32 nByteCount; // r5
+    // int nByteCount; // r5
 
     // Local variables
     u8* pSource8; // r4
     u8* pTarget8; // r3
-    u32* pSource32; // r4
-    u32* pTarget32; // r3
+    unsigned int* pSource32; // r4
+    unsigned int* pTarget32; // r3
 }
 
 // Erased
-static s32 xlHeapFill8(void* pHeap, s32 nByteCount, u8 nData) {
+static int xlHeapFill8(void* pHeap, int nByteCount, u8 nData) {
     // Parameters
     // void* pHeap; // r3
-    // s32 nByteCount; // r4
+    // int nByteCount; // r4
     // u8 nData; // r1+0x8
 
     // Local variables
@@ -227,10 +227,10 @@ static s32 xlHeapFill8(void* pHeap, s32 nByteCount, u8 nData) {
 }
 
 // Erased
-static s32 xlHeapFill16(void* pHeap, s32 nByteCount, u16 nData) {
+static int xlHeapFill16(void* pHeap, int nByteCount, u16 nData) {
     // Parameters
     // void* pHeap; // r3
-    // s32 nByteCount; // r6
+    // int nByteCount; // r6
     // u16 nData; // r1+0x8
 
     // Local variables
@@ -238,57 +238,57 @@ static s32 xlHeapFill16(void* pHeap, s32 nByteCount, u16 nData) {
 }
 
 // Range: 0x80006908 -> 0x80006AF0
-s32 xlHeapFill32(void* pHeap, s32 nByteCount, u32 nData) {
+int xlHeapFill32(void* pHeap, int nByteCount, unsigned int nData) {
     // Parameters
     // void* pHeap; // r3
-    // s32 nByteCount; // r6
-    // u32 nData; // r1+0x8
+    // int nByteCount; // r6
+    // unsigned int nData; // r1+0x8
 
     // Local variables
-    u32* pnTarget; // r3
+    unsigned int* pnTarget; // r3
 }
 
 // Range: 0x80006870 -> 0x80006908
-s32 xlHeapGetFree(s32* pnFreeBytes) {
+int xlHeapGetFree(int* pnFreeBytes) {
     // Parameters
-    // s32* pnFreeBytes; // r31
+    // int* pnFreeBytes; // r31
 
     // Local variables
-    s32 nBlockSize; // r3
-    s32 nFree; // r5
-    s32 nCount; // r1+0x8
-    u32* pBlock; // r6
-    u32 nBlock; // r7
+    int nBlockSize; // r3
+    int nFree; // r5
+    int nCount; // r1+0x8
+    unsigned int* pBlock; // r6
+    unsigned int nBlock; // r7
 
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
 }
 
 // Range: 0x800066B0 -> 0x80006870
-s32 xlHeapSetup(void* pHeap, s32 nSizeBytes) {
+int xlHeapSetup(void* pHeap, int nSizeBytes) {
     // Parameters
     // void* pHeap; // r6
-    // s32 nSizeBytes; // r1+0xC
+    // int nSizeBytes; // r1+0xC
 
     // Local variables
-    s32 nSizeWords; // r5
+    int nSizeWords; // r5
 
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gpHeap;
-    // -> s32 gnSizeHeap;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
+    // -> static unsigned int* gpHeap;
+    // -> int gnSizeHeap;
 }
 
 // Range: 0x80006648 -> 0x800066B0
-s32 xlHeapReset() {
+int xlHeapReset() {
     // Local variables
-    s32 nBlockSize; // r6
+    int nBlockSize; // r6
 
     // References
-    // -> static u32* gpHeapBlockLast;
-    // -> static u32* gpHeapBlockFirst;
-    // -> static u32* gpHeap;
-    // -> s32 gnSizeHeap;
+    // -> static unsigned int* gpHeapBlockLast;
+    // -> static unsigned int* gpHeapBlockFirst;
+    // -> static unsigned int* gpHeap;
+    // -> int gnSizeHeap;
 }

--- a/debug/Core/xlList.c
+++ b/debug/Core/xlList.c
@@ -8,8 +8,8 @@
 #include "dolphin/types.h"
 
 typedef struct tXL_LIST {
-    /* 0x0 */ s32 nItemSize;
-    /* 0x4 */ s32 nItemCount;
+    /* 0x0 */ int nItemSize;
+    /* 0x4 */ int nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
 } __anon_0x2C35; // size = 0x10
@@ -18,7 +18,7 @@ typedef struct tXL_LIST {
 static struct tXL_LIST gListList;
 
 // Erased
-static s32 xlListWipe(struct tXL_LIST* pList) {
+static int xlListWipe(struct tXL_LIST* pList) {
     // Parameters
     // struct tXL_LIST* pList; // r30
 
@@ -28,17 +28,17 @@ static s32 xlListWipe(struct tXL_LIST* pList) {
 }
 
 // Range: 0x80006550 -> 0x80006648
-s32 xlListMake(struct tXL_LIST** ppList, s32 nItemSize) {
+int xlListMake(struct tXL_LIST** ppList, int nItemSize) {
     // Parameters
     // struct tXL_LIST** ppList; // r31
-    // s32 nItemSize; // r29
+    // int nItemSize; // r29
 
     // References
     // -> static struct tXL_LIST gListList;
 }
 
 // Range: 0x80006494 -> 0x80006550
-s32 xlListFree(struct tXL_LIST** ppList) {
+int xlListFree(struct tXL_LIST** ppList) {
     // Parameters
     // struct tXL_LIST** ppList; // r29
 
@@ -47,7 +47,7 @@ s32 xlListFree(struct tXL_LIST** ppList) {
 }
 
 // Erased
-static s32 xlListTest(struct tXL_LIST* pList) {
+static int xlListTest(struct tXL_LIST* pList) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
 
@@ -59,20 +59,20 @@ static s32 xlListTest(struct tXL_LIST* pList) {
 }
 
 // Range: 0x800063E8 -> 0x80006494
-s32 xlListMakeItem(struct tXL_LIST* pList, void* ppItem) {
+int xlListMakeItem(struct tXL_LIST* pList, void* ppItem) {
     // Parameters
     // struct tXL_LIST* pList; // r30
     // void* ppItem; // r31
 
     // Local variables
-    s32 nSize; // r4
+    int nSize; // r4
     void* pListNode; // r1+0x10
     void* pNode; // r4
     void* pNodeNext; // r1+0x8
 }
 
 // Range: 0x8000633C -> 0x800063E8
-s32 xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
+int xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
     // Parameters
     // struct tXL_LIST* pList; // r31
     // void* ppItem; // r1+0xC
@@ -83,7 +83,7 @@ s32 xlListFreeItem(struct tXL_LIST* pList, void* ppItem) {
 }
 
 // Range: 0x800062B0 -> 0x8000633C
-s32 xlListTestItem(struct tXL_LIST* pList, void* pItem) {
+int xlListTestItem(struct tXL_LIST* pList, void* pItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
     // void* pItem; // r1+0x4
@@ -96,41 +96,41 @@ s32 xlListTestItem(struct tXL_LIST* pList, void* pItem) {
 }
 
 // Erased
-static s32 xlListFindItem(struct tXL_LIST* pList, s32 iItem, void* ppItem) {
+static int xlListFindItem(struct tXL_LIST* pList, int iItem, void* ppItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
-    // s32 iItem; // r1+0x4
+    // int iItem; // r1+0x4
     // void* ppItem; // r1+0x8
 
     // Local variables
-    s32 nItemCount; // r3
+    int nItemCount; // r3
     void* pListNode; // r6
 }
 
 // Erased
-static s32 xlListFindItemIndex(struct tXL_LIST* pList, s32* piItem, void* pItem) {
+static int xlListFindItemIndex(struct tXL_LIST* pList, int* piItem, void* pItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
-    // s32* piItem; // r1+0x4
+    // int* piItem; // r1+0x4
     // void* pItem; // r1+0x8
 
     // Local variables
-    s32 iItem; // r3
+    int iItem; // r3
     void* pListNode; // r6
 }
 
 // Erased
-static s32 xlListEnumerate(struct tXL_LIST* pList, s32 (*pfCallback)(void*)) {
+static int xlListEnumerate(struct tXL_LIST* pList, int (*pfCallback)(void*)) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x8
-    // s32 (* pfCallback)(void*); // r30
+    // int (* pfCallback)(void*); // r30
 
     // Local variables
     void* pNode; // r31
 }
 
 // Erased
-static s32 xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
+static int xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
     // void* ppListNode; // r1+0x4
@@ -140,7 +140,7 @@ static s32 xlListNodeGetHead(struct tXL_LIST* pList, void* ppListNode) {
 }
 
 // Erased
-static s32 xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
+static int xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
     // void* ppListNode; // r1+0x4
@@ -150,7 +150,7 @@ static s32 xlListNodeGetNext(struct tXL_LIST* pList, void* ppListNode) {
 }
 
 // Erased
-static s32 xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
+static int xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
     // void* pItem; // r1+0x4
@@ -161,7 +161,7 @@ static s32 xlListMoveItemToHead(struct tXL_LIST* pList, void* pItem) {
 }
 
 // Erased
-static s32 xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
+static int xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
     // Parameters
     // struct tXL_LIST* pList; // r1+0x0
     // void* pItem; // r1+0x4
@@ -174,10 +174,10 @@ static s32 xlListMoveItemToTail(struct tXL_LIST* pList, void* pItem) {
 }
 
 // Range: 0x80006288 -> 0x800062B0
-s32 xlListSetup() {
+int xlListSetup() {
     // References
     // -> static struct tXL_LIST gListList;
 }
 
 // Range: 0x80006280 -> 0x80006288
-s32 xlListReset() {}
+int xlListReset() {}

--- a/debug/Core/xlObject.c
+++ b/debug/Core/xlObject.c
@@ -8,8 +8,8 @@
 #include "dolphin/types.h"
 
 typedef struct tXL_LIST {
-    /* 0x0 */ s32 nItemSize;
-    /* 0x4 */ s32 nItemCount;
+    /* 0x0 */ int nItemSize;
+    /* 0x4 */ int nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
 } __anon_0x4E6F; // size = 0x10
@@ -19,9 +19,9 @@ static struct tXL_LIST* gpListData;
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x4F98; // size = 0x10
 
 typedef struct __anon_0x5062 {
@@ -30,7 +30,7 @@ typedef struct __anon_0x5062 {
 } __anon_0x5062; // size = 0x8
 
 // Erased
-static s32 xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
+static int xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
     // Parameters
     // struct __anon_0x5062** ppData; // r1+0x0
     // struct _XL_OBJECTTYPE* pType; // r1+0x4
@@ -43,7 +43,7 @@ static s32 xlObjectFindData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE
 }
 
 // Erased
-static s32 xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
+static int xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE* pType) {
     // Parameters
     // struct __anon_0x5062** ppData; // r30
     // struct _XL_OBJECTTYPE* pType; // r31
@@ -53,14 +53,14 @@ static s32 xlObjectMakeData(struct __anon_0x5062** ppData, struct _XL_OBJECTTYPE
 }
 
 // Range: 0x80007E24 -> 0x80007F80
-s32 xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) {
+int xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) {
     // Parameters
     // void* ppObject; // r28
     // void* pArgument; // r29
     // struct _XL_OBJECTTYPE* pType; // r30
 
     // Local variables
-    s32 bFlag; // r31
+    int bFlag; // r31
     struct __anon_0x5062* pData; // r1+0x14
 
     // References
@@ -68,7 +68,7 @@ s32 xlObjectMake(void* ppObject, void* pArgument, struct _XL_OBJECTTYPE* pType) 
 }
 
 // Range: 0x80007D8C -> 0x80007E24
-s32 xlObjectFree(void* ppObject) {
+int xlObjectFree(void* ppObject) {
     // Parameters
     // void* ppObject; // r30
 
@@ -77,7 +77,7 @@ s32 xlObjectFree(void* ppObject) {
 }
 
 // Range: 0x80007D24 -> 0x80007D8C
-s32 xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
+int xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
     // Parameters
     // void* pObject; // r1+0x8
     // struct _XL_OBJECTTYPE* pType; // r30
@@ -90,7 +90,7 @@ s32 xlObjectTest(void* pObject, struct _XL_OBJECTTYPE* pType) {
 }
 
 // Erased
-static s32 xlObjectFindType(void* pObject, struct _XL_OBJECTTYPE** ppType) {
+static int xlObjectFindType(void* pObject, struct _XL_OBJECTTYPE** ppType) {
     // Parameters
     // void* pObject; // r1+0x8
     // struct _XL_OBJECTTYPE** ppType; // r30
@@ -103,10 +103,10 @@ static s32 xlObjectFindType(void* pObject, struct _XL_OBJECTTYPE** ppType) {
 }
 
 // Range: 0x80007C6C -> 0x80007D24
-s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument) {
+int xlObjectEvent(void* pObject, int nEvent, void* pArgument) {
     // Parameters
     // void* pObject; // r26
-    // s32 nEvent; // r27
+    // int nEvent; // r27
     // void* pArgument; // r28
 
     // Local variables
@@ -117,13 +117,13 @@ s32 xlObjectEvent(void* pObject, s32 nEvent, void* pArgument) {
 }
 
 // Range: 0x80007C30 -> 0x80007C6C
-s32 xlObjectSetup() {
+int xlObjectSetup() {
     // References
     // -> static struct tXL_LIST* gpListData;
 }
 
 // Range: 0x80007BC0 -> 0x80007C30
-s32 xlObjectReset() {
+int xlObjectReset() {
     // Local variables
     struct __anon_0x5062* pData; // r3
     void* pListNode; // r31

--- a/debug/Core/xlPostGCN.c
+++ b/debug/Core/xlPostGCN.c
@@ -8,10 +8,10 @@
 #include "dolphin/types.h"
 
 // Range: 0x80005E14 -> 0x80005E68
-s32 xlPostText() {}
+int xlPostText() {}
 
 // Range: 0x80005E0C -> 0x80005E14
-s32 xlPostSetup() {}
+int xlPostSetup() {}
 
 // Range: 0x80005E04 -> 0x80005E0C
-s32 xlPostReset() {}
+int xlPostReset() {}

--- a/debug/Fire/THPAudioDecode.c
+++ b/debug/Fire/THPAudioDecode.c
@@ -187,14 +187,14 @@ typedef struct __anon_0x13BA7 {
     /* 0x080 */ struct __anon_0x138C7 videoInfo;
     /* 0x08C */ struct __anon_0x13947 audioInfo;
     /* 0x09C */ void* thpWork;
-    /* 0x0A0 */ s32 open;
+    /* 0x0A0 */ int open;
     /* 0x0A4 */ u8 state;
     /* 0x0A5 */ u8 internalState;
     /* 0x0A6 */ u8 playFlag;
     /* 0x0A7 */ u8 audioExist;
     /* 0x0A8 */ s32 dvdError;
     /* 0x0AC */ s32 videoError;
-    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B0 */ int onMemory;
     /* 0x0B4 */ u8* movieData;
     /* 0x0B8 */ s32 initOffset;
     /* 0x0BC */ s32 initReadSize;
@@ -223,7 +223,7 @@ struct __anon_0x13BA7 ActivePlayer;
 typedef struct __anon_0x14130 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
-    /* 0x8 */ s32 isValid;
+    /* 0x8 */ int isValid;
 } __anon_0x14130; // size = 0xC
 
 // Range: 0x80011108 -> 0x80011138
@@ -318,7 +318,7 @@ void AudioDecodeThreadStart() {
 }
 
 // Range: 0x80010D9C -> 0x80010E7C
-s32 CreateAudioDecodeThread(s32 priority, u8* ptr) {
+int CreateAudioDecodeThread(s32 priority, u8* ptr) {
     // Parameters
     // s32 priority; // r8
     // u8* ptr; // r5

--- a/debug/Fire/THPPlayer.c
+++ b/debug/Fire/THPPlayer.c
@@ -11,7 +11,7 @@
 static u16 VolumeTable[128];
 
 // size = 0x4, address = 0x80135618
-static s32 Initialized;
+static int Initialized;
 
 // size = 0x40, address = 0x800F96E0
 static s32 WorkBuffer[16];
@@ -204,7 +204,7 @@ typedef struct __anon_0x109FA {
 typedef struct __anon_0x10A84 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
-    /* 0x8 */ s32 isValid;
+    /* 0x8 */ int isValid;
 } __anon_0x10A84; // size = 0xC
 
 typedef struct __anon_0x10B6F {
@@ -214,14 +214,14 @@ typedef struct __anon_0x10B6F {
     /* 0x080 */ struct __anon_0x1080A videoInfo;
     /* 0x08C */ struct __anon_0x1088A audioInfo;
     /* 0x09C */ void* thpWork;
-    /* 0x0A0 */ s32 open;
+    /* 0x0A0 */ int open;
     /* 0x0A4 */ u8 state;
     /* 0x0A5 */ u8 internalState;
     /* 0x0A6 */ u8 playFlag;
     /* 0x0A7 */ u8 audioExist;
     /* 0x0A8 */ s32 dvdError;
     /* 0x0AC */ s32 videoError;
-    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B0 */ int onMemory;
     /* 0x0B4 */ u8* movieData;
     /* 0x0B8 */ s32 initOffset;
     /* 0x0BC */ s32 initReadSize;
@@ -290,13 +290,13 @@ static s32 THPPlayerGetVolume() {
 }
 
 // Erased
-static s32 THPPlayerSetVolume(s32 vol, s32 time) {
+static int THPPlayerSetVolume(s32 vol, s32 time) {
     // Parameters
     // s32 vol; // r28
     // s32 time; // r29
 
     // Local variables
-    s32 old; // r3
+    int old; // r3
     s32 samplePerMs; // r30
 
     // References
@@ -328,7 +328,7 @@ static void MixAudio(s16* destination, s16* source, u32 sample) {
 // Range: 0x80010888 -> 0x80010A00
 static void THPAudioMixCallback() {
     // Local variables
-    s32 old; // r30
+    int old; // r30
 
     // References
     // -> static s32 SoundBufferIndex;
@@ -346,7 +346,7 @@ void THPPlayerDrawDone() {
 
     // References
     // -> static struct OSMessageQueue UsedTextureSetQueue;
-    // -> static s32 Initialized;
+    // -> static int Initialized;
 }
 
 // Erased
@@ -386,7 +386,7 @@ static f32 THPPlayerGetFrameRate() {
 }
 
 // Erased
-static s32 THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
+static int THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
     // Parameters
     // struct __anon_0x1088A* audioInfo; // r3
 
@@ -395,7 +395,7 @@ static s32 THPPlayerGetAudioInfo(struct __anon_0x1088A* audioInfo) {
 }
 
 // Erased
-static s32 THPPlayerGetVideoInfo(struct __anon_0x1080A* videoInfo) {
+static int THPPlayerGetVideoInfo(struct __anon_0x1080A* videoInfo) {
     // Parameters
     // struct __anon_0x1080A* videoInfo; // r3
 
@@ -417,7 +417,7 @@ s32 THPPlayerDrawCurrentFrame(struct _GXRenderModeObj* rmode, u32 x, u32 y, u32 
 }
 
 // Range: 0x800105F8 -> 0x8001071C
-static s32 ProperTimingForGettingNextFrame() {
+static int ProperTimingForGettingNextFrame() {
     // Local variables
     s32 frameRate; // r30
 
@@ -426,7 +426,7 @@ static s32 ProperTimingForGettingNextFrame() {
 }
 
 // Range: 0x8001058C -> 0x800105F8
-static s32 ProperTimingForStart() {
+static int ProperTimingForStart() {
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
 }
@@ -447,9 +447,9 @@ static void PlayControl(u32 retraceCount) {
 }
 
 // Erased
-static s32 THPPlayerSkip() {
+static int THPPlayerSkip() {
     // Local variables
-    s32 old; // r3
+    int old; // r3
     s32 frameNumber; // r3
     s32 audioGet; // r29
     s32 videoGet; // r1+0x8
@@ -459,7 +459,7 @@ static s32 THPPlayerSkip() {
 }
 
 // Erased
-static s32 THPPlayerPause() {
+static int THPPlayerPause() {
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
 }
@@ -475,13 +475,13 @@ static void THPPlayerStop() {
 }
 
 // Range: 0x80010294 -> 0x800102F0
-s32 THPPlayerPlay() {
+int THPPlayerPlay() {
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
 }
 
 // Range: 0x80010020 -> 0x80010294
-s32 THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
+int THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
     // Parameters
     // s32 frameNum; // r29
     // s32 playFlag; // r26
@@ -499,16 +499,16 @@ s32 THPPlayerPrepare(s32 frameNum, s32 playFlag, s32 audioTrack) {
 }
 
 // Range: 0x8000FFF0 -> 0x80010020
-void PrepareReady(s32 flag) {
+void PrepareReady(int flag) {
     // Parameters
-    // s32 flag; // r4
+    // int flag; // r4
 
     // References
     // -> static struct OSMessageQueue PrepareReadyQueue;
 }
 
 // Erased
-static s32 WaitUntilPrepare() {
+static int WaitUntilPrepare() {
     // Local variables
     void* msg; // r1+0x8
 
@@ -531,7 +531,7 @@ static void InitAllMessageQueue() {
 }
 
 // Range: 0x8000FCE8 -> 0x8000FF24
-s32 THPPlayerSetBuffer(u8* buffer) {
+int THPPlayerSetBuffer(u8* buffer) {
     // Parameters
     // u8* buffer; // r1+0x8
 
@@ -555,16 +555,16 @@ u32 THPPlayerCalcNeedMemory() {
 }
 
 // Erased
-static s32 THPPlayerClose() {
+static int THPPlayerClose() {
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
 }
 
 // Range: 0x8000F9C8 -> 0x8000FC40
-s32 THPPlayerOpen(char* fileName, s32 onMemory) {
+int THPPlayerOpen(char* fileName, int onMemory) {
     // Parameters
     // char* fileName; // r21
-    // s32 onMemory; // r30
+    // int onMemory; // r30
 
     // Local variables
     s32 offset; // r22
@@ -573,29 +573,29 @@ s32 THPPlayerOpen(char* fileName, s32 onMemory) {
     // References
     // -> struct __anon_0x10B6F ActivePlayer;
     // -> static s32 WorkBuffer[16];
-    // -> static s32 Initialized;
+    // -> static int Initialized;
 }
 
 // Erased
 static void THPPlayerQuit() {
     // Local variables
-    s32 old; // r31
+    int old; // r31
 
     // References
-    // -> static s32 Initialized;
+    // -> static int Initialized;
     // -> static void (* OldAIDCallback)();
 }
 
 // Range: 0x8000F890 -> 0x8000F9C8
-s32 THPPlayerInit(s32 audioSystem) {
+int THPPlayerInit(s32 audioSystem) {
     // Parameters
     // s32 audioSystem; // r30
 
     // Local variables
-    s32 old; // r30
+    int old; // r30
 
     // References
-    // -> static s32 Initialized;
+    // -> static int Initialized;
     // -> static s32 SoundBufferIndex;
     // -> static s16 SoundBuffer[2][320];
     // -> static s32 AudioSystem;

--- a/debug/Fire/THPRead.c
+++ b/debug/Fire/THPRead.c
@@ -112,16 +112,16 @@ static u8 ReadThreadStack[4096];
 static f32 gOrthoMtx[4][4];
 
 // size = 0x4, address = 0x80135644
-s32 gMovieErrorToggle;
+int gMovieErrorToggle;
 
 // size = 0x4, address = 0x80135648
-static s32 toggle$184;
+static int toggle$184;
 
 // size = 0x4, address = 0x8013564C
-static s32 gbReset;
+static int gbReset;
 
 // size = 0x4, address = 0x80135650
-static u32 gnTickReset;
+static unsigned int gnTickReset;
 
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
@@ -204,7 +204,7 @@ typedef struct __anon_0x166D4 {
 typedef struct __anon_0x1675E {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
-    /* 0x8 */ s32 isValid;
+    /* 0x8 */ int isValid;
 } __anon_0x1675E; // size = 0xC
 
 typedef struct __anon_0x16849 {
@@ -214,14 +214,14 @@ typedef struct __anon_0x16849 {
     /* 0x080 */ struct __anon_0x164E4 videoInfo;
     /* 0x08C */ struct __anon_0x16564 audioInfo;
     /* 0x09C */ void* thpWork;
-    /* 0x0A0 */ s32 open;
+    /* 0x0A0 */ int open;
     /* 0x0A4 */ u8 state;
     /* 0x0A5 */ u8 internalState;
     /* 0x0A6 */ u8 playFlag;
     /* 0x0A7 */ u8 audioExist;
     /* 0x0A8 */ s32 dvdError;
     /* 0x0AC */ s32 videoError;
-    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B0 */ int onMemory;
     /* 0x0B4 */ u8* movieData;
     /* 0x0B8 */ s32 initOffset;
     /* 0x0BC */ s32 initReadSize;
@@ -384,9 +384,9 @@ typedef struct _GXColor {
 } __anon_0x17F8F; // size = 0x4
 
 // Range: 0x80012850 -> 0x80012F20
-s32 movieGXInit() {
+int movieGXInit() {
     // Local variables
-    s32 i; // r31
+    int i; // r31
     struct _GXColor GX_DEFAULT_BG; // r1+0x58
     struct _GXColor BLACK; // r1+0x54
     struct _GXColor WHITE; // r1+0x50
@@ -394,7 +394,7 @@ s32 movieGXInit() {
 }
 
 // Range: 0x80012334 -> 0x80012850
-s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
+int movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
     // Parameters
     // struct __anon_0x17E8D* tpl; // r25
     // s16 nX0; // r26
@@ -415,7 +415,7 @@ s32 movieDrawImage(struct __anon_0x17E8D* tpl, s16 nX0, s16 nY0) {
 }
 
 // Range: 0x80012170 -> 0x80012334
-s32 movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
+int movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
     // Parameters
     // enum __anon_0x17564 movieMessage; // r1+0x8
 
@@ -429,23 +429,23 @@ s32 movieDrawErrorMessage(enum __anon_0x17564 movieMessage) {
 }
 
 // Range: 0x80011F10 -> 0x80012170
-s32 movieDVDShowError(s32 nStatus) {
+int movieDVDShowError(int nStatus) {
     // Parameters
-    // s32 nStatus; // r1+0x8
+    // int nStatus; // r1+0x8
 
     // Local variables
     enum __anon_0x17564 nMessage; // r31
 
     // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
+    // -> static unsigned int gnTickReset;
+    // -> static int gbReset;
     // -> struct __anon_0x171A2 DemoPad[4];
-    // -> static s32 toggle$184;
-    // -> s32 gMovieErrorToggle;
+    // -> static int toggle$184;
+    // -> int gMovieErrorToggle;
 }
 
 // Range: 0x80011E60 -> 0x80011F10
-s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset) {
+int movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset) {
     // Parameters
     // struct DVDFileInfo* pFileInfo; // r26
     // void* anData; // r27
@@ -453,38 +453,38 @@ s32 movieDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32
     // s32 nOffset; // r29
 
     // Local variables
-    s32 nStatus; // r31
-    s32 bRetry; // r30
+    int nStatus; // r31
+    int bRetry; // r30
 
     // References
-    // -> s32 gMovieErrorToggle;
+    // -> int gMovieErrorToggle;
 }
 
 // Range: 0x80011CAC -> 0x80011E60
-s32 movieTestReset(s32 IPL, s32 forceMenu) {
+int movieTestReset(int IPL, int forceMenu) {
     // Parameters
-    // s32 IPL; // r29
-    // s32 forceMenu; // r30
+    // int IPL; // r29
+    // int forceMenu; // r30
 
     // Local variables
-    u32 bFlag; // r1+0x8
-    u32 nTick; // r1+0x8
+    unsigned int bFlag; // r1+0x8
+    unsigned int nTick; // r1+0x8
 
     // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
+    // -> static unsigned int gnTickReset;
+    // -> static int gbReset;
     // -> struct __anon_0x171A2 DemoPad[4];
 }
 
 // Range: 0x80011C0C -> 0x80011CAC
-void movieReset(s32 IPL, s32 forceMenu) {
+void movieReset(int IPL, int forceMenu) {
     // Parameters
-    // s32 IPL; // r30
-    // s32 forceMenu; // r31
+    // int IPL; // r30
+    // int forceMenu; // r31
 }
 
 // Range: 0x80011B60 -> 0x80011C0C
-s32 CreateReadThread(s32 priority) {
+int CreateReadThread(s32 priority) {
     // Parameters
     // s32 priority; // r3
 
@@ -526,7 +526,7 @@ static void* Reader() {
     // -> static struct OSThread ReadThread;
     // -> struct __anon_0x16849 ActivePlayer;
     // -> static struct OSMessageQueue ReadedBufferQueue;
-    // -> s32 gMovieErrorToggle;
+    // -> int gMovieErrorToggle;
     // -> static struct OSMessageQueue FreeReadBufferQueue;
 }
 

--- a/debug/Fire/THPVideoDecode.c
+++ b/debug/Fire/THPVideoDecode.c
@@ -190,14 +190,14 @@ typedef struct __anon_0x1999C {
     /* 0x080 */ struct __anon_0x196BC videoInfo;
     /* 0x08C */ struct __anon_0x1973C audioInfo;
     /* 0x09C */ void* thpWork;
-    /* 0x0A0 */ s32 open;
+    /* 0x0A0 */ int open;
     /* 0x0A4 */ u8 state;
     /* 0x0A5 */ u8 internalState;
     /* 0x0A6 */ u8 playFlag;
     /* 0x0A7 */ u8 audioExist;
     /* 0x0A8 */ s32 dvdError;
     /* 0x0AC */ s32 videoError;
-    /* 0x0B0 */ s32 onMemory;
+    /* 0x0B0 */ int onMemory;
     /* 0x0B4 */ u8* movieData;
     /* 0x0B8 */ s32 initOffset;
     /* 0x0BC */ s32 initReadSize;
@@ -226,7 +226,7 @@ struct __anon_0x1999C ActivePlayer;
 typedef struct __anon_0x19FA4 {
     /* 0x0 */ u8* ptr;
     /* 0x4 */ s32 frameNumber;
-    /* 0x8 */ s32 isValid;
+    /* 0x8 */ int isValid;
 } __anon_0x19FA4; // size = 0xC
 
 // Range: 0x80013410 -> 0x80013440
@@ -278,7 +278,7 @@ static void VideoDecode(struct __anon_0x19FA4* readBuffer) {
     u32 i; // r27
     u32* compSizePtr; // r26
     u8* ptr; // r25
-    s32 old; // r3
+    int old; // r3
 
     // References
     // -> static s32 First;
@@ -293,7 +293,7 @@ static void* VideoDecoderForOnMemory(void* ptr) {
 
     // Local variables
     struct __anon_0x19FA4 readBuffer; // r1+0x10
-    s32 old; // r3
+    int old; // r3
     s32 tmp; // r4
     s32 size; // r29
     s32 readFrame; // r28
@@ -307,7 +307,7 @@ static void* VideoDecoderForOnMemory(void* ptr) {
 static void* VideoDecoder() {
     // Local variables
     struct __anon_0x19FA4* readBuffer; // r28
-    s32 old; // r3
+    int old; // r3
 
     // References
     // -> struct __anon_0x1999C ActivePlayer;
@@ -328,7 +328,7 @@ void VideoDecodeThreadStart() {
 }
 
 // Range: 0x80012F20 -> 0x80013004
-s32 CreateVideoDecodeThread(s32 priority, u8* ptr) {
+int CreateVideoDecodeThread(s32 priority, u8* ptr) {
     // Parameters
     // s32 priority; // r8
     // u8* ptr; // r5

--- a/debug/Fire/_aspMain.c
+++ b/debug/Fire/_aspMain.c
@@ -8,161 +8,161 @@
 #include "dolphin/types.h"
 
 // Range: 0x8008BBDC -> 0x8008CF0C
-static s32 rspInitAudioDMEM1(struct __anon_0x5845E* pRSP) {
+static int rspInitAudioDMEM1(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Range: 0x8008B768 -> 0x8008BBDC
-s32 rspDotProduct8x15MatrixBy15x1Vector(s16* matrix, s16* vectorIn, s16* vectorOut) {
+int rspDotProduct8x15MatrixBy15x1Vector(s16* matrix, s16* vectorIn, s16* vectorOut) {
     // Parameters
     // s16* matrix; // r1+0xC
     // s16* vectorIn; // r1+0x10
     // s16* vectorOut; // r1+0x14
 
     // Local variables
-    s32 sum; // r12
-    s32 vec1; // r1+0x8
-    s32 vec2; // r1+0x8
-    s32 vec3; // r1+0x8
-    s32 vec4; // r1+0x8
-    s32 vec5; // r1+0x8
-    s32 vec6; // r1+0x8
-    s32 vec7; // r1+0x8
-    s32 vec8; // r31
-    s32 vec9; // r30
-    s32 vec10; // r29
-    s32 vec11; // r28
-    s32 vec12; // r27
-    s32 vec13; // r26
-    s32 vec14; // r5
+    int sum; // r12
+    int vec1; // r1+0x8
+    int vec2; // r1+0x8
+    int vec3; // r1+0x8
+    int vec4; // r1+0x8
+    int vec5; // r1+0x8
+    int vec6; // r1+0x8
+    int vec7; // r1+0x8
+    int vec8; // r31
+    int vec9; // r30
+    int vec10; // r29
+    int vec11; // r28
+    int vec12; // r27
+    int vec13; // r26
+    int vec14; // r5
 }
 
 // Erased
-static s32 rspMultADPCMCoef1(struct __anon_0x5845E* pRSP, s32* matrix, s16* vectorIn, s16* vectorOut, s32 nOptPred) {
+static int rspMultADPCMCoef1(struct __anon_0x5845E* pRSP, int* matrix, s16* vectorIn, s16* vectorOut, int nOptPred) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32* matrix; // r1+0xC
+    // int* matrix; // r1+0xC
     // s16* vectorIn; // r1+0x10
     // s16* vectorOut; // r1+0x14
-    // s32 nOptPred; // r1+0x18
+    // int nOptPred; // r1+0x18
 
     // Local variables
-    s32 sum; // r12
-    s32 vec0; // r1+0x8
-    s32 vec1; // r1+0x8
-    s32 vec2; // r26
-    s32 vec3; // r25
-    s32 vec4; // r24
-    s32 vec5; // r23
-    s32 vec6; // r22
-    s32 vec7; // r21
-    s32 vec8; // r20
+    int sum; // r12
+    int vec0; // r1+0x8
+    int vec1; // r1+0x8
+    int vec2; // r26
+    int vec3; // r25
+    int vec4; // r24
+    int vec5; // r23
+    int vec6; // r22
+    int vec7; // r21
+    int vec8; // r20
 }
 
 // Range: 0x8008B378 -> 0x8008B768
-s32 rspMultPolef(s16 (*matrix)[8], s16* vectorIn, s16* vectorOut) {
+int rspMultPolef(s16 (*matrix)[8], s16* vectorIn, s16* vectorOut) {
     // Parameters
     // s16 (* matrix)[8]; // r1+0xC
     // s16* vectorIn; // r1+0x10
     // s16* vectorOut; // r1+0x14
 
     // Local variables
-    s32 sum; // r22
-    s32 vec0; // r1+0x8
-    s32 vec1; // r1+0x8
-    s32 vec2; // r8
-    s32 vec3; // r9
-    s32 vec4; // r10
-    s32 vec5; // r11
-    s32 vec6; // r12
-    s32 vec7; // r31
-    s32 vec8; // r5
-    s32 vec9; // r1+0x8
+    int sum; // r22
+    int vec0; // r1+0x8
+    int vec1; // r1+0x8
+    int vec2; // r8
+    int vec3; // r9
+    int vec4; // r10
+    int vec5; // r11
+    int vec6; // r12
+    int vec7; // r31
+    int vec8; // r5
+    int vec9; // r1+0x8
 }
 
 // Erased
-static s32 rspDumpDMEMToFile(struct __anon_0x5845E* pRSP) {
+static int rspDumpDMEMToFile(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
 
     // Local variables
     struct tXL_FILE* fp; // r1+0x50
-    s32 i; // r30
-    u32 nStartAddress; // r29
-    u32 nSize; // r1+0x4C
+    int i; // r30
+    unsigned int nStartAddress; // r29
+    unsigned int nSize; // r1+0x4C
     char acDMEMLine[64]; // r1+0xC
 }
 
 // Erased
-static s32 rspDumpMotorolaSDMEMTOFile(struct __anon_0x5845E* pRSP) {
+static int rspDumpMotorolaSDMEMTOFile(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r27
 
     // Local variables
     struct tXL_FILE* fp; // r1+0x220
-    s32 i; // r29
-    u32 nStartAddress; // r28
-    u32 nSize; // r1+0x21C
+    int i; // r29
+    unsigned int nStartAddress; // r28
+    unsigned int nSize; // r1+0x21C
     char acDMEMLine[512]; // r1+0x1C
 }
 
 // Erased
-static s32 rspDumpBinaryDMEMToFile(struct __anon_0x5845E* pRSP) {
+static int rspDumpBinaryDMEMToFile(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
 
     // Local variables
     struct tXL_FILE* fp; // r1+0x10
-    s32 i; // r30
-    u32 nSize; // r1+0xC
+    int i; // r30
+    unsigned int nSize; // r1+0xC
 }
 
 // Erased
-static s32 rspLoadADPCMCoefRow(struct __anon_0x5845E* pRSP, u32 nCoefIndex, u32 nOptPred) {
+static int rspLoadADPCMCoefRow(struct __anon_0x5845E* pRSP, unsigned int nCoefIndex, unsigned int nOptPred) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCoefIndex; // r6
-    // u32 nOptPred; // r1+0x10
+    // unsigned int nCoefIndex; // r6
+    // unsigned int nOptPred; // r1+0x10
 }
 
 // Range: 0x8008B1FC -> 0x8008B378
-static s32 rspLoadADPCMCoefTable1(struct __anon_0x5845E* pRSP) {
+static int rspLoadADPCMCoefTable1(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
 
     // Local variables
-    u32 j; // r1+0x8
-    u32 nCoefIndex; // r5
+    unsigned int j; // r1+0x8
+    unsigned int nCoefIndex; // r5
 }
 
 // Range: 0x8008B080 -> 0x8008B1FC
-static s32 rspLoadADPCMCoefTable2(struct __anon_0x5845E* pRSP) {
+static int rspLoadADPCMCoefTable2(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
 
     // Local variables
-    u32 j; // r1+0x8
-    u32 nCoefIndex; // r5
+    unsigned int j; // r1+0x8
+    unsigned int nCoefIndex; // r5
 }
 
 // Erased
-static s32 rspALoadBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspALoadBuffer1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
+    // unsigned int nCommandLo; // r1+0xC
 
     // Local variables
     void* pData; // r1+0x14
-    s32 nAddress; // r5
+    int nAddress; // r5
 }
 
 // Range: 0x8008A7E0 -> 0x8008B080
-static s32 rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r21
@@ -170,58 +170,58 @@ static s32 rspAADPCMDec1Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nC
     char* pHeader; // r31
     s16* pStateAddress; // r1+0x60
     s16 anIData0; // r23
-    s32 nDMEMOut; // r30
-    s32 nCount; // r29
-    s32 nSrcAddress; // r5
-    s32 nOptPred; // r7
-    s32 nVScale; // r1+0x8
-    s32 i; // r1+0x8
-    u32 dwDecodeSelect; // r1+0x8
-    u32 n; // r1+0x8
-    s32 nA; // r8
-    s32 nB; // r9
+    int nDMEMOut; // r30
+    int nCount; // r29
+    int nSrcAddress; // r5
+    int nOptPred; // r7
+    int nVScale; // r1+0x8
+    int i; // r1+0x8
+    unsigned int dwDecodeSelect; // r1+0x8
+    unsigned int n; // r1+0x8
+    int nA; // r8
+    int nB; // r9
     s16 nSamp1; // r10
     s16 nSamp2; // r1+0x8
     s16* pTempStateAddr; // r1+0x4C
-    s32 nOutput; // r10
+    int nOutput; // r10
 }
 
 // Erased
-static s32 rspAADPCMDec1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAADPCMDec1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r20
     char* pDMEM8; // r27
     char* pHeader; // r1+0xD8
-    s32 anCoef[8]; // r1+0xAC
+    int anCoef[8]; // r1+0xAC
     s16 anIData0[8]; // r1+0x8C
     s16 anOData0[8]; // r1+0x7C
     s16* pStateAddress; // r1+0x78
     s16* pDMEM16; // r4
     s16 anInputVec[10]; // r1+0x64
-    s32 nDMEMOut; // r30
-    s32 nCount; // r14
-    s32 nSrcAddress; // r1+0x8
-    s32 nOptPred; // r1+0x8
-    s32 nVScale; // r1+0x8
-    s32 nScaleI; // r4
-    s32 i; // r1+0x8
-    s32 nHeader; // r23
-    s32 nToggle; // r1+0xD4
-    s32 nTIndex; // r1+0x8
+    int nDMEMOut; // r30
+    int nCount; // r14
+    int nSrcAddress; // r1+0x8
+    int nOptPred; // r1+0x8
+    int nVScale; // r1+0x8
+    int nScaleI; // r4
+    int i; // r1+0x8
+    int nHeader; // r23
+    int nToggle; // r1+0xD4
+    int nTIndex; // r1+0x8
     s16* pTempStateAddr; // r1+0x60
 }
 
 // Range: 0x80089E7C -> 0x8008A7E0
-static s32 rspAPoleFilter1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAPoleFilter1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r25
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r24
@@ -235,99 +235,99 @@ static s32 rspAPoleFilter1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCom
     s16 anInputVec[10]; // r1+0x6C
     s16* pStateAddress; // r1+0x68
     s16* pDMEM16; // r29
-    s32 nDMEMIn; // r28
-    s32 nDMEMOut; // r27
-    s32 nCount; // r26
-    s32 nSrcAddress; // r5
+    int nDMEMIn; // r28
+    int nDMEMOut; // r27
+    int nCount; // r26
+    int nSrcAddress; // r5
 }
 
 // Erased
-static s32 rspAClearBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAClearBuffer1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Range: 0x800892A4 -> 0x80089E7C
-static s32 rspAEnvMixer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAEnvMixer1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r23
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r1+0x104
-    u32 s; // r1+0x8
+    unsigned int s; // r1+0x8
     s16* pStateAddress; // r1+0x100
     u16 anRamp[8]; // r1+0xA8
-    s32 envVolRateL; // r1+0xFC
-    s32 envVolRateR; // r1+0xF8
-    s32 envVolFinalL; // r16
-    s32 envVolFinalR; // r18
-    s32 volVecL[8]; // r1+0x88
-    s32 volVecR[8]; // r1+0x68
+    int envVolRateL; // r1+0xFC
+    int envVolRateR; // r1+0xF8
+    int envVolFinalL; // r16
+    int envVolFinalR; // r18
+    int volVecL[8]; // r1+0x88
+    int volVecR[8]; // r1+0x68
     s16 anOutL; // r24
     s16 anOutR; // r20
     s16 anAuxL; // r24
     s16 anAuxR; // r1+0x8
     s16 anIn; // r1+0x8
-    u32 nInptr; // r1+0xF4
-    u32 nOutptrL; // r1+0xF0
-    u32 nOutptrR; // r1+0xEC
-    u32 nAuxptrL; // r1+0xE8
-    u32 nAuxptrR; // r1+0xE4
-    u32 i; // r4
-    u32 nSrcAddress; // r1+0x8
-    u32 nLoopCtl; // r1+0xE0
-    s32 nUpDownVolL; // r1+0x8
-    s32 nUpDownVolR; // r1+0x8
+    unsigned int nInptr; // r1+0xF4
+    unsigned int nOutptrL; // r1+0xF0
+    unsigned int nOutptrR; // r1+0xEC
+    unsigned int nAuxptrL; // r1+0xE8
+    unsigned int nAuxptrR; // r1+0xE4
+    unsigned int i; // r4
+    unsigned int nSrcAddress; // r1+0x8
+    unsigned int nLoopCtl; // r1+0xE0
+    int nUpDownVolL; // r1+0x8
+    int nUpDownVolR; // r1+0x8
     void* pData; // r1+0x58
-    s32* dataP; // r5
+    int* dataP; // r5
     s64 tempL; // r1+0xD8
     s64 tempR; // r1+0xD0
     s64 totalL; // r1+0xC8
     s64 totalR; // r30
     s64 resultL; // r1+0x8
     s64 resultR; // r6
-    s32 volL; // r1+0x8
-    s32 volR; // r27
+    int volL; // r1+0x8
+    int volR; // r27
     s64 temp; // r0
-    s32* dataP; // r3
+    int* dataP; // r3
 }
 
 // Erased
-static s32 rspAInterleave1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspAInterleave1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 
     // Local variables
     u16 nLeft; // r1+0x0
-    u32 iIndex; // r1+0x0
-    u32 iIndex2; // r9
+    unsigned int iIndex; // r1+0x0
+    unsigned int iIndex2; // r9
 }
 
 // Range: 0x8008920C -> 0x800892A4
-static s32 rspAMix1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAMix1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r8
+    unsigned int i; // r1+0x0
+    unsigned int nCount; // r8
     s16* srcP; // r4
-    s32 outData32; // r6
+    int outData32; // r6
 }
 
 // Range: 0x80088F14 -> 0x8008920C
-static s32 rspAResample1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAResample1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r26
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     s16* srcP; // r30
@@ -335,39 +335,39 @@ static s32 rspAResample1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComma
     s16 lastValue; // r7
     u16 nCount; // r28
     u16 i; // r10
-    s32 nSrcStep; // r1+0x8
-    s32 nCursorPos; // r8
-    s32 nExtra; // r3
-    u32 scratch; // r1+0x8
+    int nSrcStep; // r1+0x8
+    int nCursorPos; // r8
+    int nExtra; // r3
+    unsigned int scratch; // r1+0x8
     u8 flags; // r27
     s16* pData; // r1+0x34
 }
 
 // Erased
-static s32 rspASaveBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASaveBuffer1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
+    // unsigned int nCommandLo; // r1+0xC
 
     // Local variables
-    u32 nSize; // r1+0x18
-    u32* pData; // r1+0x14
-    s32 nAddress; // r5
+    unsigned int nSize; // r1+0x18
+    unsigned int* pData; // r1+0x14
+    int nAddress; // r5
 }
 
 // Erased
-static s32 rspASegment1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASegment1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 }
 
 // Range: 0x80088E0C -> 0x80088F14
-static s32 rspASetBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASetBuffer1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
     u16 nDMEMIn; // r5
@@ -376,11 +376,11 @@ static s32 rspASetBuffer1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComm
 }
 
 // Range: 0x80088D74 -> 0x80088E0C
-static s32 rspASetVolume1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASetVolume1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
     u16 nFlags; // r1+0x0
@@ -390,78 +390,78 @@ static s32 rspASetVolume1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComm
 }
 
 // Erased
-static s32 rspASetLoop1(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASetLoop1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 }
 
 // Erased
-static s32 rspADMEMMove1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADMEMMove1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u16 nDMEMOut; // r1+0x8
     u16 nCount; // r5
-    u32 nDMEMIn; // r1+0x8
+    unsigned int nDMEMIn; // r1+0x8
 }
 
 // Erased
-static s32 rspALoadADPCM1(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspALoadADPCM1(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     void* pData; // r1+0x20
-    u32 nCount; // r25
-    s32 nAddress; // r5
+    unsigned int nCount; // r25
+    int nAddress; // r5
 }
 
 // Range: 0x80088B48 -> 0x80088D74
-static s32 rspParseABI(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseABI(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
     // struct __anon_0x575BD* pTask; // r31
 
     // Local variables
     u8* pFUCode; // r1+0x1C
-    u32 nCheckSum; // r4
+    unsigned int nCheckSum; // r4
 }
 
 // Range: 0x800887E8 -> 0x80088B48
-static s32 rspParseABI1(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseABI1(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r5
-    u32* pABI32; // r1+0x28
-    u32* pABILast32; // r30
-    u32 nSize; // r28
+    unsigned int nCommandLo; // r4
+    unsigned int nCommandHi; // r5
+    unsigned int* pABI32; // r1+0x28
+    unsigned int* pABILast32; // r30
+    unsigned int nSize; // r28
 
     // References
-    // -> static s32 nFirstTime$2148;
+    // -> static int nFirstTime$2148;
 }
 
 // Range: 0x80087520 -> 0x800887E8
-static s32 rspInitAudioDMEM2(struct __anon_0x5845E* pRSP) {
+static int rspInitAudioDMEM2(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Range: 0x80086BE8 -> 0x80087520
-static s32 rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r19
@@ -469,34 +469,34 @@ static s32 rspAADPCMDec2Fast(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nC
     char* pHeader; // r31
     s16* pStateAddress; // r1+0x60
     s16 anIData0; // r19
-    s32 nDMEMOut; // r30
-    s32 nCount; // r29
-    s32 nSrcAddress; // r5
-    s32 nOptPred; // r7
-    s32 nVScale; // r19
-    s32 i; // r1+0x8
-    u32 dwDecodeSelect; // r1+0x8
-    u32 n; // r10
-    s32 nA; // r11
-    s32 nB; // r12
+    int nDMEMOut; // r30
+    int nCount; // r29
+    int nSrcAddress; // r5
+    int nOptPred; // r7
+    int nVScale; // r19
+    int i; // r1+0x8
+    unsigned int dwDecodeSelect; // r1+0x8
+    unsigned int n; // r10
+    int nA; // r11
+    int nB; // r12
     s16 nSamp1; // r27
     s16 nSamp2; // r26
     s16* pTempStateAddr; // r1+0x50
     s16 nibble[4]; // r1+0x48
-    s32 nOutput; // r19
+    int nOutput; // r19
 }
 
 // Erased
-static s32 rspAADPCMDec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAADPCMDec2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u8 nFlags; // r23
     char* pDMEM8; // r1+0x110
-    s32 anCoef[8]; // r1+0xF0
+    int anCoef[8]; // r1+0xF0
     s16 anIData1[8]; // r1+0xC0
     s16 anOData0[8]; // r1+0xB0
     s16* pStateAddress; // r1+0xAC
@@ -504,66 +504,66 @@ static s32 rspAADPCMDec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComma
     s16 anOData1[8]; // r1+0x9C
     s16 anIData0[8]; // r1+0x8C
     s16 anInputVec[10]; // r1+0x78
-    s32 nDMEMIn8; // r18
-    s32 nDMEMOut; // r30
-    s32 nCount; // r19
-    s32 nSrcAddress; // r1+0x8
-    s32 nOptPred; // r23
-    s32 nHeaderBase8; // r1+0x8
-    s32 nVScale; // r29
-    s32 nScaleI; // r22
-    s32 i; // r1+0x8
-    s32 nHeader; // r25
-    s32 nTIndex; // r1+0x8
+    int nDMEMIn8; // r18
+    int nDMEMOut; // r30
+    int nCount; // r19
+    int nSrcAddress; // r1+0x8
+    int nOptPred; // r23
+    int nHeaderBase8; // r1+0x8
+    int nVScale; // r29
+    int nScaleI; // r22
+    int i; // r1+0x8
+    int nHeader; // r25
+    int nTIndex; // r1+0x8
     s16* pTempStateAddr; // r1+0x74
 }
 
 // Erased
-static s32 rspAClearBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAClearBuffer2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Range: 0x8008691C -> 0x80086BE8
-static s32 rspANoise2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspANoise2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r23
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
-    u32 nDest; // r26
-    u32 nSource; // r25
-    u32 nCount; // r24
-    u32 i; // r12
-    u32 j; // r5
+    unsigned int nDest; // r26
+    unsigned int nSource; // r25
+    unsigned int nCount; // r24
+    unsigned int i; // r12
+    unsigned int j; // r5
     s16 vIn[16]; // r1+0x78
     s16 vOut[16]; // r1+0x58
     s64 accumulator[8]; // r1+0x18
 }
 
 // Range: 0x800868B0 -> 0x8008691C
-static s32 rspANMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspANMix2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
-    u32 nCount; // r5
-    u32 i; // r1+0x0
+    unsigned int nCount; // r5
+    unsigned int i; // r1+0x0
     s16* inP; // r6
-    s32 out; // r5
+    int out; // r5
 }
 
 // Range: 0x80086680 -> 0x800868B0
-static s32 rspAResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAResample2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     s16* srcP; // r30
@@ -571,40 +571,40 @@ static s32 rspAResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComma
     s16 lastValue; // r6
     u16 nCount; // r28
     u16 i; // r7
-    s32 nSrcStep; // r1+0x8
-    s32 nCursorPos; // r8
-    u32 scratch; // r1+0x8
+    int nSrcStep; // r1+0x8
+    int nCursorPos; // r8
+    unsigned int scratch; // r1+0x8
     u8 flags; // r27
     s16* pData; // r1+0x30
 }
 
 // Erased
-static s32 rspASResample2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASResample2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
-    s32 outp; // r7
-    s32 outCount; // r6
-    s32 pitchSpeed; // r8
-    s32 i; // r9
-    s32 mainCounter; // r10
+    int outp; // r7
+    int outCount; // r6
+    int pitchSpeed; // r8
+    int i; // r9
+    int mainCounter; // r10
 }
 
 // Range: 0x800858D0 -> 0x80086680
-static s32 rspAFirFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAFirFilter2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r16
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r16
 
     // Local variables
-    s32 filterState; // r1+0x8
-    s32 filterTable; // r27
-    s32 i; // r1+0x8
-    s32 pointer; // r19
+    int filterState; // r1+0x8
+    int filterTable; // r27
+    int i; // r1+0x8
+    int pointer; // r19
     void* pData; // r1+0x114
     s16* pStateAddress; // r29
     s16 flag; // r1+0x8
@@ -612,22 +612,22 @@ static s32 rspAFirFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComm
     s16 vOLD[8]; // r1+0xF4
     s16 vTP1[8]; // r1+0xE4
     s16 vT0[8]; // r1+0xD4
-    s32 accumulator[8]; // r1+0xB4
-    s32 temp32[8]; // r1+0x94
-    s32 stateAddr; // r1+0x8
+    int accumulator[8]; // r1+0xB4
+    int temp32[8]; // r1+0x94
+    int stateAddr; // r1+0x8
     s16 anMatrix[8]; // r1+0x84
     s16 anInputVec[15]; // r1+0x64
 
     // References
-    // -> static s32 counter$2409;
+    // -> static int counter$2409;
 }
 
 // Erased
-static s32 rspASetBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASetBuffer2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
     u16 nDMEMIn; // r1+0x0
@@ -636,384 +636,384 @@ static s32 rspASetBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nComm
 }
 
 // Erased
-static s32 rspAWMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAWMEMCopy2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Erased
-static s32 rspADMEMMove2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADMEMMove2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Erased
-static s32 rspALoadADPCM2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspALoadADPCM2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r25
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r25
 
     // Local variables
     void* pData; // r1+0x20
 }
 
 // Range: 0x80085848 -> 0x800858D0
-static s32 rspAMix2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAMix2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r7
+    unsigned int i; // r1+0x0
+    unsigned int nCount; // r7
     s16* srcP; // r8
-    s32 outData32; // r6
+    int outData32; // r6
 }
 
 // Range: 0x800855FC -> 0x80085848
-static s32 rspAInterleave2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAInterleave2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
-    s32 outp; // r6
-    s32 inpr; // r1+0x8
-    s32 inpl; // r1+0x8
-    s32 count; // r7
-    s32 i; // r1+0x8
+    int outp; // r6
+    int inpr; // r1+0x8
+    int inpl; // r1+0x8
+    int count; // r7
+    int i; // r1+0x8
 }
 
 // Range: 0x800854F0 -> 0x800855FC
-static s32 rspADistFilter2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADistFilter2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r26
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     s16 dpow; // r7
-    s32 i; // r27
+    int i; // r27
     s64 mult; // r3
 }
 
 // Erased
-static s32 rspASetLoop2(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASetLoop2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 }
 
 // Erased
-static s32 rspADMEMCopy2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADMEMCopy2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Erased
-static s32 rspAHalfCut2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAHalfCut2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
-    s32 count; // r1+0x8
-    s32 outp; // r1+0x8
-    s32 inpp; // r7
-    s32 i; // r8
+    int count; // r1+0x8
+    int outp; // r1+0x8
+    int inpp; // r7
+    int i; // r8
 }
 
 // Erased
-static s32 rspASetEnvParam2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASetEnvParam2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
     s16 temp; // r7
 }
 
 // Erased
-static s32 rspASetEnvParam22(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASetEnvParam22(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 
     // Local variables
     s16 tmp; // r6
 }
 
 // Range: 0x80085218 -> 0x800854F0
-static s32 rspAEnvMixer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAEnvMixer2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     s16 vStep[8]; // r1+0x3C
     u16 vParams[8]; // r1+0x2C
-    s32 i; // r28
-    s32 j; // r27
-    s32 inpp; // r26
-    s32 outL; // r25
-    s32 outR; // r24
-    s32 outFL; // r23
-    s32 outFR; // r22
-    s32 count; // r21
-    s32 temp; // r1+0x8
+    int i; // r28
+    int j; // r27
+    int inpp; // r26
+    int outL; // r25
+    int outR; // r24
+    int outFL; // r23
+    int outFR; // r22
+    int count; // r21
+    int temp; // r1+0x8
     s32 id; // r1+0x8
-    s32 waveL; // r20
-    s32 waveR; // r19
-    s32 waveI; // r15
-    s32 srcL; // r18
-    s32 srcR; // r17
-    s32 srcFXL; // r16
-    s32 srcFXR; // r10
+    int waveL; // r20
+    int waveR; // r19
+    int waveI; // r15
+    int srcL; // r18
+    int srcR; // r17
+    int srcFXL; // r16
+    int srcFXR; // r10
 }
 
 // Erased
-static s32 rspALoadBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspALoadBuffer2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r31
 
     // Local variables
     void* pData; // r1+0x14
 }
 
 // Erased
-static s32 rspASaveBuffer2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASaveBuffer2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r31
 
     // Local variables
     void* pData; // r1+0x14
 }
 
 // Range: 0x80084984 -> 0x80085218
-static s32 rspAPCM8Dec2(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAPCM8Dec2(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r25
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r25
 
     // Local variables
-    s32 inpp; // r31
-    s32 outp; // r30
-    s32 count; // r26
+    int inpp; // r31
+    int outp; // r30
+    int count; // r26
     s16 flags; // r1+0x8
     s16 vtmp0[8]; // r1+0x60
     s16 vtmp1[8]; // r1+0x50
-    s32 i; // r1+0x8
-    s32 j; // r1+0x8
-    s32 stateAddr; // r5
-    s32 s; // r1+0x8
+    int i; // r1+0x8
+    int j; // r1+0x8
+    int stateAddr; // r5
+    int s; // r1+0x8
     void* pData; // r1+0x4C
     s16* pStateAddress; // r29
     s16* pTempStateAddr; // r7
 }
 
 // Range: 0x8008429C -> 0x80084984
-static s32 rspParseABI2(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseABI2(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x40
-    u32* pABILast32; // r29
-    u32 nSize; // r23
+    unsigned int nCommandLo; // r4
+    unsigned int nCommandHi; // r30
+    unsigned int* pABI32; // r1+0x40
+    unsigned int* pABILast32; // r29
+    unsigned int nSize; // r23
 
     // References
-    // -> static s32 nFirstTime$2648;
+    // -> static int nFirstTime$2648;
 }
 
 // Range: 0x80082E60 -> 0x8008429C
-static s32 rspInitAudioDMEM3(struct __anon_0x5845E* pRSP) {
+static int rspInitAudioDMEM3(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Erased
-static s32 rspASetEnvParam3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASetEnvParam3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 }
 
 // Erased
-static s32 rspASetEnvParam32(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspASetEnvParam32(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 }
 
 // Erased
-static s32 rspALoadBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspALoadBuffer3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r31
 
     // Local variables
     void* pData; // r1+0x14
 }
 
 // Erased
-static s32 rspASaveBuffer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspASaveBuffer3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // u32 nCommandLo; // r4
-    // u32 nCommandHi; // r31
+    // unsigned int nCommandLo; // r4
+    // unsigned int nCommandHi; // r31
 
     // Local variables
     void* pData; // r1+0x14
 }
 
 // Range: 0x80082C2C -> 0x80082E60
-static s32 rspAEnvMixer3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAEnvMixer3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u16 vParams[8]; // r1+0x20
-    s32 i; // r27
-    s32 j; // r1+0x8
-    s32 inpp; // r26
-    s32 outL; // r25
-    s32 outR; // r24
-    s32 outFL; // r23
-    s32 outFR; // r22
-    s32 count; // r21
+    int i; // r27
+    int j; // r1+0x8
+    int inpp; // r26
+    int outL; // r25
+    int outR; // r24
+    int outFL; // r23
+    int outFR; // r22
+    int count; // r21
     s32 id; // r1+0x8
-    s32 waveL; // r20
-    s32 waveR; // r19
-    s32 waveI; // r19
-    s32 srcL; // r18
-    s32 srcR; // r17
-    s32 srcFXL; // r16
-    s32 srcFXR; // r12
+    int waveL; // r20
+    int waveR; // r19
+    int waveI; // r19
+    int srcL; // r18
+    int srcR; // r17
+    int srcFXL; // r16
+    int srcFXR; // r12
 }
 
 // Erased
-static s32 rspAHalfCut3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAHalfCut3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
-    s32 count; // r1+0x8
-    s32 outp; // r1+0x8
-    s32 inpp; // r7
-    s32 i; // r8
+    int count; // r1+0x8
+    int outp; // r1+0x8
+    int inpp; // r7
+    int i; // r8
 }
 
 // Range: 0x80082B94 -> 0x80082C2C
-static s32 rspAMix3(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspAMix3(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
-    // u32 nCommandHi; // r1+0x8
+    // unsigned int nCommandLo; // r1+0x4
+    // unsigned int nCommandHi; // r1+0x8
 
     // Local variables
-    u32 i; // r1+0x0
-    u32 nCount; // r8
+    unsigned int i; // r1+0x0
+    unsigned int nCount; // r8
     s16* srcP; // r4
-    s32 outData32; // r6
+    int outData32; // r6
 }
 
 // Erased
-static s32 rspADMEMCopy(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADMEMCopy(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 }
 
 // Range: 0x80082624 -> 0x80082B94
-static s32 rspParseABI3(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseABI3(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x38
-    u32* pABILast32; // r29
-    u32 nSize; // r23
+    unsigned int nCommandLo; // r4
+    unsigned int nCommandHi; // r30
+    unsigned int* pABI32; // r1+0x38
+    unsigned int* pABILast32; // r29
+    unsigned int nSize; // r23
 
     // References
-    // -> static s32 nFirstTime$2757;
+    // -> static int nFirstTime$2757;
 }
 
 // Range: 0x800811C0 -> 0x80082624
-static s32 rspInitAudioDMEM4(struct __anon_0x5845E* pRSP) {
+static int rspInitAudioDMEM4(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Erased
-static s32 rspARingFilter4() {}
+static int rspARingFilter4() {}
 
 // Erased
-static s32 rspAInterleave4(struct __anon_0x5845E* pRSP, u32 nCommandLo) {
+static int rspAInterleave4(struct __anon_0x5845E* pRSP, unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nCommandLo; // r1+0x4
+    // unsigned int nCommandLo; // r1+0x4
 
     // Local variables
-    u32 iIndex; // r1+0x0
-    u32 iIndex2; // r9
+    unsigned int iIndex; // r1+0x0
+    unsigned int iIndex2; // r9
 }
 
 // Erased
-static s32 rspADMEMMove4(struct __anon_0x5845E* pRSP, u32 nCommandLo, u32 nCommandHi) {
+static int rspADMEMMove4(struct __anon_0x5845E* pRSP, unsigned int nCommandLo, unsigned int nCommandHi) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // u32 nCommandLo; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0xC
+    // unsigned int nCommandHi; // r1+0x10
 
     // Local variables
     u16 nDMEMOut; // r1+0x8
     u16 nCount; // r4
-    u32 nDMEMIn; // r1+0x8
+    unsigned int nDMEMIn; // r1+0x8
 }
 
 // Range: 0x80080AA4 -> 0x800811C0
-static s32 rspParseABI4(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseABI4(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x575BD* pTask; // r5
 
     // Local variables
-    u32 nCommandLo; // r4
-    u32 nCommandHi; // r30
-    u32* pABI32; // r1+0x40
-    u32* pABILast32; // r29
-    u32 nSize; // r23
+    unsigned int nCommandLo; // r4
+    unsigned int nCommandHi; // r30
+    unsigned int* pABI32; // r1+0x40
+    unsigned int* pABILast32; // r29
+    unsigned int nSize; // r23
 
     // References
-    // -> static s32 nFirstTime$2796;
+    // -> static int nFirstTime$2796;
 }

--- a/debug/Fire/_buildtev.c
+++ b/debug/Fire/_buildtev.c
@@ -181,10 +181,10 @@ typedef enum __anon_0x8A896 {
 } __anon_0x8A896;
 
 typedef struct __anon_0x8A8FE {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x8A8FE; // size = 0x10
 
 typedef enum __anon_0x8A9AF {
@@ -228,7 +228,7 @@ typedef enum __anon_0x8AAE1 {
 typedef struct __anon_0x8AC22 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x8A896 eMode;
     /* 0x10 */ struct __anon_0x8A8FE romCopy;
     /* 0x20 */ enum __anon_0x8A9AF eTypeROM;
@@ -236,7 +236,7 @@ typedef struct __anon_0x8AC22 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x8AAE1 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x8AC22; // size = 0x88
 
 // size = 0x4, address = 0x80135600

--- a/debug/Fire/_cpuDecodePPC2.c
+++ b/debug/Fire/_cpuDecodePPC2.c
@@ -8,361 +8,361 @@
 #include "dolphin/types.h"
 
 // Range: 0x8006BC80 -> 0x8006BE68
-static s32 cpuCompile_DSLLV(s32* addressGCN) {
+static int cpuCompile_DSLLV(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r11
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r11
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006BA98 -> 0x8006BC80
-static s32 cpuCompile_DSRLV(s32* addressGCN) {
+static int cpuCompile_DSRLV(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r11
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r11
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006B894 -> 0x8006BA98
-static s32 cpuCompile_DSRAV(s32* addressGCN) {
+static int cpuCompile_DSRAV(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r1+0x8
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r1+0x8
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006B390 -> 0x8006B894
-static s32 cpuCompile_DMULT(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_DMULT(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r27
+    // int* addressGCN; // r27
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006B07C -> 0x8006B390
-static s32 cpuCompile_DMULTU(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_DMULTU(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r30
+    // int* addressGCN; // r30
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006AAC0 -> 0x8006B07C
-static s32 cpuCompile_DDIV(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_DDIV(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r16
+    // int* addressGCN; // r16
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r23
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r23
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006A6A4 -> 0x8006AAC0
-static s32 cpuCompile_DDIVU(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_DDIVU(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r24
+    // int* addressGCN; // r24
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r9
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_DADD(s32* addressGCN) {
+static int cpuCompile_DADD(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_DADDU(s32* addressGCN) {
+static int cpuCompile_DADDU(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_DSUB(s32* addressGCN) {
+static int cpuCompile_DSUB(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_DSUBU(s32* addressGCN) {
+static int cpuCompile_DSUBU(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006A364 -> 0x8006A6A4
-static s32 cpuCompile_S_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_S_SQRT(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r19
-    // s32* addressGCN; // r18
+    // int* addressGCN; // r18
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r29
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r29
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069F30 -> 0x8006A364
-static s32 cpuCompile_D_SQRT(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_D_SQRT(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r22
-    // s32* addressGCN; // r21
+    // int* addressGCN; // r21
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r21
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r21
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069D80 -> 0x80069F30
-static s32 cpuCompile_W_CVT_SD(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_W_CVT_SD(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32* addressGCN; // r30
+    // int* addressGCN; // r30
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r30
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r30
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069800 -> 0x80069D80
-static s32 cpuCompile_L_CVT_SD(s32* addressGCN) {
+static int cpuCompile_L_CVT_SD(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069644 -> 0x80069800
-static s32 cpuCompile_CEIL_W(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_CEIL_W(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069488 -> 0x80069644
-static s32 cpuCompile_FLOOR_W(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_FLOOR_W(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_ROUND_W(s32* addressGCN) {
+static int cpuCompile_ROUND_W(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Erased
-static s32 cpuCompile_TRUNC_W(s32* addressGCN) {
+static int cpuCompile_TRUNC_W(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006931C -> 0x80069488
-static s32 cpuCompile_LB(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LB(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r9
+    int nSize; // r1+0x8
 }
 
 // Range: 0x800691B0 -> 0x8006931C
-static s32 cpuCompile_LH(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LH(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r9
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80069058 -> 0x800691B0
-static s32 cpuCompile_LW(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LW(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068F00 -> 0x80069058
-static s32 cpuCompile_LBU(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LBU(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068DA8 -> 0x80068F00
-static s32 cpuCompile_LHU(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LHU(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068C4C -> 0x80068DA8
-static s32 cpuCompile_SB(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_SB(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068AF0 -> 0x80068C4C
-static s32 cpuCompile_SH(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_SH(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068994 -> 0x80068AF0
-static s32 cpuCompile_SW(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_SW(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8006880C -> 0x80068994
-static s32 cpuCompile_LDC(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_LDC(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068684 -> 0x8006880C
-static s32 cpuCompile_SDC(struct _CPU* pCPU, s32* addressGCN) {
+static int cpuCompile_SDC(struct _CPU* pCPU, int* addressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r5
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r5
+    int nSize; // r1+0x8
 }
 
 // Range: 0x800684F4 -> 0x80068684
-static s32 cpuCompile_LWL(s32* addressGCN) {
+static int cpuCompile_LWL(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r9
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r9
+    int nSize; // r1+0x8
 }
 
 // Range: 0x80068368 -> 0x800684F4
-static s32 cpuCompile_LWR(s32* addressGCN) {
+static int cpuCompile_LWR(int* addressGCN) {
     // Parameters
-    // s32* addressGCN; // r31
+    // int* addressGCN; // r31
 
     // Local variables
-    s32* compile; // r1+0x10
-    s32 count; // r7
-    s32 nSize; // r1+0x8
+    int* compile; // r1+0x10
+    int count; // r7
+    int nSize; // r1+0x8
 }

--- a/debug/Fire/_cpuGCN.c
+++ b/debug/Fire/_cpuGCN.c
@@ -8,204 +8,204 @@
 #include "dolphin/types.h"
 
 // Erased
-static s32 cpuFindBranchOffset(struct cpu_function* pFunction, s32* pnOffset, s32 nAddress, s32* anCode) {
+static int cpuFindBranchOffset(struct cpu_function* pFunction, int* pnOffset, int nAddress, int* anCode) {
     // Parameters
     // struct cpu_function* pFunction; // r1+0x4
-    // s32* pnOffset; // r1+0x8
-    // s32 nAddress; // r1+0xC
-    // s32* anCode; // r1+0x10
+    // int* pnOffset; // r1+0x8
+    // int nAddress; // r1+0xC
+    // int* anCode; // r1+0x10
 
     // Local variables
-    s32 iJump; // r8
+    int iJump; // r8
 }
 
 // Range: 0x80068238 -> 0x80068368
-static s32 cpuCheckDelaySlot(u32 opcode) {
+static int cpuCheckDelaySlot(unsigned int opcode) {
     // Parameters
-    // u32 opcode; // r1+0x0
+    // unsigned int opcode; // r1+0x0
 
     // Local variables
-    s32 flag; // r5
+    int flag; // r5
 }
 
 // Erased
-static void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
+static void cpuCompileNOP(int* anCode, int* iCode, int number) {
     // Parameters
-    // s32* anCode; // r1+0x0
-    // s32* iCode; // r1+0x4
-    // s32 number; // r5
+    // int* anCode; // r1+0x0
+    // int* iCode; // r1+0x4
+    // int number; // r5
 }
 
 // Erased
-static s32 cpuRecompileFunction(struct _CPU* pCPU, struct cpu_function* pFunction, s32 nAddressN64) {
+static int cpuRecompileFunction(struct _CPU* pCPU, struct cpu_function* pFunction, int nAddressN64) {
     // Parameters
     // struct _CPU* pCPU; // r31
     // struct cpu_function* pFunction; // r1+0xC
-    // s32 nAddressN64; // r5
+    // int nAddressN64; // r5
 }
 
 // Range: 0x8003EE04 -> 0x80068238
-static s32 cpuGetPPC(struct _CPU* pCPU, s32* pnAddress, struct cpu_function* pFunction, s32* anCode, s32* piCode,
-                     s32 bSlot) {
+static int cpuGetPPC(struct _CPU* pCPU, int* pnAddress, struct cpu_function* pFunction, int* anCode, int* piCode,
+                     int bSlot) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* pnAddress; // r18
+    // int* pnAddress; // r18
     // struct cpu_function* pFunction; // r27
-    // s32* anCode; // r31
-    // s32* piCode; // r16
-    // s32 bSlot; // r1+0x8C
+    // int* anCode; // r31
+    // int* piCode; // r16
+    // int bSlot; // r1+0x8C
 
     // Local variables
-    s32 nSize; // r1+0x88
-    s32 iHack; // r1+0x8
-    s32 bInterpret; // r22
-    s32 iCode; // r1+0x84
-    s32 iJump; // r23
-    s32 nAddress; // r29
-    s32 nDeltaAddress; // r21
-    s32 bFlag; // r15
-    s32 nAddressJump; // r6
-    s32 nOffset; // r25
-    u32 nOpcode; // r28
-    u32 nOpcodePrev; // r23
-    u32 nOpcodeNext; // r24
-    u32* pnOpcode; // r1+0x7C
-    s32 prev; // r19
-    s32 iRegisterA; // r1+0x8
-    s32 iRegisterB; // r9
-    s32 iRegisterC; // r7
-    s32 nTemp1; // r1+0x8
-    s32 nTemp2; // r1+0x8
-    s32 nTemp3; // r3
-    s32 update; // r14
-    s32 iUpdate; // r1+0x90
-    s32 nTarget; // r3
+    int nSize; // r1+0x88
+    int iHack; // r1+0x8
+    int bInterpret; // r22
+    int iCode; // r1+0x84
+    int iJump; // r23
+    int nAddress; // r29
+    int nDeltaAddress; // r21
+    int bFlag; // r15
+    int nAddressJump; // r6
+    int nOffset; // r25
+    unsigned int nOpcode; // r28
+    unsigned int nOpcodePrev; // r23
+    unsigned int nOpcodeNext; // r24
+    unsigned int* pnOpcode; // r1+0x7C
+    int prev; // r19
+    int iRegisterA; // r1+0x8
+    int iRegisterB; // r9
+    int iRegisterC; // r7
+    int nTemp1; // r1+0x8
+    int nTemp2; // r1+0x8
+    int nTemp3; // r3
+    int update; // r14
+    int iUpdate; // r1+0x90
+    int nTarget; // r3
 
     // References
-    // -> s32 ganMapGPR[32];
-    // -> static s32 cpuCompile_SDC_function;
-    // -> static s32 cpuCompile_SW_function;
-    // -> static s32 cpuCompile_LDC_function;
-    // -> static s32 cpuCompile_LW_function;
+    // -> int ganMapGPR[32];
+    // -> static int cpuCompile_SDC_function;
+    // -> static int cpuCompile_SW_function;
+    // -> static int cpuCompile_LDC_function;
+    // -> static int cpuCompile_LW_function;
     // -> struct __anon_0x3DB14* gpSystem;
-    // -> static s32 cpuCompile_SH_function;
-    // -> static s32 cpuCompile_SB_function;
-    // -> static s32 cpuCompile_LWR_function;
-    // -> static s32 cpuCompile_LHU_function;
-    // -> static s32 cpuCompile_LBU_function;
-    // -> static s32 cpuCompile_LWL_function;
-    // -> static s32 cpuCompile_LH_function;
-    // -> static s32 cpuCompile_LB_function;
-    // -> static s32 cpuCompile_L_CVT_SD_function;
-    // -> static s32 cpuCompile_W_CVT_SD_function;
-    // -> static s32 cpuCompile_TRUNC_W_function;
-    // -> static s32 cpuCompile_FLOOR_W_function;
-    // -> static s32 cpuCompile_CEIL_W_function;
-    // -> static s32 cpuCompile_ROUND_W_function;
-    // -> static s32 cpuCompile_D_SQRT_function;
-    // -> static s32 cpuCompile_S_SQRT_function;
-    // -> static s32 cpuCompile_DSUBU_function;
-    // -> static s32 cpuCompile_DSUB_function;
-    // -> static s32 cpuCompile_DADDU_function;
-    // -> static s32 cpuCompile_DADD_function;
-    // -> static s32 cpuCompile_DDIVU_function;
-    // -> static s32 cpuCompile_DDIV_function;
-    // -> static s32 cpuCompile_DMULTU_function;
-    // -> static s32 cpuCompile_DMULT_function;
-    // -> static s32 cpuCompile_DSRAV_function;
-    // -> static s32 cpuCompile_DSRLV_function;
-    // -> static s32 cpuCompile_DSLLV_function;
+    // -> static int cpuCompile_SH_function;
+    // -> static int cpuCompile_SB_function;
+    // -> static int cpuCompile_LWR_function;
+    // -> static int cpuCompile_LHU_function;
+    // -> static int cpuCompile_LBU_function;
+    // -> static int cpuCompile_LWL_function;
+    // -> static int cpuCompile_LH_function;
+    // -> static int cpuCompile_LB_function;
+    // -> static int cpuCompile_L_CVT_SD_function;
+    // -> static int cpuCompile_W_CVT_SD_function;
+    // -> static int cpuCompile_TRUNC_W_function;
+    // -> static int cpuCompile_FLOOR_W_function;
+    // -> static int cpuCompile_CEIL_W_function;
+    // -> static int cpuCompile_ROUND_W_function;
+    // -> static int cpuCompile_D_SQRT_function;
+    // -> static int cpuCompile_S_SQRT_function;
+    // -> static int cpuCompile_DSUBU_function;
+    // -> static int cpuCompile_DSUB_function;
+    // -> static int cpuCompile_DADDU_function;
+    // -> static int cpuCompile_DADD_function;
+    // -> static int cpuCompile_DDIVU_function;
+    // -> static int cpuCompile_DDIV_function;
+    // -> static int cpuCompile_DMULTU_function;
+    // -> static int cpuCompile_DMULT_function;
+    // -> static int cpuCompile_DSRAV_function;
+    // -> static int cpuCompile_DSRLV_function;
+    // -> static int cpuCompile_DSLLV_function;
 }
 
 // Range: 0x8003E974 -> 0x8003EE04
-s32 cpuMakeFunction(struct _CPU* pCPU, struct cpu_function** ppFunction, s32 nAddressN64) {
+int cpuMakeFunction(struct _CPU* pCPU, struct cpu_function** ppFunction, int nAddressN64) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // struct cpu_function** ppFunction; // r31
-    // s32 nAddressN64; // r5
+    // int nAddressN64; // r5
 
     // Local variables
-    s32 iCode; // r1+0x2028
-    s32 iCode0; // r1+0x8
-    s32 iJump; // r7
-    s32 iCheck; // r1+0x8
-    s32 firstTime; // r24
-    s32 kill_value; // r23
-    s32 memory_used; // r22
-    s32 codeMemory; // r1+0x8
-    s32 blockMemory; // r21
-    s32* chunkMemory; // r1+0x2020
-    s32* anCode; // r23
-    s32 nAddress; // r1+0x201C
+    int iCode; // r1+0x2028
+    int iCode0; // r1+0x8
+    int iJump; // r7
+    int iCheck; // r1+0x8
+    int firstTime; // r24
+    int kill_value; // r23
+    int memory_used; // r22
+    int codeMemory; // r1+0x8
+    int blockMemory; // r21
+    int* chunkMemory; // r1+0x2020
+    int* anCode; // r23
+    int nAddress; // r1+0x201C
     struct cpu_function* pFunction; // r1+0x2018
     struct __anon_0x3DE78 aJump[1024]; // r1+0x18
 }
 
 // Erased
-static s32 cpuFreeFunction(struct _CPU* pCPU, struct cpu_function* pFunction) {
+static int cpuFreeFunction(struct _CPU* pCPU, struct cpu_function* pFunction) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // struct cpu_function* pFunction; // r4
 }
 
 // Range: 0x8003E4D8 -> 0x8003E974
-static s32 cpuFindAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressGCN) {
+static int cpuFindAddress(struct _CPU* pCPU, int nAddressN64, int* pnAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 nAddressN64; // r30
-    // s32* pnAddressGCN; // r31
+    // int nAddressN64; // r30
+    // int* pnAddressGCN; // r31
 
     // Local variables
-    s32 iJump; // r6
-    s32 iCode; // r1+0x20
-    s32 nAddress; // r1+0x1C
+    int iJump; // r6
+    int iCode; // r1+0x20
+    int nAddress; // r1+0x1C
     struct cpu_function* pFunction; // r1+0x18
 }
 
 // Erased
-static s32 cpuNoBranchTo(struct cpu_function* pFunction, s32 currentAddress) {
+static int cpuNoBranchTo(struct cpu_function* pFunction, int currentAddress) {
     // Parameters
     // struct cpu_function* pFunction; // r1+0x0
-    // s32 currentAddress; // r1+0x4
+    // int currentAddress; // r1+0x4
 
     // Local variables
-    s32 i; // r1+0x0
+    int i; // r1+0x0
 }
 
 // Erased
-static s32 cpuCutStoreLoad(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+static int cpuCutStoreLoad(struct _CPU* pCPU, int currentAddress, int source) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32 source; // r1+0x8
+    // int currentAddress; // r1+0x4
+    // int source; // r1+0x8
 }
 
 // Erased
-static s32 cpuCutStoreLoadF(struct _CPU* pCPU, s32 currentAddress, s32 source) {
+static int cpuCutStoreLoadF(struct _CPU* pCPU, int currentAddress, int source) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32 source; // r1+0x8
+    // int currentAddress; // r1+0x4
+    // int source; // r1+0x8
 }
 
 // Erased
-static s32 cpuStackOffset(struct _CPU* pCPU, s32 currentAddress, s32* anCode, s32 source, s32 target) {
+static int cpuStackOffset(struct _CPU* pCPU, int currentAddress, int* anCode, int source, int target) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 currentAddress; // r1+0x4
-    // s32* anCode; // r1+0x8
-    // s32 source; // r1+0xC
-    // s32 target; // r1+0x10
+    // int currentAddress; // r1+0x4
+    // int* anCode; // r1+0x8
+    // int source; // r1+0xC
+    // int target; // r1+0x10
 }
 
 // Range: 0x8003E214 -> 0x8003E4D8
-static s32 cpuNextInstruction(struct _CPU* pCPU, s32 addressN64, s32 opcode, s32* anCode, s32* iCode) {
+static int cpuNextInstruction(struct _CPU* pCPU, int addressN64, int opcode, int* anCode, int* iCode) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // s32 addressN64; // r10
-    // s32 opcode; // r5
-    // s32* anCode; // r1+0x14
-    // s32* iCode; // r1+0x18
+    // int addressN64; // r10
+    // int opcode; // r5
+    // int* anCode; // r1+0x14
+    // int* iCode; // r1+0x18
 }
 
 // Erased
@@ -221,186 +221,186 @@ static void cpuAlarmCallback(struct OSAlarm* pAlarm) {
 }
 
 // Range: 0x8003E204 -> 0x8003E214
-static void cpuRetraceCallback(u32 nCount) {
+static void cpuRetraceCallback(unsigned int nCount) {
     // Parameters
-    // u32 nCount; // r1+0x0
+    // unsigned int nCount; // r1+0x0
 
     // References
     // -> struct __anon_0x3DB14* gpSystem;
 }
 
 // Erased
-static s32 cpuRetraceSetup(struct _CPU* pCPU) {
+static int cpuRetraceSetup(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
 }
 
 // Erased
-static s32 cpuRetraceReset() {}
+static int cpuRetraceReset() {}
 
 // Range: 0x8003DF08 -> 0x8003E204
-static s32 cpuExecuteUpdate(struct _CPU* pCPU, s32* pnAddressGCN, u32 nCount) {
+static int cpuExecuteUpdate(struct _CPU* pCPU, int* pnAddressGCN, unsigned int nCount) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32* pnAddressGCN; // r29
-    // u32 nCount; // r30
+    // int* pnAddressGCN; // r29
+    // unsigned int nCount; // r30
 
     // Local variables
     enum __anon_0x44829 eModeUpdate; // r4
     struct __anon_0x3DB14* pSystem; // r31
-    s32 nDelta; // r1+0x8
-    u32 nCounter; // r1+0x8
-    u32 nCompare; // r1+0x8
+    int nDelta; // r1+0x8
+    unsigned int nCounter; // r1+0x8
+    unsigned int nCompare; // r1+0x8
 
     // References
     // -> struct __anon_0x3DB14* gpSystem;
-    // -> u32 nTickMultiplier;
+    // -> unsigned int nTickMultiplier;
     // -> f32 fTickScale;
 }
 
 // Range: 0x80039594 -> 0x8003DF08
-static s32 cpuExecuteOpcode(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteOpcode(struct _CPU* pCPU, int nCount, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32 nCount; // r1+0xC
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r1+0x14
+    // int nCount; // r1+0xC
+    // int nAddressN64; // r22
+    // int nAddressGCN; // r1+0x14
 
     // Local variables
     u64 save; // r25
-    s32 restore; // r27
-    u32 nOpcode; // r30
-    u32* opcode; // r1+0x6C
+    int restore; // r27
+    unsigned int nOpcode; // r30
+    unsigned int* opcode; // r1+0x6C
     struct __anon_0x3EB4F** apDevice; // r28
     u8* aiDevice; // r29
-    s32 iEntry; // r4
-    s32 nCount; // r22
+    int iEntry; // r4
+    int nCount; // r22
     char nData8; // r1+0x66
     s16 nData16; // r1+0x64
-    s32 nData32; // r1+0x60
+    int nData32; // r1+0x60
     s64 nData64; // r1+0x58
-    s32 nAddress; // r23
+    int nAddress; // r23
     struct cpu_function* pFunction; // r1+0x50
 
     // References
-    // -> s32 __float_huge[];
-    // -> s32 __float_nan[];
+    // -> int __float_huge[];
+    // -> int __float_nan[];
 }
 
 // Range: 0x80039488 -> 0x80039594
-static s32 cpuExecuteIdle(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteIdle(struct _CPU* pCPU, int nCount, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32 nCount; // r28
-    // s32 nAddressN64; // r29
-    // s32 nAddressGCN; // r1+0x14
+    // int nCount; // r28
+    // int nAddressN64; // r29
+    // int nAddressGCN; // r1+0x14
 
     // Local variables
     struct __anon_0x443F6* pROM; // r30
 }
 
 // Range: 0x800393B8 -> 0x80039488
-static s32 cpuExecuteJump(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteJump(struct _CPU* pCPU, int nCount, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 nCount; // r30
-    // s32 nAddressN64; // r31
-    // s32 nAddressGCN; // r1+0x14
+    // int nCount; // r30
+    // int nAddressN64; // r31
+    // int nAddressGCN; // r1+0x14
 
     // References
     // -> struct __anon_0x3DB14* gpSystem;
 }
 
 // Range: 0x80039158 -> 0x800393B8
-static s32 cpuExecuteCall(struct _CPU* pCPU, s32 nCount, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteCall(struct _CPU* pCPU, int nCount, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32 nCount; // r29
-    // s32 nAddressN64; // r30
-    // s32 nAddressGCN; // r1+0x14
+    // int nCount; // r29
+    // int nAddressN64; // r30
+    // int nAddressGCN; // r1+0x14
 
     // Local variables
-    s32 count; // r4
-    s32* anCode; // r30
-    s32 saveGCN; // r31
+    int count; // r4
+    int* anCode; // r30
+    int saveGCN; // r31
     struct cpu_function* node; // r1+0x18
     struct cpu_callerID* block; // r5
-    s32 nDeltaAddress; // r1+0x8
+    int nDeltaAddress; // r1+0x8
 
     // References
-    // -> s32 ganMapGPR[32];
+    // -> int ganMapGPR[32];
 }
 
 // Range: 0x800382F8 -> 0x80039158
-static s32 cpuExecuteLoadStore(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteLoadStore(struct _CPU* pCPU, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r24
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r27
+    // int nAddressN64; // r22
+    // int nAddressGCN; // r27
 
     // Local variables
-    u32* opcode; // r1+0x1C
-    s32 address; // r1+0x8
-    s32 iRegisterA; // r5
-    s32 iRegisterB; // r1+0x8
+    unsigned int* opcode; // r1+0x1C
+    int address; // r1+0x8
+    int iRegisterA; // r5
+    int iRegisterB; // r1+0x8
     u8 device; // r5
-    s32 total; // r23
-    s32 count; // r31
-    s32 save; // r30
-    s32 interpret; // r29
-    s32* before; // r28
-    s32* after; // r27
-    s32 check2; // r26
-    s32* anCode; // r25
+    int total; // r23
+    int count; // r31
+    int save; // r30
+    int interpret; // r29
+    int* before; // r28
+    int* after; // r27
+    int check2; // r26
+    int* anCode; // r25
 
     // References
-    // -> s32 ganMapGPR[32];
+    // -> int ganMapGPR[32];
 }
 
 // Range: 0x8003779C -> 0x800382F8
-static s32 cpuExecuteLoadStoreF(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressGCN) {
+static int cpuExecuteLoadStoreF(struct _CPU* pCPU, int nAddressN64, int nAddressGCN) {
     // Parameters
     // struct _CPU* pCPU; // r31
-    // s32 nAddressN64; // r22
-    // s32 nAddressGCN; // r25
+    // int nAddressN64; // r22
+    // int nAddressGCN; // r25
 
     // Local variables
-    u32* opcode; // r1+0x1C
-    s32 address; // r1+0x8
-    s32 iRegisterA; // r6
-    s32 iRegisterB; // r1+0x8
+    unsigned int* opcode; // r1+0x1C
+    int address; // r1+0x8
+    int iRegisterA; // r6
+    int iRegisterB; // r1+0x8
     u8 device; // r5
-    s32 total; // r30
-    s32 count; // r29
-    s32 save; // r28
-    s32 interpret; // r27
-    s32* before; // r26
-    s32* after; // r25
-    s32 check2; // r24
-    s32* anCode; // r23
+    int total; // r30
+    int count; // r29
+    int save; // r28
+    int interpret; // r27
+    int* before; // r26
+    int* after; // r25
+    int check2; // r24
+    int* anCode; // r23
 
     // References
-    // -> s32 ganMapGPR[32];
+    // -> int ganMapGPR[32];
 }
 
 // Range: 0x800374DC -> 0x8003779C
-static s32 cpuMakeLink(struct _CPU* pCPU, void (**ppfLink)(), void (*pfFunction)()) {
+static int cpuMakeLink(struct _CPU* pCPU, void (**ppfLink)(), void (*pfFunction)()) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // void (** ppfLink)(); // r30
     // void (* pfFunction)(); // r31
 
     // Local variables
-    s32 iGPR; // r1+0x8
-    s32* pnCode; // r1+0x18
-    s32 nData; // r1+0x8
+    int iGPR; // r1+0x8
+    int* pnCode; // r1+0x18
+    int nData; // r1+0x8
 
     // References
-    // -> s32 ganMapGPR[32];
+    // -> int ganMapGPR[32];
 }
 
 // Erased
-static s32 cpuFreeLink(void (**ppfLink)()) {
+static int cpuFreeLink(void (**ppfLink)()) {
     // Parameters
     // void (** ppfLink)(); // r1+0xC
 }
@@ -409,48 +409,48 @@ static s32 cpuFreeLink(void (**ppfLink)()) {
 static void __cpuTest() {}
 
 // Range: 0x80036870 -> 0x800374DC
-s32 cpuExecute(struct _CPU* pCPU) {
+int cpuExecute(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 iGPR; // r8
-    s32* pnCode; // r1+0x54
-    s32 nData; // r1+0x8
+    int iGPR; // r8
+    int* pnCode; // r1+0x54
+    int nData; // r1+0x8
     struct cpu_function* pFunction; // r1+0x4C
     void (*pfCode)(); // r1+0x48
 
     // References
-    // -> static s32 cpuCompile_LWR_function;
-    // -> static s32 cpuCompile_LWL_function;
-    // -> static s32 cpuCompile_SDC_function;
-    // -> static s32 cpuCompile_LDC_function;
-    // -> static s32 cpuCompile_SW_function;
-    // -> static s32 cpuCompile_SH_function;
-    // -> static s32 cpuCompile_SB_function;
-    // -> static s32 cpuCompile_LHU_function;
-    // -> static s32 cpuCompile_LBU_function;
-    // -> static s32 cpuCompile_LW_function;
-    // -> static s32 cpuCompile_LH_function;
-    // -> static s32 cpuCompile_LB_function;
-    // -> static s32 cpuCompile_ROUND_W_function;
-    // -> static s32 cpuCompile_TRUNC_W_function;
-    // -> static s32 cpuCompile_FLOOR_W_function;
-    // -> static s32 cpuCompile_CEIL_W_function;
-    // -> static s32 cpuCompile_L_CVT_SD_function;
-    // -> static s32 cpuCompile_W_CVT_SD_function;
-    // -> static s32 cpuCompile_D_SQRT_function;
-    // -> static s32 cpuCompile_S_SQRT_function;
-    // -> static s32 cpuCompile_DSUBU_function;
-    // -> static s32 cpuCompile_DSUB_function;
-    // -> static s32 cpuCompile_DADDU_function;
-    // -> static s32 cpuCompile_DADD_function;
-    // -> static s32 cpuCompile_DDIVU_function;
-    // -> static s32 cpuCompile_DDIV_function;
-    // -> static s32 cpuCompile_DMULTU_function;
-    // -> static s32 cpuCompile_DMULT_function;
-    // -> static s32 cpuCompile_DSRAV_function;
-    // -> static s32 cpuCompile_DSRLV_function;
-    // -> static s32 cpuCompile_DSLLV_function;
-    // -> s32 ganMapGPR[32];
+    // -> static int cpuCompile_LWR_function;
+    // -> static int cpuCompile_LWL_function;
+    // -> static int cpuCompile_SDC_function;
+    // -> static int cpuCompile_LDC_function;
+    // -> static int cpuCompile_SW_function;
+    // -> static int cpuCompile_SH_function;
+    // -> static int cpuCompile_SB_function;
+    // -> static int cpuCompile_LHU_function;
+    // -> static int cpuCompile_LBU_function;
+    // -> static int cpuCompile_LW_function;
+    // -> static int cpuCompile_LH_function;
+    // -> static int cpuCompile_LB_function;
+    // -> static int cpuCompile_ROUND_W_function;
+    // -> static int cpuCompile_TRUNC_W_function;
+    // -> static int cpuCompile_FLOOR_W_function;
+    // -> static int cpuCompile_CEIL_W_function;
+    // -> static int cpuCompile_L_CVT_SD_function;
+    // -> static int cpuCompile_W_CVT_SD_function;
+    // -> static int cpuCompile_D_SQRT_function;
+    // -> static int cpuCompile_S_SQRT_function;
+    // -> static int cpuCompile_DSUBU_function;
+    // -> static int cpuCompile_DSUB_function;
+    // -> static int cpuCompile_DADDU_function;
+    // -> static int cpuCompile_DADD_function;
+    // -> static int cpuCompile_DDIVU_function;
+    // -> static int cpuCompile_DDIV_function;
+    // -> static int cpuCompile_DMULTU_function;
+    // -> static int cpuCompile_DMULT_function;
+    // -> static int cpuCompile_DSRAV_function;
+    // -> static int cpuCompile_DSRLV_function;
+    // -> static int cpuCompile_DSLLV_function;
+    // -> int ganMapGPR[32];
 }

--- a/debug/Fire/_frameGCN.c
+++ b/debug/Fire/_frameGCN.c
@@ -8,17 +8,17 @@
 #include "dolphin/types.h"
 
 // Erased
-static s32 frameSetProjection(struct __anon_0x24C38* pFrame, s32 iHint) {
+static int frameSetProjection(struct __anon_0x24C38* pFrame, int iHint) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
-    // s32 iHint; // r1+0xC
+    // int iHint; // r1+0xC
 
     // Local variables
     struct __anon_0x24A81* pHint; // r1+0x8
 }
 
 // Range: 0x8002C67C -> 0x8002CA14
-static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
+static int frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
 
@@ -26,8 +26,8 @@ static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
     enum _GXFogType nFogType; // r5
     f32 rNear; // r1+0x8
     f32 rFar; // f2
-    u32 nMode; // r1+0x8
-    u32 iHint; // r8
+    unsigned int nMode; // r1+0x8
+    unsigned int iHint; // r8
     f32 rFogNear; // f3
     f32 rFogFar; // f4
     f32 rFogMin; // f1
@@ -49,12 +49,12 @@ static s32 frameDrawSetupFog_Zelda1(struct __anon_0x24C38* pFrame) {
 }
 
 // Range: 0x8002C378 -> 0x8002C67C
-static s32 frameDrawSetupFog_Default(struct __anon_0x24C38* pFrame) {
+static int frameDrawSetupFog_Default(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
 
     // Local variables
-    s32 iHint; // r6
+    int iHint; // r6
     f32 rNear; // f31
     f32 rFar; // f30
     f32 rFOVY; // f29
@@ -74,20 +74,20 @@ static void frameDrawSyncCallback(u16 nToken) {
     // u16 nToken; // r1+0x0
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Erased
-static s32 frameSetVertexArray() {}
+static int frameSetVertexArray() {}
 
 // Range: 0x8002C2E4 -> 0x8002C360
 static void frameDrawDone() {
     // References
-    // -> s32 gNoSwapBuffer;
+    // -> int gNoSwapBuffer;
     // -> void* DemoCurrentBuffer;
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
-    // -> static s32 gbFrameValid;
+    // -> static int gbFrameValid;
 }
 
 // Erased
@@ -112,91 +112,91 @@ static void __DEMODoneRender() {
 }
 
 // Range: 0x8002C178 -> 0x8002C2E4
-static s32 frameMakeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 nCount, s32 nOffsetTMEM,
-                         s32 bReload) {
+static int frameMakeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, int nCount, int nOffsetTMEM,
+                         int bReload) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct _FRAME_TEXTURE* pTexture; // r28
-    // s32 nCount; // r30
-    // s32 nOffsetTMEM; // r31
-    // s32 bReload; // r1+0x18
+    // int nCount; // r30
+    // int nOffsetTMEM; // r31
+    // int bReload; // r1+0x18
 
     // Local variables
-    s32 iColor; // r5
+    int iColor; // r5
     u16* anColor; // r3
     u16 nData16; // r1+0x8
 }
 
 // Erased
-static s32 frameFreeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static int frameFreeTLUT(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // struct _FRAME_TEXTURE* pTexture; // r1+0x4
 }
 
 // Range: 0x8002A784 -> 0x8002C178
-static s32 frameMakePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, struct __anon_0x247BF* pTile,
-                           s32 bReload) {
+static int frameMakePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, struct __anon_0x247BF* pTile,
+                           int bReload) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r19
     // struct _FRAME_TEXTURE* pTexture; // r16
     // struct __anon_0x247BF* pTile; // r26
-    // s32 bReload; // r17
+    // int bReload; // r17
 
     // Local variables
     void* aPixel; // r24
-    s32 nSizeLine; // r18
-    s32 nFlip; // r9
-    s32 nSize; // r1+0x40
-    s32 nCount; // r1+0x8
-    s32 nMode; // r1+0x8
-    s32 nSizeX; // r30
-    s32 nSizeY; // r15
-    s32 nSource; // r10
-    s32 nTarget; // r11
-    s32 iPixelX; // r3
-    s32 iPixelY; // r20
-    s32 iTarget; // r1+0x8
+    int nSizeLine; // r18
+    int nFlip; // r9
+    int nSize; // r1+0x40
+    int nCount; // r1+0x8
+    int nMode; // r1+0x8
+    int nSizeX; // r30
+    int nSizeY; // r15
+    int nSource; // r10
+    int nTarget; // r11
+    int iPixelX; // r3
+    int iPixelY; // r20
+    int iTarget; // r1+0x8
     u8 nData8; // r31
     u16 nData16; // r31
-    u32 nData32; // r31
-    s32 nSizeTextureX; // r1+0x8
-    s32 nSizeTextureY; // r26
+    unsigned int nData32; // r31
+    int nSizeTextureX; // r1+0x8
+    int nSizeTextureY; // r26
     s32 lineX; // r1+0x8
     s32 lineY; // r1+0x8
     s32 linePixX; // r4
     s32 lineStep; // r5
     s32 tmemStart; // r21
     s32 tmemEnd; // r23
-    s32 __nSizeX; // r5
-    s32 __nSizeY; // r6
-    u32 rgb[3]; // r1+0x24
-    u32 yuv[3]; // r1+0x18
+    int __nSizeX; // r5
+    int __nSizeY; // r6
+    unsigned int rgb[3]; // r1+0x24
+    unsigned int yuv[3]; // r1+0x18
 
     // References
     // -> static u8 sRemapI$746[8];
 }
 
 // Erased
-static s32 frameFreePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static int frameFreePixels(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct _FRAME_TEXTURE* pTexture; // r31
 }
 
 // Range: 0x8002A4A8 -> 0x8002A784
-static s32 frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, s32 iTextureCode,
+static int frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture, int iTextureCode,
                             struct __anon_0x247BF* pTile) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r26
     // struct _FRAME_TEXTURE* pTexture; // r27
-    // s32 iTextureCode; // r1+0x18
+    // int iTextureCode; // r1+0x18
     // struct __anon_0x247BF* pTile; // r1+0x1C
 
     // Local variables
     void* pData; // r4
-    s32 iName; // r30
-    s32 nFilter; // r4
+    int iName; // r30
+    int nFilter; // r4
     enum _GXTexWrapMode eWrapS; // r29
     enum _GXTexWrapMode eWrapT; // r28
 
@@ -206,7 +206,7 @@ static s32 frameLoadTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE
 }
 
 // Range: 0x8002A2FC -> 0x8002A4A8
-s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
+int frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
 
@@ -214,7 +214,7 @@ s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
     f32 matrix44[4][4]; // r1+0x10
 
     // References
-    // -> static s32 snScissorChanged;
+    // -> static int snScissorChanged;
     // -> static u32 snScissorHeight;
     // -> static u32 snScissorWidth;
     // -> static u32 snScissorYOrig;
@@ -222,16 +222,16 @@ s32 frameDrawSetup2D(struct __anon_0x24C38* pFrame) {
 }
 
 // Range: 0x80029948 -> 0x8002A2FC
-static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag, s32 nVertexCount) {
+static int frameDrawSetupSP(struct __anon_0x24C38* pFrame, int* pnColors, int* pbFlag, int nVertexCount) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r28
-    // s32* pnColors; // r29
-    // s32* pbFlag; // r30
-    // s32 nVertexCount; // r31
+    // int* pnColors; // r29
+    // int* pbFlag; // r30
+    // int nVertexCount; // r31
 
     // Local variables
     f32 rValue23; // f1
-    s32 bTextureGen; // r22
+    int bTextureGen; // r22
     f32 rNear; // f24
     f32 rFar; // f4
     f32 rScaleS; // f25
@@ -239,10 +239,10 @@ static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* p
     f32 rSlideS; // f4
     f32 rSlideT; // f2
     struct _FRAME_TEXTURE* pTexture[8]; // r1+0x12C
-    s32 nColors; // r21
-    s32 bFlag; // r20
-    s32 iTile; // r19
-    s32 iHint; // r1+0x8
+    int nColors; // r21
+    int bFlag; // r20
+    int iTile; // r19
+    int iHint; // r1+0x8
     f32 matrix[3][4]; // r1+0xFC
     f32 matrixA[3][4]; // r1+0xCC
     f32 matrixB[3][4]; // r1+0x9C
@@ -250,12 +250,12 @@ static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* p
     f32 matrixProjection[4][4]; // r1+0x1C
     enum _GXProjectionType eTypeProjection; // r4
     f32 scale; // r1+0x8
-    s32 nCount; // r18
-    s32 iIndex; // r6
+    int nCount; // r18
+    int iIndex; // r6
 
     // References
     // -> u32 ganNameTexMtx[8];
-    // -> static s32 snScissorChanged;
+    // -> static int snScissorChanged;
     // -> static u32 snScissorWidth;
     // -> static u32 snScissorHeight;
     // -> static u32 snScissorYOrig;
@@ -263,28 +263,28 @@ static s32 frameDrawSetupSP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* p
 }
 
 // Range: 0x8002984C -> 0x80029948
-static s32 frameGetCombineColor(enum _GXTevColorArg* pnColorTEV, s32 nColorN64) {
+static int frameGetCombineColor(enum _GXTevColorArg* pnColorTEV, int nColorN64) {
     // Parameters
     // enum _GXTevColorArg* pnColorTEV; // r1+0x4
-    // s32 nColorN64; // r1+0x8
+    // int nColorN64; // r1+0x8
 }
 
 // Range: 0x800297BC -> 0x8002984C
-static s32 frameGetCombineAlpha(enum _GXTevAlphaArg* pnAlphaTEV, s32 nAlphaN64) {
+static int frameGetCombineAlpha(enum _GXTevAlphaArg* pnAlphaTEV, int nAlphaN64) {
     // Parameters
     // enum _GXTevAlphaArg* pnAlphaTEV; // r1+0x4
-    // s32 nAlphaN64; // r1+0x8
+    // int nAlphaN64; // r1+0x8
 }
 
 // Range: 0x80029250 -> 0x800297BC
-static s32 frameDrawSetupDP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* pbFlag) {
+static int frameDrawSetupDP(struct __anon_0x24C38* pFrame, int* pnColors, int* pbFlag) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
-    // s32* pnColors; // r1+0xC
-    // s32* pbFlag; // r1+0x10
+    // int* pnColors; // r1+0xC
+    // int* pbFlag; // r1+0x10
 
     // Local variables
-    u32 nMode; // r1+0x8
+    unsigned int nMode; // r1+0x8
     s32 numCycles; // r30
     u32 mode; // r1+0x8
     u32 cycle; // r4
@@ -294,87 +294,87 @@ static s32 frameDrawSetupDP(struct __anon_0x24C38* pFrame, s32* pnColors, s32* p
 }
 
 // Range: 0x80029118 -> 0x80029250
-static s32 frameDrawTriangle_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 iData; // r6
+    int iData; // r6
     u8* anData; // r7
     struct __anon_0x23FC4* pVertex; // r3
 }
 
 // Range: 0x80028F7C -> 0x80029118
-static s32 frameDrawTriangle_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 iData; // r10
+    int iData; // r10
     u8* anData; // r11
     struct __anon_0x23FC4* pVertex; // r1+0x8
     struct __anon_0x23FC4* pVertexColor; // r3
 }
 
 // Range: 0x80028DC0 -> 0x80028F7C
-static s32 frameDrawTriangle_C3T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C3T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 iData; // r9
+    int iData; // r9
     u8* anData; // r10
     struct __anon_0x23FC4* pVertex; // r8
 }
 
 // Range: 0x80028C34 -> 0x80028DC0
-static s32 frameDrawTriangle_C0T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C0T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 iData; // r6
+    int iData; // r6
     u8* anData; // r7
     struct __anon_0x23FC4* pVertex; // r3
 }
 
 // Range: 0x80028A44 -> 0x80028C34
-static s32 frameDrawTriangle_C1T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C1T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 iData; // r10
+    int iData; // r10
     u8* anData; // r11
     struct __anon_0x23FC4* pVertex; // r1+0x8
     struct __anon_0x23FC4* pVertexColor; // r3
 }
 
 // Range: 0x80027B80 -> 0x80028A44
-static s32 frameCheckTriangleDivide(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameCheckTriangleDivide(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r22
     // struct __anon_0x2D45B* pPrimitive; // r23
 
     // Local variables
-    s32 iData; // r25
+    int iData; // r25
     u8* anData; // r24
     struct __anon_0x23FC4 aNewVertArray[8]; // r1+0x184
     f32 fInterp; // r1+0x8
     f32 fTempColor1; // f2
     f32 fTempColor2; // f3
-    u32 nNewVertCount; // r5
-    u32 bInFront; // r7
-    u32 bBehind; // r8
+    unsigned int nNewVertCount; // r5
+    unsigned int bInFront; // r7
+    unsigned int bBehind; // r8
 }
 
 // Range: 0x800279DC -> 0x80027B80
-static s32 frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
@@ -383,120 +383,120 @@ static s32 frameDrawTriangle_C3T3(struct __anon_0x24C38* pFrame, struct __anon_0
     f32(*pMatrix)[4]; // r3
 
     // References
-    // -> static u32 gHackCreditsColor;
+    // -> static unsigned int gHackCreditsColor;
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
 // Range: 0x80027900 -> 0x800279DC
-static s32 frameDrawTriangle_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawTriangle_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
+    int bFlag; // r1+0x14
+    int nColors; // r1+0x10
 
     // References
-    // -> static s32 (* gapfDrawTriangle[8])(void*, void*);
+    // -> static int (* gapfDrawTriangle[8])(void*, void*);
 }
 
 // Range: 0x8002778C -> 0x80027900
-static s32 frameDrawLine_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C0T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r6
+    int iData; // r6
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r3
 }
 
 // Range: 0x800275C4 -> 0x8002778C
-static s32 frameDrawLine_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C1T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r10
+    int iData; // r10
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r1+0x8
     struct __anon_0x23FC4* pVertexColor; // r3
 }
 
 // Range: 0x800273EC -> 0x800275C4
-static s32 frameDrawLine_C2T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C2T0(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r8
+    int iData; // r8
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r9
 }
 
 // Range: 0x80027234 -> 0x800273EC
-static s32 frameDrawLine_C0T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C0T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r6
+    int iData; // r6
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r3
 }
 
 // Range: 0x80027028 -> 0x80027234
-static s32 frameDrawLine_C1T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C1T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r10
+    int iData; // r10
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r1+0x8
     struct __anon_0x23FC4* pVertexColor; // r3
 }
 
 // Range: 0x80026E0C -> 0x80027028
-static s32 frameDrawLine_C2T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_C2T2(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct __anon_0x2D45B* pPrimitive; // r30
 
     // Local variables
-    s32 iData; // r8
+    int iData; // r8
     u8* anData; // r31
     struct __anon_0x23FC4* pVertex; // r9
 }
 
 // Range: 0x80026D30 -> 0x80026E0C
-static s32 frameDrawLine_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
+static int frameDrawLine_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D45B* pPrimitive) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D45B* pPrimitive; // r31
 
     // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
+    int bFlag; // r1+0x14
+    int nColors; // r1+0x10
 
     // References
-    // -> static s32 (* gapfDrawLine[6])(void*, void*);
+    // -> static int (* gapfDrawLine[6])(void*, void*);
 }
 
 // Range: 0x80026A9C -> 0x80026D30
-static s32 frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+static int frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // struct __anon_0x2D2B6* pRectangle; // r1+0xC
 
     // Local variables
-    s32 bFlag; // r8
+    int bFlag; // r8
     f32 rDepth; // f31
     f32 rX0; // f30
     f32 rY0; // f29
@@ -505,24 +505,24 @@ static s32 frameDrawRectFill(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B
 }
 
 // Range: 0x800269EC -> 0x80026A9C
-static s32 frameDrawRectFill_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+static int frameDrawRectFill_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D2B6* pRectangle; // r31
 
     // Local variables
-    s32 bFlag; // r1+0x14
-    s32 nColors; // r1+0x10
+    int bFlag; // r1+0x14
+    int nColors; // r1+0x10
 }
 
 // Range: 0x80026514 -> 0x800269EC
-static s32 frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+static int frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x2D2B6* pRectangle; // r31
 
     // Local variables
-    s32 bCopy; // r11
+    int bCopy; // r11
     f32 rDepth; // f31
     f32 rDeltaT; // f5
     f32 rX0; // f30
@@ -535,14 +535,14 @@ static s32 frameDrawRectTexture(struct __anon_0x24C38* pFrame, struct __anon_0x2
     f32 rT1; // f23
 
     // References
-    // -> static s32 gnCountMapHack;
+    // -> static int gnCountMapHack;
     // -> struct __anon_0x26A4E* gpSystem;
     // -> static u8 sSpecialZeldaHackON;
-    // -> static s32 nCounter$1367;
+    // -> static int nCounter$1367;
 }
 
 // Range: 0x80026124 -> 0x80026514
-static s32 frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
+static int frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pRectangle) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r22
     // struct __anon_0x2D2B6* pRectangle; // r23
@@ -556,55 +556,55 @@ static s32 frameDrawRectTexture_Setup(struct __anon_0x24C38* pFrame, struct __an
     f32 rScaleT; // f28
     f32 rSlideS; // f2
     f32 rSlideT; // r1+0x8
-    u32 bFlag; // r1+0x14
-    u32 nColors; // r1+0x10
-    s32 iTile; // r25
-    s32 firstTile; // r3
-    s32 nCount; // r24
-    s32 iIndex; // r6
+    unsigned int bFlag; // r1+0x14
+    unsigned int nColors; // r1+0x10
+    int iTile; // r25
+    int firstTile; // r3
+    int nCount; // r24
+    int iIndex; // r6
     char cTempAlpha; // r20
 
     // References
-    // -> static s32 bSkip$1410;
+    // -> static int bSkip$1410;
     // -> struct __anon_0x26A4E* gpSystem;
     // -> u32 ganNameTexMtx[8];
     // -> static u8 sSpecialZeldaHackON;
 }
 
 // Erased
-static s32 frameTick() {}
+static int frameTick() {}
 
 // Erased
-static s32 frameDraw() {}
+static int frameDraw() {}
 
 // Erased
 static void CopyZBuffer() {}
 
 // Range: 0x8002611C -> 0x80026124
-s32 frameShow() {}
+int frameShow() {}
 
 // Erased
-static s32 frameHide() {}
+static int frameHide() {}
 
 // Range: 0x80025FF4 -> 0x8002611C
-s32 frameSetScissor(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pScissor) {
+int frameSetScissor(struct __anon_0x24C38* pFrame, struct __anon_0x2D2B6* pScissor) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // struct __anon_0x2D2B6* pScissor; // r1+0xC
 
     // Local variables
-    s32 nTemp; // r1+0x8
-    s32 nX0; // r3
-    s32 nY0; // r4
-    s32 nX1; // r5
-    s32 nY1; // r6
+    int nTemp; // r1+0x8
+    int nX0; // r3
+    int nY0; // r4
+    int nX1; // r5
+    int nY1; // r6
 }
 
 // Erased
-static s32 frameGetScissor() {}
+static int frameGetScissor() {}
 
 // Range: 0x80025FE4 -> 0x80025FF4
-s32 frameSetDepth(struct __anon_0x24C38* pFrame, f32 rDepth, f32 rDelta) {
+int frameSetDepth(struct __anon_0x24C38* pFrame, f32 rDepth, f32 rDelta) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // f32 rDepth; // r1+0x4
@@ -612,24 +612,24 @@ s32 frameSetDepth(struct __anon_0x24C38* pFrame, f32 rDepth, f32 rDelta) {
 }
 
 // Range: 0x80025EE8 -> 0x80025FE4
-s32 frameSetColor(struct __anon_0x24C38* pFrame, enum __anon_0x2D223 eType, u32 nRGBA) {
+int frameSetColor(struct __anon_0x24C38* pFrame, enum __anon_0x2D223 eType, unsigned int nRGBA) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
     // enum __anon_0x2D223 eType; // r30
-    // u32 nRGBA; // r1+0x10
+    // unsigned int nRGBA; // r1+0x10
 }
 
 // Range: 0x80025ECC -> 0x80025EE8
-s32 frameBeginOK() {
+int frameBeginOK() {
     // References
-    // -> static s32 gbFrameValid;
+    // -> static int gbFrameValid;
 }
 
 // Range: 0x80025C40 -> 0x80025ECC
-s32 frameBegin(struct __anon_0x24C38* pFrame, s32 nCountVertex) {
+int frameBegin(struct __anon_0x24C38* pFrame, int nCountVertex) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
-    // s32 nCountVertex; // r28
+    // int nCountVertex; // r28
 
     // Local variables
     s32 i; // r28
@@ -638,44 +638,44 @@ s32 frameBegin(struct __anon_0x24C38* pFrame, s32 nCountVertex) {
     // References
     // -> enum _GXTexCoordID ganNameTexCoord[8];
     // -> u32 ganNameTexMtx[8];
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
+    // -> static int gbFrameValid;
+    // -> static int gbFrameBegin;
 }
 
 // Range: 0x800259B8 -> 0x80025C40
-s32 frameEnd(struct __anon_0x24C38* pFrame) {
+int frameEnd(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
 
     // Local variables
     struct _CPU* pCPU; // r31
-    s32 iHint; // r7
+    int iHint; // r7
     void* pData; // r29
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
     // -> void* DemoCurrentBuffer;
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
     // -> static u16 sTempZBuf[4800][4][4];
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
+    // -> static int gbFrameValid;
+    // -> static int gbFrameBegin;
 }
 
 // Range: 0x80025890 -> 0x800259B8
-s32 _frameDrawRectangle(struct __anon_0x24C38* pFrame, u32 nColor, s32 nX, s32 nY, s32 nSizeX, s32 nSizeY) {
+int _frameDrawRectangle(struct __anon_0x24C38* pFrame, unsigned int nColor, int nX, int nY, int nSizeX, int nSizeY) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // u32 nColor; // r1+0x4
-    // s32 nX; // r11
-    // s32 nY; // r1+0xC
-    // s32 nSizeX; // r7
-    // s32 nSizeY; // r1+0x14
+    // unsigned int nColor; // r1+0x4
+    // int nX; // r11
+    // int nY; // r1+0xC
+    // int nSizeX; // r7
+    // int nSizeY; // r1+0x14
 
     // Local variables
-    s32 iY; // r10
-    s32 iX; // r11
-    u32* pnPixel; // r3
-    s32 nSizeTargetX; // r9
+    int iY; // r10
+    int iX; // r11
+    unsigned int* pnPixel; // r3
+    int nSizeTargetX; // r9
 
     // References
     // -> void* DemoFrameBuffer2;
@@ -684,25 +684,25 @@ s32 _frameDrawRectangle(struct __anon_0x24C38* pFrame, u32 nColor, s32 nX, s32 n
 }
 
 // Erased
-static s32 _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, s32 nSizeX, s32 nSizeY, s32 nX0, s32 nY0,
-                           s32 bAlpha) {
+static int _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, int nSizeX, int nSizeY, int nX0, int nY0,
+                           int bAlpha) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // u16* pnImage; // r1+0xC
-    // s32 nSizeX; // r1+0x10
-    // s32 nSizeY; // r1+0x14
-    // s32 nX0; // r1+0x18
-    // s32 nY0; // r1+0x1C
-    // s32 bAlpha; // r1+0x20
+    // int nSizeX; // r1+0x10
+    // int nSizeY; // r1+0x14
+    // int nX0; // r1+0x18
+    // int nY0; // r1+0x1C
+    // int bAlpha; // r1+0x20
 
     // Local variables
-    s32 iY; // r30
-    s32 iX; // r1+0x8
-    s32 nSizeTargetX; // r30
-    u32* pnPixel; // r3
-    u32* aPixel; // r29
-    u32 nPixelSource; // r7
-    u32 nPixelTarget; // r29
+    int iY; // r30
+    int iX; // r1+0x8
+    int nSizeTargetX; // r30
+    unsigned int* pnPixel; // r3
+    unsigned int* aPixel; // r29
+    unsigned int nPixelSource; // r7
+    unsigned int nPixelTarget; // r29
 
     // References
     // -> void* DemoFrameBuffer2;
@@ -711,10 +711,10 @@ static s32 _frameDrawImage(struct __anon_0x24C38* pFrame, u16* pnImage, s32 nSiz
 }
 
 // Erased
-static void ZeldaDrawFrameZTexture(struct __anon_0x24C38* pFrame, u32* pData) {
+static void ZeldaDrawFrameZTexture(struct __anon_0x24C38* pFrame, unsigned int* pData) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
-    // u32* pData; // r30
+    // unsigned int* pData; // r30
 
     // Local variables
     f32 matrix[3][4]; // r1+0x30
@@ -770,16 +770,16 @@ static void CopyCFBAlpha(u8* srcP) {
     // u8* srcP; // r31
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Erased
-static void CopyCFBZTexture(u32* srcP) {
+static void CopyCFBZTexture(unsigned int* srcP) {
     // Parameters
-    // u32* srcP; // r31
+    // unsigned int* srcP; // r31
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Erased
@@ -804,7 +804,7 @@ static void CopyCFB(u16* srcP) {
     // u16* srcP; // r31
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Erased
@@ -837,7 +837,7 @@ void CopyAndConvertCFB(u16* srcP) {
 
     // References
     // -> static u16 line$1630[80][4][4];
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Range: 0x80024A04 -> 0x80024D94
@@ -853,7 +853,7 @@ static void ZeldaGreyScaleConvert(struct __anon_0x24C38* pFrame) {
     // References
     // -> static struct _GXTexObj sFrameObj$1647;
     // -> static u8 cAlpha$1648;
-    // -> static u32 gHackCreditsColor;
+    // -> static unsigned int gHackCreditsColor;
     // -> void* DemoCurrentBuffer;
 }
 
@@ -863,7 +863,7 @@ static void ZeldaCopyFrameHiRes(void* pSrc) {
     // void* pSrc; // r31
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
+    // -> static int sCopyFrameSyncReceived;
 }
 
 // Erased
@@ -881,12 +881,12 @@ static void ZeldaDrawFrameHiRes(struct __anon_0x24C38* pFrame, void* pSrc) {
 }
 
 // Range: 0x800244F8 -> 0x80024A04
-void ZeldaDrawFrameShrink(struct __anon_0x24C38* pFrame, s32 posX, s32 posY, s32 size) {
+void ZeldaDrawFrameShrink(struct __anon_0x24C38* pFrame, int posX, int posY, int size) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
-    // s32 posX; // r1+0xC
-    // s32 posY; // r1+0x10
-    // s32 size; // r1+0x14
+    // int posX; // r1+0xC
+    // int posY; // r1+0x10
+    // int size; // r1+0x14
 
     // Local variables
     f32 matrix[3][4]; // r1+0x28
@@ -924,54 +924,56 @@ void ZeldaDrawFrameCamera(struct __anon_0x24C38* pFrame, void* buffer) {
 }
 
 // Range: 0x8002403C -> 0x80024204
-s32 frameHackTIMG_Zelda(struct __anon_0x24C38* pFrame, u64** pnGBI, u32* pnCommandLo, u32* pnCommandHi) {
+int frameHackTIMG_Zelda(struct __anon_0x24C38* pFrame, u64** pnGBI, unsigned int* pnCommandLo,
+                        unsigned int* pnCommandHi) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
     // u64** pnGBI; // r30
-    // u32* pnCommandLo; // r31
-    // u32* pnCommandHi; // r1+0x14
+    // unsigned int* pnCommandLo; // r31
+    // unsigned int* pnCommandHi; // r1+0x14
 
     // Local variables
-    u32 i; // r7
+    unsigned int i; // r7
 
     // References
-    // -> static u32 sDestinationBuffer;
+    // -> static unsigned int sDestinationBuffer;
     // -> struct __anon_0x26A4E* gpSystem;
-    // -> static u32 sSrcBuffer;
+    // -> static unsigned int sSrcBuffer;
     // -> static u8 sSpecialZeldaHackON;
     // -> static u32 sCommandCodes$1679[8];
 }
 
 // Range: 0x800239E4 -> 0x8002403C
-s32 frameHackCIMG_Zelda2(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI) {
+int frameHackCIMG_Zelda2(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // struct __anon_0x23B9E* pBuffer; // r31
     // u64* pnGBI; // r1+0x10
 
     // Local variables
-    u32 i; // r7
+    unsigned int i; // r7
     u32* pGBI; // r8
 
     // References
-    // -> static s32 sCopyFrameSyncReceived;
-    // -> s32 gNoSwapBuffer;
-    // -> static s32 nLastFrame$1695;
-    // -> static s32 nCopyFrame$1697;
+    // -> static int sCopyFrameSyncReceived;
+    // -> int gNoSwapBuffer;
+    // -> static int nLastFrame$1695;
+    // -> static int nCopyFrame$1697;
     // -> static u32 sCommandCodes2$1722[10];
     // -> static u32 sCommandCodes$1702[10];
 }
 
 // Range: 0x800235A4 -> 0x800239E4
-s32 frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI, u32 nCommandLo) {
+int frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u64* pnGBI,
+                        unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // struct __anon_0x23B9E* pBuffer; // r28
     // u64* pnGBI; // r1+0x10
-    // u32 nCommandLo; // r29
+    // unsigned int nCommandLo; // r29
 
     // Local variables
-    u32 i; // r30
+    unsigned int i; // r30
     u32 low2; // r1+0x8
     u32 high2; // r1+0x8
     u16* srcP; // r1+0x20
@@ -985,18 +987,18 @@ s32 frameHackCIMG_Zelda(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pB
 
     // References
     // -> static u16 tempLine$1785[16][4][4];
-    // -> static s32 sCopyFrameSyncReceived;
-    // -> s32 gNoSwapBuffer;
-    // -> static u32 sNumAddr;
-    // -> static u32 sConstantBufAddr[6];
-    // -> static s32 gnCountMapHack;
-    // -> static u32 sSrcBuffer;
-    // -> static u32 sDestinationBuffer;
+    // -> static int sCopyFrameSyncReceived;
+    // -> int gNoSwapBuffer;
+    // -> static unsigned int sNumAddr;
+    // -> static unsigned int sConstantBufAddr[6];
+    // -> static int gnCountMapHack;
+    // -> static unsigned int sSrcBuffer;
+    // -> static unsigned int sDestinationBuffer;
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
 // Range: 0x80023430 -> 0x800235A4
-s32 frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, u64** ppnGBI) {
+int frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, u64** ppnGBI) {
     // Parameters
     // struct __anon_0x2865F* pRDP; // r1+0x8
     // struct __anon_0x24C38* pFrame; // r27
@@ -1004,90 +1006,90 @@ s32 frameHackCIMG_Zelda2_Shrink(struct __anon_0x2865F* pRDP, struct __anon_0x24C
 
     // Local variables
     u64* pnGBI; // r30
-    s32 count; // r8
-    s32 nAddress; // r4
-    u32 nCommandLo; // r6
-    u32 nCommandHi; // r1+0x8
+    int count; // r8
+    int nAddress; // r4
+    unsigned int nCommandLo; // r6
+    unsigned int nCommandHi; // r1+0x8
     struct __anon_0x297E0* pRSP; // r29
-    s32 done; // r3
+    int done; // r3
     union __anon_0x2ACA3 bg; // r1+0x18
 
     // References
-    // -> static u32 GBIcode$1816[3];
+    // -> static unsigned int GBIcode$1816[3];
 }
 
 // Range: 0x800232FC -> 0x80023430
-s32 frameHackCIMG_Zelda2_Camera(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, u32 nCommandHi,
-                                u32 nCommandLo) {
+int frameHackCIMG_Zelda2_Camera(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer, unsigned int nCommandHi,
+                                unsigned int nCommandLo) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
     // struct __anon_0x23B9E* pBuffer; // r1+0xC
-    // u32 nCommandHi; // r1+0x10
-    // u32 nCommandLo; // r1+0x14
+    // unsigned int nCommandHi; // r1+0x10
+    // unsigned int nCommandLo; // r1+0x14
 }
 
 // Range: 0x80023250 -> 0x800232FC
-void PanelDrawBG8(u16* BG, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+void PanelDrawBG8(u16* BG, u16* LUT, u8* bitmap, int sizeX, int sizeY, int posX, int posY, int flip) {
     // Parameters
     // u16* BG; // r1+0x8
     // u16* LUT; // r1+0xC
     // u8* bitmap; // r1+0x10
-    // s32 sizeX; // r1+0x14
-    // s32 sizeY; // r1+0x18
-    // s32 posX; // r1+0x1C
-    // s32 posY; // r1+0x20
-    // s32 flip; // r1+0x24
+    // int sizeX; // r1+0x14
+    // int sizeY; // r1+0x18
+    // int posX; // r1+0x1C
+    // int posY; // r1+0x20
+    // int flip; // r1+0x24
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r27
+    int i; // r28
+    int j; // r27
     u16 color; // r1+0x8
 }
 
 // Range: 0x80023194 -> 0x80023250
-void PanelDrawBG16(u16* BG, u16* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 flip) {
+void PanelDrawBG16(u16* BG, u16* bitmap, int sizeX, int sizeY, int posX, int posY, int flip) {
     // Parameters
     // u16* BG; // r1+0x8
     // u16* bitmap; // r1+0xC
-    // s32 sizeX; // r1+0x10
-    // s32 sizeY; // r1+0x14
-    // s32 posX; // r1+0x18
-    // s32 posY; // r1+0x1C
-    // s32 flip; // r1+0x20
+    // int sizeX; // r1+0x10
+    // int sizeY; // r1+0x14
+    // int posX; // r1+0x18
+    // int posY; // r1+0x1C
+    // int flip; // r1+0x20
 
     // Local variables
-    s32 i; // r29
-    s32 j; // r28
+    int i; // r29
+    int j; // r28
     u16 color; // r1+0x8
 }
 
 // Range: 0x800230E0 -> 0x80023194
-void PanelDrawFR3D(u16* FR, u16* LUT, u8* bitmap, s32 sizeX, s32 sizeY, s32 posX, s32 posY, s32 first) {
+void PanelDrawFR3D(u16* FR, u16* LUT, u8* bitmap, int sizeX, int sizeY, int posX, int posY, int first) {
     // Parameters
     // u16* FR; // r1+0x8
     // u16* LUT; // r1+0xC
     // u8* bitmap; // r1+0x10
-    // s32 sizeX; // r1+0x14
-    // s32 sizeY; // r1+0x18
-    // s32 posX; // r1+0x1C
-    // s32 posY; // r1+0x20
-    // s32 first; // r1+0x24
+    // int sizeX; // r1+0x14
+    // int sizeY; // r1+0x18
+    // int posX; // r1+0x1C
+    // int posY; // r1+0x20
+    // int first; // r1+0x24
 
     // Local variables
-    s32 i; // r30
-    s32 j; // r1+0x8
+    int i; // r30
+    int j; // r1+0x8
     u16 color; // r29
 }
 
 // Range: 0x8002303C -> 0x800230E0
-s32 frameHackTIMG_Panel(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer) {
+int frameHackTIMG_Panel(struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // struct __anon_0x23B9E* pBuffer; // r1+0x4
 }
 
 // Range: 0x800217F8 -> 0x8002303C
-s32 frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer,
+int frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFrame, struct __anon_0x23B9E* pBuffer,
                         u64** ppnGBI) {
     // Parameters
     // struct __anon_0x2865F* pRDP; // r29
@@ -1098,48 +1100,48 @@ s32 frameHackCIMG_Panel(struct __anon_0x2865F* pRDP, struct __anon_0x24C38* pFra
     // Local variables
     struct __anon_0x297E0* pRSP; // r17
     u64* pnGBI; // r20
-    s32 count; // r8
-    s32 nAddress; // r5
-    s32 sizeX; // r6
-    u32 nCommandLo; // r7
-    u32 nCommandHi; // r3
+    int count; // r8
+    int nAddress; // r5
+    int sizeX; // r6
+    unsigned int nCommandLo; // r7
+    unsigned int nCommandHi; // r3
     u16* BG; // r18
     u16* FR; // r28
     u16* pLUT; // r16
     u16* pBitmap16; // r4
     u8* pBitmap8; // r5
-    s32 iTile; // r5
-    s32 nCount; // r4
+    int iTile; // r5
+    int nCount; // r4
     struct __anon_0x247BF* pTile; // r5
-    s32 iTile; // r1+0x8
-    s32 nCount; // r4
-    s32 iTile; // r5
-    s32 nCount; // r4
+    int iTile; // r1+0x8
+    int nCount; // r4
+    int iTile; // r5
+    int nCount; // r4
     union __anon_0x2ACA3 bg; // r1+0x50
     union __anon_0x2B091 objTxtr; // r1+0x38
-    u32 nLoadType; // r1+0x34
+    unsigned int nLoadType; // r1+0x34
     struct __anon_0x23B9E* pBG; // r18
 
     // References
-    // -> static u32 GBIcode2D2$1906[7];
-    // -> static u32 GBIcode3D2$1908[6];
-    // -> static u32 GBIcode3D1$1907[5];
+    // -> static unsigned int GBIcode2D2$1906[7];
+    // -> static unsigned int GBIcode3D2$1908[6];
+    // -> static unsigned int GBIcode3D1$1907[5];
 }
 
 // Range: 0x80021588 -> 0x800217F8
-s32 frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, s32 nAddress) {
+int frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, int nAddress) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // u16* pnData; // r1+0xC
-    // s32 nAddress; // r1+0x10
+    // int nAddress; // r1+0x10
 
     // Local variables
-    u32 nX; // r7
-    u32 nY; // r8
-    u32 nOffset; // r1+0x8
+    unsigned int nX; // r7
+    unsigned int nY; // r8
+    unsigned int nOffset; // r1+0x8
     s32 n64CalcValue; // r6
-    s32 exp; // r7
-    s32 mantissa; // r1+0x8
+    int exp; // r7
+    int mantissa; // r1+0x8
     s32 compare; // r3
     s32 val; // r7
     struct __anon_0x285E5 z_format[8]; // r1+0x14
@@ -1149,14 +1151,14 @@ s32 frameGetDepth(struct __anon_0x24C38* pFrame, u16* pnData, s32 nAddress) {
 }
 
 // Range: 0x80021204 -> 0x80021588
-static s32 frameEvent(struct __anon_0x24C38* pFrame, s32 nEvent) {
+static int frameEvent(struct __anon_0x24C38* pFrame, int nEvent) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
-    // -> static s32 gnCountMapHack;
-    // -> static s32 gbFrameValid;
-    // -> static s32 gbFrameBegin;
+    // -> static int gnCountMapHack;
+    // -> static int gbFrameValid;
+    // -> static int gbFrameBegin;
 }

--- a/debug/Fire/_frameGCNcc.c
+++ b/debug/Fire/_frameGCNcc.c
@@ -148,10 +148,10 @@ typedef enum __anon_0x8573D {
 } __anon_0x8573D;
 
 typedef struct __anon_0x857A7 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x857A7; // size = 0x10
 
 typedef enum __anon_0x85858 {
@@ -195,7 +195,7 @@ typedef enum __anon_0x8598C {
 typedef struct __anon_0x85ACF {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x8573D eMode;
     /* 0x10 */ struct __anon_0x857A7 romCopy;
     /* 0x20 */ enum __anon_0x85858 eTypeROM;
@@ -203,7 +203,7 @@ typedef struct __anon_0x85ACF {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x8598C storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x85ACF; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -217,11 +217,11 @@ typedef struct __anon_0x85D00 {
 } __anon_0x85D00; // size = 0x10
 
 typedef struct __anon_0x85D9A {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x85D9A; // size = 0x14
 
 typedef struct __anon_0x85EDB {
@@ -231,7 +231,7 @@ typedef struct __anon_0x85EDB {
 } __anon_0x85EDB; // size = 0xC
 
 typedef struct __anon_0x85F4B {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x85EDB rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -248,7 +248,7 @@ typedef struct __anon_0x85F4B {
 } __anon_0x85F4B; // size = 0x3C
 
 typedef struct __anon_0x8617B {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x85EDB rS;
     /* 0x10 */ struct __anon_0x85EDB rT;
     /* 0x1C */ struct __anon_0x85EDB rSRaw;
@@ -266,7 +266,7 @@ typedef struct __anon_0x86264 {
 typedef union __anon_0x863C3 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x863C3;
 
@@ -319,20 +319,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x86768;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -341,11 +341,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x867D1; // size = 0x6C
 
 typedef struct __anon_0x86B2E {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -356,7 +356,7 @@ typedef struct __anon_0x86B2E {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x86B2E; // size = 0x2C
 
 typedef enum __anon_0x86E10 {
@@ -366,93 +366,93 @@ typedef enum __anon_0x86E10 {
 } __anon_0x86E10;
 
 typedef struct __anon_0x86E99 {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x86E10 eProjection;
 } __anon_0x86E99; // size = 0x24
 
 typedef struct __anon_0x87050 {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x85D00 viewport;
     /* 0x000C8 */ struct __anon_0x85D9A aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x85F4B aLight[8];
     /* 0x00320 */ struct __anon_0x8617B lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x86264 aVertex[80];
     /* 0x00C18 */ struct __anon_0x86460 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x86B2E aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x86E10 eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -463,10 +463,10 @@ typedef struct __anon_0x87050 {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x87050; // size = 0x3D150
 
@@ -550,7 +550,7 @@ static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeT
 
     // Local variables
     s32 i; // r23
-    s32 iStart; // r1+0x8
+    int iStart; // r1+0x8
     struct _GXColor color; // r1+0x30
     struct TevOrder* toP; // r6
     struct TevColorOp* tcP; // r22
@@ -562,9 +562,9 @@ static void SetTableTevStages(struct __anon_0x87050* pFrame, struct CombineModeT
 }
 
 // Erased
-static void OutputCCMode(s32 cycle, u32 tempColor, u32 tempAlpha) {
+static void OutputCCMode(int cycle, u32 tempColor, u32 tempAlpha) {
     // Parameters
-    // s32 cycle; // r1+0x8
+    // int cycle; // r1+0x8
     // u32 tempColor; // r1+0xC
     // u32 tempAlpha; // r1+0x10
 
@@ -597,10 +597,10 @@ static void CheckNewCCMode(struct __anon_0x87050* pFrame, s32 numCycles) {
 }
 
 // Range: 0x800981E0 -> 0x800983A0
-void SetNumTexGensChans(struct __anon_0x87050* pFrame, s32 numCycles) {
+void SetNumTexGensChans(struct __anon_0x87050* pFrame, int numCycles) {
     // Parameters
     // struct __anon_0x87050* pFrame; // r1+0x8
-    // s32 numCycles; // r1+0xC
+    // int numCycles; // r1+0xC
 
     // Local variables
     u8 nColor[4]; // r1+0x14
@@ -614,16 +614,16 @@ void SetNumTexGensChans(struct __anon_0x87050* pFrame, s32 numCycles) {
 }
 
 // Range: 0x80097E5C -> 0x800981E0
-void SetTevStages(struct __anon_0x87050* pFrame, s32 cycle) {
+void SetTevStages(struct __anon_0x87050* pFrame, int cycle) {
     // Parameters
     // struct __anon_0x87050* pFrame; // r1+0x8
-    // s32 cycle; // r17
+    // int cycle; // r17
 
     // Local variables
     u8 nColor[4]; // r1+0x5C
     u8 nAlpha[4]; // r1+0x58
-    u32 tempColor; // r6
-    u32 tempAlpha; // r9
+    unsigned int tempColor; // r6
+    unsigned int tempAlpha; // r9
     enum _GXTevColorArg colorArg[4]; // r1+0x48
     enum _GXTevAlphaArg alphaArg[4]; // r1+0x38
     enum _GXTevStageID tevStages[5]; // r1+0x24

--- a/debug/Fire/_gspF3DEX.c
+++ b/debug/Fire/_gspF3DEX.c
@@ -8,95 +8,95 @@
 #include "dolphin/types.h"
 
 // Erased
-static s32 MulMatrices(f32 (*aOutMatrix)[4], f32 (*aLeftMatrix)[4], f32 (*aRightMatrix)[4]) {
+static int MulMatrices(f32 (*aOutMatrix)[4], f32 (*aLeftMatrix)[4], f32 (*aRightMatrix)[4]) {
     // Parameters
     // f32 (* aOutMatrix)[4]; // r3
     // f32 (* aLeftMatrix)[4]; // r4
     // f32 (* aRightMatrix)[4]; // r5
 
     // Local variables
-    s32 i; // r8
-    s32 j; // r1+0x0
+    int i; // r8
+    int j; // r1+0x0
 }
 
 // Range: 0x80077790 -> 0x80077850
-static s32 rspSetGeometryMode1(struct __anon_0x5845E* pRSP, s32 nMode) {
+static int rspSetGeometryMode1(struct __anon_0x5845E* pRSP, int nMode) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nMode; // r1+0xC
+    // int nMode; // r1+0xC
 
     // Local variables
-    s32 nModeFrame; // r5
+    int nModeFrame; // r5
 }
 
 // Range: 0x8007610C -> 0x80077790
-static s32 rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
+static int rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, int* pbDone) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
     // u64** ppnGBI; // r27
-    // s32* pbDone; // r24
+    // int* pbDone; // r24
 
     // Local variables
     f32 matrix[4][4]; // r1+0x3B0
     struct __anon_0x5EBE0 primitive; // r1+0xAC
-    u32 iVertex; // r4
-    u32 bDone; // r24
+    unsigned int iVertex; // r4
+    unsigned int bDone; // r24
     u64* pnGBI; // r28
-    u32 nCommandLo; // r6
-    u32 nCommandHi; // r7
+    unsigned int nCommandLo; // r6
+    unsigned int nCommandHi; // r7
     struct __anon_0x5A89F* pFrame; // r30
-    s32 nAddress; // r5
-    s32 nAddress; // r24
-    s32 nAddress; // r24
-    s32 nAddress; // r24
-    s32 bPush; // r24
+    int nAddress; // r5
+    int nAddress; // r24
+    int nAddress; // r24
+    int nAddress; // r24
+    int bPush; // r24
     u8 nSid2D; // r1+0x8
-    u32 nDLAdrs; // r7
-    u32 nFlag2D; // r1+0x8
+    unsigned int nDLAdrs; // r7
+    unsigned int nFlag2D; // r1+0x8
     union __anon_0x5F2FB bg; // r1+0x80
-    s32 nAddress; // r4
-    s32 nMode; // r24
-    s32 nAddress; // r26
-    s32 nMode; // r1+0x78
-    s32 nAddress; // r5
-    s32 nAddress; // r5
+    int nAddress; // r4
+    int nMode; // r24
+    int nAddress; // r26
+    int nMode; // r1+0x78
+    int nAddress; // r5
+    int nAddress; // r5
     void* pData; // r1+0x74
-    s32 nAddress; // r5
+    int nAddress; // r5
     void* pData; // r1+0x6C
-    s32 nAddress; // r5
+    int nAddress; // r5
     void* pData; // r1+0x68
-    s32 nAddress; // r5
+    int nAddress; // r5
     char* pData; // r1+0x64
-    s32 iLight; // r24
-    s32 nAddress; // r5
-    s32 nAddress; // r24
-    s32 nAddress; // r5
+    int iLight; // r24
+    int nAddress; // r5
+    int nAddress; // r24
+    int nAddress; // r5
     void* pBuffer; // r1+0x60
-    s32 nCount; // r6
-    s32 iVertex0; // r5
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    u32 nVertexStart; // r4
-    u32 nVertexEnd; // r5
-    s32 nWhere; // r1+0x8
-    s32 nData1; // r8
-    s32 nData2; // r1+0x8
-    s32 iRow; // r3
-    s32 iCol; // r4
-    u32 nSid; // r1+0x8
-    s32 nLight; // r1+0x8
-    u32 nData; // r1+0x8
-    u32 nSize; // r3
-    u32 nMove; // r5
-    u32 nData; // r1+0x8
-    u32 nSize; // r3
-    u32 nMove; // r5
-    u32 nValue; // r1+0x8
+    int nCount; // r6
+    int iVertex0; // r5
+    int nAddress; // r5
+    int nAddress; // r5
+    int nAddress; // r5
+    unsigned int nVertexStart; // r4
+    unsigned int nVertexEnd; // r5
+    int nWhere; // r1+0x8
+    int nData1; // r8
+    int nData2; // r1+0x8
+    int iRow; // r3
+    int iCol; // r4
+    unsigned int nSid; // r1+0x8
+    int nLight; // r1+0x8
+    unsigned int nData; // r1+0x8
+    unsigned int nSize; // r3
+    unsigned int nMove; // r5
+    unsigned int nData; // r1+0x8
+    unsigned int nSize; // r3
+    unsigned int nMove; // r5
+    unsigned int nValue; // r1+0x8
     struct __anon_0x575BD* pTask; // r4
-    s32 nAddress; // r5
-    s32 iVertex; // r4
-    s32 nVal; // r1+0x8
+    int nAddress; // r5
+    int iVertex; // r4
+    int nVal; // r1+0x8
 
     // References
     // -> static u8 flagBilerp;
@@ -107,102 +107,102 @@ static s32 rspParseGBI_F3DEX1(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pb
 }
 
 // Range: 0x80076024 -> 0x8007610C
-static s32 rspGeometryMode(struct __anon_0x5845E* pRSP, s32 nSet, s32 nClr) {
+static int rspGeometryMode(struct __anon_0x5845E* pRSP, int nSet, int nClr) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nSet; // r1+0xC
-    // s32 nClr; // r1+0x10
+    // int nSet; // r1+0xC
+    // int nClr; // r1+0x10
 
     // Local variables
-    s32 nMode; // r6
+    int nMode; // r6
 }
 
 // Range: 0x80074454 -> 0x80076024
-static s32 rspParseGBI_F3DEX2(struct __anon_0x5845E* pRSP, u64** ppnGBI, s32* pbDone) {
+static int rspParseGBI_F3DEX2(struct __anon_0x5845E* pRSP, u64** ppnGBI, int* pbDone) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
     // u64** ppnGBI; // r27
-    // s32* pbDone; // r25
+    // int* pbDone; // r25
 
     // Local variables
-    s32 iVertex; // r4
-    s32 bDone; // r25
+    int iVertex; // r4
+    int bDone; // r25
     f32 matrix[4][4]; // r1+0x410
     struct __anon_0x5EBE0 primitive; // r1+0x10C
     u64* pnGBI; // r28
-    u32 nCommandLo; // r6
-    u32 nCommandHi; // r1+0x8
+    unsigned int nCommandLo; // r6
+    unsigned int nCommandHi; // r1+0x8
     struct __anon_0x5A89F* pFrame; // r30
-    u32 nData; // r1+0x8
-    u32 nSize; // r6
-    u32 nMove; // r5
-    u32 nData; // r1+0x8
-    u32 nSize; // r6
-    u32 nMove; // r5
-    u32 nValue; // r1+0x8
+    unsigned int nData; // r1+0x8
+    unsigned int nSize; // r6
+    unsigned int nMove; // r5
+    unsigned int nData; // r1+0x8
+    unsigned int nSize; // r6
+    unsigned int nMove; // r5
+    unsigned int nValue; // r1+0x8
     struct __anon_0x575BD* pTask; // r4
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    s32 nLength; // r27
-    s32 nOffset; // r28
-    s32 nId; // r25
-    s32 nFlag; // r26
-    s32 nAddress; // r29
+    int nAddress; // r5
+    int nAddress; // r5
+    int nLength; // r27
+    int nOffset; // r28
+    int nId; // r25
+    int nFlag; // r26
+    int nAddress; // r29
     void* pData; // r1+0x104
     u16* pnData16; // r3
     s16 nFogStart; // r1+0x8
     s16 nFogEnd; // r1+0x8
-    s32 nDelta; // r3
-    s32 nStart; // r4
+    int nDelta; // r3
+    int nStart; // r4
     char* pLight; // r1+0x100
-    u32 iIndex; // r25
-    s32 bFound; // r5
+    unsigned int iIndex; // r25
+    int bFound; // r5
     void* pData; // r1+0xFC
-    s32 nAddress; // r5
+    int nAddress; // r5
     void* pData; // r1+0xF4
-    s32 iLight; // r25
-    s32 nAddress; // r5
-    s32 nAddress; // r25
-    u32 nSid; // r1+0x8
-    s32 nLight; // r1+0x8
-    s32 nAddress; // r5
-    s32 nMode; // r25
-    s32 nAddress; // r27
-    s32 nSet; // r4
-    s32 nClr; // r5
-    s32 iMatrix; // r25
-    s32 nCount; // r26
-    s32 nVertices; // r26
-    s32 nSrcAdrs; // r1+0x8
-    s32 nDestAdrs; // r27
-    s32 iCount; // r28
-    s32 bFound; // r9
-    u32 iVtxIndex; // r10
+    int iLight; // r25
+    int nAddress; // r5
+    int nAddress; // r25
+    unsigned int nSid; // r1+0x8
+    int nLight; // r1+0x8
+    int nAddress; // r5
+    int nMode; // r25
+    int nAddress; // r27
+    int nSet; // r4
+    int nClr; // r5
+    int iMatrix; // r25
+    int nCount; // r26
+    int nVertices; // r26
+    int nSrcAdrs; // r1+0x8
+    int nDestAdrs; // r27
+    int iCount; // r28
+    int bFound; // r9
+    unsigned int iVtxIndex; // r10
     struct __anon_0x5EC3E destVtx; // r1+0x9C
-    s32 nAddress; // r5
+    int nAddress; // r5
     char* pBuffer; // r1+0x94
-    s32 nCount; // r25
-    s32 iVertex0; // r26
-    s32 nAddress; // r5
-    s32 nAddress; // r5
-    s32 iVertex; // r4
-    s32 nVal; // r1+0x8
-    u32 nVertexStart; // r4
-    u32 nVertexEnd; // r5
-    s32 nAddress; // r5
-    s32 nAddress; // r25
-    s32 nAddress; // r25
-    s32 nAddress; // r25
-    s32 nAddress; // r25
+    int nCount; // r25
+    int iVertex0; // r26
+    int nAddress; // r5
+    int nAddress; // r5
+    int iVertex; // r4
+    int nVal; // r1+0x8
+    unsigned int nVertexStart; // r4
+    unsigned int nVertexEnd; // r5
+    int nAddress; // r5
+    int nAddress; // r25
+    int nAddress; // r25
+    int nAddress; // r25
+    int nAddress; // r25
     union __anon_0x5F2FB bg; // r1+0x68
     union __anon_0x5F2FB bg; // r1+0x40
     char cTempAlpha; // r25
-    s32 nAddress; // r5
+    int nAddress; // r5
     char cTempAlpha; // r25
-    s32 bPush; // r27
+    int bPush; // r27
     u8 nSid2D; // r1+0x8
-    u32 nDLAdrs; // r6
-    u32 nFlag2D; // r1+0x8
+    unsigned int nDLAdrs; // r6
+    unsigned int nFlag2D; // r1+0x8
 
     // References
     // -> struct __anon_0x5E98D* gpSystem;

--- a/debug/Fire/_gspJPEG.c
+++ b/debug/Fire/_gspJPEG.c
@@ -8,13 +8,13 @@
 #include "dolphin/types.h"
 
 // Range: 0x800801C0 -> 0x80080AA4
-static s32 rspCreateJPEGArrays(struct __anon_0x5845E* pRSP) {
+static int rspCreateJPEGArrays(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 }
 
 // Erased
-static s32 rspDestroyJPEGArrays() {}
+static int rspDestroyJPEGArrays() {}
 
 // Erased
 static void rspConvertBufferToRGBA(u8* buf, struct __anon_0x58360* rgba) {
@@ -29,8 +29,8 @@ static void rspConvertRGBAtoYUV(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 i; // r30
-    s32 j; // r1+0x8
+    int i; // r30
+    int j; // r1+0x8
     s32 Y; // r20
     s32 U; // r20
     s32 V; // r12
@@ -42,7 +42,7 @@ static void rspYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x0
 
     // Local variables
-    s32 i; // r1+0x0
+    int i; // r1+0x0
 }
 
 // Range: 0x8007F668 -> 0x8007F938
@@ -51,66 +51,66 @@ static void rspDCT(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r1+0x8
-    s32 dd; // r6
+    int c; // r1+0xA4
+    int i; // r1+0xA0
+    int j; // r1+0x8
+    int dd; // r6
     s16 t[8][8]; // r1+0x1C
 }
 
 // Range: 0x8007F4EC -> 0x8007F668
-static void rspQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+static void rspQuantize(struct __anon_0x5845E* pRSP, int scale) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 scale; // r1+0xC
+    // int scale; // r1+0xC
 
     // Local variables
-    s32 c; // r29
-    s32 i; // r28
-    s32 j; // r27
+    int c; // r29
+    int i; // r28
+    int j; // r27
     s16 q; // r6
     s16 s; // r1+0x8
 }
 
 // Erased
-static void rspZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+static void rspZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, int n, int* preDc) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
     // u8** databuf; // r1+0xC
-    // s32 n; // r1+0x10
-    // s32* preDc; // r1+0x14
+    // int n; // r1+0x10
+    // int* preDc; // r1+0x14
 
     // Local variables
     s16 Ac; // r30
-    s32 i; // r6
-    s32 z; // r7
+    int i; // r6
+    int z; // r7
 }
 
 // Erased
-static void rspUndoZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, s32 n, s32* preDc) {
+static void rspUndoZigzagData(struct __anon_0x5845E* pRSP, u8** databuf, int n, int* preDc) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
     // u8** databuf; // r1+0xC
-    // s32 n; // r1+0x10
-    // s32* preDc; // r1+0x14
+    // int n; // r1+0x10
+    // int* preDc; // r1+0x14
 
     // Local variables
     s16 Dc; // r12
     s16 Ac; // r12
-    s32 i; // r7
-    s32 z; // r31
+    int i; // r7
+    int z; // r31
 }
 
 // Range: 0x8007F368 -> 0x8007F4EC
-void rspUndoQuantize(struct __anon_0x5845E* pRSP, s32 scale) {
+void rspUndoQuantize(struct __anon_0x5845E* pRSP, int scale) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 scale; // r1+0xC
+    // int scale; // r1+0xC
 
     // Local variables
-    s32 c; // r29
-    s32 i; // r28
-    s32 j; // r27
+    int c; // r29
+    int i; // r28
+    int j; // r27
     s16 q; // r6
     s16 s; // r1+0x8
 }
@@ -121,10 +121,10 @@ void rspUndoDCT(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r5
-    s32 dd; // r6
+    int c; // r1+0xA4
+    int i; // r1+0xA0
+    int j; // r5
+    int dd; // r6
     s16 t[8][8]; // r1+0x1C
 }
 
@@ -134,8 +134,8 @@ void rspUndoYUVtoDCTBuf(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 i; // r1+0x8
-    s32 j; // r1+0x8
+    int i; // r1+0x8
+    int j; // r1+0x8
 }
 
 // Range: 0x8007E744 -> 0x8007E8F4
@@ -145,12 +145,12 @@ void rspFormatYUV(struct __anon_0x5845E* pRSP, char* imgBuf) {
     // char* imgBuf; // r4
 
     // Local variables
-    s32 i; // r10
-    s32 j; // r11
+    int i; // r10
+    int j; // r11
 }
 
 // Range: 0x8007DD0C -> 0x8007E744
-static s32 rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r19
     // struct __anon_0x575BD* pTask; // r16
@@ -158,42 +158,42 @@ static s32 rspParseJPEG_Encode(struct __anon_0x5845E* pRSP, struct __anon_0x575B
     // Local variables
     u8* temp; // r24
     u8* temp2; // r23
-    s32 i; // r10
-    s32 j; // r11
-    s32 x; // r22
-    s32 y; // r21
+    int i; // r10
+    int j; // r11
+    int x; // r22
+    int y; // r21
     u8* system_imb; // r1+0x30
     u8* system_cfb; // r1+0x2C
-    s32 scale; // r20
+    int scale; // r20
 }
 
 // Range: 0x8007D4C0 -> 0x8007DD0C
-static s32 rspParseJPEG_Decode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseJPEG_Decode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
     // struct __anon_0x575BD* pTask; // r20
 
     // Local variables
-    s32 i; // r3
-    s32 y; // r25
+    int i; // r3
+    int y; // r25
     u8* temp; // r31
     u8* temp2; // r26
     u64* system_imb; // r1+0x1C
-    s32 size; // r21
-    s32 scale; // r22
+    int size; // r21
+    int scale; // r22
 }
 
 // Range: 0x8007D1C8 -> 0x8007D4C0
-static s32 rspCreateJPEGArraysZ(struct __anon_0x5845E* pRSP, s32 qYAddress, s32 qCbAddress, s32 qCrAddress) {
+static int rspCreateJPEGArraysZ(struct __anon_0x5845E* pRSP, int qYAddress, int qCbAddress, int qCrAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r24
-    // s32 qYAddress; // r4
-    // s32 qCbAddress; // r25
-    // s32 qCrAddress; // r26
+    // int qYAddress; // r4
+    // int qCbAddress; // r25
+    // int qCrAddress; // r26
 }
 
 // Erased
-static s32 rspDestroyJPEGArraysZ() {}
+static int rspDestroyJPEGArraysZ() {}
 
 // Range: 0x8007CEF8 -> 0x8007D1C8
 static void rspDCTZ(struct __anon_0x5845E* pRSP) {
@@ -201,10 +201,10 @@ static void rspDCTZ(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r1+0x8
-    s32 dd; // r6
+    int c; // r1+0xA4
+    int i; // r1+0xA0
+    int j; // r1+0x8
+    int dd; // r6
     s16 t[8][8]; // r1+0x1C
 }
 
@@ -215,8 +215,8 @@ static void rspQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
     // s16* dataBuf; // r1+0xC
 
     // Local variables
-    s32 c; // r12
-    s32 i; // r1+0x8
+    int c; // r12
+    int i; // r1+0x8
 }
 
 // Range: 0x8007C3A4 -> 0x8007C8CC
@@ -226,7 +226,7 @@ void rspZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
     // s16* dataBuf; // r4
 
     // Local variables
-    s32 c; // r1+0x8
+    int c; // r1+0x8
 }
 
 // Range: 0x8007BDD8 -> 0x8007C3A4
@@ -236,8 +236,8 @@ void rspUndoQuantizeZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
     // s16* dataBuf; // r1+0xC
 
     // Local variables
-    s32 c; // r12
-    s32 i; // r1+0x8
+    int c; // r12
+    int i; // r1+0x8
 }
 
 // Range: 0x8007B9B0 -> 0x8007BDD8
@@ -247,7 +247,7 @@ void rspUndoZigzagDataZ(struct __anon_0x5845E* pRSP, s16* dataBuf) {
     // s16* dataBuf; // r4
 
     // Local variables
-    s32 c; // r1+0x8
+    int c; // r1+0x8
 }
 
 // Range: 0x8007B6E0 -> 0x8007B9B0
@@ -256,93 +256,93 @@ void rspUndoDCTZ(struct __anon_0x5845E* pRSP) {
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
     // Local variables
-    s32 c; // r1+0xA4
-    s32 i; // r1+0xA0
-    s32 j; // r5
-    s32 dd; // r6
+    int c; // r1+0xA4
+    int i; // r1+0xA0
+    int j; // r5
+    int dd; // r6
     s16 t[8][8]; // r1+0x1C
 }
 
 // Range: 0x8007B64C -> 0x8007B6E0
-s32 rspUndoLoadColorBufferZ(s32 r, s32 g, s32 b, s16* imgBuf, s32 index) {
+int rspUndoLoadColorBufferZ(int r, int g, int b, s16* imgBuf, int index) {
     // Parameters
-    // s32 r; // r3
-    // s32 g; // r1+0x8
-    // s32 b; // r4
+    // int r; // r3
+    // int g; // r1+0x8
+    // int b; // r4
     // s16* imgBuf; // r1+0x10
-    // s32 index; // r1+0x14
+    // int index; // r1+0x14
 }
 
 // Range: 0x8007B244 -> 0x8007B64C
-s32 rspUndoRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
+int rspUndoRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
     // s16* imgBuf; // r29
 
     // Local variables
-    s32 i; // r1+0x8
-    s32 j; // r24
-    s32 r; // r1+0x8
-    s32 g; // r1+0x8
-    s32 b; // r1+0x8
-    s32 y; // r7
-    s32 u; // r5
-    s32 v; // r1+0x8
+    int i; // r1+0x8
+    int j; // r24
+    int r; // r1+0x8
+    int g; // r1+0x8
+    int b; // r1+0x8
+    int y; // r7
+    int u; // r5
+    int v; // r1+0x8
 }
 
 // Erased
-static s32 rspLoadColorBufferZ(s32* r, s32* g, s32* b, s16* imgBuf, s32 index) {
+static int rspLoadColorBufferZ(int* r, int* g, int* b, s16* imgBuf, int index) {
     // Parameters
-    // s32* r; // r1+0x4
-    // s32* g; // r1+0x8
-    // s32* b; // r1+0xC
+    // int* r; // r1+0x4
+    // int* g; // r1+0x8
+    // int* b; // r1+0xC
     // s16* imgBuf; // r1+0x10
-    // s32 index; // r1+0x14
+    // int index; // r1+0x14
 }
 
 // Range: 0x8007AE64 -> 0x8007B244
-s32 rspRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
+int rspRecon420Z(struct __anon_0x5845E* pRSP, s16* imgBuf) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
     // s16* imgBuf; // r1+0xC
 
     // Local variables
-    s32 i; // r1+0x10
-    s32 j; // r26
-    s32 r; // r10
-    s32 g; // r7
-    s32 b; // r11
-    s32 y; // r6
-    s32 u; // r9
-    s32 v; // r1+0x8
+    int i; // r1+0x10
+    int j; // r26
+    int r; // r10
+    int g; // r7
+    int b; // r11
+    int y; // r6
+    int u; // r9
+    int v; // r1+0x8
 }
 
 // Range: 0x8007AD68 -> 0x8007AE64
-static s32 rspParseJPEG_EncodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseJPEG_EncodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x575BD* pTask; // r4
 
     // Local variables
-    s32 y; // r31
+    int y; // r31
     s16* temp; // r1+0x8
     s16* temp2; // r30
     u64* system_imb; // r1+0x20
-    u32* infoStruct; // r1+0x1C
-    s32 size; // r29
+    unsigned int* infoStruct; // r1+0x1C
+    int size; // r29
 }
 
 // Range: 0x8007AC6C -> 0x8007AD68
-static s32 rspParseJPEG_DecodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseJPEG_DecodeZ(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x575BD* pTask; // r4
 
     // Local variables
-    s32 y; // r31
+    int y; // r31
     s16* temp; // r1+0x8
     s16* temp2; // r30
     u64* system_imb; // r1+0x20
-    u32* infoStruct; // r1+0x1C
-    s32 size; // r29
+    unsigned int* infoStruct; // r1+0x1C
+    int size; // r29
 }

--- a/debug/Fire/_gspS2DEX.c
+++ b/debug/Fire/_gspS2DEX.c
@@ -8,10 +8,10 @@
 #include "dolphin/types.h"
 
 // Erased
-static s32 frameFillVertex(struct __anon_0x5A89F* pFrame, s32 nIndex, s16 nX, s16 nY, s16 nZ, f32 rS, f32 rT) {
+static int frameFillVertex(struct __anon_0x5A89F* pFrame, int nIndex, s16 nX, s16 nY, s16 nZ, f32 rS, f32 rT) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r1+0x8
-    // s32 nIndex; // r1+0xC
+    // int nIndex; // r1+0xC
     // s16 nX; // r1+0x10
     // s16 nY; // r1+0x12
     // s16 nZ; // r1+0x14
@@ -20,16 +20,16 @@ static s32 frameFillVertex(struct __anon_0x5A89F* pFrame, s32 nIndex, s16 nX, s1
 }
 
 // Range: 0x8007AC1C -> 0x8007AC6C
-static s32 Matrix4by4Identity(f32 (*matrix4b4)[4]) {
+static int Matrix4by4Identity(f32 (*matrix4b4)[4]) {
     // Parameters
     // f32 (* matrix4b4)[4]; // r1+0x0
 }
 
 // Range: 0x8007AB54 -> 0x8007AC1C
-static s32 rspFillObjSprite(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F63B* pSprite) {
+static int rspFillObjSprite(struct __anon_0x5845E* pRSP, int nAddress, union __anon_0x5F63B* pSprite) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
+    // int nAddress; // r4
     // union __anon_0x5F63B* pSprite; // r31
 
     // Local variables
@@ -39,24 +39,24 @@ static s32 rspFillObjSprite(struct __anon_0x5845E* pRSP, s32 nAddress, union __a
 }
 
 // Range: 0x8007AA74 -> 0x8007AB54
-s32 rspFillObjBgScale(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+int rspFillObjBgScale(struct __anon_0x5845E* pRSP, int nAddress, union __anon_0x5F2FB* pBg) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
+    // int nAddress; // r4
     // union __anon_0x5F2FB* pBg; // r31
 
     // Local variables
     u8* pnData8; // r1+0x8
     u8* pObjBg; // r1+0x14
     u16* pnData16; // r1+0x8
-    u32* pnData32; // r1+0x8
+    unsigned int* pnData32; // r1+0x8
 }
 
 // Range: 0x8007A97C -> 0x8007AA74
-s32 rspFillObjBg(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB* pBg) {
+int rspFillObjBg(struct __anon_0x5845E* pRSP, int nAddress, union __anon_0x5F2FB* pBg) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
+    // int nAddress; // r4
     // union __anon_0x5F2FB* pBg; // r31
 
     // Local variables
@@ -66,82 +66,82 @@ s32 rspFillObjBg(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5F2FB
 }
 
 // Erased
-static s32 rspSetTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nSize, s32 nTmem, s32 nTLUT,
-                      s32 nFormat, s32 nMaskS, s32 nMaskT, s32 nModeS, s32 nModeT, s32 nShiftS, s32 nShiftT) {
+static int rspSetTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, int nSize, int nTmem, int nTLUT,
+                      int nFormat, int nMaskS, int nMaskT, int nModeS, int nModeT, int nShiftS, int nShiftT) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r3
     // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nSize; // r1+0x10
-    // s32 nTmem; // r1+0x14
-    // s32 nTLUT; // r1+0x18
-    // s32 nFormat; // r1+0x20
-    // s32 nMaskS; // r1+0x24
-    // s32 nMaskT; // r1+0x8
-    // s32 nModeS; // r8
-    // s32 nModeT; // r6
-    // s32 nShiftS; // r9
-    // s32 nShiftT; // r8
+    // int nSize; // r1+0x10
+    // int nTmem; // r1+0x14
+    // int nTLUT; // r1+0x18
+    // int nFormat; // r1+0x20
+    // int nMaskS; // r1+0x24
+    // int nMaskT; // r1+0x8
+    // int nModeS; // r8
+    // int nModeT; // r6
+    // int nShiftS; // r9
+    // int nShiftT; // r8
 }
 
 // Range: 0x8007A8E8 -> 0x8007A97C
-s32 rspSetImage(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, s32 nFormat, s32 nWidth, s32 nSize,
-                s32 nImage) {
+int rspSetImage(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, int nFormat, int nWidth, int nSize,
+                int nImage) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r31
     // struct __anon_0x5845E* pRSP; // r1+0xC
-    // s32 nFormat; // r1+0x10
-    // s32 nWidth; // r1+0x14
-    // s32 nSize; // r1+0x18
-    // s32 nImage; // r1+0x1C
+    // int nFormat; // r1+0x10
+    // int nWidth; // r1+0x14
+    // int nSize; // r1+0x18
+    // int nImage; // r1+0x1C
 
     // Local variables
-    s32 addr; // r5
+    int addr; // r5
     struct __anon_0x59558* pBuffer; // r9
 }
 
 // Erased
-static s32 rspLoadBlock(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                        s32 nY1) {
+static int rspLoadBlock(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, int nX0, int nY0, int nX1,
+                        int nY1) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r3
     // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
+    // int nX0; // r1+0x10
+    // int nY0; // r1+0x14
+    // int nX1; // r1+0x18
+    // int nY1; // r1+0x1C
 }
 
 // Erased
-static s32 rspLoadTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                       s32 nY1) {
+static int rspLoadTile(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, int nX0, int nY0, int nX1,
+                       int nY1) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r3
     // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
+    // int nX0; // r1+0x10
+    // int nY0; // r1+0x14
+    // int nX1; // r1+0x18
+    // int nY1; // r1+0x1C
 }
 
 // Erased
-static s32 rspSetTileSize(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, s32 nX0, s32 nY0, s32 nX1,
-                          s32 nY1) {
+static int rspSetTileSize(struct __anon_0x5A89F* pFrame, struct __anon_0x5A2EC* pTile, int nX0, int nY0, int nX1,
+                          int nY1) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r3
     // struct __anon_0x5A2EC* pTile; // r1+0xC
-    // s32 nX0; // r1+0x10
-    // s32 nY0; // r1+0x14
-    // s32 nX1; // r1+0x18
-    // s32 nY1; // r1+0x1C
+    // int nX0; // r1+0x10
+    // int nY0; // r1+0x14
+    // int nX1; // r1+0x18
+    // int nY1; // r1+0x1C
 }
 
 // Erased
-static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
+static int guS2DEmuSetScissor(unsigned int ulx, unsigned int uly, unsigned int lrx, unsigned int lry, u8 flag) {
     // Parameters
-    // u32 ulx; // r1+0x0
-    // u32 uly; // r1+0x4
-    // u32 lrx; // r1+0x8
-    // u32 lry; // r1+0xC
+    // unsigned int ulx; // r1+0x0
+    // unsigned int uly; // r1+0x4
+    // unsigned int lrx; // r1+0x8
+    // unsigned int lry; // r1+0xC
     // u8 flag; // r1+0x10
 
     // References
@@ -153,30 +153,30 @@ static s32 guS2DEmuSetScissor(u32 ulx, u32 uly, u32 lrx, u32 lry, u8 flag) {
 }
 
 // Range: 0x8007A7D4 -> 0x8007A8E8
-static s32 tmemLoad_B(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+static int tmemLoad_B(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, unsigned int imagePtr, s16 loadLines,
                       s16 tmemSH) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r30
     // struct __anon_0x5845E* pRSP; // r1+0xC
-    // u32 imagePtr; // r1+0x10
+    // unsigned int imagePtr; // r1+0x10
     // s16 loadLines; // r31
     // s16 tmemSH; // r28
 
     // Local variables
     struct __anon_0x59558* pBuffer; // r8
-    s32 nAddr; // r5
+    int nAddr; // r5
 
     // References
     // -> static u16 imageSrcWsize;
 }
 
 // Range: 0x8007A728 -> 0x8007A7D4
-static s32 tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32 imagePtr, s16 loadLines,
+static int tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, unsigned int imagePtr, s16 loadLines,
                       s16 tmemAdrs, s16 tmemSH) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r27
     // struct __anon_0x5845E* pRSP; // r28
-    // u32 imagePtr; // r29
+    // unsigned int imagePtr; // r29
     // s16 loadLines; // r30
     // s16 tmemAdrs; // r1+0x16
     // s16 tmemSH; // r31
@@ -186,12 +186,12 @@ static s32 tmemLoad_A(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP
 }
 
 // Range: 0x8007A4B8 -> 0x8007A728
-static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, u32* imagePtr, s16* imageRemain,
-                    s16 drawLines, s16 flagBilerp) {
+static int tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, unsigned int* imagePtr,
+                    s16* imageRemain, s16 drawLines, s16 flagBilerp) {
     // Parameters
     // struct __anon_0x5A89F* pFrame; // r21
     // struct __anon_0x5845E* pRSP; // r22
-    // u32* imagePtr; // r23
+    // unsigned int* imagePtr; // r23
     // s16* imageRemain; // r24
     // s16 drawLines; // r25
     // s16 flagBilerp; // r1+0x1A
@@ -202,10 +202,10 @@ static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, 
     s16 SubSliceL2; // r6
     s16 SubSliceD2; // r28
     s16 SubSliceY2; // r7
-    u32 imageTopSeg; // r30
-    u32 imagePtr2; // r5
-    u32 imagePtr1A; // r27
-    u32 imagePtr1B; // r5
+    unsigned int imageTopSeg; // r30
+    unsigned int imagePtr2; // r5
+    unsigned int imagePtr1A; // r27
+    unsigned int imagePtr1B; // r5
     s16 SubSliceY1; // r4
     s16 SubSliceL1; // r26
     s16 tmemSH_A; // r20
@@ -213,7 +213,7 @@ static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, 
 
     // References
     // -> static u16 imageSrcWsize;
-    // -> static u32 imageTop;
+    // -> static unsigned int imageTop;
     // -> static u16 imagePtrX0;
     // -> static s16 tmemSrcLines;
     // -> static u16 tmemSliceWmax;
@@ -221,7 +221,7 @@ static s32 tmemLoad(struct __anon_0x5A89F* pFrame, struct __anon_0x5845E* pRSP, 
 }
 
 // Range: 0x80079D7C -> 0x8007A4B8
-static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, union __anon_0x5F2FB* pBG) {
+static int guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, union __anon_0x5F2FB* pBG) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r15
     // struct __anon_0x5A89F* pFrame; // r29
@@ -236,20 +236,20 @@ static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F
     s16 imageY0; // r4
     s16 imageSliceW; // r9
     s16 imageW; // r21
-    s32 imageYorig; // r5
+    int imageYorig; // r5
     s16 scaleW; // r1+0x8
     s16 scaleH; // r1+0x8
     s16 imageSrcW; // r6
     s16 imageSrcH; // r7
     s16 imageSliceLines; // r25
-    s32 frameSliceLines; // r22
-    s32 frameSliceCount; // r28
+    int frameSliceLines; // r22
+    int frameSliceCount; // r28
     u16 imageS; // r18
     u16 imageT; // r24
-    u32 imagePtr; // r1+0x44
+    unsigned int imagePtr; // r1+0x44
     s16 imageISliceL0; // r20
     s16 imageIY0; // r1+0x8
-    s32 frameLSliceL0; // r7
+    int frameLSliceL0; // r7
     s16 pixX0; // r3
     s16 pixY0; // r4
     s16 pixX1; // r1+0x8
@@ -257,18 +257,18 @@ static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F
     s16 frameY0; // r5
     s16 frameW; // r3
     s16 frameH; // r7
-    s32 frameWmax; // r1+0x8
-    s32 frameHmax; // r7
+    int frameWmax; // r1+0x8
+    int frameHmax; // r7
     s16 tmemSize; // r1+0x8
     s16 tmemMask; // r18
     s16 tmemShift; // r10
-    s32 imageNumSlice; // r1+0x8
-    s32 imageSliceWmax; // r6
-    s32 imageLYoffset; // r4
-    s32 frameLYoffset; // r4
-    s32 imageLHidden; // r4
-    s32 frameLHidden; // r6
-    s32 frameLYslice; // r6
+    int imageNumSlice; // r1+0x8
+    int imageSliceWmax; // r6
+    int imageLYoffset; // r4
+    int frameLYoffset; // r4
+    int imageLHidden; // r4
+    int frameLHidden; // r6
+    int frameLYslice; // r6
     s16 imageRemain; // r1+0x40
     s16 imageSliceH; // r1+0x8
     s16 frameSliceH; // r30
@@ -280,11 +280,11 @@ static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F
     // -> static u8 flagBilerp;
     // -> static s16 tmemSrcLines;
     // -> static u16 imageSrcWsize;
-    // -> static u32 imageTop;
+    // -> static unsigned int imageTop;
     // -> static u16 imagePtrX0;
     // -> static u16 tmemSliceWmax;
-    // -> static u32 rdpSetTile_w0;
-    // -> static u32 rdpSetTimg_w0;
+    // -> static unsigned int rdpSetTile_w0;
+    // -> static unsigned int rdpSetTimg_w0;
     // -> static s16 TMEMSHIFT$3465[4];
     // -> static s16 TMEMMASK$3464[4];
     // -> static s16 TMEMSIZE$3463[5];
@@ -296,42 +296,42 @@ static s32 guS2DEmuBgRect1Cyc(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F
 }
 
 // Range: 0x80079C1C -> 0x80079D7C
-s32 rspFillObjTxtr(struct __anon_0x5845E* pRSP, s32 nAddress, union __anon_0x5FC1B* pTxtr, u32* pLoadType) {
+int rspFillObjTxtr(struct __anon_0x5845E* pRSP, int nAddress, union __anon_0x5FC1B* pTxtr, unsigned int* pLoadType) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
+    // int nAddress; // r4
     // union __anon_0x5FC1B* pTxtr; // r30
-    // u32* pLoadType; // r31
+    // unsigned int* pLoadType; // r31
 
     // Local variables
-    u32* pnData32; // r1+0x8
+    unsigned int* pnData32; // r1+0x8
     u16* pnData16; // r1+0x8
     u8* pTxtrBlock; // r1+0x18
-    u32 nLoadType; // r1+0x8
+    unsigned int nLoadType; // r1+0x8
 }
 
 // Range: 0x800797D0 -> 0x80079C1C
-static s32 rspObjLoadTxtr(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjLoadTxtr(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
     // struct __anon_0x5A89F* pFrame; // r29
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
-    u32 nSizDefine; // r26
-    u32 nLoadType; // r1+0x30
-    s32 nAddr; // r5
+    unsigned int nSizDefine; // r26
+    unsigned int nLoadType; // r1+0x30
+    int nAddr; // r5
     struct __anon_0x5A2EC* pTile; // r31
     struct __anon_0x59558* pBuffer; // r30
     union __anon_0x5FC1B objTxtr; // r1+0x18
 }
 
 // Range: 0x80079234 -> 0x800797D0
-static s32 rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r27
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
     u16 nSizLineBytes; // r5
@@ -340,17 +340,17 @@ static s32 rspObjRectangle(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* p
     union __anon_0x5F63B objSprite; // r1+0x48
     struct __anon_0x5A2EC* pTile; // r31
     struct __anon_0x5F759 primitive; // r1+0x1C
-    s32 nClampSetting; // r1+0x8
-    s32 nTexTrim2; // r29
-    s32 nTexTrim5; // r28
+    int nClampSetting; // r1+0x8
+    int nTexTrim2; // r29
+    int nTexTrim5; // r28
 }
 
 // Range: 0x8007876C -> 0x80079234
-static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
     u16 nSizLineBytes; // r5
@@ -366,9 +366,9 @@ static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFra
     f32 fScaleY; // f22
     f32 fSpriteWidth; // f2
     f32 fSpriteHeight; // f4
-    s32 nTexTrim2; // r28
-    s32 nTexTrim5; // r27
-    s32 nClampSetting; // r1+0x8
+    int nTexTrim2; // r28
+    int nTexTrim5; // r27
+    int nClampSetting; // r1+0x8
     union __anon_0x5F63B objSprite; // r1+0x438
     struct __anon_0x5A2EC* pTile; // r31
     struct __anon_0x5EBE0 primitive; // r1+0x12C
@@ -382,11 +382,11 @@ static s32 rspObjSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFra
 }
 
 // Range: 0x80077CB8 -> 0x8007876C
-static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
     u16 nSizLineBytes; // r5
@@ -398,11 +398,11 @@ static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* 
     f32 fTexBottom; // f25
     f32 fTexLeft; // f24
     f32 fTexTop; // f23
-    s32 nTexTrim2; // r28
-    s32 nTexTrim5; // r27
+    int nTexTrim2; // r28
+    int nTexTrim5; // r27
     f32 fSpriteWidth; // f22
     f32 fSpriteHeight; // f1
-    s32 nClampSetting; // r1+0x8
+    int nClampSetting; // r1+0x8
     union __anon_0x5F63B objSprite; // r1+0x438
     struct __anon_0x5A2EC* pTile; // r31
     struct __anon_0x5EBE0 primitive; // r1+0x12C
@@ -416,41 +416,41 @@ static s32 rspObjRectangleR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* 
 }
 
 // Erased
-static s32 rspObjLoadTxRect(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjLoadTxRect(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
+    // int nAddress; // r31
 }
 
 // Erased
-static s32 rspObjLoadTxRectR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjLoadTxRectR(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
+    // int nAddress; // r31
 }
 
 // Erased
-static s32 rspObjLoadTxSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+static int rspObjLoadTxSprite(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // struct __anon_0x5A89F* pFrame; // r30
-    // s32 nAddress; // r31
+    // int nAddress; // r31
 }
 
 // Range: 0x80077B18 -> 0x80077CB8
-s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s32 nAddress) {
+int rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
     // struct __anon_0x5A89F* pFrame; // r31
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
     union __anon_0x5F2FB bg; // r1+0x48
     union __anon_0x5F2FB bgScale; // r1+0x20
-    u32 nOldMode1; // r1+0x18
-    u32 nOldMode2; // r1+0x14
+    unsigned int nOldMode1; // r1+0x18
+    unsigned int nOldMode2; // r1+0x14
 
     // References
     // -> static u8 flagBilerp;
@@ -461,10 +461,10 @@ s32 rspBgRectCopy(struct __anon_0x5845E* pRSP, struct __anon_0x5A89F* pFrame, s3
 }
 
 // Erased
-static s32 rspObjSubMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+static int rspObjSubMatrix(struct __anon_0x5845E* pRSP, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
     u16* pnData16; // r6
@@ -475,26 +475,26 @@ static s32 rspObjSubMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
 }
 
 // Range: 0x800779B0 -> 0x80077B18
-static s32 rspObjMatrix(struct __anon_0x5845E* pRSP, s32 nAddress) {
+static int rspObjMatrix(struct __anon_0x5845E* pRSP, int nAddress) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
-    // s32 nAddress; // r5
+    // int nAddress; // r5
 
     // Local variables
-    u32* pnData32; // r1+0x8
+    unsigned int* pnData32; // r1+0x8
     u16* pnData16; // r1+0x8
     u8* pObjMtx; // r1+0x18
     u16 nBaseScaleX; // r6
     u16 nBaseScaleY; // r8
-    s32 nA; // r5
-    s32 nB; // r4
-    s32 nC; // r1+0x8
-    s32 nD; // r9
+    int nA; // r5
+    int nB; // r4
+    int nC; // r1+0x8
+    int nD; // r9
     s16 nY; // r1+0x8
 }
 
 // Range: 0x80077850 -> 0x800779B0
-static s32 rspSetupS2DEX(struct __anon_0x5845E* pRSP) {
+static int rspSetupS2DEX(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
 

--- a/debug/Fire/audio.c
+++ b/debug/Fire/audio.c
@@ -9,73 +9,73 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x752F4; // size = 0x10
 
 // size = 0x10, address = 0x800EE778
 struct _XL_OBJECTTYPE gClassAudio;
 
 typedef struct __anon_0x753E7 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 bEnable;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int bEnable;
     /* 0x08 */ void* pHost;
-    /* 0x0C */ s32 nControl;
-    /* 0x10 */ s32 nAddress;
-    /* 0x14 */ s32 nRateBit;
-    /* 0x18 */ s32 nRateDAC;
-    /* 0x1C */ s32 nStatus;
+    /* 0x0C */ int nControl;
+    /* 0x10 */ int nAddress;
+    /* 0x14 */ int nRateBit;
+    /* 0x18 */ int nRateDAC;
+    /* 0x1C */ int nStatus;
 } __anon_0x753E7; // size = 0x20
 
 // Range: 0x8008E898 -> 0x8008E8A0
-s32 audioPut8() {}
+int audioPut8() {}
 
 // Range: 0x8008E890 -> 0x8008E898
-s32 audioPut16() {}
+int audioPut16() {}
 
 // Range: 0x8008E748 -> 0x8008E890
-s32 audioPut32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
+int audioPut32(struct __anon_0x753E7* pAudio, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x753E7* pAudio; // r31
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
     void* pBuffer; // r1+0x14
 }
 
 // Range: 0x8008E740 -> 0x8008E748
-s32 audioPut64() {}
+int audioPut64() {}
 
 // Range: 0x8008E738 -> 0x8008E740
-s32 audioGet8() {}
+int audioGet8() {}
 
 // Range: 0x8008E730 -> 0x8008E738
-s32 audioGet16() {}
+int audioGet16() {}
 
 // Range: 0x8008E628 -> 0x8008E730
-s32 audioGet32(struct __anon_0x753E7* pAudio, u32 nAddress, s32* pData) {
+int audioGet32(struct __anon_0x753E7* pAudio, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x753E7* pAudio; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r31
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r31
 }
 
 // Range: 0x8008E620 -> 0x8008E628
-s32 audioGet64() {}
+int audioGet64() {}
 
 // Range: 0x8008E5C8 -> 0x8008E620
-s32 audioEnable(struct __anon_0x753E7* pAudio, s32 bEnable) {
+int audioEnable(struct __anon_0x753E7* pAudio, int bEnable) {
     // Parameters
     // struct __anon_0x753E7* pAudio; // r3
-    // s32 bEnable; // r1+0xC
+    // int bEnable; // r1+0xC
 }
 
 // Range: 0x8008E4A8 -> 0x8008E5C8
-s32 audioEvent(struct __anon_0x753E7* pAudio, s32 nEvent, void* pArgument) {
+int audioEvent(struct __anon_0x753E7* pAudio, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x753E7* pAudio; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/codeGCN.c
+++ b/debug/Fire/codeGCN.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x1F88E; // size = 0x10
 
 // size = 0x10, address = 0x800EA7C8
@@ -56,12 +56,12 @@ typedef struct DVDFileInfo {
 } __anon_0x1FDCE; // size = 0x3C
 
 typedef struct tXL_FILE {
-    /* 0x00 */ s32 iBuffer;
+    /* 0x00 */ int iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
-    /* 0x0C */ s32 nAttributes;
-    /* 0x10 */ s32 nSize;
-    /* 0x14 */ s32 nOffset;
+    /* 0x0C */ int nAttributes;
+    /* 0x10 */ int nSize;
+    /* 0x14 */ int nOffset;
     /* 0x18 */ enum __anon_0x1F980 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x1FE86; // size = 0x58
@@ -70,56 +70,56 @@ typedef struct tXL_FILE {
 static void* gpBufferFunction;
 
 // size = 0x4, address = 0x80135684
-static u32* ganDataCode;
+static unsigned int* ganDataCode;
 
 typedef struct _CODE_CACHE_NODE {
-    /* 0x0 */ s32 checksum;
-    /* 0x4 */ s32 length;
+    /* 0x0 */ int checksum;
+    /* 0x4 */ int length;
     /* 0x8 */ struct _CODE_CACHE_NODE* next;
     /* 0xC */ struct _CODE_CACHE_NODE* child;
 } __anon_0x20141; // size = 0x10
 
 // Erased
-static s32 hioInitSend() {}
+static int hioInitSend() {}
 
 // Erased
-static s32 hioCallbackDevice() {}
+static int hioCallbackDevice() {}
 
 // Erased
 static void hioCallback() {}
 
 // Erased
-static s32 hioSendBuffer() {}
+static int hioSendBuffer() {}
 
 // Erased
-static s32 hioInit() {}
+static int hioInit() {}
 
 // Erased
-static s32 codeSendFilePart() {}
+static int codeSendFilePart() {}
 
 // Erased
-static s32 codeCheckCatalog(s32 nAddress0, s32 nAddress1) {
+static int codeCheckCatalog(int nAddress0, int nAddress1) {
     // Parameters
-    // s32 nAddress0; // r4
-    // s32 nAddress1; // r5
+    // int nAddress0; // r4
+    // int nAddress1; // r5
 
     // Local variables
-    s32 iFunction; // r1+0x8
-    s32 instruction; // r31
-    u32 checksum; // r1+0x14
+    int iFunction; // r1+0x8
+    int instruction; // r31
+    unsigned int checksum; // r1+0x14
 
     // References
-    // -> static u32 gnCountFunction;
-    // -> static u32* ganDataCode;
-    // -> static s32 gCatalogLoaded;
+    // -> static unsigned int gnCountFunction;
+    // -> static unsigned int* ganDataCode;
+    // -> static int gCatalogLoaded;
 }
 
 // Range: 0x8001C444 -> 0x8001C498
-s32 codeEvent(s32 nEvent) {
+int codeEvent(int nEvent) {
     // Parameters
-    // s32 nEvent; // r1+0x4
+    // int nEvent; // r1+0x4
 
     // References
-    // -> static u32* ganDataCode;
+    // -> static unsigned int* ganDataCode;
     // -> static void* gpBufferFunction;
 }

--- a/debug/Fire/cpu.c
+++ b/debug/Fire/cpu.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x3CBBE; // size = 0x10
 
 // size = 0x10, address = 0x800EB658
@@ -48,115 +48,115 @@ static u8 RegimmOpcode[32];
 void* gHeapTree;
 
 // size = 0x14, address = 0x800EBE28
-static u32 ganOpcodeSaveFP1[5];
+static unsigned int ganOpcodeSaveFP1[5];
 
 // size = 0x14, address = 0x800EBE3C
-static u32 ganOpcodeSaveFP2_0[5];
+static unsigned int ganOpcodeSaveFP2_0[5];
 
 // size = 0xC, address = 0x800EBE50
-static u32 ganOpcodeSaveFP2_1[3];
+static unsigned int ganOpcodeSaveFP2_1[3];
 
 // size = 0x14, address = 0x800EBE5C
-static u32 ganOpcodeLoadFP[5];
+static unsigned int ganOpcodeLoadFP[5];
 
 // size = 0x80, address = 0x800EBE70
-s32 ganMapGPR[32];
+int ganMapGPR[32];
 
 // size = 0x4, address = 0x801356E4
-static s32 cpuCompile_DSLLV_function;
+static int cpuCompile_DSLLV_function;
 
 // size = 0x4, address = 0x801356E8
-static s32 cpuCompile_DSRLV_function;
+static int cpuCompile_DSRLV_function;
 
 // size = 0x4, address = 0x801356EC
-static s32 cpuCompile_DSRAV_function;
+static int cpuCompile_DSRAV_function;
 
 // size = 0x4, address = 0x801356F0
-static s32 cpuCompile_DMULT_function;
+static int cpuCompile_DMULT_function;
 
 // size = 0x4, address = 0x801356F4
-static s32 cpuCompile_DMULTU_function;
+static int cpuCompile_DMULTU_function;
 
 // size = 0x4, address = 0x801356F8
-static s32 cpuCompile_DDIV_function;
+static int cpuCompile_DDIV_function;
 
 // size = 0x4, address = 0x801356FC
-static s32 cpuCompile_DDIVU_function;
+static int cpuCompile_DDIVU_function;
 
 // size = 0x4, address = 0x80135700
-static s32 cpuCompile_DADD_function;
+static int cpuCompile_DADD_function;
 
 // size = 0x4, address = 0x80135704
-static s32 cpuCompile_DADDU_function;
+static int cpuCompile_DADDU_function;
 
 // size = 0x4, address = 0x80135708
-static s32 cpuCompile_DSUB_function;
+static int cpuCompile_DSUB_function;
 
 // size = 0x4, address = 0x8013570C
-static s32 cpuCompile_DSUBU_function;
+static int cpuCompile_DSUBU_function;
 
 // size = 0x4, address = 0x80135710
-static s32 cpuCompile_S_SQRT_function;
+static int cpuCompile_S_SQRT_function;
 
 // size = 0x4, address = 0x80135714
-static s32 cpuCompile_D_SQRT_function;
+static int cpuCompile_D_SQRT_function;
 
 // size = 0x4, address = 0x80135718
-static s32 cpuCompile_W_CVT_SD_function;
+static int cpuCompile_W_CVT_SD_function;
 
 // size = 0x4, address = 0x8013571C
-static s32 cpuCompile_L_CVT_SD_function;
+static int cpuCompile_L_CVT_SD_function;
 
 // size = 0x4, address = 0x80135720
-static s32 cpuCompile_CEIL_W_function;
+static int cpuCompile_CEIL_W_function;
 
 // size = 0x4, address = 0x80135724
-static s32 cpuCompile_FLOOR_W_function;
+static int cpuCompile_FLOOR_W_function;
 
 // size = 0x4, address = 0x80135728
-static s32 cpuCompile_ROUND_W_function;
+static int cpuCompile_ROUND_W_function;
 
 // size = 0x4, address = 0x8013572C
-static s32 cpuCompile_TRUNC_W_function;
+static int cpuCompile_TRUNC_W_function;
 
 // size = 0x4, address = 0x80135730
-static s32 cpuCompile_LB_function;
+static int cpuCompile_LB_function;
 
 // size = 0x4, address = 0x80135734
-static s32 cpuCompile_LH_function;
+static int cpuCompile_LH_function;
 
 // size = 0x4, address = 0x80135738
-static s32 cpuCompile_LW_function;
+static int cpuCompile_LW_function;
 
 // size = 0x4, address = 0x8013573C
-static s32 cpuCompile_LBU_function;
+static int cpuCompile_LBU_function;
 
 // size = 0x4, address = 0x80135740
-static s32 cpuCompile_LHU_function;
+static int cpuCompile_LHU_function;
 
 // size = 0x4, address = 0x80135744
-static s32 cpuCompile_SB_function;
+static int cpuCompile_SB_function;
 
 // size = 0x4, address = 0x80135748
-static s32 cpuCompile_SH_function;
+static int cpuCompile_SH_function;
 
 // size = 0x4, address = 0x8013574C
-static s32 cpuCompile_SW_function;
+static int cpuCompile_SW_function;
 
 // size = 0x4, address = 0x80135750
-static s32 cpuCompile_LDC_function;
+static int cpuCompile_LDC_function;
 
 // size = 0x4, address = 0x80135754
-static s32 cpuCompile_SDC_function;
+static int cpuCompile_SDC_function;
 
 // size = 0x4, address = 0x80135758
-static s32 cpuCompile_LWL_function;
+static int cpuCompile_LWL_function;
 
 // size = 0x4, address = 0x8013575C
-static s32 cpuCompile_LWR_function;
+static int cpuCompile_LWR_function;
 
 // size = 0x1F4, address = 0x80130A58
-u32 aHeapTreeFlag[125];
+unsigned int aHeapTreeFlag[125];
 
 typedef enum __anon_0x3D79A {
     SM_NONE = -1,
@@ -165,10 +165,10 @@ typedef enum __anon_0x3D79A {
 } __anon_0x3D79A;
 
 typedef struct __anon_0x3D7FC {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x3D7FC; // size = 0x10
 
 typedef enum __anon_0x3D8AD {
@@ -212,7 +212,7 @@ typedef enum __anon_0x3D9D9 {
 typedef struct __anon_0x3DB14 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x3D79A eMode;
     /* 0x10 */ struct __anon_0x3D7FC romCopy;
     /* 0x20 */ enum __anon_0x3D8AD eTypeROM;
@@ -220,38 +220,38 @@ typedef struct __anon_0x3DB14 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x3D9D9 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x3DB14; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x3DB14* gpSystem;
 
 typedef struct __anon_0x3DE78 {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x3DE78; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x3DEDE; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x3DE78* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -270,8 +270,8 @@ typedef union __anon_0x3E22D {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -285,8 +285,8 @@ typedef union __anon_0x3E22D {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x3E22D;
 
@@ -294,51 +294,51 @@ typedef union __anon_0x3E641 {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x3E641;
 
 typedef struct __anon_0x3EB4F {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x3EB4F; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x3EE1D; // size = 0x84
 
 typedef struct __anon_0x3F080 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x3F080; // size = 0xC
 
 typedef struct OSContext {
@@ -370,77 +370,77 @@ typedef struct OSAlarm {
 } __anon_0x3F402; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x3F51D; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x3E22D aGPR[32];
     /* 0x00140 */ union __anon_0x3E641 aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x3EB4F* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x3F080 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x3F6CA; // size = 0x12090
 
 typedef struct cpu_disk_node {
-    /* 0x00 */ u32 functionLength;
-    /* 0x04 */ u32 checksum;
-    /* 0x08 */ s32 startAddress;
-    /* 0x0C */ s32 endAddress;
-    /* 0x10 */ u32 specialFlag;
-    /* 0x14 */ u32 frequency;
-    /* 0x18 */ u32 inCatalog;
-    /* 0x1C */ u32* length;
-    /* 0x20 */ u32 size;
-    /* 0x24 */ u32 GCNsize;
-    /* 0x28 */ u32* N64code;
-    /* 0x2C */ u32* GCNcode;
+    /* 0x00 */ unsigned int functionLength;
+    /* 0x04 */ unsigned int checksum;
+    /* 0x08 */ int startAddress;
+    /* 0x0C */ int endAddress;
+    /* 0x10 */ unsigned int specialFlag;
+    /* 0x14 */ unsigned int frequency;
+    /* 0x18 */ unsigned int inCatalog;
+    /* 0x1C */ unsigned int* length;
+    /* 0x20 */ unsigned int size;
+    /* 0x24 */ unsigned int GCNsize;
+    /* 0x28 */ unsigned int* N64code;
+    /* 0x2C */ unsigned int* GCNcode;
     /* 0x30 */ struct cpu_disk_node* prev;
     /* 0x34 */ struct cpu_disk_node* left;
     /* 0x38 */ struct cpu_disk_node* right;
@@ -461,33 +461,33 @@ typedef enum __anon_0x43B0A {
 } __anon_0x43B0A;
 
 typedef struct __anon_0x43B69 {
-    /* 0x0 */ s32 iCache;
-    /* 0x4 */ u32 nSize;
-    /* 0x8 */ u32 nTickUsed;
+    /* 0x0 */ int iCache;
+    /* 0x4 */ unsigned int nSize;
+    /* 0x8 */ unsigned int nTickUsed;
     /* 0xC */ char keep;
 } __anon_0x43B69; // size = 0x10
 
 typedef struct __anon_0x43C7D {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 (*pCallback)();
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int (*pCallback)();
     /* 0x08 */ u8* pTarget;
-    /* 0x0C */ u32 nSize;
-    /* 0x10 */ u32 nOffset;
+    /* 0x0C */ unsigned int nSize;
+    /* 0x10 */ unsigned int nOffset;
 } __anon_0x43C7D; // size = 0x14
 
 typedef struct __anon_0x43D5D {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 bDone;
-    /* 0x08 */ s32 nResult;
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int bDone;
+    /* 0x08 */ int nResult;
     /* 0x0C */ u8* anData;
-    /* 0x10 */ s32 (*pCallback)();
-    /* 0x14 */ s32 iCache;
-    /* 0x18 */ s32 iBlock;
-    /* 0x1C */ s32 nOffset;
-    /* 0x20 */ u32 nOffset0;
-    /* 0x24 */ u32 nOffset1;
-    /* 0x28 */ u32 nSize;
-    /* 0x2C */ u32 nSizeRead;
+    /* 0x10 */ int (*pCallback)();
+    /* 0x14 */ int iCache;
+    /* 0x18 */ int iBlock;
+    /* 0x1C */ int nOffset;
+    /* 0x20 */ unsigned int nOffset0;
+    /* 0x24 */ unsigned int nOffset1;
+    /* 0x28 */ unsigned int nSize;
+    /* 0x2C */ unsigned int nSizeRead;
 } __anon_0x43D5D; // size = 0x30
 
 typedef struct DVDDiskID {
@@ -525,38 +525,38 @@ typedef struct DVDFileInfo {
 typedef struct __anon_0x443F6 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
-    /* 0x00008 */ s32 bFlip;
-    /* 0x0000C */ s32 bLoad;
+    /* 0x00008 */ int bFlip;
+    /* 0x0000C */ int bLoad;
     /* 0x00010 */ char acNameFile[513];
-    /* 0x00214 */ u32 nSize;
+    /* 0x00214 */ unsigned int nSize;
     /* 0x00218 */ enum __anon_0x43B0A eModeLoad;
     /* 0x0021C */ struct __anon_0x43B69 aBlock[4096];
-    /* 0x1021C */ u32 nTick;
+    /* 0x1021C */ unsigned int nTick;
     /* 0x10220 */ u8* pCacheRAM;
     /* 0x10224 */ u8 anBlockCachedRAM[1024];
     /* 0x10624 */ u8 anBlockCachedARAM[2046];
     /* 0x10E24 */ struct __anon_0x43C7D copy;
     /* 0x10E38 */ struct __anon_0x43D5D load;
-    /* 0x10E68 */ s32 nCountBlockRAM;
-    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E68 */ int nCountBlockRAM;
+    /* 0x10E6C */ int nSizeCacheRAM;
     /* 0x10E70 */ u8 acHeader[64];
-    /* 0x10EB0 */ u32* anOffsetBlock;
-    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB0 */ unsigned int* anOffsetBlock;
+    /* 0x10EB4 */ int nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
-    /* 0x10EF4 */ s32 offsetToRom;
+    /* 0x10EF4 */ int offsetToRom;
 } __anon_0x443F6; // size = 0x10EF8
 
 // size = 0x0, address = 0x800F3E78
-s32 __float_nan[];
+int __float_nan[];
 
 // size = 0x0, address = 0x800F3E7C
-s32 __float_huge[];
+int __float_huge[];
 
 // size = 0x4, address = 0x80134E64
 f32 fTickScale;
 
 // size = 0x4, address = 0x80134E60
-u32 nTickMultiplier;
+unsigned int nTickMultiplier;
 
 typedef enum __anon_0x44829 {
     RUM_NONE = 0,
@@ -608,8 +608,8 @@ typedef enum __anon_0x45AE1 {
 } __anon_0x45AE1;
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x45F28; // size = 0xC
 
@@ -617,7 +617,7 @@ typedef struct _CPU_ADDRESS {
 struct _XL_OBJECTTYPE gClassRAM;
 
 // Erased
-static s32 cpuHackIdle(struct _CPU* pCPU) {
+static int cpuHackIdle(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
 
@@ -626,252 +626,252 @@ static s32 cpuHackIdle(struct _CPU* pCPU) {
 }
 
 // Erased
-static s32 cpuHackCacheInstruction(struct _CPU* pCPU) {
+static int cpuHackCacheInstruction(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    u32* pnCode; // r1+0x10
+    unsigned int* pnCode; // r1+0x10
 }
 
 // Range: 0x80036658 -> 0x80036870
-static s32 cpuHackHandler(struct _CPU* pCPU) {
+static int cpuHackHandler(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r27
 
     // Local variables
-    u32 nSize; // r1+0x10
-    u32* pnCode; // r1+0xC
-    s32 iCode; // r3
-    s32 iSave1; // r30
-    s32 iSave2; // r29
-    s32 iLoad; // r28
+    unsigned int nSize; // r1+0x10
+    unsigned int* pnCode; // r1+0xC
+    int iCode; // r3
+    int iSave1; // r30
+    int iSave2; // r29
+    int iLoad; // r28
 
     // References
-    // -> static u32 ganOpcodeLoadFP[5];
-    // -> static u32 ganOpcodeSaveFP2_1[3];
-    // -> static u32 ganOpcodeSaveFP2_0[5];
-    // -> static u32 ganOpcodeSaveFP1[5];
+    // -> static unsigned int ganOpcodeLoadFP[5];
+    // -> static unsigned int ganOpcodeSaveFP2_1[3];
+    // -> static unsigned int ganOpcodeSaveFP2_0[5];
+    // -> static unsigned int ganOpcodeSaveFP1[5];
     // -> struct _XL_OBJECTTYPE gClassRAM;
 }
 
 // Erased
-static s32 cpuMakeCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32 nAddressHost, struct cpu_function* pFunction) {
+static int cpuMakeCachedAddress(struct _CPU* pCPU, int nAddressN64, int nAddressHost, struct cpu_function* pFunction) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 nAddressN64; // r1+0x4
-    // s32 nAddressHost; // r1+0x8
+    // int nAddressN64; // r1+0x4
+    // int nAddressHost; // r1+0x8
     // struct cpu_function* pFunction; // r1+0xC
 
     // Local variables
-    s32 iAddress; // r7
+    int iAddress; // r7
     struct _CPU_ADDRESS* aAddressCache; // r9
 }
 
 // Range: 0x800365C4 -> 0x80036658
-s32 cpuFreeCachedAddress(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+int cpuFreeCachedAddress(struct _CPU* pCPU, int nAddress0, int nAddress1) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 nAddress0; // r1+0x4
-    // s32 nAddress1; // r1+0x8
+    // int nAddress0; // r1+0x4
+    // int nAddress1; // r1+0x8
 
     // Local variables
-    s32 iAddress; // r10
-    s32 iAddressNext; // r11
-    s32 nAddressN64; // r1+0x0
+    int iAddress; // r10
+    int iAddressNext; // r11
+    int nAddressN64; // r1+0x0
     struct _CPU_ADDRESS* aAddressCache; // r12
 }
 
 // Range: 0x800363E8 -> 0x800365C4
-static s32 cpuFindCachedAddress(struct _CPU* pCPU, s32 nAddressN64, s32* pnAddressHost) {
+static int cpuFindCachedAddress(struct _CPU* pCPU, int nAddressN64, int* pnAddressHost) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // s32 nAddressN64; // r1+0xC
-    // s32* pnAddressHost; // r1+0x10
+    // int nAddressN64; // r1+0xC
+    // int* pnAddressHost; // r1+0x10
 
     // Local variables
-    s32 iAddress; // r10
+    int iAddress; // r10
     struct cpu_function* pFunction; // r1+0x8
     struct _CPU_ADDRESS addressFound; // r1+0x14
     struct _CPU_ADDRESS* aAddressCache; // r6
 }
 
 // Range: 0x8003630C -> 0x800363E8
-s32 cpuTestInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+int cpuTestInterrupt(struct _CPU* pCPU, int nMaskIP) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // s32 nMaskIP; // r31
+    // int nMaskIP; // r31
 }
 
 // Erased
-static s32 cpuResetInterrupt(struct _CPU* pCPU, s32 nMaskIP) {
+static int cpuResetInterrupt(struct _CPU* pCPU, int nMaskIP) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 nMaskIP; // r1+0x4
+    // int nMaskIP; // r1+0x4
 }
 
 // Range: 0x8003604C -> 0x8003630C
-s32 cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, s32 nMaskIP) {
+int cpuException(struct _CPU* pCPU, enum __anon_0x45AE1 eCode, int nMaskIP) {
     // Parameters
     // struct _CPU* pCPU; // r27
     // enum __anon_0x45AE1 eCode; // r28
-    // s32 nMaskIP; // r29
+    // int nMaskIP; // r29
 }
 
 // Range: 0x80035F3C -> 0x8003604C
-static s32 cpuMakeDevice(struct _CPU* pCPU, s32* piDevice, void* pObject, s32 nOffset, u32 nAddress0, u32 nAddress1,
-                         s32 nType) {
+static int cpuMakeDevice(struct _CPU* pCPU, int* piDevice, void* pObject, int nOffset, unsigned int nAddress0,
+                         unsigned int nAddress1, int nType) {
     // Parameters
     // struct _CPU* pCPU; // r25
-    // s32* piDevice; // r1+0xC
+    // int* piDevice; // r1+0xC
     // void* pObject; // r26
-    // s32 nOffset; // r27
-    // u32 nAddress0; // r28
-    // u32 nAddress1; // r29
-    // s32 nType; // r30
+    // int nOffset; // r27
+    // unsigned int nAddress0; // r28
+    // unsigned int nAddress1; // r29
+    // int nType; // r30
 
     // Local variables
     struct __anon_0x3EB4F* pDevice; // r1+0x28
-    s32 iDevice; // r31
+    int iDevice; // r31
 }
 
 // Range: 0x80035E98 -> 0x80035F3C
-static s32 cpuFreeDevice(struct _CPU* pCPU, s32 iDevice) {
+static int cpuFreeDevice(struct _CPU* pCPU, int iDevice) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 iDevice; // r30
+    // int iDevice; // r30
 
     // Local variables
-    s32 iAddress; // r4
+    int iAddress; // r4
 }
 
 // Erased
-static s32 cpuWipeDevices(struct _CPU* pCPU, s32 bFree) {
+static int cpuWipeDevices(struct _CPU* pCPU, int bFree) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32 bFree; // r29
+    // int bFree; // r29
 
     // Local variables
-    s32 iDevice; // r30
+    int iDevice; // r30
 }
 
 // Range: 0x80035CD0 -> 0x80035E98
-static s32 cpuMapAddress(struct _CPU* pCPU, s32* piDevice, u32 nVirtual, u32 nPhysical, s32 nSize) {
+static int cpuMapAddress(struct _CPU* pCPU, int* piDevice, unsigned int nVirtual, unsigned int nPhysical, int nSize) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* piDevice; // r31
-    // u32 nVirtual; // r28
-    // u32 nPhysical; // r6
-    // s32 nSize; // r29
+    // int* piDevice; // r31
+    // unsigned int nVirtual; // r28
+    // unsigned int nPhysical; // r6
+    // int nSize; // r29
 
     // Local variables
-    s32 iDeviceTarget; // r1+0x1C
-    s32 iDeviceSource; // r5
-    u32 nAddressVirtual0; // r5
-    u32 nAddressVirtual1; // r6
+    int iDeviceTarget; // r1+0x1C
+    int iDeviceSource; // r5
+    unsigned int nAddressVirtual0; // r5
+    unsigned int nAddressVirtual1; // r6
 }
 
 // Erased
-static s32 cpuCountTLB(struct _CPU* pCPU, s32* pnCount) {
+static int cpuCountTLB(struct _CPU* pCPU, int* pnCount) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // s32* pnCount; // r1+0x4
+    // int* pnCount; // r1+0x4
 
     // Local variables
-    s32 iEntry; // r8
-    s32 nCount; // r9
+    int iEntry; // r8
+    int nCount; // r9
 }
 
 // Range: 0x800359EC -> 0x80035CD0
-static s32 cpuSetTLB(struct _CPU* pCPU, s32 iEntry) {
+static int cpuSetTLB(struct _CPU* pCPU, int iEntry) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32 iEntry; // r1+0xC
+    // int iEntry; // r1+0xC
 
     // Local variables
-    s32 iDevice; // r1+0x10
-    u32 nMask; // r1+0x8
-    u32 nVirtual; // r27
-    u32 nPhysical; // r30
+    int iDevice; // r1+0x10
+    unsigned int nMask; // r1+0x8
+    unsigned int nVirtual; // r27
+    unsigned int nPhysical; // r30
 }
 
 // Erased
-static s32 cpuGetTLB(struct _CPU* pCPU, s32 iEntry) {
+static int cpuGetTLB(struct _CPU* pCPU, int iEntry) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 iEntry; // r1+0x4
+    // int iEntry; // r1+0x4
 }
 
 // Erased
-static s32 cpuFindTLB(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuFindTLB(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 
     // Local variables
-    s32 iEntry; // r12
-    u32 nMask; // r1+0x0
-    u32 nVirtual; // r1+0x0
+    int iEntry; // r12
+    unsigned int nMask; // r1+0x0
+    unsigned int nVirtual; // r1+0x0
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_User32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_User32(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_User64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_User64(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_Super32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_Super32(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_Super64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_Super64(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_Kernel32(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_Kernel32(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // u64 nAddressVirtual; // r1+0x8
-    // u32* pnAddressPhysical; // r1+0x10
+    // unsigned int* pnAddressPhysical; // r1+0x10
 }
 
 // Erased
-static s32 cpuVirtualToPhysical_Kernel64(struct _CPU* pCPU, u64 nAddressVirtual, u32* pnAddressPhysical) {
+static int cpuVirtualToPhysical_Kernel64(struct _CPU* pCPU, u64 nAddressVirtual, unsigned int* pnAddressPhysical) {
     // Parameters
     // struct _CPU* pCPU; // r28
     // u64 nAddressVirtual; // r30
-    // u32* pnAddressPhysical; // r31
+    // unsigned int* pnAddressPhysical; // r31
 }
 
 // Range: 0x80035914 -> 0x800359EC
-static s32 cpuGetMode(u64 nStatus, enum __anon_0x44AE9* peMode) {
+static int cpuGetMode(u64 nStatus, enum __anon_0x44AE9* peMode) {
     // Parameters
     // u64 nStatus; // r1+0x0
     // enum __anon_0x44AE9* peMode; // r1+0x8
 }
 
 // Range: 0x800357D0 -> 0x80035914
-static s32 cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44AE9* peMode) {
+static int cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44AE9* peMode) {
     // Parameters
     // u64 nStatus; // r29
     // enum __anon_0x42F73* peSize; // r30
@@ -882,14 +882,14 @@ static s32 cpuGetSize(u64 nStatus, enum __anon_0x42F73* peSize, enum __anon_0x44
 }
 
 // Erased
-static s32 cpuSetCP0_Config(struct _CPU* pCPU, u32 nConfig) {
+static int cpuSetCP0_Config(struct _CPU* pCPU, unsigned int nConfig) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // u32 nConfig; // r1+0x4
+    // unsigned int nConfig; // r1+0x4
 }
 
 // Range: 0x8003573C -> 0x800357D0
-static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
+static int cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // u64 nStatus; // r31
@@ -902,132 +902,134 @@ static s32 cpuSetCP0_Status(struct _CPU* pCPU, u64 nStatus) {
 }
 
 // Range: 0x80035570 -> 0x8003573C
-s32 cpuSetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64 nData) {
+int cpuSetRegisterCP0(struct _CPU* pCPU, int iRegister, s64 nData) {
     // Parameters
     // struct _CPU* pCPU; // r26
-    // s32 iRegister; // r27
+    // int iRegister; // r27
     // s64 nData; // r29
 
     // Local variables
-    s32 bFlag; // r30
+    int bFlag; // r30
 
     // References
     // -> static s64 ganMaskSetCP0[32];
 }
 
 // Range: 0x800352C8 -> 0x80035570
-s32 cpuGetRegisterCP0(struct _CPU* pCPU, s32 iRegister, s64* pnData) {
+int cpuGetRegisterCP0(struct _CPU* pCPU, int iRegister, s64* pnData) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // s32 iRegister; // r1+0xC
+    // int iRegister; // r1+0xC
     // s64* pnData; // r1+0x10
 
     // Local variables
-    s32 bFlag; // r1+0x8
+    int bFlag; // r1+0x8
 
     // References
     // -> static s64 ganMaskGetCP0[32];
 }
 
 // Range: 0x8003522C -> 0x800352C8
-s32 __cpuERET(struct _CPU* pCPU) {
+int __cpuERET(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Range: 0x80035218 -> 0x8003522C
-s32 __cpuBreak(struct _CPU* pCPU) {
+int __cpuBreak(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Erased
-static s32 cpuGetOpcodeText() {}
+static int cpuGetOpcodeText() {}
 
 // Range: 0x80035068 -> 0x80035218
-s32 cpuMapObject(struct _CPU* pCPU, void* pObject, u32 nAddress0, u32 nAddress1, s32 nType) {
+int cpuMapObject(struct _CPU* pCPU, void* pObject, unsigned int nAddress0, unsigned int nAddress1, int nType) {
     // Parameters
     // struct _CPU* pCPU; // r31
     // void* pObject; // r27
-    // u32 nAddress0; // r28
-    // u32 nAddress1; // r29
-    // s32 nType; // r30
+    // unsigned int nAddress0; // r28
+    // unsigned int nAddress1; // r29
+    // int nType; // r30
 
     // Local variables
-    s32 iDevice; // r1+0x24
-    s32 iAddress; // r4
-    u32 nAddressVirtual0; // r5
-    u32 nAddressVirtual1; // r6
+    int iDevice; // r1+0x24
+    int iAddress; // r4
+    unsigned int nAddressVirtual0; // r5
+    unsigned int nAddressVirtual1; // r6
 }
 
 // Range: 0x80035050 -> 0x80035068
-s32 cpuSetDeviceGet(struct __anon_0x3EB4F* pDevice, s32 (*pfGet8)(void*, u32, char*), s32 (*pfGet16)(void*, u32, s16*),
-                    s32 (*pfGet32)(void*, u32, s32*), s32 (*pfGet64)(void*, u32, s64*)) {
+int cpuSetDeviceGet(struct __anon_0x3EB4F* pDevice, int (*pfGet8)(void*, unsigned int, char*),
+                    int (*pfGet16)(void*, unsigned int, s16*), int (*pfGet32)(void*, unsigned int, int*),
+                    int (*pfGet64)(void*, unsigned int, s64*)) {
     // Parameters
     // struct __anon_0x3EB4F* pDevice; // r1+0x4
-    // s32 (* pfGet8)(void*, u32, char*); // r1+0x8
-    // s32 (* pfGet16)(void*, u32, s16*); // r1+0xC
-    // s32 (* pfGet32)(void*, u32, s32*); // r1+0x10
-    // s32 (* pfGet64)(void*, u32, s64*); // r1+0x14
+    // int (* pfGet8)(void*, unsigned int, char*); // r1+0x8
+    // int (* pfGet16)(void*, unsigned int, s16*); // r1+0xC
+    // int (* pfGet32)(void*, unsigned int, int*); // r1+0x10
+    // int (* pfGet64)(void*, unsigned int, s64*); // r1+0x14
 }
 
 // Range: 0x80035038 -> 0x80035050
-s32 cpuSetDevicePut(struct __anon_0x3EB4F* pDevice, s32 (*pfPut8)(void*, u32, char*), s32 (*pfPut16)(void*, u32, s16*),
-                    s32 (*pfPut32)(void*, u32, s32*), s32 (*pfPut64)(void*, u32, s64*)) {
+int cpuSetDevicePut(struct __anon_0x3EB4F* pDevice, int (*pfPut8)(void*, unsigned int, char*),
+                    int (*pfPut16)(void*, unsigned int, s16*), int (*pfPut32)(void*, unsigned int, int*),
+                    int (*pfPut64)(void*, unsigned int, s64*)) {
     // Parameters
     // struct __anon_0x3EB4F* pDevice; // r1+0x4
-    // s32 (* pfPut8)(void*, u32, char*); // r1+0x8
-    // s32 (* pfPut16)(void*, u32, s16*); // r1+0xC
-    // s32 (* pfPut32)(void*, u32, s32*); // r1+0x10
-    // s32 (* pfPut64)(void*, u32, s64*); // r1+0x14
+    // int (* pfPut8)(void*, unsigned int, char*); // r1+0x8
+    // int (* pfPut16)(void*, unsigned int, s16*); // r1+0xC
+    // int (* pfPut32)(void*, unsigned int, int*); // r1+0x10
+    // int (* pfPut64)(void*, unsigned int, s64*); // r1+0x14
 }
 
 // Range: 0x80034FCC -> 0x80035038
-s32 cpuSetCodeHack(struct _CPU* pCPU, s32 nAddress, s32 nOpcodeOld, s32 nOpcodeNew) {
+int cpuSetCodeHack(struct _CPU* pCPU, int nAddress, int nOpcodeOld, int nOpcodeNew) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // s32 nAddress; // r1+0x4
-    // s32 nOpcodeOld; // r1+0x8
-    // s32 nOpcodeNew; // r1+0xC
+    // int nAddress; // r1+0x4
+    // int nOpcodeOld; // r1+0x8
+    // int nOpcodeNew; // r1+0xC
 
     // Local variables
-    s32 iHack; // r9
+    int iHack; // r9
 }
 
 // Range: 0x80034AE8 -> 0x80034FCC
-s32 cpuReset(struct _CPU* pCPU) {
+int cpuReset(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
-    s32 iTLB; // r1+0x8
+    int iRegister; // r1+0x8
+    int iTLB; // r1+0x8
 
     // References
     // -> void* gHeapTree;
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Erased
-static s32 cpuGetXPC(struct _CPU* pCPU, s32* pnPC, s32* pnLo, s32* pnHi) {
+static int cpuGetXPC(struct _CPU* pCPU, signed int* pnPC, signed int* pnLo, signed int* pnHi) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32* pnPC; // r29
-    // s32* pnLo; // r30
-    // s32* pnHi; // r31
+    // signed int* pnPC; // r29
+    // signed int* pnLo; // r30
+    // signed int* pnHi; // r31
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Erased
-static s32 cpuGetGPR(struct _CPU* pCPU, s32* anRegister) {
+static int cpuGetGPR(struct _CPU* pCPU, signed int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // signed int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
     enum __anon_0x42F73 eSize; // r1+0x18
 
     // References
@@ -1035,47 +1037,47 @@ static s32 cpuGetGPR(struct _CPU* pCPU, s32* anRegister) {
 }
 
 // Erased
-static s32 cpuGetCP0(struct _CPU* pCPU, s32* anRegister) {
+static int cpuGetCP0(struct _CPU* pCPU, signed int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // signed int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Erased
-static s32 cpuGetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
+static int cpuGetFPR(struct _CPU* pCPU, f64* arRegister, int bDouble) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // f64* arRegister; // r30
-    // s32 bDouble; // r31
+    // int bDouble; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Erased
-static s32 cpuGetFCR(struct _CPU* pCPU, s32* anRegister) {
+static int cpuGetFCR(struct _CPU* pCPU, int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Range: 0x80034A6C -> 0x80034AE8
-s32 cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
+int cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
     // Parameters
     // struct _CPU* pCPU; // r26
     // s64 nPC; // r0
@@ -1087,13 +1089,13 @@ s32 cpuSetXPC(struct _CPU* pCPU, s64 nPC, s64 nLo, s64 nHi) {
 }
 
 // Erased
-static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
+static int cpuSetGPR(struct _CPU* pCPU, signed int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // signed int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
     enum __anon_0x42F73 eSize; // r1+0x18
 
     // References
@@ -1101,214 +1103,215 @@ static s32 cpuSetGPR(struct _CPU* pCPU, s32* anRegister) {
 }
 
 // Erased
-static s32 cpuSetCP0(struct _CPU* pCPU, s32* anRegister) {
+static int cpuSetCP0(struct _CPU* pCPU, signed int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // signed int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Erased
-static s32 cpuSetFPR(struct _CPU* pCPU, f64* arRegister, s32 bDouble) {
+static int cpuSetFPR(struct _CPU* pCPU, f64* arRegister, int bDouble) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // f64* arRegister; // r30
-    // s32 bDouble; // r31
+    // int bDouble; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Erased
-static s32 cpuSetFCR(struct _CPU* pCPU, s32* anRegister) {
+static int cpuSetFCR(struct _CPU* pCPU, int* anRegister) {
     // Parameters
     // struct _CPU* pCPU; // r30
-    // s32* anRegister; // r31
+    // int* anRegister; // r31
 
     // Local variables
-    s32 iRegister; // r1+0x8
+    int iRegister; // r1+0x8
 
     // References
     // -> struct _XL_OBJECTTYPE gClassCPU;
 }
 
 // Range: 0x80034864 -> 0x80034A6C
-s32 cpuEvent(struct _CPU* pCPU, s32 nEvent, void* pArgument) {
+int cpuEvent(struct _CPU* pCPU, int nEvent, void* pArgument) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r1+0x10
 }
 
 // Range: 0x800347F8 -> 0x80034864
-s32 cpuGetAddressOffset(struct _CPU* pCPU, s32* pnOffset, u32 nAddress) {
+int cpuGetAddressOffset(struct _CPU* pCPU, int* pnOffset, unsigned int nAddress) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32* pnOffset; // r1+0x4
-    // u32 nAddress; // r1+0x8
+    // int* pnOffset; // r1+0x4
+    // unsigned int nAddress; // r1+0x8
 
     // Local variables
-    s32 iDevice; // r1+0x0
+    int iDevice; // r1+0x0
 }
 
 // Range: 0x80034780 -> 0x800347F8
-s32 cpuGetAddressBuffer(struct _CPU* pCPU, void* ppBuffer, u32 nAddress) {
+int cpuGetAddressBuffer(struct _CPU* pCPU, void* ppBuffer, unsigned int nAddress) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
     // void* ppBuffer; // r4
-    // u32 nAddress; // r5
+    // unsigned int nAddress; // r5
 
     // Local variables
     struct __anon_0x3EB4F* pDevice; // r1+0x8
 }
 
 // Range: 0x800345F0 -> 0x80034780
-s32 cpuGetOffsetAddress(struct _CPU* pCPU, u32* anAddress, s32* pnCount, u32 nOffset, u32 nSize) {
+int cpuGetOffsetAddress(struct _CPU* pCPU, unsigned int* anAddress, int* pnCount, unsigned int nOffset,
+                        unsigned int nSize) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // u32* anAddress; // r1+0xC
-    // s32* pnCount; // r1+0x10
-    // u32 nOffset; // r1+0x14
-    // u32 nSize; // r1+0x18
+    // unsigned int* anAddress; // r1+0xC
+    // int* pnCount; // r1+0x10
+    // unsigned int nOffset; // r1+0x14
+    // unsigned int nSize; // r1+0x18
 
     // Local variables
-    s32 iEntry; // r1+0x8
-    s32 iAddress; // r7
-    u32 nAddress; // r1+0x8
-    u32 nMask; // r1+0x8
-    u32 nSizeMapped; // r26
+    int iEntry; // r1+0x8
+    int iAddress; // r7
+    unsigned int nAddress; // r1+0x8
+    unsigned int nMask; // r1+0x8
+    unsigned int nSizeMapped; // r26
 }
 
 // Range: 0x80034564 -> 0x800345F0
-s32 cpuInvalidateCache(struct _CPU* pCPU, s32 nAddress0, s32 nAddress1) {
+int cpuInvalidateCache(struct _CPU* pCPU, int nAddress0, int nAddress1) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 nAddress0; // r30
-    // s32 nAddress1; // r31
+    // int nAddress0; // r30
+    // int nAddress1; // r31
 }
 
 // Range: 0x80034324 -> 0x80034564
-s32 cpuGetFunctionChecksum(struct _CPU* pCPU, u32* pnChecksum, struct cpu_function* pFunction) {
+int cpuGetFunctionChecksum(struct _CPU* pCPU, unsigned int* pnChecksum, struct cpu_function* pFunction) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // u32* pnChecksum; // r30
+    // unsigned int* pnChecksum; // r30
     // struct cpu_function* pFunction; // r31
 
     // Local variables
-    s32 nSize; // r10
-    u32* pnBuffer; // r1+0x18
-    u32 nChecksum; // r11
-    u32 nData; // r12
+    int nSize; // r10
+    unsigned int* pnBuffer; // r1+0x18
+    unsigned int nChecksum; // r11
+    unsigned int nData; // r12
 }
 
 // Range: 0x80034288 -> 0x80034324
-static s32 cpuHeapReset(u32* array, s32 count) {
+static int cpuHeapReset(unsigned int* array, int count) {
     // Parameters
-    // u32* array; // r3
-    // s32 count; // r1+0x4
+    // unsigned int* array; // r3
+    // int count; // r1+0x4
 
     // Local variables
-    s32 i; // r6
+    int i; // r6
 }
 
 // Range: 0x80034028 -> 0x80034288
-s32 cpuHeapTake(void* heap, struct _CPU* pCPU, struct cpu_function* pFunction, s32 memory_size) {
+int cpuHeapTake(void* heap, struct _CPU* pCPU, struct cpu_function* pFunction, int memory_size) {
     // Parameters
     // void* heap; // r3
     // struct _CPU* pCPU; // r1+0xC
     // struct cpu_function* pFunction; // r1+0x10
-    // s32 memory_size; // r6
+    // int memory_size; // r6
 
     // Local variables
-    s32 done; // r12
-    s32 second; // r7
-    u32* anPack; // r8
-    s32 nPackCount; // r9
-    s32 nBlockCount; // r10
-    s32 nOffset; // r27
-    s32 nCount; // r26
-    s32 iPack; // r1+0x8
-    u32 nPack; // r25
-    u32 nMask; // r24
-    u32 nMask0; // r23
+    int done; // r12
+    int second; // r7
+    unsigned int* anPack; // r8
+    int nPackCount; // r9
+    int nBlockCount; // r10
+    int nOffset; // r27
+    int nCount; // r26
+    int iPack; // r1+0x8
+    unsigned int nPack; // r25
+    unsigned int nMask; // r24
+    unsigned int nMask0; // r23
 }
 
 // Range: 0x80033F3C -> 0x80034028
-s32 cpuHeapFree(struct _CPU* pCPU, struct cpu_function* pFunction) {
+int cpuHeapFree(struct _CPU* pCPU, struct cpu_function* pFunction) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
     // struct cpu_function* pFunction; // r4
 
     // Local variables
-    u32* anPack; // r8
-    s32 iPack; // r1+0x8
-    u32 nMask; // r6
+    unsigned int* anPack; // r8
+    int iPack; // r1+0x8
+    unsigned int nMask; // r6
 }
 
 // Range: 0x80033E88 -> 0x80033F3C
-static s32 cpuTreeTake(void* heap, s32* where) {
+static int cpuTreeTake(void* heap, int* where) {
     // Parameters
     // void* heap; // r1+0x0
-    // s32* where; // r1+0x4
+    // int* where; // r1+0x4
 
     // Local variables
-    s32 done; // r5
-    s32 nOffset; // r8
-    s32 nCount; // r1+0x0
-    s32 iPack; // r1+0x0
-    u32 nPack; // r9
-    u32 nMask; // r10
-    u32 nMask0; // r1+0x0
+    int done; // r5
+    int nOffset; // r8
+    int nCount; // r1+0x0
+    int iPack; // r1+0x0
+    unsigned int nPack; // r9
+    unsigned int nMask; // r10
+    unsigned int nMask0; // r1+0x0
 
     // References
     // -> void* gHeapTree;
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Erased
-static s32 cpuTreeFree(struct cpu_function* pFunction) {
+static int cpuTreeFree(struct cpu_function* pFunction) {
     // Parameters
     // struct cpu_function* pFunction; // r1+0x0
 
     // Local variables
-    u32* anPack; // r1+0x0
-    s32 iPack; // r1+0x0
-    u32 nMask; // r5
+    unsigned int* anPack; // r1+0x0
+    int iPack; // r1+0x0
+    unsigned int nMask; // r5
 
     // References
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Range: 0x80033304 -> 0x80033E88
-s32 cpuFindFunction(struct _CPU* pCPU, s32 theAddress, struct cpu_function** tree_node) {
+int cpuFindFunction(struct _CPU* pCPU, int theAddress, struct cpu_function** tree_node) {
     // Parameters
     // struct _CPU* pCPU; // r22
-    // s32 theAddress; // r1+0x38
+    // int theAddress; // r1+0x38
     // struct cpu_function** tree_node; // r28
 
     // Local variables
     struct __anon_0x3EB4F** apDevice; // r26
     u8* aiDevice; // r27
-    u32 opcode; // r1+0x34
+    unsigned int opcode; // r1+0x34
     u8 follow; // r1+0x3D
     u8 valid; // r16
     u8 check; // r1+0x3C
     u8 end_flag; // r18
     u8 save_restore; // r14
     u8 alert; // r15
-    s32 beginAddress; // r21
-    s32 cheat_address; // r17
-    s32 current_address; // r31
-    s32 temp_address; // r30
-    s32 branch; // r1+0x8
+    int beginAddress; // r21
+    int cheat_address; // r17
+    int current_address; // r31
+    int temp_address; // r30
+    int branch; // r1+0x8
 
     // References
     // -> static u8 Opcode[64];
@@ -1317,95 +1320,95 @@ s32 cpuFindFunction(struct _CPU* pCPU, s32 theAddress, struct cpu_function** tre
 }
 
 // Range: 0x800331A4 -> 0x80033304
-static s32 cpuDMAUpdateFunction(struct _CPU* pCPU, s32 start, s32 end) {
+static int cpuDMAUpdateFunction(struct _CPU* pCPU, int start, int end) {
     // Parameters
     // struct _CPU* pCPU; // r28
-    // s32 start; // r29
-    // s32 end; // r30
+    // int start; // r29
+    // int end; // r30
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x8
-    s32 count; // r1+0x8
-    s32 cancel; // r5
+    int count; // r1+0x8
+    int cancel; // r5
 }
 
 // Erased
-static void treeCallerInit(struct cpu_callerID* block, s32 total) {
+static void treeCallerInit(struct cpu_callerID* block, int total) {
     // Parameters
     // struct cpu_callerID* block; // r3
-    // s32 total; // r1+0x4
+    // int total; // r1+0x4
 
     // Local variables
-    s32 count; // r6
+    int count; // r6
 }
 
 // Erased
-static s32 treeCallerKill(struct _CPU* pCPU, struct cpu_function* kill) {
+static int treeCallerKill(struct _CPU* pCPU, struct cpu_function* kill) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // struct cpu_function* kill; // r30
 
     // Local variables
-    s32 left; // r1+0x14
-    s32 right; // r1+0x10
+    int left; // r1+0x14
+    int right; // r1+0x10
     struct cpu_treeRoot* root; // r31
 }
 
 // Range: 0x800330A0 -> 0x800331A4
-static s32 treeCallerCheck(struct _CPU* pCPU, struct cpu_function* tree, s32 flag, s32 nAddress0, s32 nAddress1) {
+static int treeCallerCheck(struct _CPU* pCPU, struct cpu_function* tree, int flag, int nAddress0, int nAddress1) {
     // Parameters
     // struct _CPU* pCPU; // r24
     // struct cpu_function* tree; // r25
-    // s32 flag; // r26
-    // s32 nAddress0; // r27
-    // s32 nAddress1; // r28
+    // int flag; // r26
+    // int nAddress0; // r27
+    // int nAddress1; // r28
 
     // Local variables
-    s32 count; // r30
-    s32 saveGCN; // r6
-    s32 saveN64; // r1+0x8
-    s32* addr_function; // r1+0x8
-    s32* addr_call; // r29
+    int count; // r30
+    int saveGCN; // r6
+    int saveN64; // r1+0x8
+    int* addr_function; // r1+0x8
+    int* addr_call; // r29
 }
 
 // Range: 0x80033048 -> 0x800330A0
-static s32 treeInit(struct _CPU* pCPU, s32 root_address) {
+static int treeInit(struct _CPU* pCPU, int root_address) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32 root_address; // r1+0x4
+    // int root_address; // r1+0x4
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x0
 }
 
 // Range: 0x80032F2C -> 0x80033048
-static s32 treeInitNode(struct cpu_function** tree, struct cpu_function* prev, s32 start, s32 end) {
+static int treeInitNode(struct cpu_function** tree, struct cpu_function* prev, int start, int end) {
     // Parameters
     // struct cpu_function** tree; // r30
     // struct cpu_function* prev; // r31
-    // s32 start; // r28
-    // s32 end; // r29
+    // int start; // r28
+    // int end; // r29
 
     // Local variables
     struct cpu_function* node; // r1+0x1C
-    s32 where; // r1+0x18
+    int where; // r1+0x18
 }
 
 // Range: 0x80032C84 -> 0x80032F2C
-static s32 treeKill(struct _CPU* pCPU) {
+static int treeKill(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r28
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x8
-    s32 count; // r29
+    int count; // r29
 
     // References
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Range: 0x800329D4 -> 0x80032C84
-static s32 treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
+static int treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
     // Parameters
     // struct _CPU* pCPU; // r24
     // struct cpu_function* tree; // r25
@@ -1413,14 +1416,14 @@ static s32 treeKillNodes(struct _CPU* pCPU, struct cpu_function* tree) {
     // Local variables
     struct cpu_function* current; // r27
     struct cpu_function* kill; // r28
-    s32 count; // r26
+    int count; // r26
 
     // References
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Range: 0x80032674 -> 0x800329D4
-static s32 treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct cpu_function* kill) {
+static int treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct cpu_function* kill) {
     // Parameters
     // struct _CPU* pCPU; // r30
     // struct cpu_function** top; // r1+0xC
@@ -1433,49 +1436,49 @@ static s32 treeDeleteNode(struct _CPU* pCPU, struct cpu_function** top, struct c
     struct cpu_function* connect; // r1+0x8
 
     // References
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Erased
-static s32 treeRebuild(struct _CPU* pCPU, s32 start_address, struct cpu_function** node) {
+static int treeRebuild(struct _CPU* pCPU, int start_address, struct cpu_function** node) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 start_address; // r30
+    // int start_address; // r30
     // struct cpu_function** node; // r31
 }
 
 // Erased
-static s32 treeInsertAndReturn(struct _CPU* pCPU, s32 start, s32 end, struct cpu_function** ppFunction) {
+static int treeInsertAndReturn(struct _CPU* pCPU, int start, int end, struct cpu_function** ppFunction) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // s32 start; // r28
-    // s32 end; // r29
+    // int start; // r28
+    // int end; // r29
     // struct cpu_function** ppFunction; // r30
 
     // Local variables
     struct cpu_treeRoot* root; // r31
-    s32 flag; // r3
+    int flag; // r3
 }
 
 // Range: 0x80032558 -> 0x80032674
-s32 treeInsert(struct _CPU* pCPU, s32 start, s32 end) {
+int treeInsert(struct _CPU* pCPU, int start, int end) {
     // Parameters
     // struct _CPU* pCPU; // r3
-    // s32 start; // r29
-    // s32 end; // r30
+    // int start; // r29
+    // int end; // r30
 
     // Local variables
     struct cpu_treeRoot* root; // r31
     struct cpu_function* current; // r1+0x14
-    s32 flag; // r3
+    int flag; // r3
 }
 
 // Range: 0x80032470 -> 0x80032558
-static s32 treeInsertNode(struct cpu_function** tree, s32 start, s32 end, struct cpu_function** ppFunction) {
+static int treeInsertNode(struct cpu_function** tree, int start, int end, struct cpu_function** ppFunction) {
     // Parameters
     // struct cpu_function** tree; // r31
-    // s32 start; // r8
-    // s32 end; // r7
+    // int start; // r8
+    // int end; // r7
     // struct cpu_function** ppFunction; // r30
 
     // Local variables
@@ -1484,7 +1487,7 @@ static s32 treeInsertNode(struct cpu_function** tree, s32 start, s32 end, struct
 }
 
 // Range: 0x800322D8 -> 0x80032470
-static s32 treeBalance(struct cpu_treeRoot* root) {
+static int treeBalance(struct cpu_treeRoot* root) {
     // Parameters
     // struct cpu_treeRoot* root; // r1+0x0
 
@@ -1492,47 +1495,47 @@ static s32 treeBalance(struct cpu_treeRoot* root) {
     struct cpu_function* tree; // r8
     struct cpu_function* current; // r4
     struct cpu_function* save; // r6
-    s32 total; // r9
-    s32 count; // r7
+    int total; // r9
+    int count; // r7
 }
 
 // Range: 0x800320EC -> 0x800322D8
-static s32 treeAdjustRoot(struct _CPU* pCPU, s32 new_end) {
+static int treeAdjustRoot(struct _CPU* pCPU, int new_end) {
     // Parameters
     // struct _CPU* pCPU; // r23
-    // s32 new_end; // r24
+    // int new_end; // r24
 
     // Local variables
-    s32 old_root; // r1+0x8
-    s32 new_root; // r30
-    s32 kill_start; // r29
-    s32 check1; // r1+0x8
-    s32 check2; // r28
+    int old_root; // r1+0x8
+    int new_root; // r30
+    int kill_start; // r29
+    int check1; // r1+0x8
+    int check2; // r28
     u16 total; // r27
-    s32 total_memory; // r26
-    s32 address; // r22
+    int total_memory; // r26
+    int address; // r22
     struct cpu_treeRoot* root; // r25
     struct cpu_function* node; // r1+0x18
     struct cpu_function* change; // r1+0x14
 }
 
 // Erased
-static s32 treeSearch(struct _CPU* pCPU, s32 target, struct cpu_function** node) {
+static int treeSearch(struct _CPU* pCPU, int target, struct cpu_function** node) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
-    // s32 target; // r4
+    // int target; // r4
     // struct cpu_function** node; // r5
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x8
-    s32 flag; // r3
+    int flag; // r3
 }
 
 // Range: 0x80032088 -> 0x800320EC
-static s32 treeSearchNode(struct cpu_function* tree, s32 target, struct cpu_function** node) {
+static int treeSearchNode(struct cpu_function* tree, int target, struct cpu_function** node) {
     // Parameters
     // struct cpu_function* tree; // r3
-    // s32 target; // r1+0x4
+    // int target; // r1+0x4
     // struct cpu_function** node; // r1+0x8
 
     // Local variables
@@ -1540,12 +1543,12 @@ static s32 treeSearchNode(struct cpu_function* tree, s32 target, struct cpu_func
 }
 
 // Range: 0x800318F0 -> 0x80032088
-static s32 treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, s32 start, s32 end) {
+static int treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, int start, int end) {
     // Parameters
     // struct _CPU* pCPU; // r31
     // struct cpu_function* tree; // r24
-    // s32 start; // r25
-    // s32 end; // r26
+    // int start; // r25
+    // int end; // r26
 
     // Local variables
     struct cpu_treeRoot* root; // r29
@@ -1554,33 +1557,33 @@ static s32 treeKillRange(struct _CPU* pCPU, struct cpu_function* tree, s32 start
     struct cpu_function* save1; // r3
     struct cpu_function* save2; // r4
     struct cpu_function* connect; // r5
-    s32 update; // r28
-    s32 count; // r27
+    int update; // r28
+    int count; // r27
 
     // References
-    // -> u32 aHeapTreeFlag[125];
+    // -> unsigned int aHeapTreeFlag[125];
 }
 
 // Range: 0x80031860 -> 0x800318F0
-static s32 treeKillReason(struct _CPU* pCPU, s32* value) {
+static int treeKillReason(struct _CPU* pCPU, int* value) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
-    // s32* value; // r1+0x4
+    // int* value; // r1+0x4
 }
 
 // Range: 0x8003174C -> 0x80031860
-static s32 treeTimerCheck(struct _CPU* pCPU) {
+static int treeTimerCheck(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x8
-    s32 begin; // r1+0x10
-    s32 end; // r1+0xC
+    int begin; // r1+0x10
+    int end; // r1+0xC
 }
 
 // Erased
-static s32 treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
+static int treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // struct cpu_function* node; // r30
@@ -1590,18 +1593,18 @@ static s32 treeCleanUpCheck(struct _CPU* pCPU, struct cpu_function* node) {
 }
 
 // Range: 0x8003161C -> 0x8003174C
-static s32 treeCleanUp(struct _CPU* pCPU, struct cpu_treeRoot* root) {
+static int treeCleanUp(struct _CPU* pCPU, struct cpu_treeRoot* root) {
     // Parameters
     // struct _CPU* pCPU; // r29
     // struct cpu_treeRoot* root; // r31
 
     // Local variables
-    s32 done; // r3
-    s32 complete; // r30
+    int done; // r3
+    int complete; // r30
 }
 
 // Range: 0x8003133C -> 0x8003161C
-static s32 treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
+static int treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
     // Parameters
     // struct _CPU* pCPU; // r27
     // struct cpu_function* top; // r1+0xC
@@ -1610,26 +1613,26 @@ static s32 treeCleanNodes(struct _CPU* pCPU, struct cpu_function* top) {
     struct cpu_function** current; // r30
     struct cpu_function* kill; // r29
     struct cpu_treeRoot* root; // r1+0x8
-    s32 kill_limit; // r28
+    int kill_limit; // r28
 }
 
 // Erased
-static s32 treeForceCleanUp(struct _CPU* pCPU, struct cpu_function* node, s32 kill_value) {
+static int treeForceCleanUp(struct _CPU* pCPU, struct cpu_function* node, int kill_value) {
     // Parameters
     // struct _CPU* pCPU; // r3
     // struct cpu_function* node; // r1+0xC
-    // s32 kill_value; // r5
+    // int kill_value; // r5
 
     // Local variables
     struct cpu_treeRoot* root; // r31
 }
 
 // Range: 0x80031168 -> 0x8003133C
-static s32 treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, s32 kill_limit) {
+static int treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, int kill_limit) {
     // Parameters
     // struct _CPU* pCPU; // r28
     // struct cpu_function* tree; // r1+0xC
-    // s32 kill_limit; // r29
+    // int kill_limit; // r29
 
     // Local variables
     struct cpu_function* current; // r31
@@ -1637,90 +1640,90 @@ static s32 treeForceCleanNodes(struct _CPU* pCPU, struct cpu_function* tree, s32
 }
 
 // Erased
-static s32 treePrint(struct _CPU* pCPU) {
+static int treePrint(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r29
 
     // Local variables
     struct cpu_treeRoot* root; // r1+0x8
-    s32 left; // r1+0x10
-    s32 right; // r1+0xC
+    int left; // r1+0x10
+    int right; // r1+0xC
 }
 
 // Range: 0x80030F84 -> 0x80031168
-static s32 treePrintNode(struct _CPU* pCPU, struct cpu_function* tree, s32 print_flag, s32* left, s32* right) {
+static int treePrintNode(struct _CPU* pCPU, struct cpu_function* tree, int print_flag, int* left, int* right) {
     // Parameters
     // struct _CPU* pCPU; // r21
     // struct cpu_function* tree; // r22
-    // s32 print_flag; // r1+0x10
-    // s32* left; // r23
-    // s32* right; // r24
+    // int print_flag; // r1+0x10
+    // int* left; // r23
+    // int* right; // r24
 
     // Local variables
     struct cpu_function* current; // r27
-    s32 flag; // r26
-    s32 level; // r25
+    int flag; // r26
+    int level; // r25
 
     // References
-    // -> s32 ganMapGPR[32];
+    // -> int ganMapGPR[32];
 }
 
 // Erased
-static s32 treeMemory(struct _CPU* pCPU) {
+static int treeMemory(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Range: 0x80030E70 -> 0x80030F84
-static s32 cpuOpcodeChecksum(u32 opcode) {
+static int cpuOpcodeChecksum(unsigned int opcode) {
     // Parameters
-    // u32 opcode; // r1+0x0
+    // unsigned int opcode; // r1+0x0
 
     // Local variables
-    s32 flag; // r5
+    int flag; // r5
 }
 
 // Erased
-static s32 cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, s32 start) {
+static int cpuDoubleCheckSameChecksum(struct cpu_disk_node* pDisk, int start) {
     // Parameters
     // struct cpu_disk_node* pDisk; // r30
-    // s32 start; // r4
+    // int start; // r4
 
     // Local variables
-    s32 count; // r1+0x8
-    s32 instruction; // r1+0x8
-    u32* last; // r31
-    u32* current; // r1+0x10
+    int count; // r1+0x8
+    int instruction; // r1+0x8
+    unsigned int* last; // r31
+    unsigned int* current; // r1+0x10
 
     // References
     // -> struct __anon_0x3DB14* gpSystem;
 }
 
 // Erased
-static s32 cpuCheckOpcodeHack(struct _CPU* pCPU, s32 startAddress, s32 instruction) {
+static int cpuCheckOpcodeHack(struct _CPU* pCPU, int startAddress, int instruction) {
     // Parameters
     // struct _CPU* pCPU; // r29
-    // s32 startAddress; // r30
-    // s32 instruction; // r31
+    // int startAddress; // r30
+    // int instruction; // r31
 
     // Local variables
-    s32 iHack; // r1+0x8
-    u32* opcode; // r1+0x14
+    int iHack; // r1+0x8
+    unsigned int* opcode; // r1+0x14
 }
 
 // Erased
-static s32 cpuUpdateDiskChecksum(u32* checksum, s32 startAddress, s32 endAddress) {
+static int cpuUpdateDiskChecksum(unsigned int* checksum, int startAddress, int endAddress) {
     // Parameters
-    // u32* checksum; // r29
-    // s32 startAddress; // r4
-    // s32 endAddress; // r1+0x10
+    // unsigned int* checksum; // r29
+    // int startAddress; // r4
+    // int endAddress; // r1+0x10
 
     // Local variables
-    s32 count; // r31
-    s32 instruction; // r30
-    s32 check; // r1+0x8
-    u32* opcode; // r1+0x14
-    u32 part; // r27
+    int count; // r31
+    int instruction; // r30
+    int check; // r1+0x8
+    unsigned int* opcode; // r1+0x14
+    unsigned int part; // r27
 
     // References
     // -> struct __anon_0x3DB14* gpSystem;

--- a/debug/Fire/disk.c
+++ b/debug/Fire/disk.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x73A37; // size = 0x10
 
 // size = 0x10, address = 0x800EE748
@@ -22,76 +22,76 @@ typedef struct __anon_0x73B29 {
 } __anon_0x73B29; // size = 0x4
 
 // Range: 0x8008DA14 -> 0x8008DA1C
-static s32 diskPutROM8() {}
+static int diskPutROM8() {}
 
 // Range: 0x8008DA0C -> 0x8008DA14
-static s32 diskPutROM16() {}
+static int diskPutROM16() {}
 
 // Range: 0x8008DA04 -> 0x8008DA0C
-static s32 diskPutROM32() {}
+static int diskPutROM32() {}
 
 // Range: 0x8008D9FC -> 0x8008DA04
-static s32 diskPutROM64() {}
+static int diskPutROM64() {}
 
 // Range: 0x8008D9EC -> 0x8008D9FC
-static s32 diskGetROM8(char* pData) {
+static int diskGetROM8(char* pData) {
     // Parameters
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8008D9DC -> 0x8008D9EC
-static s32 diskGetROM16(s16* pData) {
+static int diskGetROM16(s16* pData) {
     // Parameters
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8008D9CC -> 0x8008D9DC
-static s32 diskGetROM32(s32* pData) {
+static int diskGetROM32(int* pData) {
     // Parameters
-    // s32* pData; // r1+0x8
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8008D9B8 -> 0x8008D9CC
-static s32 diskGetROM64(s64* pData) {
+static int diskGetROM64(s64* pData) {
     // Parameters
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8008D9B0 -> 0x8008D9B8
-static s32 diskPutDrive8() {}
+static int diskPutDrive8() {}
 
 // Range: 0x8008D9A8 -> 0x8008D9B0
-static s32 diskPutDrive16() {}
+static int diskPutDrive16() {}
 
 // Range: 0x8008D97C -> 0x8008D9A8
-static s32 diskPutDrive32(u32 nAddress) {
+static int diskPutDrive32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x8008D974 -> 0x8008D97C
-static s32 diskPutDrive64() {}
+static int diskPutDrive64() {}
 
 // Range: 0x8008D96C -> 0x8008D974
-static s32 diskGetDrive8() {}
+static int diskGetDrive8() {}
 
 // Range: 0x8008D964 -> 0x8008D96C
-static s32 diskGetDrive16() {}
+static int diskGetDrive16() {}
 
 // Range: 0x8008D92C -> 0x8008D964
-static s32 diskGetDrive32(u32 nAddress, s32* pData) {
+static int diskGetDrive32(unsigned int nAddress, int* pData) {
     // Parameters
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8008D924 -> 0x8008D92C
-static s32 diskGetDrive64() {}
+static int diskGetDrive64() {}
 
 // Range: 0x8008D788 -> 0x8008D924
-s32 diskEvent(struct __anon_0x73B29* pDisk, s32 nEvent, void* pArgument) {
+int diskEvent(struct __anon_0x73B29* pDisk, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x73B29* pDisk; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/flash.c
+++ b/debug/Fire/flash.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x7419C; // size = 0x10
 
 // size = 0x10, address = 0x800EE758
@@ -19,75 +19,75 @@ struct _XL_OBJECTTYPE gClassFlash;
 
 typedef struct __anon_0x7428F {
     /* 0x0 */ void* pHost;
-    /* 0x4 */ s32 flashCommand;
+    /* 0x4 */ int flashCommand;
     /* 0x8 */ char* flashBuffer;
-    /* 0xC */ s32 flashStatus;
+    /* 0xC */ int flashStatus;
 } __anon_0x7428F; // size = 0x10
 
 // Range: 0x8008DFF4 -> 0x8008E138
-s32 flashCopyFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nOffsetFLASH, s32 nSize) {
+int flashCopyFLASH(struct __anon_0x7428F* pFLASH, int nOffsetRAM, int nOffsetFLASH, int nSize) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r30
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetFLASH; // r31
-    // s32 nSize; // r1+0x14
+    // int nOffsetRAM; // r4
+    // int nOffsetFLASH; // r31
+    // int nSize; // r1+0x14
 
     // Local variables
     void* pTarget; // r1+0x18
 }
 
 // Range: 0x8008DEE0 -> 0x8008DFF4
-s32 flashTransferFLASH(struct __anon_0x7428F* pFLASH, s32 nOffsetRAM, s32 nSize) {
+int flashTransferFLASH(struct __anon_0x7428F* pFLASH, int nOffsetRAM, int nSize) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r31
-    // s32 nOffsetRAM; // r4
-    // s32 nSize; // r1+0x14
+    // int nOffsetRAM; // r4
+    // int nSize; // r1+0x14
 
     // Local variables
     void* pTarget; // r1+0x18
-    s32 i; // r4
+    int i; // r4
 }
 
 // Range: 0x8008DED8 -> 0x8008DEE0
-static s32 flashPut8() {}
+static int flashPut8() {}
 
 // Range: 0x8008DED0 -> 0x8008DED8
-static s32 flashPut16() {}
+static int flashPut16() {}
 
 // Range: 0x8008DC00 -> 0x8008DED0
-static s32 flashPut32(struct __anon_0x7428F* pFLASH, s32* pData) {
+static int flashPut32(struct __anon_0x7428F* pFLASH, int* pData) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r30
-    // s32* pData; // r31
+    // int* pData; // r31
 
     // Local variables
-    s32 i; // r1+0x8
+    int i; // r1+0x8
     char buffer[128]; // r1+0x1C
 }
 
 // Range: 0x8008DBF8 -> 0x8008DC00
-static s32 flashPut64() {}
+static int flashPut64() {}
 
 // Range: 0x8008DBF0 -> 0x8008DBF8
-static s32 flashGet8() {}
+static int flashGet8() {}
 
 // Range: 0x8008DBE8 -> 0x8008DBF0
-static s32 flashGet16() {}
+static int flashGet16() {}
 
 // Range: 0x8008DB44 -> 0x8008DBE8
-static s32 flashGet32(struct __anon_0x7428F* pFLASH, s32* pData) {
+static int flashGet32(struct __anon_0x7428F* pFLASH, int* pData) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r1+0x0
-    // s32* pData; // r1+0x8
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8008DB3C -> 0x8008DB44
-static s32 flashGet64() {}
+static int flashGet64() {}
 
 // Range: 0x8008DA1C -> 0x8008DB3C
-s32 flashEvent(struct __anon_0x7428F* pFLASH, s32 nEvent, void* pArgument) {
+int flashEvent(struct __anon_0x7428F* pFLASH, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x7428F* pFLASH; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/frame.c
+++ b/debug/Fire/frame.c
@@ -9,22 +9,22 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x22648; // size = 0x10
 
 // size = 0x10, address = 0x800EA848
 struct _XL_OBJECTTYPE gClassFrame;
 
 // size = 0x4, address = 0x80135688
-static s32 gbFrameValid;
+static int gbFrameValid;
 
 // size = 0x4, address = 0x8013568C
-static s32 gbFrameBegin;
+static int gbFrameBegin;
 
 // size = 0x4, address = 0x80135690
-static s32 snScissorChanged;
+static int snScissorChanged;
 
 // size = 0x4, address = 0x80135694
 static u32 snScissorXOrig;
@@ -39,28 +39,28 @@ static u32 snScissorWidth;
 static u32 snScissorHeight;
 
 // size = 0x4, address = 0x801356A4
-static s32 sCopyFrameSyncReceived;
+static int sCopyFrameSyncReceived;
 
 // size = 0x1, address = 0x801356A8
 static u8 sSpecialZeldaHackON;
 
 // size = 0x4, address = 0x801356AC
-static u32 sDestinationBuffer;
+static unsigned int sDestinationBuffer;
 
 // size = 0x4, address = 0x801356B0
-static u32 sSrcBuffer;
+static unsigned int sSrcBuffer;
 
 // size = 0x18, address = 0x801085A0
-static u32 sConstantBufAddr[6];
+static unsigned int sConstantBufAddr[6];
 
 // size = 0x4, address = 0x801356B4
-static u32 sNumAddr;
+static unsigned int sNumAddr;
 
 // size = 0x4, address = 0x801356B8
-static u32 gHackCreditsColor;
+static unsigned int gHackCreditsColor;
 
 // size = 0x4, address = 0x801356BC
-s32 gNoSwapBuffer;
+int gNoSwapBuffer;
 
 // size = 0x20, address = 0x800EA858
 u32 ganNameColor[8];
@@ -111,19 +111,19 @@ static char* gaszNameColor[20];
 static char* gaszNameAlpha[9];
 
 // size = 0x20, address = 0x800EA994
-static s32 (*gapfDrawTriangle[8])(void*, void*);
+static int (*gapfDrawTriangle[8])(void*, void*);
 
 // size = 0x18, address = 0x800EA9B4
-static s32 (*gapfDrawLine[6])(void*, void*);
+static int (*gapfDrawLine[6])(void*, void*);
 
 // size = 0x4, address = 0x801356C0
-static s32 gnCountMapHack;
+static int gnCountMapHack;
 
 // size = 0x4, address = 0x801356C4
-static s32 nCounter$1367;
+static int nCounter$1367;
 
 // size = 0x4, address = 0x801356C8
-static s32 bSkip$1410;
+static int bSkip$1410;
 
 // size = 0x25800, address = 0x801085C0
 static u16 sTempZBuf[4800][4][4];
@@ -181,10 +181,10 @@ static struct _GXTexObj frameObj$1673;
 static u32 sCommandCodes$1679[8];
 
 // size = 0x4, address = 0x801356CC
-static s32 nLastFrame$1695;
+static int nLastFrame$1695;
 
 // size = 0x4, address = 0x801356D0
-static s32 nCopyFrame$1697;
+static int nCopyFrame$1697;
 
 // size = 0x28, address = 0x800EAA58
 static u32 sCommandCodes$1702[10];
@@ -196,28 +196,28 @@ static u32 sCommandCodes2$1722[10];
 static u16 tempLine$1785[16][4][4];
 
 // size = 0xC, address = 0x800EAAA8
-static u32 GBIcode$1816[3];
+static unsigned int GBIcode$1816[3];
 
 // size = 0x1C, address = 0x800EAAB4
-static u32 GBIcode2D2$1906[7];
+static unsigned int GBIcode2D2$1906[7];
 
 // size = 0x14, address = 0x800EAAD0
-static u32 GBIcode3D1$1907[5];
+static unsigned int GBIcode3D1$1907[5];
 
 // size = 0x18, address = 0x800EAAE4
-static u32 GBIcode3D2$1908[6];
+static unsigned int GBIcode3D2$1908[6];
 
 // size = 0x190, address = 0x800EAAFC
-u32 anRenderModeDatabaseCycle2[100];
+unsigned int anRenderModeDatabaseCycle2[100];
 
 // size = 0x190, address = 0x800EAC8C
-u32 anRenderModeDatabaseCopy[100];
+unsigned int anRenderModeDatabaseCopy[100];
 
 // size = 0x190, address = 0x800EAE1C
-u32 anRenderModeDatabaseFill[100];
+unsigned int anRenderModeDatabaseFill[100];
 
 // size = 0x190, address = 0x800EAFAC
-u32 anRenderModeDatabaseCycle1[100];
+unsigned int anRenderModeDatabaseCycle1[100];
 
 typedef struct __anon_0x239BA {
     /* 0x0 */ f32 x;
@@ -233,15 +233,15 @@ typedef struct __anon_0x23B04 {
 } __anon_0x23B04; // size = 0x10
 
 typedef struct __anon_0x23B9E {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x23B9E; // size = 0x14
 
 typedef struct __anon_0x23CAB {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x274AD rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -258,7 +258,7 @@ typedef struct __anon_0x23CAB {
 } __anon_0x23CAB; // size = 0x3C
 
 typedef struct __anon_0x23EDB {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x274AD rS;
     /* 0x10 */ struct __anon_0x274AD rT;
     /* 0x1C */ struct __anon_0x274AD rSRaw;
@@ -276,7 +276,7 @@ typedef struct __anon_0x23FC4 {
 typedef union __anon_0x24123 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x24123;
 
@@ -318,20 +318,20 @@ typedef struct _GXTlutObj {
 } __anon_0x2441B; // size = 0xC
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -340,11 +340,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x24462; // size = 0x6C
 
 typedef struct __anon_0x247BF {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -355,97 +355,97 @@ typedef struct __anon_0x247BF {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x247BF; // size = 0x2C
 
 typedef struct __anon_0x24A81 {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x25D5E eProjection;
 } __anon_0x24A81; // size = 0x24
 
 typedef struct __anon_0x24C38 {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x23B04 viewport;
     /* 0x000C8 */ struct __anon_0x23B9E aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x23CAB aLight[8];
     /* 0x00320 */ struct __anon_0x23EDB lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x23FC4 aVertex[80];
     /* 0x00C18 */ struct __anon_0x241C0 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x247BF aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x25D5E eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -456,16 +456,16 @@ typedef struct __anon_0x24C38 {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x24C38; // size = 0x3D150
 
 typedef struct __anon_0x25A82 {
-    /* 0x0 */ s32 nSizeTextures;
-    /* 0x4 */ s32 nCountTextures;
+    /* 0x0 */ int nSizeTextures;
+    /* 0x4 */ int nCountTextures;
 } __anon_0x25A82; // size = 0x8
 
 typedef enum __anon_0x25D5E {
@@ -496,10 +496,10 @@ typedef enum __anon_0x266CE {
 } __anon_0x266CE;
 
 typedef struct __anon_0x26732 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x26732; // size = 0x10
 
 typedef enum __anon_0x267E3 {
@@ -543,7 +543,7 @@ typedef enum __anon_0x26911 {
 typedef struct __anon_0x26A4E {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x266CE eMode;
     /* 0x10 */ struct __anon_0x26732 romCopy;
     /* 0x20 */ enum __anon_0x267E3 eTypeROM;
@@ -551,7 +551,7 @@ typedef struct __anon_0x26A4E {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x26911 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x26A4E; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -564,10 +564,10 @@ typedef enum __anon_0x26C3F {
 } __anon_0x26C3F;
 
 // size = 0x0, address = 0x800F3E78
-s32 __float_nan[];
+int __float_nan[];
 
 // size = 0x0, address = 0x800F3E7C
-s32 __float_huge[];
+int __float_huge[];
 
 typedef struct __anon_0x274AD {
     /* 0x0 */ f32 x;
@@ -603,42 +603,42 @@ typedef enum __anon_0x2813A {
 } __anon_0x2813A;
 
 typedef struct __anon_0x285E5 {
-    /* 0x0 */ s32 shift;
+    /* 0x0 */ int shift;
     /* 0x4 */ s32 add;
 } __anon_0x285E5; // size = 0x8
 
 typedef struct __anon_0x2865F {
-    /* 0x00 */ s32 nBIST;
-    /* 0x04 */ s32 nStatus;
+    /* 0x00 */ int nBIST;
+    /* 0x04 */ int nStatus;
     /* 0x08 */ void* pHost;
-    /* 0x0C */ s32 nModeTest;
-    /* 0x10 */ s32 nDataTest;
-    /* 0x14 */ s32 nAddressTest;
-    /* 0x18 */ s32 nAddress0;
-    /* 0x1C */ s32 nAddress1;
-    /* 0x20 */ s32 nClock;
-    /* 0x24 */ s32 nClockCmd;
-    /* 0x28 */ s32 nClockPipe;
-    /* 0x2C */ s32 nClockTMEM;
+    /* 0x0C */ int nModeTest;
+    /* 0x10 */ int nDataTest;
+    /* 0x14 */ int nAddressTest;
+    /* 0x18 */ int nAddress0;
+    /* 0x1C */ int nAddress1;
+    /* 0x20 */ int nClock;
+    /* 0x24 */ int nClockCmd;
+    /* 0x28 */ int nClockPipe;
+    /* 0x2C */ int nClockTMEM;
 } __anon_0x2865F; // size = 0x30
 
 typedef struct __anon_0x28835 {
-    /* 0x00 */ s32 nType;
-    /* 0x04 */ s32 nFlag;
-    /* 0x08 */ s32 nOffsetBoot;
-    /* 0x0C */ s32 nLengthBoot;
-    /* 0x10 */ s32 nOffsetCode;
-    /* 0x14 */ s32 nLengthCode;
-    /* 0x18 */ s32 nOffsetData;
-    /* 0x1C */ s32 nLengthData;
-    /* 0x20 */ s32 nOffsetStack;
-    /* 0x24 */ s32 nLengthStack;
-    /* 0x28 */ s32 nOffsetBuffer;
-    /* 0x2C */ s32 nLengthBuffer;
-    /* 0x30 */ s32 nOffsetMBI;
-    /* 0x34 */ s32 nLengthMBI;
-    /* 0x38 */ s32 nOffsetYield;
-    /* 0x3C */ s32 nLengthYield;
+    /* 0x00 */ int nType;
+    /* 0x04 */ int nFlag;
+    /* 0x08 */ int nOffsetBoot;
+    /* 0x0C */ int nLengthBoot;
+    /* 0x10 */ int nOffsetCode;
+    /* 0x14 */ int nLengthCode;
+    /* 0x18 */ int nOffsetData;
+    /* 0x1C */ int nLengthData;
+    /* 0x20 */ int nOffsetStack;
+    /* 0x24 */ int nLengthStack;
+    /* 0x28 */ int nOffsetBuffer;
+    /* 0x2C */ int nLengthBuffer;
+    /* 0x30 */ int nOffsetMBI;
+    /* 0x34 */ int nLengthMBI;
+    /* 0x38 */ int nOffsetYield;
+    /* 0x3C */ int nLengthYield;
 } __anon_0x28835; // size = 0x40
 
 typedef enum __anon_0x28AC5 {
@@ -660,14 +660,14 @@ typedef enum __anon_0x28AC5 {
 } __anon_0x28AC5;
 
 typedef struct __anon_0x28C10 {
-    /* 0x00 */ s32 iDL;
-    /* 0x04 */ s32 bValid;
+    /* 0x00 */ int iDL;
+    /* 0x04 */ int bValid;
     /* 0x08 */ struct __anon_0x28835 task;
-    /* 0x48 */ s32 nCountVertex;
+    /* 0x48 */ int nCountVertex;
     /* 0x4C */ enum __anon_0x28AC5 eTypeUCode;
-    /* 0x50 */ u32 n2TriMult;
-    /* 0x54 */ u32 nVersionUCode;
-    /* 0x58 */ s32 anBaseSegment[16];
+    /* 0x50 */ unsigned int n2TriMult;
+    /* 0x54 */ unsigned int nVersionUCode;
+    /* 0x58 */ int anBaseSegment[16];
     /* 0x98 */ u64* apDL[16];
 } __anon_0x28C10; // size = 0xD8
 
@@ -723,8 +723,8 @@ typedef enum __anon_0x29567 {
 } __anon_0x29567;
 
 typedef struct tXL_LIST {
-    /* 0x0 */ s32 nItemSize;
-    /* 0x4 */ s32 nItemCount;
+    /* 0x0 */ int nItemSize;
+    /* 0x4 */ int nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
 } __anon_0x295E5; // size = 0x10
@@ -743,34 +743,34 @@ typedef struct __anon_0x29770 {
 } __anon_0x29770; // size = 0x6
 
 typedef struct __anon_0x297E0 {
-    /* 0x0000 */ s32 nMode;
+    /* 0x0000 */ int nMode;
     /* 0x0004 */ struct __anon_0x28C10 yield;
-    /* 0x00DC */ u32 nTickLast;
-    /* 0x00E0 */ s32 (*pfUpdateWaiting)();
-    /* 0x00E4 */ u32 n2TriMult;
-    /* 0x00E8 */ s32 aStatus[4];
+    /* 0x00DC */ unsigned int nTickLast;
+    /* 0x00E0 */ int (*pfUpdateWaiting)();
+    /* 0x00E4 */ unsigned int n2TriMult;
+    /* 0x00E8 */ int aStatus[4];
     /* 0x00F8 */ f32 aMatrixOrtho[4][4];
-    /* 0x0138 */ u32 nMode2D;
+    /* 0x0138 */ unsigned int nMode2D;
     /* 0x013C */ struct __anon_0x28E31 twoDValues;
-    /* 0x015C */ s32 nPass;
-    /* 0x0160 */ u32 nZSortSubDL;
-    /* 0x0164 */ u32 nStatusSubDL;
-    /* 0x0168 */ u32 nNumZSortLights;
-    /* 0x016C */ s32 aLightAddresses[8];
-    /* 0x018C */ s32 nAmbientLightAddress;
+    /* 0x015C */ int nPass;
+    /* 0x0160 */ unsigned int nZSortSubDL;
+    /* 0x0164 */ unsigned int nStatusSubDL;
+    /* 0x0168 */ unsigned int nNumZSortLights;
+    /* 0x016C */ int aLightAddresses[8];
+    /* 0x018C */ int nAmbientLightAddress;
     /* 0x0190 */ struct __anon_0x28F3E aZSortVertex[128];
     /* 0x0B90 */ struct __anon_0x29056 aZSortNormal[128];
     /* 0x0D10 */ struct __anon_0x290D5 aZSortMaterial[128];
     /* 0x0F10 */ struct __anon_0x29178 aZSortMatrix[128];
     /* 0x2F10 */ struct __anon_0x291D6 aZSortLight[8];
-    /* 0x2F40 */ s32 aZSortInvW[128];
+    /* 0x2F40 */ int aZSortInvW[128];
     /* 0x3140 */ s16 aZSortWiVal[128];
-    /* 0x3240 */ u32 nNumZSortMatrices;
-    /* 0x3244 */ u32 nNumZSortVertices;
-    /* 0x3248 */ u32 nTotalZSortVertices;
-    /* 0x324C */ u32 nNumZSortNormals;
-    /* 0x3250 */ u32 nNumZSortMaterials;
-    /* 0x3254 */ s32 anAudioBaseSegment[16];
+    /* 0x3240 */ unsigned int nNumZSortMatrices;
+    /* 0x3244 */ unsigned int nNumZSortVertices;
+    /* 0x3248 */ unsigned int nTotalZSortVertices;
+    /* 0x324C */ unsigned int nNumZSortNormals;
+    /* 0x3250 */ unsigned int nNumZSortMaterials;
+    /* 0x3254 */ int anAudioBaseSegment[16];
     /* 0x3294 */ s16* anAudioBuffer;
     /* 0x3298 */ s16 anADPCMCoef[5][2][8];
     /* 0x3338 */ u16 nAudioDMOutR[2];
@@ -780,24 +780,24 @@ typedef struct __anon_0x297E0 {
     /* 0x3348 */ u16 nAudioFlags;
     /* 0x334A */ u16 nAudioDMEMIn[2];
     /* 0x334E */ u16 nAudioDMEMOut[2];
-    /* 0x3354 */ u32 nAudioLoopAddress;
-    /* 0x3358 */ u32 nAudioDryAmt;
-    /* 0x335C */ u32 nAudioWetAmt;
-    /* 0x3360 */ u32 nAudioVolL;
-    /* 0x3364 */ u32 nAudioVolR;
-    /* 0x3368 */ u32 nAudioVolTGTL;
-    /* 0x336C */ u32 nAudioVolRateLM;
-    /* 0x3370 */ u32 nAudioVolRateLL;
-    /* 0x3374 */ u32 nAudioVolTGTR;
-    /* 0x3378 */ u32 nAudioVolRateRM;
-    /* 0x337C */ u32 nAudioVolRateRL;
+    /* 0x3354 */ unsigned int nAudioLoopAddress;
+    /* 0x3358 */ unsigned int nAudioDryAmt;
+    /* 0x335C */ unsigned int nAudioWetAmt;
+    /* 0x3360 */ unsigned int nAudioVolL;
+    /* 0x3364 */ unsigned int nAudioVolR;
+    /* 0x3368 */ unsigned int nAudioVolTGTL;
+    /* 0x336C */ unsigned int nAudioVolRateLM;
+    /* 0x3370 */ unsigned int nAudioVolRateLL;
+    /* 0x3374 */ unsigned int nAudioVolTGTR;
+    /* 0x3378 */ unsigned int nAudioVolRateRM;
+    /* 0x337C */ unsigned int nAudioVolRateRL;
     /* 0x3380 */ struct __anon_0x29487 vParams;
     /* 0x3390 */ s16 stepF;
     /* 0x3392 */ s16 stepL;
     /* 0x3394 */ s16 stepR;
-    /* 0x3398 */ s32 anGenReg[32];
+    /* 0x3398 */ int anGenReg[32];
     /* 0x3418 */ struct __anon_0x29487 aVectorReg[32];
-    /* 0x3618 */ s32 anCP0Reg[32];
+    /* 0x3618 */ int anCP0Reg[32];
     /* 0x3698 */ struct __anon_0x29487 anCP2Reg[32];
     /* 0x3898 */ s16 anAcc[24];
     /* 0x38C8 */ s16 nVCC;
@@ -808,36 +808,36 @@ typedef struct __anon_0x297E0 {
     /* 0x38D6 */ u16 nAudioADPCMOffset;
     /* 0x38D8 */ u16 nAudioScratchOffset;
     /* 0x38DA */ u16 nAudioParBase;
-    /* 0x38DC */ s32 nPC;
-    /* 0x38E0 */ s32 iDL;
-    /* 0x38E4 */ s32 nBIST;
+    /* 0x38DC */ int nPC;
+    /* 0x38E0 */ int iDL;
+    /* 0x38E4 */ int nBIST;
     /* 0x38E8 */ void* pHost;
     /* 0x38EC */ void* pDMEM;
     /* 0x38F0 */ void* pIMEM;
-    /* 0x38F4 */ s32 nStatus;
-    /* 0x38F8 */ s32 nFullDMA;
-    /* 0x38FC */ s32 nBusyDMA;
-    /* 0x3900 */ s32 nSizeGet;
-    /* 0x3904 */ s32 nSizePut;
-    /* 0x3908 */ s32 nSemaphore;
-    /* 0x390C */ s32 nAddressSP;
-    /* 0x3910 */ s32 nGeometryMode;
-    /* 0x3914 */ s32 nAddressRDRAM;
+    /* 0x38F4 */ int nStatus;
+    /* 0x38F8 */ int nFullDMA;
+    /* 0x38FC */ int nBusyDMA;
+    /* 0x3900 */ int nSizeGet;
+    /* 0x3904 */ int nSizePut;
+    /* 0x3908 */ int nSemaphore;
+    /* 0x390C */ int nAddressSP;
+    /* 0x3910 */ int nGeometryMode;
+    /* 0x3914 */ int nAddressRDRAM;
     /* 0x3918 */ struct tXL_LIST* pListUCode;
-    /* 0x391C */ s32 nCountVertex;
+    /* 0x391C */ int nCountVertex;
     /* 0x3920 */ enum __anon_0x28AC5 eTypeUCode;
-    /* 0x3924 */ u32 nVersionUCode;
-    /* 0x3928 */ s32 anBaseSegment[16];
+    /* 0x3924 */ unsigned int nVersionUCode;
+    /* 0x3928 */ int anBaseSegment[16];
     /* 0x3968 */ u64* apDL[16];
-    /* 0x39A8 */ s32* Coeff;
+    /* 0x39A8 */ int* Coeff;
     /* 0x39AC */ s16* QTable;
     /* 0x39B0 */ s16* QYTable;
     /* 0x39B4 */ s16* QCbTable;
     /* 0x39B8 */ s16* QCrTable;
-    /* 0x39BC */ s32* Zigzag;
+    /* 0x39BC */ int* Zigzag;
     /* 0x39C0 */ struct __anon_0x296E2* rgbaBuf;
     /* 0x39C4 */ struct __anon_0x29770* yuvBuf;
-    /* 0x39C8 */ s32* dctBuf;
+    /* 0x39C8 */ int* dctBuf;
 } __anon_0x297E0; // size = 0x39CC
 
 typedef struct __anon_0x2A6F7 {
@@ -849,7 +849,7 @@ typedef struct __anon_0x2A6F7 {
     /* 0x0A */ u16 imageH;
     /* 0x0C */ s16 frameY;
     /* 0x0E */ u16 frameH;
-    /* 0x10 */ u32 imagePtr;
+    /* 0x10 */ unsigned int imagePtr;
     /* 0x14 */ u16 imageLoad;
     /* 0x16 */ u8 imageFmt;
     /* 0x17 */ u8 imageSiz;
@@ -872,7 +872,7 @@ typedef struct __anon_0x2AA02 {
     /* 0x0A */ u16 imageH;
     /* 0x0C */ s16 frameY;
     /* 0x0E */ u16 frameH;
-    /* 0x10 */ u32 imagePtr;
+    /* 0x10 */ unsigned int imagePtr;
     /* 0x14 */ u16 imageLoad;
     /* 0x16 */ u8 imageFmt;
     /* 0x17 */ u8 imageSiz;
@@ -880,7 +880,7 @@ typedef struct __anon_0x2AA02 {
     /* 0x1A */ u16 imageFlip;
     /* 0x1C */ u16 scaleW;
     /* 0x1E */ u16 scaleH;
-    /* 0x20 */ s32 imageYorig;
+    /* 0x20 */ int imageYorig;
     /* 0x24 */ u8 padding[4];
 } __anon_0x2AA02; // size = 0x28
 
@@ -891,36 +891,36 @@ typedef union __anon_0x2ACA3 {
 } __anon_0x2ACA3;
 
 typedef struct __anon_0x2AD2F {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 tmem;
     /* 0x0A */ u16 tsize;
     /* 0x0C */ u16 tline;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x2AD2F; // size = 0x18
 
 typedef struct __anon_0x2AE4F {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 tmem;
     /* 0x0A */ u16 twidth;
     /* 0x0C */ u16 theight;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x2AE4F; // size = 0x18
 
 typedef struct __anon_0x2AF72 {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 phead;
     /* 0x0A */ u16 pnum;
     /* 0x0C */ u16 zero;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x2AF72; // size = 0x18
 
 typedef union __anon_0x2B091 {
@@ -947,31 +947,31 @@ void* DemoFrameBuffer1;
 void* DemoFrameBuffer2;
 
 typedef struct __anon_0x2B2A7 {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x2B2A7; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x2B30D; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x2B2A7* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -990,8 +990,8 @@ typedef union __anon_0x2B65C {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -1005,8 +1005,8 @@ typedef union __anon_0x2B65C {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x2B65C;
 
@@ -1014,57 +1014,57 @@ typedef union __anon_0x2BA70 {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x2BA70;
 
 typedef struct __anon_0x2BF7E {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x2BF7E; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x2C24C; // size = 0x84
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x2C48D; // size = 0xC
 
 typedef struct __anon_0x2C542 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x2C542; // size = 0xC
 
 typedef struct OSContext {
@@ -1096,61 +1096,61 @@ typedef struct OSAlarm {
 } __anon_0x2C8C4; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x2C9DF; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x2B65C aGPR[32];
     /* 0x00140 */ union __anon_0x2BA70 aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x2BF7E* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x2C542 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x2CB8C; // size = 0x12090
 
@@ -1165,12 +1165,12 @@ typedef enum __anon_0x2D223 {
 } __anon_0x2D223;
 
 typedef struct __anon_0x2D2B6 {
-    /* 0x00 */ s32 bFlip;
-    /* 0x04 */ s32 iTile;
-    /* 0x08 */ s32 nX0;
-    /* 0x0C */ s32 nY0;
-    /* 0x10 */ s32 nX1;
-    /* 0x14 */ s32 nY1;
+    /* 0x00 */ int bFlip;
+    /* 0x04 */ int iTile;
+    /* 0x08 */ int nX0;
+    /* 0x0C */ int nY0;
+    /* 0x10 */ int nX1;
+    /* 0x14 */ int nY1;
     /* 0x18 */ f32 rS;
     /* 0x1C */ f32 rT;
     /* 0x20 */ f32 rDeltaS;
@@ -1178,7 +1178,7 @@ typedef struct __anon_0x2D2B6 {
 } __anon_0x2D2B6; // size = 0x28
 
 typedef struct __anon_0x2D45B {
-    /* 0x0 */ s32 nCount;
+    /* 0x0 */ int nCount;
     /* 0x4 */ u8 anData[768];
 } __anon_0x2D45B; // size = 0x304
 
@@ -1253,7 +1253,7 @@ typedef enum _GXFogType {
 } __anon_0x2D8A4;
 
 // Erased
-static s32 frameVectorTimesMatrix(f32* fOutVector, f32* fInVector, f32 (*matrix)[4]) {
+static int frameVectorTimesMatrix(f32* fOutVector, f32* fInVector, f32 (*matrix)[4]) {
     // Parameters
     // f32* fOutVector; // r1+0x4
     // f32* fInVector; // r1+0x8
@@ -1261,7 +1261,7 @@ static s32 frameVectorTimesMatrix(f32* fOutVector, f32* fInVector, f32 (*matrix)
 }
 
 // Range: 0x8002113C -> 0x80021204
-s32 frameScaleMatrix(f32 (*matrixResult)[4], f32 (*matrix)[4], f32 rScale) {
+int frameScaleMatrix(f32 (*matrixResult)[4], f32 (*matrix)[4], f32 rScale) {
     // Parameters
     // f32 (* matrixResult)[4]; // r1+0x0
     // f32 (* matrix)[4]; // r1+0x4
@@ -1269,7 +1269,7 @@ s32 frameScaleMatrix(f32 (*matrixResult)[4], f32 (*matrix)[4], f32 rScale) {
 }
 
 // Erased
-static s32 frameConcatenateMatrix(f32 (*matrixResult)[4], f32 (*matrixA)[4], f32 (*matrixB)[4]) {
+static int frameConcatenateMatrix(f32 (*matrixResult)[4], f32 (*matrixA)[4], f32 (*matrixB)[4]) {
     // Parameters
     // f32 (* matrixResult)[4]; // r1+0x8
     // f32 (* matrixA)[4]; // r4
@@ -1277,239 +1277,239 @@ static s32 frameConcatenateMatrix(f32 (*matrixResult)[4], f32 (*matrixA)[4], f32
 }
 
 // Range: 0x80021070 -> 0x8002113C
-static s32 frameConvertYUVtoRGB(u32* YUV, u32* RGB) {
+static int frameConvertYUVtoRGB(unsigned int* YUV, unsigned int* RGB) {
     // Parameters
-    // u32* YUV; // r1+0x0
-    // u32* RGB; // r1+0x4
+    // unsigned int* YUV; // r1+0x0
+    // unsigned int* RGB; // r1+0x4
 
     // Local variables
     s32 Yl; // r7
-    s32 R; // r1+0x0
-    s32 G; // r5
-    s32 B; // r8
+    int R; // r1+0x0
+    int G; // r5
+    int B; // r8
 }
 
 // Range: 0x80020FA4 -> 0x80021070
-static s32 packTakeBlocks(s32* piPack, u32* anPack, s32 nPackCount, s32 nBlockCount) {
+static int packTakeBlocks(int* piPack, unsigned int* anPack, int nPackCount, int nBlockCount) {
     // Parameters
-    // s32* piPack; // r1+0x0
-    // u32* anPack; // r4
-    // s32 nPackCount; // r5
-    // s32 nBlockCount; // r1+0xC
+    // int* piPack; // r1+0x0
+    // unsigned int* anPack; // r4
+    // int nPackCount; // r5
+    // int nBlockCount; // r1+0xC
 
     // Local variables
-    s32 nOffset; // r9
-    s32 nCount; // r10
-    s32 iPack; // r11
-    u32 nPack; // r5
-    u32 nMask; // r12
-    u32 nMask0; // r7
+    int nOffset; // r9
+    int nCount; // r10
+    int iPack; // r11
+    unsigned int nPack; // r5
+    unsigned int nMask; // r12
+    unsigned int nMask0; // r7
 }
 
 // Range: 0x80020F3C -> 0x80020FA4
-static s32 packFreeBlocks(s32* piPack, u32* anPack) {
+static int packFreeBlocks(int* piPack, unsigned int* anPack) {
     // Parameters
-    // s32* piPack; // r1+0x0
-    // u32* anPack; // r1+0x4
+    // int* piPack; // r1+0x0
+    // unsigned int* anPack; // r1+0x4
 
     // Local variables
-    s32 iPack; // r1+0x0
-    u32 nMask; // r7
+    int iPack; // r1+0x0
+    unsigned int nMask; // r7
 }
 
 // Erased
-static s32 packReset(u32* anPack, s32 nPackCount) {
+static int packReset(unsigned int* anPack, int nPackCount) {
     // Parameters
-    // u32* anPack; // r3
-    // s32 nPackCount; // r1+0x4
+    // unsigned int* anPack; // r3
+    // int nPackCount; // r1+0x4
 
     // Local variables
-    s32 iPack; // r7
+    int iPack; // r7
 }
 
 // Range: 0x80020E20 -> 0x80020F3C
-static s32 frameMakeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture) {
+static int frameMakeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
     // struct _FRAME_TEXTURE** ppTexture; // r1+0xC
 
     // Local variables
-    u32 nMask; // r5
-    s32 iTexture; // r9
-    s32 iTextureUsed; // r8
+    unsigned int nMask; // r5
+    int iTexture; // r9
+    int iTextureUsed; // r8
 }
 
 // Erased
-static s32 frameFreeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
+static int frameFreeTexture(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE* pTexture) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
     // struct _FRAME_TEXTURE* pTexture; // r29
 
     // Local variables
-    s32 iTexture; // r30
+    int iTexture; // r30
 }
 
 // Range: 0x80020958 -> 0x80020E20
-static s32 frameSetupCache(struct __anon_0x24C38* pFrame) {
+static int frameSetupCache(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
 
     // Local variables
-    s32 iTexture; // r1+0x8
+    int iTexture; // r1+0x8
 }
 
 // Erased
-static s32 frameResetCache(struct __anon_0x24C38* pFrame) {
+static int frameResetCache(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r31
 }
 
 // Range: 0x80020764 -> 0x80020958
-static s32 frameUpdateCache(struct __anon_0x24C38* pFrame) {
+static int frameUpdateCache(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r23
 
     // Local variables
-    s32 nCount; // r1+0x8
-    s32 nCountFree; // r1+0x8
-    u32 nMask; // r27
-    s32 nFrameCount; // r26
-    s32 nFrameDelta; // r1+0x8
-    s32 iTexture; // r1+0x8
-    s32 iTextureUsed; // r25
-    s32 iTextureCached; // r1+0x8
+    int nCount; // r1+0x8
+    int nCountFree; // r1+0x8
+    unsigned int nMask; // r27
+    int nFrameCount; // r26
+    int nFrameDelta; // r1+0x8
+    int iTexture; // r1+0x8
+    int iTextureUsed; // r25
+    int iTextureCached; // r1+0x8
     struct _FRAME_TEXTURE* pTexture; // r24
     struct _FRAME_TEXTURE* pTextureCached; // r4
     struct _FRAME_TEXTURE* pTextureLast; // r5
 }
 
 // Erased
-static s32 frameMultiTexture(struct __anon_0x24C38* pFrame) {
+static int frameMultiTexture(struct __anon_0x24C38* pFrame) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
 
     // Local variables
-    s32 iMode; // r5
-    s32 iType; // r1+0x0
-    s32 nMode; // r1+0x0
-    s32 nUsed; // r6
+    int iMode; // r5
+    int iType; // r1+0x0
+    int nMode; // r1+0x0
+    int nUsed; // r6
 }
 
 // Range: 0x80020340 -> 0x80020764
-static s32 frameLoadTile(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture, s32 iTileCode) {
+static int frameLoadTile(struct __anon_0x24C38* pFrame, struct _FRAME_TEXTURE** ppTexture, int iTileCode) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // struct _FRAME_TEXTURE** ppTexture; // r30
-    // s32 iTileCode; // r31
+    // int iTileCode; // r31
 
     // Local variables
-    s32 bFlag; // r27
+    int bFlag; // r27
     struct __anon_0x247BF* pTile; // r26
     struct _FRAME_TEXTURE* pTexture; // r1+0x18
     struct _FRAME_TEXTURE* pTextureLast; // r25
-    u32 nData0; // r24
-    u32 nData1; // r23
-    u32 nData2; // r22
-    u32 nData3; // r21
-    s32 iTexture; // r1+0x8
-    s32 nShift; // r3
+    unsigned int nData0; // r24
+    unsigned int nData1; // r23
+    unsigned int nData2; // r22
+    unsigned int nData3; // r21
+    int iTexture; // r1+0x8
+    int nShift; // r3
 }
 
 // Erased
-static s32 frameSetupTrackBuffer() {}
+static int frameSetupTrackBuffer() {}
 
 // Erased
-static s32 frameCheckTrackBuffer() {}
+static int frameCheckTrackBuffer() {}
 
 // Erased
-static s32 frameUpdateTrackBuffer() {}
+static int frameUpdateTrackBuffer() {}
 
 // Range: 0x800202FC -> 0x80020340
-s32 frameDrawReset(struct __anon_0x24C38* pFrame, s32 nFlag) {
+int frameDrawReset(struct __anon_0x24C38* pFrame, int nFlag) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nFlag; // r1+0x4
+    // int nFlag; // r1+0x4
 }
 
 // Range: 0x800202D0 -> 0x800202FC
-s32 frameSetFill(struct __anon_0x24C38* pFrame, s32 bFill) {
+int frameSetFill(struct __anon_0x24C38* pFrame, int bFill) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 bFill; // r1+0x4
+    // int bFill; // r1+0x4
 }
 
 // Erased
-static s32 frameGetFill(struct __anon_0x24C38* pFrame, s32* pbFill) {
+static int frameGetFill(struct __anon_0x24C38* pFrame, int* pbFill) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32* pbFill; // r1+0x4
+    // int* pbFill; // r1+0x4
 }
 
 // Erased
-static s32 frameSetWire(struct __anon_0x24C38* pFrame, s32 bWire) {
+static int frameSetWire(struct __anon_0x24C38* pFrame, int bWire) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 bWire; // r1+0x4
+    // int bWire; // r1+0x4
 }
 
 // Erased
-static s32 frameGetWire(struct __anon_0x24C38* pFrame, s32* pbWire) {
+static int frameGetWire(struct __anon_0x24C38* pFrame, int* pbWire) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32* pbWire; // r1+0x4
+    // int* pbWire; // r1+0x4
 }
 
 // Range: 0x800201A8 -> 0x800202D0
-s32 frameSetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32 nSizeX, s32 nSizeY) {
+int frameSetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, int nSizeX, int nSizeY) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // enum __anon_0x2813A eSize; // r1+0xC
-    // s32 nSizeX; // r1+0x10
-    // s32 nSizeY; // r1+0x14
+    // int nSizeX; // r1+0x10
+    // int nSizeY; // r1+0x14
 }
 
 // Erased
-static s32 frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, s32* pnSizeX, s32* pnSizeY) {
+static int frameGetSize(struct __anon_0x24C38* pFrame, enum __anon_0x2813A eSize, int* pnSizeX, int* pnSizeY) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // enum __anon_0x2813A eSize; // r1+0x4
-    // s32* pnSizeX; // r1+0x8
-    // s32* pnSizeY; // r1+0xC
+    // int* pnSizeX; // r1+0x8
+    // int* pnSizeY; // r1+0xC
 }
 
 // Range: 0x80020014 -> 0x800201A8
-s32 frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32 nMode) {
+int frameSetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, unsigned int nMode) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // enum __anon_0x27E96 eType; // r1+0x4
-    // u32 nMode; // r1+0x8
+    // unsigned int nMode; // r1+0x8
 
     // Local variables
-    u32 nFlag; // r8
-    u32 nModeChanged; // r9
+    unsigned int nFlag; // r8
+    unsigned int nModeChanged; // r9
 }
 
 // Range: 0x8001FFFC -> 0x80020014
-s32 frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, u32* pnMode) {
+int frameGetMode(struct __anon_0x24C38* pFrame, enum __anon_0x27E96 eType, unsigned int* pnMode) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // enum __anon_0x27E96 eType; // r1+0x4
-    // u32* pnMode; // r1+0x8
+    // unsigned int* pnMode; // r1+0x8
 }
 
 // Range: 0x8001F970 -> 0x8001FFFC
-s32 frameSetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bLoad, s32 bPush,
-                   s32 nAddressN64) {
+int frameSetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, int bLoad, int bPush,
+                   int nAddressN64) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // f32 (* matrix)[4]; // r30
     // enum __anon_0x27B8C eType; // r26
-    // s32 bLoad; // r28
-    // s32 bPush; // r27
-    // s32 nAddressN64; // r31
+    // int bLoad; // r28
+    // int bPush; // r27
+    // int nAddressN64; // r31
 
     // Local variables
-    s32 bFlag; // r28
+    int bFlag; // r28
     f32(*matrixTarget)[4]; // r3
     f32 matrixResult[4][4]; // r1+0x48
 
@@ -1518,19 +1518,19 @@ s32 frameSetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_
 }
 
 // Range: 0x8001F850 -> 0x8001F970
-s32 frameGetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, s32 bPull) {
+int frameGetMatrix(struct __anon_0x24C38* pFrame, f32 (*matrix)[4], enum __anon_0x27B8C eType, int bPull) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // f32 (* matrix)[4]; // r7
     // enum __anon_0x27B8C eType; // r1+0x10
-    // s32 bPull; // r31
+    // int bPull; // r31
 }
 
 // Erased
-static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, f32* prX, f32* prY, f32* prZ) {
+static int frameProjectVertex(struct __anon_0x24C38* pFrame, int iVertex, f32* prX, f32* prY, f32* prZ) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 iVertex; // r1+0x4
+    // int iVertex; // r1+0x4
     // f32* prX; // r1+0x8
     // f32* prY; // r1+0xC
     // f32* prZ; // r1+0x10
@@ -1541,18 +1541,18 @@ static s32 frameProjectVertex(struct __anon_0x24C38* pFrame, s32 iVertex, f32* p
 }
 
 // Range: 0x8001EDCC -> 0x8001F850
-s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, s32 nCount) {
+int frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, int iVertex0, int nCount) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
     // void* pBuffer; // r4
-    // s32 iVertex0; // r20
-    // s32 nCount; // r31
+    // int iVertex0; // r20
+    // int nCount; // r31
 
     // Local variables
     f32 mag; // f5
-    s32 iLight; // r29
-    s32 nLight; // r28
-    s32 nTexGen; // r27
+    int iLight; // r29
+    int nLight; // r28
+    int nTexGen; // r27
     f32 colorS; // f7
     f32 colorT; // f6
     f32 rS; // f8
@@ -1560,10 +1560,10 @@ s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, 
     f32 arNormal[3]; // r1+0x40
     f32 arPosition[3]; // r1+0x34
     struct __anon_0x23FC4* pVertex; // r8
-    u32 nData32; // r12
+    unsigned int nData32; // r12
     struct __anon_0x23CAB* aLight; // r26
     struct __anon_0x23CAB* pLight; // r25
-    s32 iVertex1; // r1+0x8
+    int iVertex1; // r1+0x8
     f32 rScale; // r1+0x8
     f32 rScaleST; // r1+0x8
     char* pnData8; // r24
@@ -1581,16 +1581,16 @@ s32 frameLoadVertex(struct __anon_0x24C38* pFrame, void* pBuffer, s32 iVertex0, 
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
-    // -> s32 __float_huge[];
-    // -> s32 __float_nan[];
+    // -> int __float_huge[];
+    // -> int __float_nan[];
 }
 
 // Range: 0x8001EC80 -> 0x8001EDCC
-s32 frameCullDL(struct __anon_0x24C38* pFrame, s32 nVertexStart, s32 nVertexEnd) {
+int frameCullDL(struct __anon_0x24C38* pFrame, int nVertexStart, int nVertexEnd) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nVertexStart; // r1+0x4
-    // s32 nVertexEnd; // r1+0x8
+    // int nVertexStart; // r1+0x4
+    // int nVertexEnd; // r1+0x8
 
     // Local variables
     f32 rX; // r1+0x0
@@ -1600,21 +1600,21 @@ s32 frameCullDL(struct __anon_0x24C38* pFrame, s32 nVertexStart, s32 nVertexEnd)
     f32(*matrix)[4]; // r5
     struct __anon_0x23FC4* vtxP; // r6
     struct __anon_0x23FC4* endVtxP; // r4
-    s32 nCode; // r1+0x0
-    s32 nCodeFull; // r7
+    int nCode; // r1+0x0
+    int nCodeFull; // r7
 }
 
 // Range: 0x8001EBA0 -> 0x8001EC80
-s32 frameLoadTLUT(struct __anon_0x24C38* pFrame, s32 nCount, s32 iTile) {
+int frameLoadTLUT(struct __anon_0x24C38* pFrame, int nCount, int iTile) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r30
-    // s32 nCount; // r1+0xC
-    // s32 iTile; // r1+0x10
+    // int nCount; // r1+0xC
+    // int iTile; // r1+0x10
 
     // Local variables
-    s32 iTMEM; // r28
-    s32 nSize; // r27
-    u32 nSum; // r26
+    int iTMEM; // r28
+    int nSize; // r27
+    unsigned int nSum; // r26
     u64 nData64; // r25
     u16 nData16; // r3
     u16* pSource; // r31
@@ -1622,49 +1622,49 @@ s32 frameLoadTLUT(struct __anon_0x24C38* pFrame, s32 nCount, s32 iTile) {
 }
 
 // Range: 0x8001DC58 -> 0x8001EBA0
-s32 frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, s32 iTile) {
+int frameLoadTMEM(struct __anon_0x24C38* pFrame, enum __anon_0x26C3F eType, int iTile) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r29
     // enum __anon_0x26C3F eType; // r30
-    // s32 iTile; // r31
+    // int iTile; // r31
 
     // Local variables
-    s32 bFlip; // r10
-    s32 iTMEM; // r5
-    s32 nSize; // r6
-    s32 nStep; // r11
-    s32 nDelta; // r12
-    s32 iScan; // r12
-    s32 nOffset; // r7
+    int bFlip; // r10
+    int iTMEM; // r5
+    int nSize; // r6
+    int nStep; // r11
+    int nDelta; // r12
+    int iScan; // r12
+    int nOffset; // r7
     struct __anon_0x247BF* pTile; // r1+0x8
     u8 nData8; // r30
     u16 nData16; // r30
-    u32 nData32; // r30
-    u32 nSum; // r1+0x8
+    unsigned int nData32; // r30
+    unsigned int nSum; // r1+0x8
     u64* pSource; // r4
-    s32 nCount; // r6
-    s32 nScanFull; // r7
-    s32 nScanPart; // r8
+    int nCount; // r6
+    int nScanFull; // r7
+    int nScanPart; // r8
     u8* pSource8; // r31
     u16* pSource16; // r31
-    u32* pSource32; // r31
+    unsigned int* pSource32; // r31
 
     // References
     // -> struct __anon_0x26A4E* gpSystem;
 }
 
 // Range: 0x8001DC4C -> 0x8001DC58
-s32 frameSetLightCount(struct __anon_0x24C38* pFrame, s32 nCount) {
+int frameSetLightCount(struct __anon_0x24C38* pFrame, int nCount) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 nCount; // r1+0x4
+    // int nCount; // r1+0x4
 }
 
 // Range: 0x8001DB24 -> 0x8001DC4C
-s32 frameSetLight(struct __anon_0x24C38* pFrame, s32 iLight, char* pData) {
+int frameSetLight(struct __anon_0x24C38* pFrame, int iLight, char* pData) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
-    // s32 iLight; // r1+0xC
+    // int iLight; // r1+0xC
     // char* pData; // r1+0x10
 
     // Local variables
@@ -1672,21 +1672,21 @@ s32 frameSetLight(struct __anon_0x24C38* pFrame, s32 iLight, char* pData) {
 }
 
 // Range: 0x8001DA74 -> 0x8001DB24
-s32 frameSetLookAt(struct __anon_0x24C38* pFrame, s32 iLookAt, char* pData) {
+int frameSetLookAt(struct __anon_0x24C38* pFrame, int iLookAt, char* pData) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
-    // s32 iLookAt; // r1+0x4
+    // int iLookAt; // r1+0x4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8001D8E0 -> 0x8001DA74
-s32 frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
+int frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x8
     // s16* pData; // r1+0xC
 
     // Local variables
-    s32 iScale; // r1+0x8
+    int iScale; // r1+0x8
     f32 rY; // f1
     f32 rSizeX; // f3
     f32 rSizeY; // r1+0x8
@@ -1694,53 +1694,53 @@ s32 frameSetViewport(struct __anon_0x24C38* pFrame, s16* pData) {
 }
 
 // Range: 0x8001D830 -> 0x8001D8E0
-s32 frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
+int frameResetUCode(struct __anon_0x24C38* pFrame, enum __anon_0x2625D eType) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // enum __anon_0x2625D eType; // r1+0x4
 
     // Local variables
-    s32 iMode; // r6
+    int iMode; // r6
 }
 
 // Range: 0x8001D7F8 -> 0x8001D830
-s32 frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
+int frameSetBuffer(struct __anon_0x24C38* pFrame, enum __anon_0x2614E eType) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r1+0x0
     // enum __anon_0x2614E eType; // r1+0x4
 }
 
 // Range: 0x8001D740 -> 0x8001D7F8
-s32 frameFixMatrixHint(struct __anon_0x24C38* pFrame, s32 nAddressFloat, s32 nAddressFixed) {
+int frameFixMatrixHint(struct __anon_0x24C38* pFrame, int nAddressFloat, int nAddressFixed) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
-    // s32 nAddressFloat; // r1+0x4
-    // s32 nAddressFixed; // r1+0x8
+    // int nAddressFloat; // r1+0x4
+    // int nAddressFixed; // r1+0x8
 
     // Local variables
-    s32 iHint; // r8
-    s32 iHintTest; // r9
+    int iHint; // r8
+    int iHintTest; // r9
 }
 
 // Erased
-static s32 frameGetMatrixHint(struct __anon_0x24C38* pFrame, u32 nAddress, s32* piHint) {
+static int frameGetMatrixHint(struct __anon_0x24C38* pFrame, unsigned int nAddress, int* piHint) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
-    // u32 nAddress; // r1+0x4
-    // s32* piHint; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* piHint; // r1+0x8
 
     // Local variables
-    s32 iHint; // r8
+    int iHint; // r8
 }
 
 // Range: 0x8001D624 -> 0x8001D740
-s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, s32 nAddressFloat,
-                       s32 nAddressFixed, f32 rNear, f32 rFar, f32 rFOVY, f32 rAspect, f32 rScale) {
+int frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProjection, int nAddressFloat,
+                       int nAddressFixed, f32 rNear, f32 rFar, f32 rFOVY, f32 rAspect, f32 rScale) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
     // enum __anon_0x25D5E eProjection; // r1+0x4
-    // s32 nAddressFloat; // r5
-    // s32 nAddressFixed; // r6
+    // int nAddressFloat; // r5
+    // int nAddressFixed; // r6
     // f32 rNear; // f1
     // f32 rFar; // r1+0x14
     // f32 rFOVY; // r1+0x18
@@ -1748,34 +1748,34 @@ s32 frameSetMatrixHint(struct __anon_0x24C38* pFrame, enum __anon_0x25D5E eProje
     // f32 rScale; // r1+0x20
 
     // Local variables
-    s32 iHint; // r10
+    int iHint; // r10
 }
 
 // Range: 0x8001D4B8 -> 0x8001D624
-s32 frameInvalidateCache(struct __anon_0x24C38* pFrame, s32 nOffset0, s32 nOffset1) {
+int frameInvalidateCache(struct __anon_0x24C38* pFrame, int nOffset0, int nOffset1) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r25
-    // s32 nOffset0; // r1+0xC
-    // s32 nOffset1; // r1+0x10
+    // int nOffset0; // r1+0xC
+    // int nOffset1; // r1+0x10
 
     // Local variables
-    s32 iTexture0; // r28
-    s32 iTexture1; // r27
+    int iTexture0; // r28
+    int iTexture1; // r27
     struct _FRAME_TEXTURE* pTexture; // r23
     struct _FRAME_TEXTURE* pTextureNext; // r26
 }
 
 // Range: 0x8001D39C -> 0x8001D4B8
-s32 frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
+int frameGetTextureInfo(struct __anon_0x24C38* pFrame, struct __anon_0x25A82* pInfo) {
     // Parameters
     // struct __anon_0x24C38* pFrame; // r3
     // struct __anon_0x25A82* pInfo; // r1+0xC
 
     // Local variables
     struct _FRAME_TEXTURE* pTexture; // r10
-    s32 iTexture; // r5
-    s32 nCount; // r6
-    s32 nSize; // r1+0x8
+    int iTexture; // r5
+    int nCount; // r6
+    int nSize; // r1+0x8
 }
 
 // Range: 0x8001D34C -> 0x8001D39C

--- a/debug/Fire/library.c
+++ b/debug/Fire/library.c
@@ -9,16 +9,16 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x78CD6; // size = 0x10
 
 // size = 0x10, address = 0x800EEB0C
 struct _XL_OBJECTTYPE gClassLibrary;
 
 // size = 0x100, address = 0x800EEB1C
-static u32 __osRcpImTable[64];
+static unsigned int __osRcpImTable[64];
 
 // size = 0x4, address = 0x80135328
 static f32 dtor$466;
@@ -27,34 +27,34 @@ static f32 dtor$466;
 static f32 dtor$480;
 
 // size = 0x4, address = 0x80135330
-static u32 nAddress$605;
+static unsigned int nAddress$605;
 
 typedef struct __anon_0x78E87 {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x78E87; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x78EED; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x78E87* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -73,8 +73,8 @@ typedef union __anon_0x7923C {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -88,54 +88,54 @@ typedef union __anon_0x7923C {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x7923C;
 
 typedef struct __anon_0x79A22 {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x79A22; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x79CF0; // size = 0x84
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x79F31; // size = 0xC
 
 typedef struct __anon_0x79FE6 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x79FE6; // size = 0xC
 
 typedef struct OSContext {
@@ -167,82 +167,82 @@ typedef struct OSAlarm {
 } __anon_0x7A368; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x7A483; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x7923C aGPR[32];
     /* 0x00140 */ union __anon_0x7D2DB aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x79A22* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x79FE6 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x7A630; // size = 0x12090
 
 typedef struct __anon_0x7AD10 {
     /* 0x0 */ char* szName;
     /* 0x4 */ void (*pfLibrary)(struct _CPU*);
-    /* 0x8 */ u32 anData[17];
+    /* 0x8 */ unsigned int anData[17];
 } __anon_0x7AD10; // size = 0x4C
 
 // size = 0x1008, address = 0x800EEF2C
 struct __anon_0x7AD10 gaFunction[54];
 
 typedef struct __anon_0x7AE26 {
-    /* 0x00 */ s32 nFlag;
+    /* 0x00 */ int nFlag;
     /* 0x04 */ void* pHost;
-    /* 0x08 */ s32 nAddStackSwap;
-    /* 0x0C */ s32 nCountFunction;
-    /* 0x10 */ s32 nAddressException;
+    /* 0x08 */ int nAddStackSwap;
+    /* 0x0C */ int nCountFunction;
+    /* 0x10 */ int nAddressException;
     /* 0x14 */ struct __anon_0x7AD10* aFunction;
     /* 0x18 */ void* apData[10];
-    /* 0x40 */ s32 anAddress[10];
+    /* 0x40 */ int anAddress[10];
 } __anon_0x7AE26; // size = 0x68
 
 typedef struct __anon_0x7BB81 {
@@ -288,12 +288,12 @@ typedef struct __anon_0x7BC50 {
     /* 0x0E0 */ u64 ra;
     /* 0x0E8 */ u64 lo;
     /* 0x0F0 */ u64 hi;
-    /* 0x0F8 */ u32 sr;
-    /* 0x0FC */ u32 pc;
-    /* 0x100 */ u32 cause;
-    /* 0x104 */ u32 badvaddr;
-    /* 0x108 */ u32 rcp;
-    /* 0x10C */ u32 fpcsr;
+    /* 0x0F8 */ unsigned int sr;
+    /* 0x0FC */ unsigned int pc;
+    /* 0x100 */ unsigned int cause;
+    /* 0x104 */ unsigned int badvaddr;
+    /* 0x108 */ unsigned int rcp;
+    /* 0x10C */ unsigned int fpcsr;
     /* 0x110 */ union __anon_0x7BBDC fp0;
     /* 0x118 */ union __anon_0x7BBDC fp2;
     /* 0x120 */ union __anon_0x7BBDC fp4;
@@ -314,22 +314,22 @@ typedef struct __anon_0x7BC50 {
 
 typedef struct __OSThread_s {
     /* 0x00 */ struct __OSThread_s* next;
-    /* 0x04 */ s32 priority;
+    /* 0x04 */ int priority;
     /* 0x08 */ struct __OSThread_s** queue;
     /* 0x0C */ struct __OSThread_s* tlnext;
     /* 0x10 */ u16 state;
     /* 0x12 */ u16 flags;
-    /* 0x14 */ s32 id;
-    /* 0x18 */ s32 fp;
+    /* 0x14 */ int id;
+    /* 0x18 */ int fp;
     /* 0x20 */ struct __anon_0x7BC50 context;
 } __anon_0x7C319; // size = 0x1B0
 
 typedef struct OSMesgQueue_s {
     /* 0x00 */ struct __OSThread_s* mtqueue;
     /* 0x04 */ struct __OSThread_s* fullqueue;
-    /* 0x08 */ s32 validCount;
-    /* 0x0C */ s32 first;
-    /* 0x10 */ s32 msgCount;
+    /* 0x08 */ int validCount;
+    /* 0x0C */ int first;
+    /* 0x10 */ int msgCount;
     /* 0x14 */ void* msg;
 } __anon_0x7C481; // size = 0x18
 
@@ -370,19 +370,19 @@ typedef union __anon_0x7D2DB {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x7D2DB;
 
 typedef struct __anon_0x7DB47 {
-    /* 0x0 */ s32 x1;
-    /* 0x4 */ s32 y1;
-    /* 0x8 */ s32 x2;
-    /* 0xC */ s32 y2;
+    /* 0x0 */ int x1;
+    /* 0x4 */ int y1;
+    /* 0x8 */ int x2;
+    /* 0xC */ int y2;
 } __anon_0x7DB47; // size = 0x10
 
 typedef union __anon_0x7DBF9 {
@@ -398,11 +398,11 @@ typedef struct __anon_0x7F9D8 {
 } __anon_0x7F9D8; // size = 0x10
 
 typedef struct __anon_0x7FA72 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x7FA72; // size = 0x14
 
 typedef struct __anon_0x7FBB3 {
@@ -412,7 +412,7 @@ typedef struct __anon_0x7FBB3 {
 } __anon_0x7FBB3; // size = 0xC
 
 typedef struct __anon_0x7FC23 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x7FBB3 rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -429,7 +429,7 @@ typedef struct __anon_0x7FC23 {
 } __anon_0x7FC23; // size = 0x3C
 
 typedef struct __anon_0x7FE53 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x7FBB3 rS;
     /* 0x10 */ struct __anon_0x7FBB3 rT;
     /* 0x1C */ struct __anon_0x7FBB3 rSRaw;
@@ -447,7 +447,7 @@ typedef struct __anon_0x7FF3C {
 typedef union __anon_0x8009B {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x8009B;
 
@@ -500,20 +500,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x80440;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -522,11 +522,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x804A9; // size = 0x6C
 
 typedef struct __anon_0x80806 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -537,7 +537,7 @@ typedef struct __anon_0x80806 {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x80806; // size = 0x2C
 
 typedef enum __anon_0x80AE8 {
@@ -547,14 +547,14 @@ typedef enum __anon_0x80AE8 {
 } __anon_0x80AE8;
 
 typedef struct __anon_0x80B6D {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x80AE8 eProjection;
 } __anon_0x80B6D; // size = 0x24
 
@@ -566,81 +566,81 @@ typedef struct _GXColor {
 } __anon_0x80D02; // size = 0x4
 
 typedef struct __anon_0x80DBD {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x7F9D8 viewport;
     /* 0x000C8 */ struct __anon_0x7FA72 aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x7FC23 aLight[8];
     /* 0x00320 */ struct __anon_0x7FE53 lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x7FF3C aVertex[80];
     /* 0x00C18 */ struct __anon_0x80138 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x80806 aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x80AE8 eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -651,37 +651,37 @@ typedef struct __anon_0x80DBD {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x80DBD; // size = 0x3D150
 
 // Range: 0x80096AB8 -> 0x8009779C
-static s32 __osException(struct _CPU* pCPU) {
+static int __osException(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r29
 
     // Local variables
-    s32 iBit; // r3
+    int iBit; // r3
     struct __anon_0x7AE26* pLibrary; // r1+0x8
     s64 nData64; // r1+0x28
     s64 nCause; // r1+0x20
     struct __OSThread_s* __osRunningThread; // r1+0x18
     struct __anon_0x79A22** apDevice; // r31
     u8* aiDevice; // r30
-    u32 nStatus; // r22
-    u32 nStatusRSP; // r1+0x14
-    u32 nData32; // r1+0x10
-    u32 __OSGlobalIntMask; // r23
-    u32 nS0; // r18
-    u32 nS1; // r17
-    u32 nMask; // r1+0xC
+    unsigned int nStatus; // r22
+    unsigned int nStatusRSP; // r1+0x14
+    unsigned int nData32; // r1+0x10
+    unsigned int __OSGlobalIntMask; // r23
+    unsigned int nS0; // r18
+    unsigned int nS1; // r17
+    unsigned int nMask; // r1+0xC
 }
 
 // Range: 0x80096728 -> 0x80096AB8
-static s32 send_mesg(struct _CPU* pCPU) {
+static int send_mesg(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r28
 
@@ -692,7 +692,7 @@ static s32 send_mesg(struct _CPU* pCPU) {
 }
 
 // Range: 0x8009643C -> 0x80096728
-static s32 __osEnqueueAndYield(struct _CPU* pCPU) {
+static int __osEnqueueAndYield(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
@@ -700,16 +700,16 @@ static s32 __osEnqueueAndYield(struct _CPU* pCPU) {
     s64 nData64; // r1+0x18
     struct __anon_0x7AE26* pLibrary; // r3
     struct __OSThread_s* __osRunningThread; // r1+0x10
-    u32 __OSGlobalIntMask; // r31
-    u32 nStatus; // r1+0x8
-    u32 nData32; // r5
-    u32 nMask; // r1+0xC
+    unsigned int __OSGlobalIntMask; // r31
+    unsigned int nStatus; // r1+0x8
+    unsigned int nData32; // r5
+    unsigned int nMask; // r1+0xC
     struct __anon_0x79A22** apDevice; // r6
     u8* aiDevice; // r7
 }
 
 // Range: 0x80096214 -> 0x8009643C
-static s32 __osEnqueueThread(struct _CPU* pCPU) {
+static int __osEnqueueThread(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r29
 
@@ -719,7 +719,7 @@ static s32 __osEnqueueThread(struct _CPU* pCPU) {
 }
 
 // Range: 0x80096140 -> 0x80096214
-static s32 __osPopThread(struct _CPU* pCPU) {
+static int __osPopThread(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r29
 
@@ -729,58 +729,58 @@ static s32 __osPopThread(struct _CPU* pCPU) {
 }
 
 // Range: 0x80095B9C -> 0x80096140
-static s32 __osDispatchThread(struct _CPU* pCPU) {
+static int __osDispatchThread(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r27
 
     // Local variables
     struct __anon_0x7AE26* pLibrary; // r29
-    u32 nAddress; // r5
+    unsigned int nAddress; // r5
     u64 nData64; // r0
     struct __OSThread_s* __osRunningThread; // r1+0x10
-    u32 nData32; // r1+0xC
-    u32 __OSGlobalIntMask; // r28
-    u32 nStatus; // r6
-    u32 nMask; // r6
+    unsigned int nData32; // r1+0xC
+    unsigned int __OSGlobalIntMask; // r28
+    unsigned int nStatus; // r6
+    unsigned int nMask; // r6
 
     // References
-    // -> static u32 __osRcpImTable[64];
+    // -> static unsigned int __osRcpImTable[64];
 }
 
 // Erased
-static s32 __ptException() {}
+static int __ptException() {}
 
 // Range: 0x80095B48 -> 0x80095B9C
-static s32 osGetMemSize(struct _CPU* pCPU) {
+static int osGetMemSize(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    u32 nSize; // r1+0xC
+    unsigned int nSize; // r1+0xC
 }
 
 // Range: 0x80095AC0 -> 0x80095B48
-static s32 osInvalICache(struct _CPU* pCPU) {
+static int osInvalICache(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r29
 
     // Local variables
-    u32 nAddress; // r30
-    u32 nSize; // r1+0x8
+    unsigned int nAddress; // r30
+    unsigned int nSize; // r1+0x8
 }
 
 // Range: 0x80095A30 -> 0x80095AC0
-static s32 __osDisableInt(struct _CPU* pCPU) {
+static int __osDisableInt(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
     // Local variables
-    u32 nStatus; // r1+0x8
+    unsigned int nStatus; // r1+0x8
     u64 nData64; // r1+0x18
 }
 
 // Range: 0x800959A4 -> 0x80095A30
-static s32 __osRestoreInt(struct _CPU* pCPU) {
+static int __osRestoreInt(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
@@ -789,12 +789,12 @@ static s32 __osRestoreInt(struct _CPU* pCPU) {
 }
 
 // Range: 0x80095954 -> 0x800959A4
-static s32 __osSpSetStatus(struct _CPU* pCPU) {
+static int __osSpSetStatus(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
 
     // Local variables
-    u32 nData32; // r1+0xC
+    unsigned int nData32; // r1+0xC
 }
 
 // Range: 0x80095920 -> 0x80095954
@@ -815,7 +815,7 @@ void _bzero(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
+    int nSize; // r5
     void* pBuffer; // r1+0xC
 }
 
@@ -825,7 +825,7 @@ void _bcopy(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
+    int nSize; // r5
     void* pSource; // r1+0x10
     void* pTarget; // r1+0xC
 }
@@ -836,7 +836,7 @@ void _memcpy(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 nSize; // r5
+    int nSize; // r5
     void* pSource; // r1+0x10
     void* pTarget; // r1+0xC
 }
@@ -859,14 +859,14 @@ void guMtxCatF(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r23
 
     // Local variables
-    s32 i; // r9
-    s32 j; // r23
+    int i; // r9
+    int j; // r23
     f32 temp[4][4]; // r1+0x38
     union __anon_0x7D2DB data1; // r1+0x30
     union __anon_0x7D2DB data2; // r1+0x28
-    u32* mf; // r1+0x24
-    u32* nf; // r1+0x20
-    u32* res; // r1+0x1C
+    unsigned int* mf; // r1+0x24
+    unsigned int* nf; // r1+0x20
+    unsigned int* res; // r1+0x1C
 }
 
 // Range: 0x8009524C -> 0x80095454
@@ -876,14 +876,14 @@ void guMtxF2L(struct _CPU* pCPU) {
 
     // Local variables
     f32* mf; // r1+0x24
-    s32 e1; // r6
-    s32 e2; // r7
-    s32 i; // r8
-    s32 j; // r1+0x8
-    s32* m; // r1+0x20
+    int e1; // r6
+    int e2; // r7
+    int i; // r8
+    int j; // r1+0x8
+    int* m; // r1+0x20
     union __anon_0x7D2DB data; // r1+0x18
-    s32* ai; // r9
-    s32* af; // r10
+    int* ai; // r9
+    int* af; // r10
 }
 
 // Range: 0x80095178 -> 0x8009524C
@@ -893,8 +893,8 @@ void guMtxIdentF(struct _CPU* pCPU) {
 
     // Local variables
     f32* mf; // r1+0x20
-    s32 i; // r7
-    s32 j; // r1+0x8
+    int i; // r7
+    int j; // r1+0x8
     union __anon_0x7D2DB data1; // r1+0x18
     union __anon_0x7D2DB data0; // r1+0x10
 }
@@ -905,7 +905,7 @@ void guMtxIdent(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r3
 
     // Local variables
-    s32* m; // r1+0xC
+    int* m; // r1+0xC
 }
 
 // Range: 0x80094E54 -> 0x800950C4
@@ -914,10 +914,10 @@ void guOrthoF(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 i; // r8
-    s32 j; // r4
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
+    int i; // r8
+    int j; // r4
+    unsigned int* mf; // r1+0x2C
+    unsigned int* sp; // r1+0x28
     f32 l; // f29
     f32 r; // f28
     f32 b; // f27
@@ -936,16 +936,16 @@ void guOrtho(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32* m; // r1+0x60
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
+    int* m; // r1+0x60
+    int i; // r6
+    int j; // r1+0x8
+    int e1; // r7
+    int e2; // r8
     union __anon_0x7D2DB data; // r1+0x58
     f32 mf[4][4]; // r1+0x18
-    u32* sp; // r1+0x14
-    s32* ai; // r9
-    s32* af; // r10
+    unsigned int* sp; // r1+0x14
+    int* ai; // r9
+    int* af; // r10
     f32 l; // f31
     f32 r; // f30
     f32 b; // f29
@@ -961,12 +961,12 @@ void guPerspectiveF(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 i; // r8
-    s32 j; // r4
+    int i; // r8
+    int j; // r4
     f32 cot; // f2
     s16* perspNorm; // r1+0x30
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
+    unsigned int* mf; // r1+0x2C
+    unsigned int* sp; // r1+0x28
     union __anon_0x7D2DB data0; // r1+0x20
     union __anon_0x7D2DB data1; // r1+0x18
     union __anon_0x7D2DB data; // r1+0x10
@@ -983,22 +983,22 @@ void guPerspective(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32* m; // r1+0x60
+    int* m; // r1+0x60
     f32 fovy; // f30
     f32 aspect; // f29
     f32 rNear; // f28
     f32 rFar; // f27
     f32 scale; // f5
     f32 _cot; // f2
-    s32 i; // r6
-    s32 j; // r1+0x8
+    int i; // r6
+    int j; // r1+0x8
     union __anon_0x7D2DB data; // r1+0x58
     f32 mf[4][4]; // r1+0x18
-    s32 e1; // r7
-    s32 e2; // r8
-    u32* sp; // r1+0x14
-    s32* ai; // r9
-    s32* af; // r10
+    int e1; // r7
+    int e2; // r8
+    unsigned int* sp; // r1+0x14
+    int* ai; // r9
+    int* af; // r10
 }
 
 // Range: 0x800945A8 -> 0x80094658
@@ -1008,8 +1008,8 @@ void GenPerspective_1080(struct _CPU* pCPU) {
 
     // Local variables
     union __anon_0x7D2DB data; // r1+0x18
-    u32* mf; // r1+0x10
-    u32* sp; // r1+0xC
+    unsigned int* mf; // r1+0x10
+    unsigned int* sp; // r1+0xC
     f32 fovy; // f3
     f32 aspect; // f4
     f32 rNear; // f1
@@ -1023,9 +1023,9 @@ void guScaleF(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 i; // r8
-    s32 j; // r4
-    u32* mf; // r1+0x20
+    int i; // r8
+    int j; // r4
+    unsigned int* mf; // r1+0x20
     union __anon_0x7D2DB data0; // r1+0x18
     union __anon_0x7D2DB data1; // r1+0x10
 }
@@ -1037,14 +1037,14 @@ void guScale(struct _CPU* pCPU) {
 
     // Local variables
     f32 mf[4][4]; // r1+0x24
-    s32* m; // r1+0x20
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
+    int* m; // r1+0x20
+    int i; // r6
+    int j; // r1+0x8
+    int e1; // r7
+    int e2; // r8
     union __anon_0x7D2DB data; // r1+0x18
-    s32* ai; // r9
-    s32* af; // r10
+    int* ai; // r9
+    int* af; // r10
 }
 
 // Range: 0x80094174 -> 0x80094294
@@ -1053,9 +1053,9 @@ void guTranslateF(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 i; // r8
-    s32 j; // r4
-    u32* mf; // r1+0x20
+    int i; // r8
+    int j; // r4
+    unsigned int* mf; // r1+0x20
     union __anon_0x7D2DB data0; // r1+0x18
     union __anon_0x7D2DB data1; // r1+0x10
 }
@@ -1066,15 +1066,15 @@ void guTranslate(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32* m; // r1+0x60
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
+    int* m; // r1+0x60
+    int i; // r6
+    int j; // r1+0x8
+    int e1; // r7
+    int e2; // r8
     union __anon_0x7D2DB data; // r1+0x58
     f32 mf[4][4]; // r1+0x14
-    s32* ai; // r9
-    s32* af; // r10
+    int* ai; // r9
+    int* af; // r10
 }
 
 // Range: 0x80093C78 -> 0x80093F88
@@ -1084,14 +1084,14 @@ void guRotateF(struct _CPU* pCPU) {
 
     // Local variables
     f32 m; // f2
-    s32 i; // r8
-    s32 j; // r4
+    int i; // r8
+    int j; // r4
     f32 a; // f31
     f32 x; // f30
     f32 y; // f29
     f32 z; // f28
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
+    unsigned int* mf; // r1+0x2C
+    unsigned int* sp; // r1+0x28
     union __anon_0x7D2DB data; // r1+0x20
     union __anon_0x7D2DB data0; // r1+0x18
     union __anon_0x7D2DB data1; // r1+0x10
@@ -1112,13 +1112,13 @@ void guRotate(struct _CPU* pCPU) {
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32* m; // r1+0x64
-    u32* sp; // r1+0x60
+    int* m; // r1+0x64
+    unsigned int* sp; // r1+0x60
     union __anon_0x7D2DB data; // r1+0x58
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
+    int i; // r6
+    int j; // r1+0x8
+    int e1; // r7
+    int e2; // r8
     f32 mf[4][4]; // r1+0x18
     f32 sine; // r1+0x8
     f32 cosine; // r1+0x8
@@ -1131,8 +1131,8 @@ void guRotate(struct _CPU* pCPU) {
     f32 ca; // f29
     f32 t; // f26
     f32 magnitude; // f2
-    s32* ai; // r9
-    s32* af; // r10
+    int* ai; // r9
+    int* af; // r10
 
     // References
     // -> static f32 dtor$480;
@@ -1154,8 +1154,8 @@ void guLookAtF(struct _CPU* pCPU) {
     f32 xEye; // f3
     f32 yEye; // f4
     f32 zEye; // f5
-    u32* mf; // r1+0x34
-    u32* sp; // r1+0x30
+    unsigned int* mf; // r1+0x34
+    unsigned int* sp; // r1+0x30
     f32 xLook; // f6
     f32 yLook; // f7
     f32 zLook; // f8
@@ -1174,15 +1174,15 @@ void guLookAt(struct _CPU* pCPU) {
 
     // Local variables
     f32 mf[4][4]; // r1+0x30
-    s32* m; // r1+0x2C
-    u32* sp; // r1+0x28
+    int* m; // r1+0x2C
+    unsigned int* sp; // r1+0x28
     union __anon_0x7D2DB data; // r1+0x20
-    s32 i; // r6
-    s32 j; // r1+0x8
-    s32 e1; // r7
-    s32 e2; // r8
-    s32* ai; // r9
-    s32* af; // r10
+    int i; // r6
+    int j; // r1+0x8
+    int e1; // r7
+    int e2; // r8
+    int* ai; // r9
+    int* af; // r10
     f32 len; // f6
     f32 xLook; // f3
     f32 yLook; // f4
@@ -1202,7 +1202,7 @@ void guLookAt(struct _CPU* pCPU) {
 }
 
 // Erased
-static s32 __float2int(f32 x) {
+static int __float2int(f32 x) {
     // Parameters
     // f32 x; // r1+0x8
 }
@@ -1216,8 +1216,8 @@ void guLookAtHiliteF(struct _CPU* pCPU) {
     struct __anon_0x7D2A5* l; // r1+0x3C
     union __anon_0x7DBF9* h; // r1+0x38
     union __anon_0x7D2DB data; // r1+0x30
-    u32* mf; // r1+0x2C
-    u32* sp; // r1+0x28
+    unsigned int* mf; // r1+0x2C
+    unsigned int* sp; // r1+0x28
     f32 len; // f5
     f32 xLook; // r1+0x8
     f32 yLook; // f1
@@ -1243,8 +1243,8 @@ void guLookAtHiliteF(struct _CPU* pCPU) {
     f32 xl2; // f9
     f32 yl2; // f10
     f32 zl2; // f11
-    s32 twidth; // r6
-    s32 theight; // r7
+    int twidth; // r6
+    int theight; // r7
 }
 
 // Range: 0x80091E60 -> 0x80092834
@@ -1255,16 +1255,16 @@ void guLookAtHilite(struct _CPU* pCPU) {
     // Local variables
     struct __anon_0x7D2A5* l; // r1+0x84
     union __anon_0x7DBF9* h; // r1+0x80
-    s32 i; // r7
-    s32 j; // r1+0x8
-    s32 e1; // r5
-    s32 e2; // r8
+    int i; // r7
+    int j; // r1+0x8
+    int e1; // r5
+    int e2; // r8
     union __anon_0x7D2DB data; // r1+0x78
     f32 mf[4][4]; // r1+0x38
-    u32* m; // r1+0x34
-    u32* sp; // r1+0x30
-    s32* ai; // r9
-    s32* af; // r10
+    unsigned int* m; // r1+0x34
+    unsigned int* sp; // r1+0x30
+    int* ai; // r9
+    int* af; // r10
     f32 len; // f5
     f32 xLook; // r1+0x8
     f32 yLook; // f1
@@ -1290,8 +1290,8 @@ void guLookAtHilite(struct _CPU* pCPU) {
     f32 xl2; // f9
     f32 yl2; // f10
     f32 zl2; // f11
-    s32 twidth; // r6
-    s32 theight; // r7
+    int twidth; // r6
+    int theight; // r7
 }
 
 // Range: 0x8009190C -> 0x80091E60
@@ -1302,8 +1302,8 @@ void guLookAtReflectF(struct _CPU* pCPU) {
     // Local variables
     struct __anon_0x7D2A5* l; // r1+0x28
     union __anon_0x7D2DB data; // r1+0x20
-    u32* mf; // r1+0x1C
-    u32* sp; // r1+0x18
+    unsigned int* mf; // r1+0x1C
+    unsigned int* sp; // r1+0x18
     f32 xEye; // f3
     f32 yEye; // f4
     f32 zEye; // f5
@@ -1329,16 +1329,16 @@ void guLookAtReflect(struct _CPU* pCPU) {
 
     // Local variables
     struct __anon_0x7D2A5* l; // r1+0x70
-    s32 i; // r7
-    s32 j; // r1+0x8
-    s32 e1; // r5
-    s32 e2; // r8
+    int i; // r7
+    int j; // r1+0x8
+    int e1; // r5
+    int e2; // r8
     union __anon_0x7D2DB data; // r1+0x68
     f32 mf[4][4]; // r1+0x28
-    u32* m; // r1+0x24
-    u32* sp; // r1+0x20
-    s32* ai; // r9
-    s32* af; // r10
+    unsigned int* m; // r1+0x24
+    unsigned int* sp; // r1+0x20
+    int* ai; // r9
+    int* af; // r10
     f32 xEye; // f3
     f32 yEye; // f4
     f32 zEye; // f5
@@ -1358,39 +1358,39 @@ void guLookAtReflect(struct _CPU* pCPU) {
 }
 
 // Range: 0x8009120C -> 0x80091338
-s32 osAiSetFrequency(struct _CPU* pCPU) {
+int osAiSetFrequency(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    u32 dacRate; // r1+0x8
+    unsigned int dacRate; // r1+0x8
     u8 bitRate; // r28
-    u32 nData32; // r1+0x10
+    unsigned int nData32; // r1+0x10
 }
 
 // Range: 0x80091100 -> 0x8009120C
-s32 osAiSetNextBuffer(struct _CPU* pCPU) {
+int osAiSetNextBuffer(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
     // Local variables
-    u32 size; // r31
-    u32 nData32; // r1+0x10
+    unsigned int size; // r31
+    unsigned int nData32; // r1+0x10
 }
 
 // Range: 0x80091028 -> 0x80091100
-s32 __osEepStatus(struct _CPU* pCPU) {
+int __osEepStatus(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
-    s32 ret; // r5
-    s32 nSize; // r1+0x10
+    int ret; // r5
+    int nSize; // r1+0x10
     u8* status; // r1+0xC
 }
 
 // Range: 0x80090FB0 -> 0x80091028
-s32 osEepromRead(struct _CPU* pCPU) {
+int osEepromRead(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
@@ -1400,7 +1400,7 @@ s32 osEepromRead(struct _CPU* pCPU) {
 }
 
 // Range: 0x80090F38 -> 0x80090FB0
-s32 osEepromWrite(struct _CPU* pCPU) {
+int osEepromWrite(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r30
 
@@ -1410,111 +1410,111 @@ s32 osEepromWrite(struct _CPU* pCPU) {
 }
 
 // Range: 0x80090E8C -> 0x80090F38
-s32 osEepromLongRead(struct _CPU* pCPU) {
+int osEepromLongRead(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r28
 
     // Local variables
-    s32 length; // r31
-    s32 ret; // r30
+    int length; // r31
+    int ret; // r30
     u8 address; // r29
     u8* buffer; // r1+0xC
 }
 
 // Range: 0x80090DE0 -> 0x80090E8C
-s32 osEepromLongWrite(struct _CPU* pCPU) {
+int osEepromLongWrite(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r28
 
     // Local variables
-    s32 length; // r31
-    s32 ret; // r30
+    int length; // r31
+    int ret; // r30
     u8 address; // r29
     u8* buffer; // r1+0xC
 }
 
 // Range: 0x80090C78 -> 0x80090DE0
-s32 starfoxCopy(struct _CPU* pCPU) {
+int starfoxCopy(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r25
 
     // Local variables
-    s32* A0; // r1+0x18
-    s32 A1; // r31
-    s32 A2; // r30
-    s32 A3; // r29
-    s32 T0; // r28
-    s32 T1; // r24
-    s32 T2; // r1+0x8
-    s32 T3; // r23
-    s32 T8; // r27
-    s32 T9; // r26
+    int* A0; // r1+0x18
+    int A1; // r31
+    int A2; // r30
+    int A3; // r29
+    int T0; // r28
+    int T1; // r24
+    int T2; // r1+0x8
+    int T3; // r23
+    int T8; // r27
+    int T9; // r26
     s16* pData16; // r1+0x14
     char* source; // r1+0x10
     char* target; // r1+0xC
 }
 
 // Range: 0x80090C68 -> 0x80090C78
-s32 pictureSnap_Zelda2(struct _CPU* pCPU) {
+int pictureSnap_Zelda2(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Range: 0x80090B40 -> 0x80090C68
-s32 dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
+int dmaSoundRomHandler_ZELDA1(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r31
 
     // Local variables
     void* pTarget; // r1+0x18
     struct OSMesgQueue_s* mq; // r1+0x14
-    u32* msg; // r1+0x10
+    unsigned int* msg; // r1+0x10
     struct __anon_0x7C62D* pIOMessage; // r1+0xC
-    s32 first; // r30
-    s32 msgCount; // r29
-    s32 validCount; // r28
-    s32 nSize; // r6
-    s32 nAddress; // r5
-    s32 nOffsetRAM; // r5
-    s32 nOffsetROM; // r5
+    int first; // r30
+    int msgCount; // r29
+    int validCount; // r28
+    int nSize; // r6
+    int nAddress; // r5
+    int nOffsetRAM; // r5
+    int nOffsetROM; // r5
 }
 
 // Range: 0x80090AD8 -> 0x80090B40
-s32 osViSwapBuffer_Entry(struct _CPU* pCPU) {
+int osViSwapBuffer_Entry(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x8
 
     // References
-    // -> static u32 nAddress$605;
+    // -> static unsigned int nAddress$605;
 }
 
 // Range: 0x80090AC4 -> 0x80090AD8
-s32 zeldaLoadSZS_Entry(struct _CPU* pCPU) {
+int zeldaLoadSZS_Entry(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Range: 0x80090AB0 -> 0x80090AC4
-s32 zeldaLoadSZS_Exit(struct _CPU* pCPU) {
+int zeldaLoadSZS_Exit(struct _CPU* pCPU) {
     // Parameters
     // struct _CPU* pCPU; // r1+0x0
 }
 
 // Range: 0x800907B0 -> 0x80090AB0
-static s32 libraryFindException(struct __anon_0x7AE26* pLibrary, s32 bException) {
+static int libraryFindException(struct __anon_0x7AE26* pLibrary, int bException) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r27
-    // s32 bException; // r28
+    // int bException; // r28
 
     // Local variables
     struct _CPU* pCPU; // r30
     struct __anon_0x79A22** apDevice; // r29
     u8* aiDevice; // r31
-    u32 anCode[6]; // r1+0x10
+    unsigned int anCode[6]; // r1+0x10
 }
 
 // Range: 0x8009007C -> 0x800907B0
-static s32 libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
+static int libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r24
 
@@ -1522,74 +1522,74 @@ static s32 libraryFindVariables(struct __anon_0x7AE26* pLibrary) {
     struct _CPU* pCPU; // r27
     struct __anon_0x79A22** apDevice; // r26
     u8* aiDevice; // r25
-    u32 nAddress; // r23
-    u32 nAddressLast; // r28
-    u32 nOffset; // r1+0x28
-    u32 nOpcode; // r1+0x24
-    u32 anCode[6]; // r1+0xC
+    unsigned int nAddress; // r23
+    unsigned int nAddressLast; // r28
+    unsigned int nOffset; // r1+0x28
+    unsigned int nOpcode; // r1+0x24
+    unsigned int anCode[6]; // r1+0xC
 }
 
 // Range: 0x8008FB6C -> 0x8009007C
-static s32 libraryFindFunctions(struct __anon_0x7AE26* pLibrary) {
+static int libraryFindFunctions(struct __anon_0x7AE26* pLibrary) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r24
 
     // Local variables
     struct _CPU* pCPU; // r3
-    s32 iFunction; // r29
+    int iFunction; // r29
     struct __anon_0x79A22** apDevice; // r28
     u8* aiDevice; // r27
-    u32 nOpcode; // r1+0x10
-    u32* pnCode; // r1+0xC
-    u32 nAddress; // r29
-    u32 nAddressLast; // r31
-    u32 nAddressEnqueueThread; // r26
-    u32 nAddressDispatchThread; // r25
+    unsigned int nOpcode; // r1+0x10
+    unsigned int* pnCode; // r1+0xC
+    unsigned int nAddress; // r29
+    unsigned int nAddressLast; // r31
+    unsigned int nAddressEnqueueThread; // r26
+    unsigned int nAddressDispatchThread; // r25
 
     // References
     // -> struct __anon_0x7AD10 gaFunction[54];
 }
 
 // Erased
-static s32 libraryCheckHandler(struct __anon_0x7AE26* pLibrary, s32 bException) {
+static int libraryCheckHandler(struct __anon_0x7AE26* pLibrary, int bException) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r31
-    // s32 bException; // r4
+    // int bException; // r4
 }
 
 // Range: 0x8008F584 -> 0x8008FB6C
-s32 libraryTestFunction(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+int libraryTestFunction(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r30
     // struct cpu_function* pFunction; // r26
 
     // Local variables
-    s32 iFunction; // r31
-    s32 iData; // r24
-    s32 bFlag; // r29
-    s32 bDone; // r27
-    s32 bReturn; // r21
-    u32 iCode; // r5
-    u32* pnCode; // r1+0x1C
-    u32* pnCodeTemp; // r1+0x18
-    u32 nSizeCode; // r1+0x8
-    u32 nChecksum; // r1+0x14
-    u32 nOpcode; // r1+0x8
-    u32 nAddress; // r1+0x8
+    int iFunction; // r31
+    int iData; // r24
+    int bFlag; // r29
+    int bDone; // r27
+    int bReturn; // r21
+    unsigned int iCode; // r5
+    unsigned int* pnCode; // r1+0x1C
+    unsigned int* pnCodeTemp; // r1+0x18
+    unsigned int nSizeCode; // r1+0x8
+    unsigned int nChecksum; // r1+0x14
+    unsigned int nOpcode; // r1+0x8
+    unsigned int nAddress; // r1+0x8
 
     // References
     // -> struct __anon_0x7AD10 gaFunction[54];
 }
 
 // Range: 0x8008F420 -> 0x8008F584
-static s32 librarySearch(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
+static int librarySearch(struct __anon_0x7AE26* pLibrary, struct cpu_function* pFunction) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r29
     // struct cpu_function* pFunction; // r30
 }
 
 // Erased
-static s32 libraryUpdate(struct __anon_0x7AE26* pLibrary) {
+static int libraryUpdate(struct __anon_0x7AE26* pLibrary) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r31
 
@@ -1599,30 +1599,30 @@ static s32 libraryUpdate(struct __anon_0x7AE26* pLibrary) {
 }
 
 // Range: 0x8008F32C -> 0x8008F420
-s32 libraryFunctionReplaced(s32 iFunction) {
+int libraryFunctionReplaced(int iFunction) {
     // Parameters
-    // s32 iFunction; // r1+0x4
+    // int iFunction; // r1+0x4
 
     // References
     // -> struct __anon_0x7AD10 gaFunction[54];
 }
 
 // Range: 0x8008F234 -> 0x8008F32C
-s32 libraryCall(struct __anon_0x7AE26* pLibrary, struct _CPU* pCPU, s32 iFunction) {
+int libraryCall(struct __anon_0x7AE26* pLibrary, struct _CPU* pCPU, int iFunction) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r29
     // struct _CPU* pCPU; // r30
-    // s32 iFunction; // r31
+    // int iFunction; // r31
 
     // References
     // -> struct __anon_0x7AD10 gaFunction[54];
 }
 
 // Range: 0x8008F0F4 -> 0x8008F234
-s32 libraryEvent(struct __anon_0x7AE26* pLibrary, s32 nEvent, void* pArgument) {
+int libraryEvent(struct __anon_0x7AE26* pLibrary, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x7AE26* pLibrary; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r1+0x10
 
     // References

--- a/debug/Fire/mcardGCN.c
+++ b/debug/Fire/mcardGCN.c
@@ -14,7 +14,7 @@ static char gMCardCardWorkArea[40960];
 s32 currentIdx;
 
 // size = 0x4, address = 0x80135664
-static s32 yes$771;
+static int yes$771;
 
 typedef enum __anon_0x1A5F0 {
     MC_M_NONE = 0,
@@ -76,25 +76,25 @@ static enum __anon_0x1A5F0 prevMenuEntry$772;
 static enum __anon_0x1A5F0 nextMenuEntry$773;
 
 // size = 0x4, address = 0x80135670
-static s32 toggle2$1029;
+static int toggle2$1029;
 
 // size = 0x4, address = 0x80134DB8
-static s32 toggle$1034;
+static int toggle$1034;
 
 // size = 0x4, address = 0x80135674
-static s32 checkFailCount$1490;
+static int checkFailCount$1490;
 
 typedef struct OSCalendarTime {
-    /* 0x00 */ s32 sec;
-    /* 0x04 */ s32 min;
-    /* 0x08 */ s32 hour;
-    /* 0x0C */ s32 mday;
-    /* 0x10 */ s32 mon;
-    /* 0x14 */ s32 year;
-    /* 0x18 */ s32 wday;
-    /* 0x1C */ s32 yday;
-    /* 0x20 */ s32 msec;
-    /* 0x24 */ s32 usec;
+    /* 0x00 */ int sec;
+    /* 0x04 */ int min;
+    /* 0x08 */ int hour;
+    /* 0x0C */ int mday;
+    /* 0x10 */ int mon;
+    /* 0x14 */ int year;
+    /* 0x18 */ int wday;
+    /* 0x1C */ int yday;
+    /* 0x20 */ int msec;
+    /* 0x24 */ int usec;
 } __anon_0x1A9EE; // size = 0x28
 
 // size = 0x28, address = 0x80107960
@@ -107,12 +107,12 @@ s32 bWrite2Card;
 s32 bNoWriteInCurrentFrame[10];
 
 typedef struct __anon_0x1AC1A {
-    /* 0x00 */ s32 configuration;
-    /* 0x04 */ s32 size;
-    /* 0x08 */ s32 offset;
+    /* 0x00 */ int configuration;
+    /* 0x04 */ int size;
+    /* 0x08 */ int offset;
     /* 0x0C */ char* buffer;
-    /* 0x10 */ s32* writtenBlocks;
-    /* 0x14 */ s32 writtenConfig;
+    /* 0x10 */ int* writtenBlocks;
+    /* 0x14 */ int writtenConfig;
 } __anon_0x1AC1A; // size = 0x18
 
 typedef struct CARDFileInfo {
@@ -125,16 +125,16 @@ typedef struct CARDFileInfo {
 } __anon_0x1ADBD; // size = 0x14
 
 typedef struct __anon_0x1AEB5 {
-    /* 0x000 */ s32 currentGame;
-    /* 0x004 */ s32 fileSize;
+    /* 0x000 */ int currentGame;
+    /* 0x004 */ int fileSize;
     /* 0x008 */ char name[33];
-    /* 0x02C */ s32 numberOfGames;
+    /* 0x02C */ int numberOfGames;
     /* 0x030 */ struct __anon_0x1AC1A game;
-    /* 0x048 */ s32 changedDate;
-    /* 0x04C */ s32 changedChecksum;
-    /* 0x050 */ s32 gameSize[16];
-    /* 0x090 */ s32 gameOffset[16];
-    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x048 */ int changedDate;
+    /* 0x04C */ int changedChecksum;
+    /* 0x050 */ int gameSize[16];
+    /* 0x090 */ int gameOffset[16];
+    /* 0x0D0 */ int gameConfigIndex[16];
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
@@ -172,32 +172,32 @@ typedef enum __anon_0x1B0CB {
 typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x1AEB5 file;
     /* 0x35C */ enum __anon_0x1B0CB error;
-    /* 0x360 */ s32 slot;
-    /* 0x364 */ s32 (*pPollFunction)();
-    /* 0x368 */ s32 pollPrevBytes;
-    /* 0x36C */ s32 pollSize;
+    /* 0x360 */ int slot;
+    /* 0x364 */ int (*pPollFunction)();
+    /* 0x368 */ int pollPrevBytes;
+    /* 0x36C */ int pollSize;
     /* 0x370 */ char pollMessage[256];
-    /* 0x470 */ s32 saveToggle;
+    /* 0x470 */ int saveToggle;
     /* 0x474 */ char* writeBuffer;
     /* 0x478 */ char* readBuffer;
-    /* 0x47C */ s32 writeToggle;
-    /* 0x480 */ s32 soundToggle;
-    /* 0x484 */ s32 writeStatus;
-    /* 0x488 */ s32 writeIndex;
-    /* 0x48C */ s32 accessType;
-    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x47C */ int writeToggle;
+    /* 0x480 */ int soundToggle;
+    /* 0x484 */ int writeStatus;
+    /* 0x488 */ int writeIndex;
+    /* 0x48C */ int accessType;
+    /* 0x490 */ int gameIsLoaded;
     /* 0x494 */ char saveFileName[256];
     /* 0x594 */ char saveComment[256];
     /* 0x694 */ char* saveIcon;
     /* 0x698 */ char* saveBanner;
     /* 0x69C */ char saveGameName[256];
-    /* 0x79C */ s32 saveFileSize;
-    /* 0x7A0 */ s32 saveGameSize;
-    /* 0x7A4 */ s32 bufferCreated;
-    /* 0x7A8 */ s32 cardSize;
-    /* 0x7AC */ s32 wait;
-    /* 0x7B0 */ s32 isBroken;
-    /* 0x7B4 */ s32 saveConfiguration;
+    /* 0x79C */ int saveFileSize;
+    /* 0x7A0 */ int saveGameSize;
+    /* 0x7A4 */ int bufferCreated;
+    /* 0x7A8 */ int cardSize;
+    /* 0x7AC */ int wait;
+    /* 0x7B0 */ int isBroken;
+    /* 0x7B4 */ int saveConfiguration;
 } __anon_0x1B36F; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
@@ -210,10 +210,10 @@ typedef enum __anon_0x1B813 {
 } __anon_0x1B813;
 
 typedef struct __anon_0x1B87B {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x1B87B; // size = 0x10
 
 typedef enum __anon_0x1B92C {
@@ -257,7 +257,7 @@ typedef enum __anon_0x1BA5D {
 typedef struct __anon_0x1BB9D {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x1B813 eMode;
     /* 0x10 */ struct __anon_0x1B87B romCopy;
     /* 0x20 */ enum __anon_0x1B92C eTypeROM;
@@ -265,7 +265,7 @@ typedef struct __anon_0x1BB9D {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x1BA5D storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x1BB9D; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -282,7 +282,7 @@ typedef enum __anon_0x1BD8E {
 } __anon_0x1BD8E;
 
 // size = 0x4, address = 0x801355D4
-s32 gButtonDownToggle;
+int gButtonDownToggle;
 
 typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
@@ -375,67 +375,67 @@ static void mcardUnpackTexPalette(struct __anon_0x1F5D4* pal) {
 }
 
 // Range: 0x8001C2A0 -> 0x8001C444
-static s32 mcardGCErrorHandler(struct _MCARD* pMCard, s32 gcError) {
+static int mcardGCErrorHandler(struct _MCARD* pMCard, int gcError) {
     // Parameters
     // struct _MCARD* pMCard; // r1+0x0
-    // s32 gcError; // r1+0x4
+    // int gcError; // r1+0x4
 }
 
 // Range: 0x8001C240 -> 0x8001C2A0
-static s32 mcardCalculateChecksum(struct _MCARD* pMCard, s32* checksum) {
+static int mcardCalculateChecksum(struct _MCARD* pMCard, int* checksum) {
     // Parameters
     // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
+    // int* checksum; // r1+0x4
 
     // Local variables
-    s32 i; // r1+0x0
+    int i; // r1+0x0
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x8001C0D8 -> 0x8001C240
-static s32 mcardCalculateChecksumFileBlock1(struct _MCARD* pMCard, s32* checksum) {
+static int mcardCalculateChecksumFileBlock1(struct _MCARD* pMCard, int* checksum) {
     // Parameters
     // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
+    // int* checksum; // r1+0x4
 
     // Local variables
-    s32 i; // r8
+    int i; // r8
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x8001BF70 -> 0x8001C0D8
-static s32 mcardCalculateChecksumFileBlock2(struct _MCARD* pMCard, s32* checksum) {
+static int mcardCalculateChecksumFileBlock2(struct _MCARD* pMCard, int* checksum) {
     // Parameters
     // struct _MCARD* pMCard; // r1+0x0
-    // s32* checksum; // r1+0x4
+    // int* checksum; // r1+0x4
 
     // Local variables
-    s32 i; // r8
+    int i; // r8
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x8001BC14 -> 0x8001BF70
-static s32 mcardSaveChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+static int mcardSaveChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r30
     // char* buffer; // r31
 
     // Local variables
     char buffer2[8192]; // r1+0x1C
-    s32 checksum; // r1+0x18
+    int checksum; // r1+0x18
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+static int mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
     // Parameters
     // struct _MCARD* pMCard; // r29
     // struct OSCalendarTime* time; // r30
@@ -445,14 +445,14 @@ static s32 mcardGetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) 
 }
 
 // Range: 0x8001B794 -> 0x8001BC14
-static s32 mcardReplaceFileBlock(struct _MCARD* pMCard, s32 index) {
+static int mcardReplaceFileBlock(struct _MCARD* pMCard, int index) {
     // Parameters
     // struct _MCARD* pMCard; // r28
-    // s32 index; // r29
+    // int index; // r29
 
     // Local variables
-    s32 checksum1; // r1+0x2238
-    s32 checksum2; // r30
+    int checksum1; // r1+0x2238
+    int checksum2; // r30
     char buffer[8192]; // r1+0x238
 
     // References
@@ -460,22 +460,22 @@ static s32 mcardReplaceFileBlock(struct _MCARD* pMCard, s32 index) {
 }
 
 // Range: 0x8001B480 -> 0x8001B794
-static s32 mcardCheckChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
+static int mcardCheckChecksumFileHeader(struct _MCARD* pMCard, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r29
     // char* buffer; // r27
 
     // Local variables
-    s32 checksum; // r31
+    int checksum; // r31
     char buffer2[8192]; // r1+0x18
-    s32 toggle; // r30
+    int toggle; // r30
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x8001B254 -> 0x8001B480
-static s32 mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
+static int mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -487,14 +487,14 @@ static s32 mcardVerifyChecksumFileHeader(struct _MCARD* pMCard) {
 }
 
 // Erased
-static s32 mcardCompareName(char* name1, char* name2) {
+static int mcardCompareName(char* name1, char* name2) {
     // Parameters
     // char* name1; // r4
     // char* name2; // r5
 }
 
 // Erased
-static s32 mcardCopyName(char* name1, char* name2) {
+static int mcardCopyName(char* name1, char* name2) {
     // Parameters
     // char* name1; // r4
     // char* name2; // r5
@@ -504,7 +504,7 @@ static s32 mcardCopyName(char* name1, char* name2) {
 }
 
 // Range: 0x8001B168 -> 0x8001B254
-static s32 mcardPoll(struct _MCARD* pMCard) {
+static int mcardPoll(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 
@@ -513,13 +513,13 @@ static s32 mcardPoll(struct _MCARD* pMCard) {
 }
 
 // Range: 0x8001AFD4 -> 0x8001B168
-static s32 mcardReadyCard(struct _MCARD* pMCard) {
+static int mcardReadyCard(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
     // Local variables
-    s32 i; // r31
-    s32 sectorSize; // r1+0xC
+    int i; // r31
+    int sectorSize; // r1+0xC
 
     // References
     // -> static char gMCardCardWorkArea[40960];
@@ -527,29 +527,29 @@ static s32 mcardReadyCard(struct _MCARD* pMCard) {
 }
 
 // Erased
-static s32 mcardFinishCard(struct _MCARD* pMCard) {
+static int mcardFinishCard(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r3
 }
 
 // Erased
-static s32 mcardReadyFile(struct _MCARD* pMCard) {
+static int mcardReadyFile(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 }
 
 // Erased
-static s32 mcardFinishFile(struct _MCARD* pMCard) {
+static int mcardFinishFile(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 }
 
 // Erased
-static s32 mcardReadAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+static int mcardReadAnywhereNoTime(struct _MCARD* pMCard, int offset, int size, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r29
-    // s32 offset; // r3
-    // s32 size; // r30
+    // int offset; // r3
+    // int size; // r30
     // char* buffer; // r31
 
     // References
@@ -557,11 +557,11 @@ static s32 mcardReadAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, 
 }
 
 // Erased
-static s32 mcardWriteAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+static int mcardWriteAnywhereNoTime(struct _MCARD* pMCard, int offset, int size, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r28
-    // s32 offset; // r29
-    // s32 size; // r30
+    // int offset; // r29
+    // int size; // r30
     // char* buffer; // r31
 
     // References
@@ -569,7 +569,7 @@ static s32 mcardWriteAnywhereNoTime(struct _MCARD* pMCard, s32 offset, s32 size,
 }
 
 // Erased
-static s32 mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
+static int mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) {
     // Parameters
     // struct _MCARD* pMCard; // r30
     // struct OSCalendarTime* time; // r31
@@ -582,7 +582,7 @@ static s32 mcardSetFileTime(struct _MCARD* pMCard, struct OSCalendarTime* time) 
 }
 
 // Erased
-static s32 mcardTimeCheck(struct _MCARD* pMCard) {
+static int mcardTimeCheck(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -591,11 +591,11 @@ static s32 mcardTimeCheck(struct _MCARD* pMCard) {
 }
 
 // Range: 0x8001AE64 -> 0x8001AFD4
-static s32 mcardReadAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+static int mcardReadAnywhere(struct _MCARD* pMCard, int offset, int size, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r27
-    // s32 offset; // r28
-    // s32 size; // r29
+    // int offset; // r28
+    // int size; // r29
     // char* buffer; // r30
 
     // References
@@ -603,11 +603,11 @@ static s32 mcardReadAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* 
 }
 
 // Range: 0x8001ACC8 -> 0x8001AE64
-static s32 mcardWriteAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer) {
+static int mcardWriteAnywhere(struct _MCARD* pMCard, int offset, int size, char* buffer) {
     // Parameters
     // struct _MCARD* pMCard; // r31
-    // s32 offset; // r27
-    // s32 size; // r28
+    // int offset; // r27
+    // int size; // r28
     // char* buffer; // r29
 
     // References
@@ -615,22 +615,22 @@ static s32 mcardWriteAnywhere(struct _MCARD* pMCard, s32 offset, s32 size, char*
 }
 
 // Range: 0x8001AB1C -> 0x8001ACC8
-static s32 mcardWriteAnywherePartial(struct _MCARD* pMCard, s32 offset, s32 size, char* buffer, s32 partialOffset,
-                                     s32 totalSize) {
+static int mcardWriteAnywherePartial(struct _MCARD* pMCard, int offset, int size, char* buffer, int partialOffset,
+                                     int totalSize) {
     // Parameters
     // struct _MCARD* pMCard; // r31
-    // s32 offset; // r25
-    // s32 size; // r26
+    // int offset; // r25
+    // int size; // r26
     // char* buffer; // r27
-    // s32 partialOffset; // r28
-    // s32 totalSize; // r29
+    // int partialOffset; // r28
+    // int totalSize; // r29
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x8001A8F8 -> 0x8001AB1C
-static s32 mcardReadFileHeader(struct _MCARD* pMCard) {
+static int mcardReadFileHeader(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 
@@ -642,7 +642,7 @@ static s32 mcardReadFileHeader(struct _MCARD* pMCard) {
 }
 
 // Range: 0x8001A53C -> 0x8001A8F8
-static s32 mcardWriteFileHeader(struct _MCARD* pMCard) {
+static int mcardWriteFileHeader(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -654,7 +654,7 @@ static s32 mcardWriteFileHeader(struct _MCARD* pMCard) {
 }
 
 // Range: 0x8001A3E4 -> 0x8001A53C
-static s32 mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
+static int mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -666,7 +666,7 @@ static s32 mcardReadFileHeaderInitial(struct _MCARD* pMCard) {
 }
 
 // Range: 0x8001A1C0 -> 0x8001A3E4
-static s32 mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
+static int mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 
@@ -678,7 +678,7 @@ static s32 mcardWriteFileHeaderInitial(struct _MCARD* pMCard) {
 }
 
 // Erased
-static s32 mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+static int mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
     // Parameters
     // struct _MCARD* pMCard; // r30
     // char* cardHeader; // r31
@@ -691,7 +691,7 @@ static s32 mcardReadCardHeader(struct _MCARD* pMCard, char* cardHeader) {
 }
 
 // Erased
-static s32 mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
+static int mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
     // Parameters
     // struct _MCARD* pMCard; // r29
     // char* cardHeader; // r30
@@ -704,10 +704,10 @@ static s32 mcardWriteCardHeader(struct _MCARD* pMCard, char* cardHeader) {
 }
 
 // Range: 0x80019FDC -> 0x8001A1C0
-static s32 mcardWriteBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+static int mcardWriteBufferAsynch(struct _MCARD* pMCard, int offset) {
     // Parameters
     // struct _MCARD* pMCard; // r29
-    // s32 offset; // r30
+    // int offset; // r30
 
     // Local variables
     struct OSCalendarTime date; // r1+0x258
@@ -717,29 +717,29 @@ static s32 mcardWriteBufferAsynch(struct _MCARD* pMCard, s32 offset) {
 }
 
 // Range: 0x80019E38 -> 0x80019FDC
-static s32 mcardReadBufferAsynch(struct _MCARD* pMCard, s32 offset) {
+static int mcardReadBufferAsynch(struct _MCARD* pMCard, int offset) {
     // Parameters
     // struct _MCARD* pMCard; // r30
-    // s32 offset; // r27
+    // int offset; // r27
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 mcardWriteConfigPrepareWriteBuffer(struct _MCARD* pMCard) {
+static int mcardWriteConfigPrepareWriteBuffer(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r29
 
     // Local variables
-    s32 checksum; // r1+0x4A0
+    int checksum; // r1+0x4A0
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80019C74 -> 0x80019E38
-static s32 mcardWriteConfigAsynch(struct _MCARD* pMCard) {
+static int mcardWriteConfigAsynch(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -748,13 +748,13 @@ static s32 mcardWriteConfigAsynch(struct _MCARD* pMCard) {
 }
 
 // Erased
-static s32 mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
+static int mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r29
 
     // Local variables
     char dateString[32]; // r1+0x4A4
-    s32 checksum; // r1+0x4A0
+    int checksum; // r1+0x4A0
 
     // References
     // -> struct OSCalendarTime gDate;
@@ -762,7 +762,7 @@ static s32 mcardWriteTimePrepareWriteBuffer(struct _MCARD* pMCard) {
 }
 
 // Range: 0x80019A70 -> 0x80019C74
-static s32 mcardWriteTimeAsynch(struct _MCARD* pMCard) {
+static int mcardWriteTimeAsynch(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -772,56 +772,56 @@ static s32 mcardWriteTimeAsynch(struct _MCARD* pMCard) {
 }
 
 // Erased
-static s32 mcardReplaceBlock(struct _MCARD* pMCard, s32 index) {
+static int mcardReplaceBlock(struct _MCARD* pMCard, int index) {
     // Parameters
     // struct _MCARD* pMCard; // r27
-    // s32 index; // r28
+    // int index; // r28
 
     // Local variables
-    s32 checksum1; // r1+0x4A4
-    s32 checksum2; // r29
+    int checksum1; // r1+0x4A4
+    int checksum2; // r29
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x800196D8 -> 0x80019A70
-s32 mcardReadGameData(struct _MCARD* pMCard) {
+int mcardReadGameData(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r23
 
     // Local variables
-    s32 checksum1; // r1+0x260
-    s32 checksum2; // r26
-    s32 i; // r25
-    s32 toggle; // r24
+    int checksum1; // r1+0x260
+    int checksum2; // r26
+    int i; // r25
+    int toggle; // r24
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 mcardWriteGameData(struct _MCARD* pMCard, s32 offset) {
+static int mcardWriteGameData(struct _MCARD* pMCard, int offset) {
     // Parameters
     // struct _MCARD* pMCard; // r3
-    // s32 offset; // r4
+    // int offset; // r4
 }
 
 // Erased
-static s32 mcardWriteGameDataWait(struct _MCARD* pMCard) {
+static int mcardWriteGameDataWait(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r24
 
     // Local variables
-    s32 checksum; // r1+0x258
-    s32 i; // r25
+    int checksum; // r1+0x258
+    int i; // r25
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80019670 -> 0x800196D8
-s32 mcardWriteGameDataReset(struct _MCARD* pMCard) {
+int mcardWriteGameDataReset(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 
@@ -830,73 +830,73 @@ s32 mcardWriteGameDataReset(struct _MCARD* pMCard) {
 }
 
 // Range: 0x800194D8 -> 0x80019670
-s32 mcardReInit(struct _MCARD* pMCard) {
+int mcardReInit(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 }
 
 // Range: 0x8001947C -> 0x800194D8
-s32 mcardInit(struct _MCARD* pMCard) {
+int mcardInit(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 }
 
 // Range: 0x80019058 -> 0x8001947C
-s32 mcardFileSet(struct _MCARD* pMCard, char* name) {
+int mcardFileSet(struct _MCARD* pMCard, char* name) {
     // Parameters
     // struct _MCARD* pMCard; // r30
     // char* name; // r4
 
     // Local variables
-    s32 i; // r7
+    int i; // r7
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 mcardGameSetNoSave(struct _MCARD* pMCard, s32 size) {
+static int mcardGameSetNoSave(struct _MCARD* pMCard, int size) {
     // Parameters
     // struct _MCARD* pMCard; // r30
-    // s32 size; // r31
+    // int size; // r31
 
     // References
     // -> struct __anon_0x1BB9D* gpSystem;
 }
 
 // Range: 0x80018C50 -> 0x80019058
-s32 mcardGameSet(struct _MCARD* pMCard, char* name) {
+int mcardGameSet(struct _MCARD* pMCard, char* name) {
     // Parameters
     // struct _MCARD* pMCard; // r31
     // char* name; // r28
 
     // Local variables
-    s32 i; // r29
+    int i; // r29
 
     // References
     // -> struct __anon_0x1BB9D* gpSystem;
 }
 
 // Range: 0x800185F8 -> 0x80018C50
-s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, s32 size) {
+int mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon, char* banner, int size) {
     // Parameters
     // struct _MCARD* pMCard; // r31
     // char* name; // r21
     // char* comment; // r25
     // char* icon; // r27
     // char* banner; // r26
-    // s32 size; // r1+0x1C
+    // int size; // r1+0x1C
 
     // Local variables
-    s32 freeBytes; // r1+0x104
-    s32 freeFiles; // r1+0x100
-    s32 totalSize; // r30
-    s32 i; // r21
+    int freeBytes; // r1+0x104
+    int freeFiles; // r1+0x100
+    int totalSize; // r30
+    int i; // r21
     char* buffer; // r1+0xFC
     struct _GXTexObj texObj; // r1+0xDC
     void* dataP; // r4
     struct CARDStat cardStatus; // r1+0x70
-    s32 fileNo; // r21
+    int fileNo; // r21
     struct OSCalendarTime date; // r1+0x48
     char dateString[32]; // r1+0x28
 
@@ -905,79 +905,79 @@ s32 mcardFileCreate(struct _MCARD* pMCard, char* name, char* comment, char* icon
 }
 
 // Range: 0x80017D60 -> 0x800185F8
-s32 mcardGameCreate(struct _MCARD* pMCard, char* name, s32 defaultConfiguration, s32 size) {
+int mcardGameCreate(struct _MCARD* pMCard, char* name, int defaultConfiguration, int size) {
     // Parameters
     // struct _MCARD* pMCard; // r25
     // char* name; // r30
-    // s32 defaultConfiguration; // r29
-    // s32 size; // r27
+    // int defaultConfiguration; // r29
+    // int size; // r27
 
     // Local variables
-    s32 i; // r26
+    int i; // r26
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 mcardGameCreateDuringGame(struct _MCARD* pMCard, char* name, s32 size) {
+static int mcardGameCreateDuringGame(struct _MCARD* pMCard, char* name, int size) {
     // Parameters
     // struct _MCARD* pMCard; // r25
     // char* name; // r29
-    // s32 size; // r24
+    // int size; // r24
 
     // Local variables
-    s32 i; // r26
+    int i; // r26
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80017C24 -> 0x80017D60
-s32 mcardCardErase(struct _MCARD* pMCard) {
+int mcardCardErase(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r29
 
     // Local variables
-    s32 slot; // r30
+    int slot; // r30
 }
 
 // Range: 0x80017A94 -> 0x80017C24
-s32 mcardFileErase(struct _MCARD* pMCard) {
+int mcardFileErase(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 }
 
 // Range: 0x800178EC -> 0x80017A94
-s32 mcardGameErase(struct _MCARD* pMCard, s32 index) {
+int mcardGameErase(struct _MCARD* pMCard, int index) {
     // Parameters
     // struct _MCARD* pMCard; // r31
-    // s32 index; // r30
+    // int index; // r30
 }
 
 // Erased
-static s32 mcardFileRelease(struct _MCARD* pMCard) {
+static int mcardFileRelease(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r30
 }
 
 // Range: 0x80017844 -> 0x800178EC
-s32 mcardGameRelease(struct _MCARD* pMCard) {
+int mcardGameRelease(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 }
 
 // Range: 0x80017814 -> 0x80017844
-s32 mcardRead(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+int mcardRead(struct _MCARD* pMCard, int address, int size, char* data) {
     // Parameters
     // struct _MCARD* pMCard; // r3
-    // s32 address; // r4
-    // s32 size; // r5
+    // int address; // r4
+    // int size; // r5
     // char* data; // r6
 }
 
 // Range: 0x80016E70 -> 0x80017814
-s32 mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_0x1BD8E* pCommand) {
+int mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_0x1BD8E* pCommand) {
     // Parameters
     // struct _MCARD* pMCard; // r29
     // enum __anon_0x1A5F0 menuEntry; // r4
@@ -985,55 +985,55 @@ s32 mcardMenu(struct _MCARD* pMCard, enum __anon_0x1A5F0 menuEntry, enum __anon_
 
     // References
     // -> static enum __anon_0x1A5F0 nextMenuEntry$773;
-    // -> static s32 yes$771;
+    // -> static int yes$771;
     // -> static enum __anon_0x1A5F0 prevMenuEntry$772;
 }
 
 // Range: 0x80016D90 -> 0x80016E70
-s32 mcardOpenError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+int mcardOpenError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
     // Parameters
     // struct _MCARD* pMCard; // r3
     // enum __anon_0x1BD8E* pCommand; // r4
 }
 
 // Range: 0x80016CB0 -> 0x80016D90
-s32 mcardOpenDuringGameError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
+int mcardOpenDuringGameError(struct _MCARD* pMCard, enum __anon_0x1BD8E* pCommand) {
     // Parameters
     // struct _MCARD* pMCard; // r3
     // enum __anon_0x1BD8E* pCommand; // r4
 }
 
 // Erased
-static s32 corruptionCheck(struct _MCARD* pMCard) {
+static int corruptionCheck(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r23
 
     // Local variables
     char* buffer; // r1+0x4AC
-    s32 checksum1; // r1+0x4A8
-    s32 checksum2; // r26
-    s32 i; // r25
-    s32 toggle; // r24
+    int checksum1; // r1+0x4A8
+    int checksum2; // r26
+    int i; // r25
+    int toggle; // r24
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80016950 -> 0x80016CB0
-s32 mcardWrite(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
+int mcardWrite(struct _MCARD* pMCard, int address, int size, char* data) {
     // Parameters
     // struct _MCARD* pMCard; // r28
-    // s32 address; // r29
-    // s32 size; // r30
+    // int address; // r29
+    // int size; // r30
     // char* data; // r31
 
     // Local variables
-    s32 i; // r1+0x8
+    int i; // r1+0x8
     char testByte; // r25
 
     // References
-    // -> static s32 toggle2$1029;
-    // -> static s32 toggle$1034;
+    // -> static int toggle2$1029;
+    // -> static int toggle$1034;
     // -> struct __anon_0x1BB9D* gpSystem;
     // -> s32 currentIdx;
     // -> s32 bNoWriteInCurrentFrame[10];
@@ -1041,26 +1041,26 @@ s32 mcardWrite(struct _MCARD* pMCard, s32 address, s32 size, char* data) {
 }
 
 // Erased
-static s32 mcardGetError(struct _MCARD* pMCard, enum __anon_0x1B0CB* pMCardError) {
+static int mcardGetError(struct _MCARD* pMCard, enum __anon_0x1B0CB* pMCardError) {
     // Parameters
     // struct _MCARD* pMCard; // r1+0x0
     // enum __anon_0x1B0CB* pMCardError; // r1+0x4
 }
 
 // Erased
-static s32 mcardCheckSpace(struct _MCARD* pMCard, s32 size) {
+static int mcardCheckSpace(struct _MCARD* pMCard, int size) {
     // Parameters
     // struct _MCARD* pMCard; // r30
-    // s32 size; // r31
+    // int size; // r31
 
     // Local variables
-    s32 freeBytes; // r1+0x18
-    s32 freeFiles; // r1+0x14
+    int freeBytes; // r1+0x18
+    int freeFiles; // r1+0x14
 }
 
 // Range: 0x8001514C -> 0x80016950
-s32 mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
-              s32* defaultConfiguration, s32 fileSize, s32 gameSize) {
+int mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, char* banner, char* gameName,
+              int* defaultConfiguration, int fileSize, int gameSize) {
     // Parameters
     // struct _MCARD* pMCard; // r31
     // char* fileName; // r28
@@ -1068,60 +1068,60 @@ s32 mcardOpen(struct _MCARD* pMCard, char* fileName, char* comment, char* icon, 
     // char* icon; // r23
     // char* banner; // r22
     // char* gameName; // r29
-    // s32* defaultConfiguration; // r21
-    // s32 fileSize; // r26
-    // s32 gameSize; // r30
+    // int* defaultConfiguration; // r21
+    // int fileSize; // r26
+    // int gameSize; // r30
 
     // Local variables
-    s32 i; // r19
+    int i; // r19
     enum __anon_0x1BD8E command; // r1+0x34
 
     // References
     // -> struct __anon_0x1BB9D* gpSystem;
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
 }
 
 // Range: 0x800145FC -> 0x8001514C
-s32 mcardOpenDuringGame(struct _MCARD* pMCard) {
+int mcardOpenDuringGame(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r31
 
     // Local variables
-    s32 i; // r28
+    int i; // r28
     enum __anon_0x1BD8E command; // r1+0x18
-    s32 loadToggle; // r27
+    int loadToggle; // r27
 
     // References
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
 }
 
 // Range: 0x800136F4 -> 0x800145FC
-s32 mcardStore(struct _MCARD* pMCard) {
+int mcardStore(struct _MCARD* pMCard) {
     // Parameters
     // struct _MCARD* pMCard; // r29
 
     // Local variables
-    s32 i; // r30
-    s32 checksum; // r1+0x4DC
-    s32 bufferOffset; // r4
+    int i; // r30
+    int checksum; // r1+0x4DC
+    int bufferOffset; // r4
     enum __anon_0x1BD8E command; // r1+0x4C8
 
     // References
-    // -> static s32 checkFailCount$1490;
+    // -> static int checkFailCount$1490;
     // -> struct _MCARD mCard;
     // -> struct OSCalendarTime gDate;
 }
 
 // Range: 0x80013440 -> 0x800136F4
-s32 mcardUpdate() {
+int mcardUpdate() {
     // Local variables
-    s32 j; // r5
-    s32 i; // r5
-    s32 toggle; // r25
+    int j; // r5
+    int i; // r5
+    int toggle; // r25
     enum __anon_0x1BD8E command; // r1+0x8
-    s32 prevIndex; // r24
-    s32 index; // r23
-    s32 counter; // r22
+    int prevIndex; // r24
+    int index; // r23
+    int counter; // r22
 
     // References
     // -> struct _MCARD mCard;

--- a/debug/Fire/mips.c
+++ b/debug/Fire/mips.c
@@ -9,19 +9,19 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x7322B; // size = 0x10
 
 // size = 0x10, address = 0x800EE6D0
 struct _XL_OBJECTTYPE gClassMips;
 
 typedef struct __anon_0x7331D {
-    /* 0x0 */ s32 nMask;
-    /* 0x4 */ s32 nMode;
+    /* 0x0 */ int nMask;
+    /* 0x4 */ int nMode;
     /* 0x8 */ void* pHost;
-    /* 0xC */ s32 nInterrupt;
+    /* 0xC */ int nInterrupt;
 } __anon_0x7331D; // size = 0x10
 
 typedef enum __anon_0x736C0 {
@@ -35,66 +35,66 @@ typedef enum __anon_0x736C0 {
 } __anon_0x736C0;
 
 // Range: 0x8008D69C -> 0x8008D788
-s32 mipsSetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+int mipsSetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r1+0x0
     // enum __anon_0x736C0 eType; // r1+0x4
 
     // Local variables
-    s32 nInterrupt; // r5
+    int nInterrupt; // r5
 }
 
 // Range: 0x8008D5F8 -> 0x8008D69C
-s32 mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
+int mipsResetInterrupt(struct __anon_0x7331D* pMips, enum __anon_0x736C0 eType) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r1+0x0
     // enum __anon_0x736C0 eType; // r1+0x4
 
     // Local variables
-    s32 nInterrupt; // r5
+    int nInterrupt; // r5
 }
 
 // Range: 0x8008D5F0 -> 0x8008D5F8
-s32 mipsPut8() {}
+int mipsPut8() {}
 
 // Range: 0x8008D5E8 -> 0x8008D5F0
-s32 mipsPut16() {}
+int mipsPut16() {}
 
 // Range: 0x8008D3E0 -> 0x8008D5E8
-s32 mipsPut32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
+int mipsPut32(struct __anon_0x7331D* pMips, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
-    s32 nData; // r31
+    int nData; // r31
 }
 
 // Range: 0x8008D3D8 -> 0x8008D3E0
-s32 mipsPut64() {}
+int mipsPut64() {}
 
 // Range: 0x8008D3D0 -> 0x8008D3D8
-s32 mipsGet8() {}
+int mipsGet8() {}
 
 // Range: 0x8008D3C8 -> 0x8008D3D0
-s32 mipsGet16() {}
+int mipsGet16() {}
 
 // Range: 0x8008D360 -> 0x8008D3C8
-s32 mipsGet32(struct __anon_0x7331D* pMips, u32 nAddress, s32* pData) {
+int mipsGet32(struct __anon_0x7331D* pMips, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8008D358 -> 0x8008D360
-s32 mipsGet64() {}
+int mipsGet64() {}
 
 // Range: 0x8008D248 -> 0x8008D358
-s32 mipsEvent(struct __anon_0x7331D* pMips, s32 nEvent, void* pArgument) {
+int mipsEvent(struct __anon_0x7331D* pMips, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x7331D* pMips; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/movie.c
+++ b/debug/Fire/movie.c
@@ -11,7 +11,7 @@
 u8* gBufferP;
 
 // size = 0x4, address = 0x80135420
-s32 __OSCurrHeap;
+int __OSCurrHeap;
 
 typedef enum __anon_0xEF02 {
     VI_TVMODE_NTSC_INT = 0,
@@ -60,7 +60,7 @@ void MovieInit() {
 
     // References
     // -> u8* gBufferP;
-    // -> s32 __OSCurrHeap;
+    // -> int __OSCurrHeap;
 }
 
 // Erased
@@ -76,5 +76,5 @@ void MovieDraw() {
 static void MovieDestroy() {
     // References
     // -> u8* gBufferP;
-    // -> s32 __OSCurrHeap;
+    // -> int __OSCurrHeap;
 }

--- a/debug/Fire/peripheral.c
+++ b/debug/Fire/peripheral.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x83C1D; // size = 0x10
 
 // size = 0x10, address = 0x800EFFBC
@@ -19,19 +19,19 @@ struct _XL_OBJECTTYPE gClassPeripheral;
 
 typedef struct __anon_0x83D15 {
     /* 0x00 */ void* pHost;
-    /* 0x04 */ s32 nStatus;
-    /* 0x08 */ s32 nSizeGet;
-    /* 0x0C */ s32 nSizePut;
-    /* 0x10 */ s32 nLatency1;
-    /* 0x14 */ s32 nLatency2;
-    /* 0x18 */ s32 nRelease1;
-    /* 0x1C */ s32 nRelease2;
-    /* 0x20 */ s32 nSizePage1;
-    /* 0x24 */ s32 nSizePage2;
-    /* 0x28 */ s32 nAddressRAM;
-    /* 0x2C */ s32 nAddressROM;
-    /* 0x30 */ s32 nWidthPulse1;
-    /* 0x34 */ s32 nWidthPulse2;
+    /* 0x04 */ int nStatus;
+    /* 0x08 */ int nSizeGet;
+    /* 0x0C */ int nSizePut;
+    /* 0x10 */ int nLatency1;
+    /* 0x14 */ int nLatency2;
+    /* 0x18 */ int nRelease1;
+    /* 0x1C */ int nRelease2;
+    /* 0x20 */ int nSizePage1;
+    /* 0x24 */ int nSizePage2;
+    /* 0x28 */ int nAddressRAM;
+    /* 0x2C */ int nAddressROM;
+    /* 0x30 */ int nWidthPulse1;
+    /* 0x34 */ int nWidthPulse2;
 } __anon_0x83D15; // size = 0x38
 
 typedef enum __anon_0x8415D {
@@ -62,10 +62,10 @@ typedef enum __anon_0x843DE {
 } __anon_0x843DE;
 
 typedef struct __anon_0x84447 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x84447; // size = 0x10
 
 typedef enum __anon_0x844F8 {
@@ -88,7 +88,7 @@ typedef enum __anon_0x844F8 {
 typedef struct __anon_0x8464B {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x843DE eMode;
     /* 0x10 */ struct __anon_0x84447 romCopy;
     /* 0x20 */ enum __anon_0x844F8 eTypeROM;
@@ -96,14 +96,14 @@ typedef struct __anon_0x8464B {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x8415D storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x8464B; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x8464B* gpSystem;
 
 // Range: 0x80097D58 -> 0x80097D9C
-static s32 peripheralDMA_Complete() {
+static int peripheralDMA_Complete() {
     // Local variables
     struct __anon_0x83D15* pPeripheral; // r3
 
@@ -112,47 +112,47 @@ static s32 peripheralDMA_Complete() {
 }
 
 // Range: 0x80097D50 -> 0x80097D58
-s32 peripheralPut8() {}
+int peripheralPut8() {}
 
 // Range: 0x80097D48 -> 0x80097D50
-s32 peripheralPut16() {}
+int peripheralPut16() {}
 
 // Range: 0x800979C4 -> 0x80097D48
-s32 peripheralPut32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+int peripheralPut32(struct __anon_0x83D15* pPeripheral, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x83D15* pPeripheral; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
-    s32 bFlag; // r31
+    int bFlag; // r31
     enum __anon_0x8415D storageDevice; // r1+0x14
 }
 
 // Range: 0x800979BC -> 0x800979C4
-s32 peripheralPut64() {}
+int peripheralPut64() {}
 
 // Range: 0x800979B4 -> 0x800979BC
-s32 peripheralGet8() {}
+int peripheralGet8() {}
 
 // Range: 0x800979AC -> 0x800979B4
-s32 peripheralGet16() {}
+int peripheralGet16() {}
 
 // Range: 0x800978AC -> 0x800979AC
-s32 peripheralGet32(struct __anon_0x83D15* pPeripheral, u32 nAddress, s32* pData) {
+int peripheralGet32(struct __anon_0x83D15* pPeripheral, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x83D15* pPeripheral; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x800978A4 -> 0x800978AC
-s32 peripheralGet64() {}
+int peripheralGet64() {}
 
 // Range: 0x8009779C -> 0x800978A4
-s32 peripheralEvent(struct __anon_0x83D15* pPeripheral, s32 nEvent, void* pArgument) {
+int peripheralEvent(struct __anon_0x83D15* pPeripheral, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x83D15* pPeripheral; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/pif.c
+++ b/debug/Fire/pif.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x4A7FA; // size = 0x10
 
 // size = 0x10, address = 0x800ED6B8
@@ -39,7 +39,7 @@ typedef enum __anon_0x4B3FE {
 } __anon_0x4B3FE;
 
 // Erased
-static s32 pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
+static int pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
     // Parameters
     // u16* ptr; // r4
     // u16* csum; // r1+0x8
@@ -47,23 +47,23 @@ static s32 pifIdCheckSum(u16* ptr, u16* csum, u16* icsum) {
 
     // Local variables
     u16 data; // r7
-    u32 j; // r1+0x0
+    unsigned int j; // r1+0x0
 }
 
 // Range: 0x8006CC74 -> 0x8006CD98
-s32 pifReadRumble(u16 address, u8* data) {
+int pifReadRumble(u16 address, u8* data) {
     // Parameters
     // u16 address; // r1+0x8
     // u8* data; // r1+0xC
 
     // Local variables
-    s32 i; // r1+0x0
+    int i; // r1+0x0
 }
 
 // Range: 0x8006CC1C -> 0x8006CC74
-s32 pifWriteRumble(s32 channel, u16 address, u8* data) {
+int pifWriteRumble(int channel, u16 address, u8* data) {
     // Parameters
-    // s32 channel; // r4
+    // int channel; // r4
     // u16 address; // r1+0x10
     // u8* data; // r1+0x14
 }
@@ -74,46 +74,46 @@ static u8 pifContDataCrc(u8* data) {
     // u8* data; // r4
 
     // Local variables
-    u32 temp; // r3
-    u32 i; // r5
-    u32 j; // r6
+    unsigned int temp; // r3
+    unsigned int i; // r5
+    unsigned int j; // r6
 }
 
 // Range: 0x8006C994 -> 0x8006CAA4
-s32 pifSetControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE type) {
+int pifSetControllerType(struct __anon_0x4A974* pPIF, int channel, enum __anon_0x4B3FE type) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r29
-    // s32 channel; // r30
+    // int channel; // r30
     // enum __anon_0x4B3FE type; // r31
 }
 
 // Range: 0x8006C97C -> 0x8006C994
-s32 pifGetEControllerType(struct __anon_0x4A974* pPIF, s32 channel, enum __anon_0x4B3FE* type) {
+int pifGetEControllerType(struct __anon_0x4A974* pPIF, int channel, enum __anon_0x4B3FE* type) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // s32 channel; // r1+0x4
+    // int channel; // r1+0x4
     // enum __anon_0x4B3FE* type; // r1+0x8
 }
 
 // Range: 0x8006C918 -> 0x8006C97C
-s32 pifSetEEPROMType(struct __anon_0x4A974* pPIF, enum __anon_0x4B3FE type) {
+int pifSetEEPROMType(struct __anon_0x4A974* pPIF, enum __anon_0x4B3FE type) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
     // enum __anon_0x4B3FE type; // r1+0x4
 }
 
 // Erased
-static s32 pifGetControllerInput(s32 channel, u32* controllerInput) {
+static int pifGetControllerInput(int channel, unsigned int* controllerInput) {
     // Parameters
-    // s32 channel; // r4
-    // u32* controllerInput; // r5
+    // int channel; // r4
+    // unsigned int* controllerInput; // r5
 }
 
 // Erased
-static s32 pifGetControllerType(struct __anon_0x4A974* pPIF, s32 channel, u16* type, char* status) {
+static int pifGetControllerType(struct __anon_0x4A974* pPIF, int channel, u16* type, char* status) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // s32 channel; // r1+0x4
+    // int channel; // r1+0x4
     // u16* type; // r1+0x8
     // char* status; // r1+0xC
 
@@ -122,151 +122,151 @@ static s32 pifGetControllerType(struct __anon_0x4A974* pPIF, s32 channel, u16* t
 }
 
 // Range: 0x8006C8D4 -> 0x8006C918
-s32 pifGetEEPROMSize(struct __anon_0x4A974* pPIF, u32* size) {
+int pifGetEEPROMSize(struct __anon_0x4A974* pPIF, unsigned int* size) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32* size; // r1+0x4
+    // unsigned int* size; // r1+0x4
 }
 
 // Erased
-static s32 pifQueryController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+static int pifQueryController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, int channel) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
     // u8* buffer; // r1+0x4
     // u8* prx; // r1+0xC
-    // s32 channel; // r1+0x10
+    // int channel; // r1+0x10
 }
 
 // Erased
-static s32 pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+static int pifReadController(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, int channel) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x8
     // u8* buffer; // r4
     // u8* prx; // r1+0x14
-    // s32 channel; // r7
+    // int channel; // r7
 
     // Local variables
     enum __anon_0x4B3FE type; // r1+0x8
 }
 
 // Range: 0x8006C8B0 -> 0x8006C8D4
-static s32 pifPut8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
+static int pifPut8(struct __anon_0x4A974* pPIF, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8006C888 -> 0x8006C8B0
-static s32 pifPut16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+static int pifPut16(struct __anon_0x4A974* pPIF, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8006C860 -> 0x8006C888
-static s32 pifPut32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+static int pifPut32(struct __anon_0x4A974* pPIF, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8006C82C -> 0x8006C860
-static s32 pifPut64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+static int pifPut64(struct __anon_0x4A974* pPIF, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8006C7F8 -> 0x8006C82C
-static s32 pifGet8(struct __anon_0x4A974* pPIF, u32 nAddress, char* pData) {
+static int pifGet8(struct __anon_0x4A974* pPIF, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8006C7BC -> 0x8006C7F8
-static s32 pifGet16(struct __anon_0x4A974* pPIF, u32 nAddress, s16* pData) {
+static int pifGet16(struct __anon_0x4A974* pPIF, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8006C780 -> 0x8006C7BC
-static s32 pifGet32(struct __anon_0x4A974* pPIF, u32 nAddress, s32* pData) {
+static int pifGet32(struct __anon_0x4A974* pPIF, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8006C72C -> 0x8006C780
-static s32 pifGet64(struct __anon_0x4A974* pPIF, u32 nAddress, s64* pData) {
+static int pifGet64(struct __anon_0x4A974* pPIF, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8006C488 -> 0x8006C72C
-s32 pifExecuteCommand(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, s32 channel) {
+int pifExecuteCommand(struct __anon_0x4A974* pPIF, u8* buffer, u8* prx, int channel) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r30
     // u8* buffer; // r31
     // u8* prx; // r1+0x14
-    // s32 channel; // r7
+    // int channel; // r7
 }
 
 // Range: 0x8006C2F8 -> 0x8006C488
-s32 pifProcessInputData(struct __anon_0x4A974* pPIF) {
+int pifProcessInputData(struct __anon_0x4A974* pPIF) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r30
 
     // Local variables
     u8* prx; // r6
     u8* ptx; // r5
-    s32 iData; // r29
-    s32 channel; // r31
+    int iData; // r29
+    int channel; // r31
 }
 
 // Range: 0x8006C15C -> 0x8006C2F8
-s32 pifProcessOutputData(struct __anon_0x4A974* pPIF) {
+int pifProcessOutputData(struct __anon_0x4A974* pPIF) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r29
 
     // Local variables
     u8* prx; // r6
     u8* ptx; // r5
-    s32 iData; // r31
-    s32 channel; // r30
+    int iData; // r31
+    int channel; // r30
 }
 
 // Range: 0x8006C0FC -> 0x8006C15C
-s32 pifSetData(struct __anon_0x4A974* pPIF, u8* acData) {
+int pifSetData(struct __anon_0x4A974* pPIF, u8* acData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r31
     // u8* acData; // r4
 }
 
 // Range: 0x8006C090 -> 0x8006C0FC
-s32 pifGetData(struct __anon_0x4A974* pPIF, u8* acData) {
+int pifGetData(struct __anon_0x4A974* pPIF, u8* acData) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r30
     // u8* acData; // r31
 }
 
 // Range: 0x8006BE68 -> 0x8006C090
-s32 pifEvent(struct __anon_0x4A974* pPIF, s32 nEvent, void* pArgument) {
+int pifEvent(struct __anon_0x4A974* pPIF, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x4A974* pPIF; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 
     // Local variables
-    s32 i; // r31
+    int i; // r31
 }

--- a/debug/Fire/ram.c
+++ b/debug/Fire/ram.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x4BEF6; // size = 0x10
 
 // size = 0x10, address = 0x800ED6C8
@@ -20,166 +20,166 @@ struct _XL_OBJECTTYPE gClassRAM;
 typedef struct __anon_0x4BFE7 {
     /* 0x0 */ void* pHost;
     /* 0x4 */ void* pBuffer;
-    /* 0x8 */ u32 nSize;
+    /* 0x8 */ unsigned int nSize;
 } __anon_0x4BFE7; // size = 0xC
 
 // Range: 0x8006D3A4 -> 0x8006D3AC
-static s32 ramPutControl8() {}
+static int ramPutControl8() {}
 
 // Range: 0x8006D39C -> 0x8006D3A4
-static s32 ramPutControl16() {}
+static int ramPutControl16() {}
 
 // Range: 0x8006D368 -> 0x8006D39C
-static s32 ramPutControl32(u32 nAddress) {
+static int ramPutControl32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x8006D360 -> 0x8006D368
-static s32 ramPutControl64() {}
+static int ramPutControl64() {}
 
 // Range: 0x8006D358 -> 0x8006D360
-static s32 ramGetControl8() {}
+static int ramGetControl8() {}
 
 // Range: 0x8006D350 -> 0x8006D358
-static s32 ramGetControl16() {}
+static int ramGetControl16() {}
 
 // Range: 0x8006D31C -> 0x8006D350
-static s32 ramGetControl32(u32 nAddress) {
+static int ramGetControl32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x8006D314 -> 0x8006D31C
-static s32 ramGetControl64() {}
+static int ramGetControl64() {}
 
 // Range: 0x8006D30C -> 0x8006D314
-static s32 ramPutRI8() {}
+static int ramPutRI8() {}
 
 // Range: 0x8006D304 -> 0x8006D30C
-static s32 ramPutRI16() {}
+static int ramPutRI16() {}
 
 // Range: 0x8006D2D0 -> 0x8006D304
-static s32 ramPutRI32(u32 nAddress) {
+static int ramPutRI32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x8006D2C8 -> 0x8006D2D0
-static s32 ramPutRI64() {}
+static int ramPutRI64() {}
 
 // Range: 0x8006D2C0 -> 0x8006D2C8
-static s32 ramGetRI8() {}
+static int ramGetRI8() {}
 
 // Range: 0x8006D2B8 -> 0x8006D2C0
-static s32 ramGetRI16() {}
+static int ramGetRI16() {}
 
 // Range: 0x8006D284 -> 0x8006D2B8
-static s32 ramGetRI32(u32 nAddress) {
+static int ramGetRI32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x8006D27C -> 0x8006D284
-static s32 ramGetRI64() {}
+static int ramGetRI64() {}
 
 // Range: 0x8006D258 -> 0x8006D27C
-static s32 ramPut8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
+static int ramPut8(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
+    // unsigned int nAddress; // r6
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8006D230 -> 0x8006D258
-static s32 ramPut16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
+static int ramPut16(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
+    // unsigned int nAddress; // r6
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8006D208 -> 0x8006D230
-static s32 ramPut32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+static int ramPut32(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r6
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r6
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8006D1D4 -> 0x8006D208
-static s32 ramPut64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+static int ramPut64(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8006D1A4 -> 0x8006D1D4
-static s32 ramGet8(struct __anon_0x4BFE7* pRAM, u32 nAddress, char* pData) {
+static int ramGet8(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8006D170 -> 0x8006D1A4
-static s32 ramGet16(struct __anon_0x4BFE7* pRAM, u32 nAddress, s16* pData) {
+static int ramGet16(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8006D13C -> 0x8006D170
-static s32 ramGet32(struct __anon_0x4BFE7* pRAM, u32 nAddress, s32* pData) {
+static int ramGet32(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8006D0F8 -> 0x8006D13C
-static s32 ramGet64(struct __anon_0x4BFE7* pRAM, u32 nAddress, s64* pData) {
+static int ramGet64(struct __anon_0x4BFE7* pRAM, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8006D0A0 -> 0x8006D0F8
-s32 ramGetBuffer(struct __anon_0x4BFE7* pRAM, void* ppRAM, u32 nOffset, u32* pnSize) {
+int ramGetBuffer(struct __anon_0x4BFE7* pRAM, void* ppRAM, unsigned int nOffset, unsigned int* pnSize) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
     // void* ppRAM; // r1+0x4
-    // u32 nOffset; // r5
-    // u32* pnSize; // r1+0xC
+    // unsigned int nOffset; // r5
+    // unsigned int* pnSize; // r1+0xC
 }
 
 // Range: 0x8006D058 -> 0x8006D0A0
-s32 ramWipe(struct __anon_0x4BFE7* pRAM) {
+int ramWipe(struct __anon_0x4BFE7* pRAM) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r3
 }
 
 // Range: 0x8006CFE8 -> 0x8006D058
-s32 ramSetSize(struct __anon_0x4BFE7* pRAM, u32 nSize) {
+int ramSetSize(struct __anon_0x4BFE7* pRAM, unsigned int nSize) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r30
-    // u32 nSize; // r31
+    // unsigned int nSize; // r31
 }
 
 // Range: 0x8006CFD0 -> 0x8006CFE8
-s32 ramGetSize(struct __anon_0x4BFE7* pRAM, u32* pnSize) {
+int ramGetSize(struct __anon_0x4BFE7* pRAM, unsigned int* pnSize) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r1+0x0
-    // u32* pnSize; // r1+0x4
+    // unsigned int* pnSize; // r1+0x4
 }
 
 // Range: 0x8006CD98 -> 0x8006CFD0
-s32 ramEvent(struct __anon_0x4BFE7* pRAM, s32 nEvent, void* pArgument) {
+int ramEvent(struct __anon_0x4BFE7* pRAM, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x4BFE7* pRAM; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/rdb.c
+++ b/debug/Fire/rdb.c
@@ -9,62 +9,62 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x568FE; // size = 0x10
 
 // size = 0x10, address = 0x800EE1B0
 struct _XL_OBJECTTYPE gClassRdb;
 
 typedef struct __anon_0x56A0F {
-    /* 0x000 */ s32 nHackCount;
+    /* 0x000 */ int nHackCount;
     /* 0x004 */ char szString[256];
-    /* 0x104 */ s32 nIndexString;
-    /* 0x108 */ s32 nAddress;
+    /* 0x104 */ int nIndexString;
+    /* 0x108 */ int nAddress;
     /* 0x10C */ void* pHost;
 } __anon_0x56A0F; // size = 0x110
 
 // Range: 0x80071BB0 -> 0x80071BB8
-static s32 rdbPut8() {}
+static int rdbPut8() {}
 
 // Range: 0x80071BA8 -> 0x80071BB0
-static s32 rdbPut16() {}
+static int rdbPut16() {}
 
 // Range: 0x8007172C -> 0x80071BA8
-static s32 rdbPut32(struct __anon_0x56A0F* pRDB, u32 nAddress, s32* pData) {
+static int rdbPut32(struct __anon_0x56A0F* pRDB, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x56A0F* pRDB; // r3
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
-    s32 nLength; // r7
-    s32 iCounter; // r5
+    int nLength; // r7
+    int iCounter; // r5
 }
 
 // Range: 0x80071724 -> 0x8007172C
-static s32 rdbPut64() {}
+static int rdbPut64() {}
 
 // Range: 0x8007171C -> 0x80071724
-static s32 rdbGet8() {}
+static int rdbGet8() {}
 
 // Range: 0x80071714 -> 0x8007171C
-static s32 rdbGet16() {}
+static int rdbGet16() {}
 
 // Range: 0x800716E0 -> 0x80071714
-static s32 rdbGet32(u32 nAddress) {
+static int rdbGet32(unsigned int nAddress) {
     // Parameters
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
 }
 
 // Range: 0x800716D8 -> 0x800716E0
-static s32 rdbGet64() {}
+static int rdbGet64() {}
 
 // Range: 0x800715D0 -> 0x800716D8
-s32 rdbEvent(struct __anon_0x56A0F* pRDB, s32 nEvent, void* pArgument) {
+int rdbEvent(struct __anon_0x56A0F* pRDB, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x56A0F* pRDB; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/rdp.c
+++ b/debug/Fire/rdp.c
@@ -9,45 +9,45 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x52A92; // size = 0x10
 
 // size = 0x10, address = 0x800EDF40
 struct _XL_OBJECTTYPE gClassRDP;
 
 // size = 0x4, address = 0x80135770
-static s32 nCount$122;
+static int nCount$122;
 
 // size = 0x4, address = 0x80135774
-static s32 nBlurCount$123;
+static int nBlurCount$123;
 
 // size = 0x4, address = 0x80135778
-static s32 nNoteCount$124;
+static int nNoteCount$124;
 
 // size = 0x4, address = 0x8013577C
-static s32 nZCount$125;
+static int nZCount$125;
 
 // size = 0x4, address = 0x80135780
-static s32 nZBufferCount$126;
+static int nZBufferCount$126;
 
 // size = 0xC, address = 0x800EDF50
-static u32 sCommandCodes$168[3];
+static unsigned int sCommandCodes$168[3];
 
 typedef struct __anon_0x52CD0 {
-    /* 0x00 */ s32 nBIST;
-    /* 0x04 */ s32 nStatus;
+    /* 0x00 */ int nBIST;
+    /* 0x04 */ int nStatus;
     /* 0x08 */ void* pHost;
-    /* 0x0C */ s32 nModeTest;
-    /* 0x10 */ s32 nDataTest;
-    /* 0x14 */ s32 nAddressTest;
-    /* 0x18 */ s32 nAddress0;
-    /* 0x1C */ s32 nAddress1;
-    /* 0x20 */ s32 nClock;
-    /* 0x24 */ s32 nClockCmd;
-    /* 0x28 */ s32 nClockPipe;
-    /* 0x2C */ s32 nClockTMEM;
+    /* 0x0C */ int nModeTest;
+    /* 0x10 */ int nDataTest;
+    /* 0x14 */ int nAddressTest;
+    /* 0x18 */ int nAddress0;
+    /* 0x1C */ int nAddress1;
+    /* 0x20 */ int nClock;
+    /* 0x24 */ int nClockCmd;
+    /* 0x28 */ int nClockPipe;
+    /* 0x2C */ int nClockTMEM;
 } __anon_0x52CD0; // size = 0x30
 
 typedef enum __anon_0x533F6 {
@@ -57,10 +57,10 @@ typedef enum __anon_0x533F6 {
 } __anon_0x533F6;
 
 typedef struct __anon_0x53458 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x53458; // size = 0x10
 
 typedef enum __anon_0x53509 {
@@ -104,7 +104,7 @@ typedef enum __anon_0x53635 {
 typedef struct __anon_0x53770 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x533F6 eMode;
     /* 0x10 */ struct __anon_0x53458 romCopy;
     /* 0x20 */ enum __anon_0x53509 eTypeROM;
@@ -112,7 +112,7 @@ typedef struct __anon_0x53770 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x53635 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x53770; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -165,11 +165,11 @@ typedef struct __anon_0x53DD5 {
 } __anon_0x53DD5; // size = 0x10
 
 typedef struct __anon_0x53E6F {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x53E6F; // size = 0x14
 
 typedef struct __anon_0x53FB0 {
@@ -179,7 +179,7 @@ typedef struct __anon_0x53FB0 {
 } __anon_0x53FB0; // size = 0xC
 
 typedef struct __anon_0x54020 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x53FB0 rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -196,7 +196,7 @@ typedef struct __anon_0x54020 {
 } __anon_0x54020; // size = 0x3C
 
 typedef struct __anon_0x54250 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x53FB0 rS;
     /* 0x10 */ struct __anon_0x53FB0 rT;
     /* 0x1C */ struct __anon_0x53FB0 rSRaw;
@@ -214,7 +214,7 @@ typedef struct __anon_0x54339 {
 typedef union __anon_0x54498 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x54498;
 
@@ -267,20 +267,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x5483D;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -289,11 +289,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x548A6; // size = 0x6C
 
 typedef struct __anon_0x54C03 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -304,7 +304,7 @@ typedef struct __anon_0x54C03 {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x54C03; // size = 0x2C
 
 typedef enum __anon_0x54EE5 {
@@ -314,14 +314,14 @@ typedef enum __anon_0x54EE5 {
 } __anon_0x54EE5;
 
 typedef struct __anon_0x54F66 {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x54EE5 eProjection;
 } __anon_0x54F66; // size = 0x24
 
@@ -333,81 +333,81 @@ typedef struct _GXColor {
 } __anon_0x550FB; // size = 0x4
 
 typedef struct __anon_0x551B6 {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x53DD5 viewport;
     /* 0x000C8 */ struct __anon_0x53E6F aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x54020 aLight[8];
     /* 0x00320 */ struct __anon_0x54250 lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x54339 aVertex[80];
     /* 0x00C18 */ struct __anon_0x54535 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x54C03 aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x54EE5 eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -418,20 +418,20 @@ typedef struct __anon_0x551B6 {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x551B6; // size = 0x3D150
 
 typedef struct __anon_0x56000 {
-    /* 0x00 */ s32 bFlip;
-    /* 0x04 */ s32 iTile;
-    /* 0x08 */ s32 nX0;
-    /* 0x0C */ s32 nY0;
-    /* 0x10 */ s32 nX1;
-    /* 0x14 */ s32 nY1;
+    /* 0x00 */ int bFlip;
+    /* 0x04 */ int iTile;
+    /* 0x08 */ int nX0;
+    /* 0x0C */ int nY0;
+    /* 0x10 */ int nX1;
+    /* 0x14 */ int nY1;
     /* 0x18 */ f32 rS;
     /* 0x1C */ f32 rT;
     /* 0x20 */ f32 rDeltaS;
@@ -439,40 +439,40 @@ typedef struct __anon_0x56000 {
 } __anon_0x56000; // size = 0x28
 
 // Range: 0x80070340 -> 0x800715D0
-s32 rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {
+int rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r25
     // u64** ppnGBI; // r26
 
     // Local variables
-    u32 nA; // r4
-    u32 nB; // r3
-    u32 nC; // r5
-    u32 nD; // r6
+    unsigned int nA; // r4
+    unsigned int nB; // r3
+    unsigned int nC; // r5
+    unsigned int nD; // r6
     u64* pnGBI; // r1+0x9C
-    u32 nCommandLo; // r1+0x98
-    u32 nCommandHi; // r1+0x94
+    unsigned int nCommandLo; // r1+0x98
+    unsigned int nCommandHi; // r1+0x94
     struct __anon_0x551B6* pFrame; // r30
-    s32 nFound; // r31
-    s32 i; // r5
-    u32 nAddress; // r29
-    s32 nSetLens; // r28
+    int nFound; // r31
+    int i; // r5
+    unsigned int nAddress; // r29
+    int nSetLens; // r28
     struct __anon_0x53E6F* pBuffer; // r27
-    s32 i; // r7
-    u32* pGBI; // r1+0x8
-    s32 nAddress; // r5
+    int i; // r7
+    unsigned int* pGBI; // r1+0x8
+    int nAddress; // r5
     struct __anon_0x53E6F* pBuffer; // r8
-    s32 nAddress; // r5
+    int nAddress; // r5
     struct __anon_0x53E6F* pBuffer; // r27
-    u32 nColor; // r5
+    unsigned int nColor; // r5
     struct __anon_0x56000 primitive; // r1+0x6C
-    s32 iTile; // r1+0x8
+    int iTile; // r1+0x8
     struct __anon_0x54C03* pTile; // r5
-    s32 iTile; // r6
-    s32 iTile; // r5
+    int iTile; // r6
+    int iTile; // r5
     struct __anon_0x54C03* pTile; // r5
-    s32 iTile; // r5
-    s32 nCount; // r4
+    int iTile; // r5
+    int nCount; // r4
     f32 rDepth; // f1
     f32 rDelta; // f2
     struct __anon_0x56000 rectangle; // r1+0x40
@@ -481,95 +481,95 @@ s32 rdpParseGBI(struct __anon_0x52CD0* pRDP, u64** ppnGBI) {
     f32 rY0; // f30
     f32 rX1; // f29
     f32 rY1; // f28
-    u32* pGBI; // r1+0x8
-    u32* pGBI; // r4
+    unsigned int* pGBI; // r1+0x8
+    unsigned int* pGBI; // r4
 
     // References
     // -> struct __anon_0x53770* gpSystem;
     // -> struct _GXRenderModeObj* rmode;
-    // -> static s32 nCount$122;
-    // -> static s32 nBlurCount$123;
-    // -> static s32 nNoteCount$124;
-    // -> static s32 nZCount$125;
-    // -> static u32 sCommandCodes$168[3];
-    // -> static s32 nZBufferCount$126;
+    // -> static int nCount$122;
+    // -> static int nBlurCount$123;
+    // -> static int nNoteCount$124;
+    // -> static int nZCount$125;
+    // -> static unsigned int sCommandCodes$168[3];
+    // -> static int nZBufferCount$126;
 }
 
 // Range: 0x80070338 -> 0x80070340
-static s32 rdpPut8() {}
+static int rdpPut8() {}
 
 // Range: 0x80070330 -> 0x80070338
-static s32 rdpPut16() {}
+static int rdpPut16() {}
 
 // Range: 0x8007022C -> 0x80070330
-static s32 rdpPut32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+static int rdpPut32(struct __anon_0x52CD0* pRDP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r3
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
-    s32 nData; // r4
+    int nData; // r4
 }
 
 // Range: 0x80070224 -> 0x8007022C
-static s32 rdpPut64() {}
+static int rdpPut64() {}
 
 // Range: 0x8007021C -> 0x80070224
-static s32 rdpGet8() {}
+static int rdpGet8() {}
 
 // Range: 0x80070214 -> 0x8007021C
-static s32 rdpGet16() {}
+static int rdpGet16() {}
 
 // Range: 0x80070170 -> 0x80070214
-static s32 rdpGet32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+static int rdpGet32(struct __anon_0x52CD0* pRDP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x80070168 -> 0x80070170
-static s32 rdpGet64() {}
+static int rdpGet64() {}
 
 // Range: 0x80070160 -> 0x80070168
-static s32 rdpPutSpan8() {}
+static int rdpPutSpan8() {}
 
 // Range: 0x80070158 -> 0x80070160
-static s32 rdpPutSpan16() {}
+static int rdpPutSpan16() {}
 
 // Range: 0x800700F4 -> 0x80070158
-static s32 rdpPutSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+static int rdpPutSpan32(struct __anon_0x52CD0* pRDP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x800700EC -> 0x800700F4
-static s32 rdpPutSpan64() {}
+static int rdpPutSpan64() {}
 
 // Range: 0x800700E4 -> 0x800700EC
-static s32 rdpGetSpan8() {}
+static int rdpGetSpan8() {}
 
 // Range: 0x800700DC -> 0x800700E4
-static s32 rdpGetSpan16() {}
+static int rdpGetSpan16() {}
 
 // Range: 0x8007006C -> 0x800700DC
-static s32 rdpGetSpan32(struct __anon_0x52CD0* pRDP, u32 nAddress, s32* pData) {
+static int rdpGetSpan32(struct __anon_0x52CD0* pRDP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x80070064 -> 0x8007006C
-static s32 rdpGetSpan64() {}
+static int rdpGetSpan64() {}
 
 // Range: 0x8006FEC0 -> 0x80070064
-s32 rdpEvent(struct __anon_0x52CD0* pRDP, s32 nEvent, void* pArgument) {
+int rdpEvent(struct __anon_0x52CD0* pRDP, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x52CD0* pRDP; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/rom.c
+++ b/debug/Fire/rom.c
@@ -9,28 +9,28 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x4CD3A; // size = 0x10
 
 // size = 0x10, address = 0x800ED8E8
 struct _XL_OBJECTTYPE gClassROM;
 
 // size = 0x318, address = 0x800ED8F8
-static u32 ganOffsetBlock_ZLJ[198];
+static unsigned int ganOffsetBlock_ZLJ[198];
 
 // size = 0x318, address = 0x800EDC10
-static u32 ganOffsetBlock_URAZLJ[198];
+static unsigned int ganOffsetBlock_URAZLJ[198];
 
 // size = 0x4, address = 0x80135760
-static s32 gbProgress;
+static int gbProgress;
 
 // size = 0x4, address = 0x80135764
 static void* gpImageBack;
 
 // size = 0x4, address = 0x80135768
-static s32 iImage$294;
+static int iImage$294;
 
 typedef enum __anon_0x4CF87 {
     RLM_NONE = -1,
@@ -40,33 +40,33 @@ typedef enum __anon_0x4CF87 {
 } __anon_0x4CF87;
 
 typedef struct __anon_0x4CFE6 {
-    /* 0x0 */ s32 iCache;
-    /* 0x4 */ u32 nSize;
-    /* 0x8 */ u32 nTickUsed;
+    /* 0x0 */ int iCache;
+    /* 0x4 */ unsigned int nSize;
+    /* 0x8 */ unsigned int nTickUsed;
     /* 0xC */ char keep;
 } __anon_0x4CFE6; // size = 0x10
 
 typedef struct __anon_0x4D0FA {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 (*pCallback)();
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int (*pCallback)();
     /* 0x08 */ u8* pTarget;
-    /* 0x0C */ u32 nSize;
-    /* 0x10 */ u32 nOffset;
+    /* 0x0C */ unsigned int nSize;
+    /* 0x10 */ unsigned int nOffset;
 } __anon_0x4D0FA; // size = 0x14
 
 typedef struct __anon_0x4D1DA {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 bDone;
-    /* 0x08 */ s32 nResult;
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int bDone;
+    /* 0x08 */ int nResult;
     /* 0x0C */ u8* anData;
-    /* 0x10 */ s32 (*pCallback)();
-    /* 0x14 */ s32 iCache;
-    /* 0x18 */ s32 iBlock;
-    /* 0x1C */ s32 nOffset;
-    /* 0x20 */ u32 nOffset0;
-    /* 0x24 */ u32 nOffset1;
-    /* 0x28 */ u32 nSize;
-    /* 0x2C */ u32 nSizeRead;
+    /* 0x10 */ int (*pCallback)();
+    /* 0x14 */ int iCache;
+    /* 0x18 */ int iBlock;
+    /* 0x1C */ int nOffset;
+    /* 0x20 */ unsigned int nOffset0;
+    /* 0x24 */ unsigned int nOffset1;
+    /* 0x28 */ unsigned int nSize;
+    /* 0x2C */ unsigned int nSizeRead;
 } __anon_0x4D1DA; // size = 0x30
 
 typedef struct DVDDiskID {
@@ -104,25 +104,25 @@ typedef struct DVDFileInfo {
 typedef struct __anon_0x4D873 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
-    /* 0x00008 */ s32 bFlip;
-    /* 0x0000C */ s32 bLoad;
+    /* 0x00008 */ int bFlip;
+    /* 0x0000C */ int bLoad;
     /* 0x00010 */ char acNameFile[513];
-    /* 0x00214 */ u32 nSize;
+    /* 0x00214 */ unsigned int nSize;
     /* 0x00218 */ enum __anon_0x4CF87 eModeLoad;
     /* 0x0021C */ struct __anon_0x4CFE6 aBlock[4096];
-    /* 0x1021C */ u32 nTick;
+    /* 0x1021C */ unsigned int nTick;
     /* 0x10220 */ u8* pCacheRAM;
     /* 0x10224 */ u8 anBlockCachedRAM[1024];
     /* 0x10624 */ u8 anBlockCachedARAM[2046];
     /* 0x10E24 */ struct __anon_0x4D0FA copy;
     /* 0x10E38 */ struct __anon_0x4D1DA load;
-    /* 0x10E68 */ s32 nCountBlockRAM;
-    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E68 */ int nCountBlockRAM;
+    /* 0x10E6C */ int nSizeCacheRAM;
     /* 0x10E70 */ u8 acHeader[64];
-    /* 0x10EB0 */ u32* anOffsetBlock;
-    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB0 */ unsigned int* anOffsetBlock;
+    /* 0x10EB4 */ int nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
-    /* 0x10EF4 */ s32 offsetToRom;
+    /* 0x10EF4 */ int offsetToRom;
 } __anon_0x4D873; // size = 0x10EF8
 
 typedef enum __anon_0x4DD08 {
@@ -132,42 +132,42 @@ typedef enum __anon_0x4DD08 {
 } __anon_0x4DD08;
 
 typedef struct tXL_FILE {
-    /* 0x00 */ s32 iBuffer;
+    /* 0x00 */ int iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
-    /* 0x0C */ s32 nAttributes;
-    /* 0x10 */ s32 nSize;
-    /* 0x14 */ s32 nOffset;
+    /* 0x0C */ int nAttributes;
+    /* 0x10 */ int nSize;
+    /* 0x14 */ int nOffset;
     /* 0x18 */ enum __anon_0x4DD08 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x4DD5C; // size = 0x58
 
 typedef struct __anon_0x4F17B {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x4F17B; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x4F1E1; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x4F17B* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -186,8 +186,8 @@ typedef union __anon_0x4F530 {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -201,8 +201,8 @@ typedef union __anon_0x4F530 {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x4F530;
 
@@ -210,57 +210,57 @@ typedef union __anon_0x4F944 {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x4F944;
 
 typedef struct __anon_0x4FE52 {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x4FE52; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x50120; // size = 0x84
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x50361; // size = 0xC
 
 typedef struct __anon_0x50416 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x50416; // size = 0xC
 
 typedef struct OSContext {
@@ -292,61 +292,61 @@ typedef struct OSAlarm {
 } __anon_0x50798; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x508B3; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x4F530 aGPR[32];
     /* 0x00140 */ union __anon_0x4F944 aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x4FE52* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x50416 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x50A60; // size = 0x12090
 
@@ -357,10 +357,10 @@ typedef enum __anon_0x51281 {
 } __anon_0x51281;
 
 typedef struct __anon_0x512E3 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x512E3; // size = 0x10
 
 typedef enum __anon_0x51394 {
@@ -404,7 +404,7 @@ typedef enum __anon_0x514C0 {
 typedef struct __anon_0x515FB {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x51281 eMode;
     /* 0x10 */ struct __anon_0x512E3 romCopy;
     /* 0x20 */ enum __anon_0x51394 eTypeROM;
@@ -412,20 +412,20 @@ typedef struct __anon_0x515FB {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x514C0 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x515FB; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x515FB* gpSystem;
 
 // size = 0x4, address = 0x801355D8
-s32 gDVDResetToggle;
+int gDVDResetToggle;
 
 // size = 0x4, address = 0x801356D8
-u32 gnFlagZelda;
+unsigned int gnFlagZelda;
 
 // size = 0x4, address = 0x801355FC
-s32 gbDisplayedError;
+int gbDisplayedError;
 
 typedef struct _GXTexObj {
     /* 0x0 */ u32 dummy[8];
@@ -438,95 +438,95 @@ typedef enum __anon_0x5219D {
 } __anon_0x5219D;
 
 // Erased
-static s32 romTestARAM() {}
+static int romTestARAM() {}
 
 // Erased
-static s32 romMatchRange(struct __anon_0x4D873* pROM, u32 nOffset, s32* pnOffset0, s32* pnOffset1) {
+static int romMatchRange(struct __anon_0x4D873* pROM, unsigned int nOffset, int* pnOffset0, int* pnOffset1) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // u32 nOffset; // r1+0x4
-    // s32* pnOffset0; // r1+0x8
-    // s32* pnOffset1; // r1+0xC
+    // unsigned int nOffset; // r1+0x4
+    // int* pnOffset0; // r1+0x8
+    // int* pnOffset1; // r1+0xC
 
     // Local variables
-    s32 iBlock; // r10
+    int iBlock; // r10
 }
 
 // Erased
-static s32 romFreeBlock(struct __anon_0x4D873* pROM, s32 iBlock) {
+static int romFreeBlock(struct __anon_0x4D873* pROM, int iBlock) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32 iBlock; // r1+0x4
+    // int iBlock; // r1+0x4
 
     // Local variables
-    s32 iCache; // r4
+    int iCache; // r4
     struct __anon_0x4CFE6* pBlock; // r1+0x0
 }
 
 // Range: 0x8006FDFC -> 0x8006FEC0
-static s32 romFindFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+static int romFindFreeCache(struct __anon_0x4D873* pROM, int* piCache, enum __anon_0x5219D eType) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* piCache; // r1+0x4
+    // int* piCache; // r1+0x4
     // enum __anon_0x5219D eType; // r1+0x8
 
     // Local variables
-    s32 iBlock; // r7
+    int iBlock; // r7
 }
 
 // Range: 0x8006FC4C -> 0x8006FDFC
-static s32 romFindOldestBlock(struct __anon_0x4D873* pROM, s32* piBlock, enum __anon_0x5219D eTypeCache,
-                              s32 whichBlock) {
+static int romFindOldestBlock(struct __anon_0x4D873* pROM, int* piBlock, enum __anon_0x5219D eTypeCache,
+                              int whichBlock) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // s32* piBlock; // r1+0x4
+    // int* piBlock; // r1+0x4
     // enum __anon_0x5219D eTypeCache; // r1+0x8
-    // s32 whichBlock; // r1+0xC
+    // int whichBlock; // r1+0xC
 
     // Local variables
     struct __anon_0x4CFE6* pBlock; // r7
-    s32 iBlock; // r8
-    s32 iBlockOldest; // r9
-    u32 nTick; // r10
-    u32 nTickDelta; // r11
-    u32 nTickDeltaOldest; // r12
+    int iBlock; // r8
+    int iBlockOldest; // r9
+    unsigned int nTick; // r10
+    unsigned int nTickDelta; // r11
+    unsigned int nTickDeltaOldest; // r12
 }
 
 // Range: 0x8006FA38 -> 0x8006FC4C
-static s32 romMakeFreeCache(struct __anon_0x4D873* pROM, s32* piCache, enum __anon_0x5219D eType) {
+static int romMakeFreeCache(struct __anon_0x4D873* pROM, int* piCache, enum __anon_0x5219D eType) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r30
-    // s32* piCache; // r31
+    // int* piCache; // r31
     // enum __anon_0x5219D eType; // r1+0x10
 
     // Local variables
-    s32 iCache; // r1+0x20
-    s32 iBlockOldest; // r1+0x1C
+    int iCache; // r1+0x20
+    int iBlockOldest; // r1+0x1C
 }
 
 // Range: 0x8006F7E0 -> 0x8006FA38
-static s32 romSetBlockCache(struct __anon_0x4D873* pROM, s32 iBlock, enum __anon_0x5219D eType) {
+static int romSetBlockCache(struct __anon_0x4D873* pROM, int iBlock, enum __anon_0x5219D eType) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r30
-    // s32 iBlock; // r1+0xC
+    // int iBlock; // r1+0xC
     // enum __anon_0x5219D eType; // r1+0x10
 
     // Local variables
     struct __anon_0x4CFE6* pBlock; // r31
-    s32 iCacheRAM; // r1+0x18
-    s32 iCacheARAM; // r1+0x14
-    s32 nOffsetRAM; // r28
-    s32 nOffsetARAM; // r29
+    int iCacheRAM; // r1+0x18
+    int iCacheARAM; // r1+0x14
+    int nOffsetRAM; // r28
+    int nOffsetARAM; // r29
 }
 
 // Range: 0x8006F6EC -> 0x8006F7E0
-static s32 __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
+static int __romLoadBlock_Complete(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x8
 
     // Local variables
-    u32 iData; // r9
-    u32 nData; // r1+0x8
+    unsigned int iData; // r9
+    unsigned int nData; // r1+0x8
 }
 
 // Range: 0x8006F6D0 -> 0x8006F6EC
@@ -542,222 +542,222 @@ static void __romLoadBlock_CompleteGCN(s32 nResult) {
 }
 
 // Range: 0x8006F5D4 -> 0x8006F6D0
-static s32 romLoadBlock(struct __anon_0x4D873* pROM, s32 iBlock, s32 iCache, s32 (*pCallback)()) {
+static int romLoadBlock(struct __anon_0x4D873* pROM, int iBlock, int iCache, int (*pCallback)()) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r31
-    // s32 iBlock; // r1+0xC
-    // s32 iCache; // r1+0x10
-    // s32 (* pCallback)(); // r1+0x14
+    // int iBlock; // r1+0xC
+    // int iCache; // r1+0x10
+    // int (* pCallback)(); // r1+0x14
 
     // Local variables
     u8* anData; // r8
-    s32 nSizeRead; // r10
-    u32 nSize; // r10
-    u32 nOffset; // r1+0x8
+    int nSizeRead; // r10
+    unsigned int nSize; // r10
+    unsigned int nOffset; // r1+0x8
 }
 
 // Erased
-static s32 romKeepCheck() {}
+static int romKeepCheck() {}
 
 // Range: 0x8006F488 -> 0x8006F5D4
-static s32 romLoadRange(struct __anon_0x4D873* pROM, s32 begin, s32 end, s32* blockCount, s32 whichBlock,
-                        s32 (*pfProgress)(f32)) {
+static int romLoadRange(struct __anon_0x4D873* pROM, int begin, int end, int* blockCount, int whichBlock,
+                        int (*pfProgress)(f32)) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r26
-    // s32 begin; // r1+0xC
-    // s32 end; // r1+0x10
-    // s32* blockCount; // r27
-    // s32 whichBlock; // r1+0x18
-    // s32 (* pfProgress)(f32); // r28
+    // int begin; // r1+0xC
+    // int end; // r1+0x10
+    // int* blockCount; // r27
+    // int whichBlock; // r1+0x18
+    // int (* pfProgress)(f32); // r28
 
     // Local variables
-    s32 iCache; // r1+0x20
-    u32 iBlock; // r30
-    u32 iBlockLast; // r29
+    int iCache; // r1+0x20
+    unsigned int iBlock; // r30
+    unsigned int iBlockLast; // r29
 }
 
 // Range: 0x8006F208 -> 0x8006F488
-static s32 romCacheGame_ZELDA(f32 rProgress) {
+static int romCacheGame_ZELDA(f32 rProgress) {
     // Parameters
     // f32 rProgress; // f31
 
     // Local variables
-    s32 nSize; // r31
+    int nSize; // r31
     f32 matrix44[4][4]; // r1+0x2C
     struct _GXTexObj textureObject; // r1+0xC
 
     // References
-    // -> static s32 gbProgress;
-    // -> static s32 iImage$294;
+    // -> static int gbProgress;
+    // -> static int iImage$294;
     // -> struct __anon_0x515FB* gpSystem;
     // -> static void* gpImageBack;
-    // -> s32 gbDisplayedError;
+    // -> int gbDisplayedError;
 }
 
 // Range: 0x8006EC58 -> 0x8006F208
-static s32 romCacheGame(struct __anon_0x4D873* pROM) {
+static int romCacheGame(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r31
 
     // Local variables
-    s32 blockCount; // r1+0x68
-    s32 nSize; // r30
+    int blockCount; // r1+0x68
+    int nSize; // r30
     char* szName; // r5
     struct tXL_FILE* pFile; // r1+0x5C
 
     // References
-    // -> s32 gDVDResetToggle;
-    // -> u32 gnFlagZelda;
-    // -> s32 gbDisplayedError;
-    // -> static s32 gbProgress;
+    // -> int gDVDResetToggle;
+    // -> unsigned int gnFlagZelda;
+    // -> int gbDisplayedError;
+    // -> static int gbProgress;
     // -> static void* gpImageBack;
-    // -> static u32 ganOffsetBlock_URAZLJ[198];
-    // -> static u32 ganOffsetBlock_ZLJ[198];
+    // -> static unsigned int ganOffsetBlock_URAZLJ[198];
+    // -> static unsigned int ganOffsetBlock_ZLJ[198];
 }
 
 // Range: 0x8006EC3C -> 0x8006EC58
-static s32 __romLoadUpdate_Complete() {
+static int __romLoadUpdate_Complete() {
     // References
     // -> struct __anon_0x515FB* gpSystem;
 }
 
 // Erased
-static s32 romLoadInProgress(struct __anon_0x4D873* pROM) {
+static int romLoadInProgress(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
 }
 
 // Range: 0x8006EADC -> 0x8006EC3C
-static s32 romLoadUpdate(struct __anon_0x4D873* pROM) {
+static int romLoadUpdate(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r29
 
     // Local variables
-    s32 iCache; // r1+0xC
+    int iCache; // r1+0xC
     struct __anon_0x4CFE6* pBlock; // r4
-    u32 iBlock0; // r31
-    u32 iBlock1; // r25
+    unsigned int iBlock0; // r31
+    unsigned int iBlock1; // r25
     struct _CPU* pCPU; // r30
 }
 
 // Range: 0x8006EAC0 -> 0x8006EADC
-static s32 __romCopyUpdate_Complete() {
+static int __romCopyUpdate_Complete() {
     // References
     // -> struct __anon_0x515FB* gpSystem;
 }
 
 // Range: 0x8006E83C -> 0x8006EAC0
-static s32 romCopyUpdate(struct __anon_0x4D873* pROM) {
+static int romCopyUpdate(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r29
 
     // Local variables
     struct __anon_0x4CFE6* pBlock; // r28
-    s32 iCache; // r1+0xC
-    s32 nTickLast; // r27
+    int iCache; // r1+0xC
+    int nTickLast; // r27
     u8* anData; // r1+0x8
-    u32 iBlock; // r26
-    u32 nSize; // r26
-    u32 nOffsetBlock; // r1+0x8
+    unsigned int iBlock; // r26
+    unsigned int nSize; // r26
+    unsigned int nOffsetBlock; // r1+0x8
     struct _CPU* pCPU; // r30
 }
 
 // Erased
-static s32 romCacheAllBlocks(struct __anon_0x4D873* pROM) {
+static int romCacheAllBlocks(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r27
 
     // Local variables
-    s32 iCache; // r1+0xC
-    u32 iBlock; // r28
-    u32 iBlockLast; // r1+0x8
+    int iCache; // r1+0xC
+    unsigned int iBlock; // r28
+    unsigned int iBlockLast; // r1+0x8
 }
 
 // Range: 0x8006E3D4 -> 0x8006E83C
-static s32 romLoadFullOrPart(struct __anon_0x4D873* pROM) {
+static int romLoadFullOrPart(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r31
 
     // Local variables
     struct tXL_FILE* pFile; // r1+0x1C
-    s32 iBlock; // r1+0x8
-    s32 nLoad; // r27
-    s32 nStep; // r28
-    s32 iData; // r7
-    u32 nData; // r1+0x8
+    int iBlock; // r1+0x8
+    int nLoad; // r27
+    int nStep; // r28
+    int iData; // r7
+    unsigned int nData; // r1+0x8
 }
 
 // Erased
-static s32 romLoad(struct __anon_0x4D873* pROM) {
+static int romLoad(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r31
 }
 
 // Range: 0x8006E1D8 -> 0x8006E3D4
-s32 romGetPC(struct __anon_0x4D873* pROM, u64* pnPC) {
+int romGetPC(struct __anon_0x4D873* pROM, u64* pnPC) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
     // u64* pnPC; // r31
 
     // Local variables
-    s32 nOffset; // r5
-    u32 nData; // r5
-    u32 iData; // r1+0x8
-    u32 anData[1024]; // r1+0x18
+    int nOffset; // r5
+    unsigned int nData; // r5
+    unsigned int iData; // r1+0x8
+    unsigned int anData[1024]; // r1+0x18
 }
 
 // Range: 0x8006E1A4 -> 0x8006E1D8
-s32 romGetCode(struct __anon_0x4D873* pROM, char* acCode) {
+int romGetCode(struct __anon_0x4D873* pROM, char* acCode) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
     // char* acCode; // r1+0x4
 }
 
 // Erased
-static s32 romGetName(struct __anon_0x4D873* pROM, char* acName) {
+static int romGetName(struct __anon_0x4D873* pROM, char* acName) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
     // char* acName; // r1+0x4
 
     // Local variables
-    s32 iName; // r10
+    int iName; // r10
 }
 
 // Erased
-static s32 romGetMask(struct __anon_0x4D873* pROM, s32* pnMask) {
+static int romGetMask(struct __anon_0x4D873* pROM, int* pnMask) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnMask; // r1+0x4
+    // int* pnMask; // r1+0x4
 }
 
 // Range: 0x8006E0E0 -> 0x8006E1A4
-s32 romTestCode(struct __anon_0x4D873* pROM, char* acCode) {
+int romTestCode(struct __anon_0x4D873* pROM, char* acCode) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x8
     // char* acCode; // r1+0xC
 
     // Local variables
-    s32 iCode; // r1+0x8
+    int iCode; // r1+0x8
     char acCodeCurrent[5]; // r1+0x1C
 }
 
 // Range: 0x8006E0D8 -> 0x8006E0E0
-static s32 romPut8() {}
+static int romPut8() {}
 
 // Range: 0x8006E0D0 -> 0x8006E0D8
-static s32 romPut16() {}
+static int romPut16() {}
 
 // Range: 0x8006E0C8 -> 0x8006E0D0
-static s32 romPut32() {}
+static int romPut32() {}
 
 // Range: 0x8006E0C0 -> 0x8006E0C8
-static s32 romPut64() {}
+static int romPut64() {}
 
 // Range: 0x8006E050 -> 0x8006E0C0
-static s32 romGet8(struct __anon_0x4D873* pROM, u32 nAddress, char* pData) {
+static int romGet8(struct __anon_0x4D873* pROM, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // char* pData; // r31
 
     // Local variables
@@ -765,10 +765,10 @@ static s32 romGet8(struct __anon_0x4D873* pROM, u32 nAddress, char* pData) {
 }
 
 // Range: 0x8006DFE0 -> 0x8006E050
-static s32 romGet16(struct __anon_0x4D873* pROM, u32 nAddress, s16* pData) {
+static int romGet16(struct __anon_0x4D873* pROM, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // s16* pData; // r31
 
     // Local variables
@@ -776,21 +776,21 @@ static s32 romGet16(struct __anon_0x4D873* pROM, u32 nAddress, s16* pData) {
 }
 
 // Range: 0x8006DF70 -> 0x8006DFE0
-static s32 romGet32(struct __anon_0x4D873* pROM, u32 nAddress, s32* pData) {
+static int romGet32(struct __anon_0x4D873* pROM, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
-    // s32* pData; // r31
+    // unsigned int nAddress; // r4
+    // int* pData; // r31
 
     // Local variables
-    u32 nData; // r1+0x14
+    unsigned int nData; // r1+0x14
 }
 
 // Range: 0x8006DEF4 -> 0x8006DF70
-static s32 romGet64(struct __anon_0x4D873* pROM, u32 nAddress, s64* pData) {
+static int romGet64(struct __anon_0x4D873* pROM, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r3
-    // u32 nAddress; // r4
+    // unsigned int nAddress; // r4
     // s64* pData; // r31
 
     // Local variables
@@ -798,56 +798,56 @@ static s32 romGet64(struct __anon_0x4D873* pROM, u32 nAddress, s64* pData) {
 }
 
 // Range: 0x8006DEEC -> 0x8006DEF4
-static s32 romPutDebug8() {}
+static int romPutDebug8() {}
 
 // Range: 0x8006DEE4 -> 0x8006DEEC
-static s32 romPutDebug16() {}
+static int romPutDebug16() {}
 
 // Range: 0x8006DEDC -> 0x8006DEE4
-static s32 romPutDebug32() {}
+static int romPutDebug32() {}
 
 // Range: 0x8006DED4 -> 0x8006DEDC
-static s32 romPutDebug64() {}
+static int romPutDebug64() {}
 
 // Range: 0x8006DEC4 -> 0x8006DED4
-static s32 romGetDebug8(char* pData) {
+static int romGetDebug8(char* pData) {
     // Parameters
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8006DEB4 -> 0x8006DEC4
-static s32 romGetDebug16(s16* pData) {
+static int romGetDebug16(s16* pData) {
     // Parameters
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8006DEA4 -> 0x8006DEB4
-static s32 romGetDebug32(s32* pData) {
+static int romGetDebug32(int* pData) {
     // Parameters
-    // s32* pData; // r1+0x8
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8006DE90 -> 0x8006DEA4
-static s32 romGetDebug64(s64* pData) {
+static int romGetDebug64(s64* pData) {
     // Parameters
     // s64* pData; // r1+0x8
 }
 
 // Erased
-static s32 romGetSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+static int romGetSize(struct __anon_0x4D873* pROM, int* pnSize) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnSize; // r1+0x4
+    // int* pnSize; // r1+0x4
 }
 
 // Range: 0x8006DBF8 -> 0x8006DE90
-s32 romCopy(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffset, u32 nSize, s32 (*pCallback)()) {
+int romCopy(struct __anon_0x4D873* pROM, void* pTarget, int nOffset, unsigned int nSize, int (*pCallback)()) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r27
     // void* pTarget; // r28
-    // s32 nOffset; // r29
-    // u32 nSize; // r30
-    // s32 (* pCallback)(); // r31
+    // int nOffset; // r29
+    // unsigned int nSize; // r30
+    // int (* pCallback)(); // r31
 
     // Local variables
     void* pSource; // r4
@@ -855,82 +855,82 @@ s32 romCopy(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffset, u32 nSize, 
 }
 
 // Range: 0x8006D990 -> 0x8006DBF8
-s32 romCopyImmediate(struct __anon_0x4D873* pROM, void* pTarget, s32 nOffsetROM, u32 nSize) {
+int romCopyImmediate(struct __anon_0x4D873* pROM, void* pTarget, int nOffsetROM, unsigned int nSize) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r26
     // void* pTarget; // r27
-    // s32 nOffsetROM; // r28
-    // u32 nSize; // r29
+    // int nOffsetROM; // r28
+    // unsigned int nSize; // r29
 
     // Local variables
     void* pSource; // r4
     struct __anon_0x4CFE6* pBlock; // r3
-    s32 nOffsetARAM; // r23
-    s32 nSizeCopy; // r31
-    s32 nOffsetBlock; // r1+0x8
-    s32 nSizeCopyARAM; // r22
-    s32 nSizeDMA; // r21
-    s32 nOffset; // r20
-    s32 nOffsetTarget; // r19
+    int nOffsetARAM; // r23
+    int nSizeCopy; // r31
+    int nOffsetBlock; // r1+0x8
+    int nSizeCopyARAM; // r22
+    int nSizeDMA; // r21
+    int nOffset; // r20
+    int nOffsetTarget; // r19
     u8* pBuffer; // r30
     u8 anBuffer[608]; // r1+0x18
 }
 
 // Range: 0x8006D830 -> 0x8006D990
-s32 romUpdate(struct __anon_0x4D873* pROM) {
+int romUpdate(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r31
 
     // Local variables
-    s32 nStatus; // r30
+    int nStatus; // r30
 }
 
 // Erased
-static s32 romCopyBusy(struct __anon_0x4D873* pROM) {
+static int romCopyBusy(struct __anon_0x4D873* pROM) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
 }
 
 // Range: 0x8006D794 -> 0x8006D830
-s32 romSetCacheSize(struct __anon_0x4D873* pROM, s32 nSize) {
+int romSetCacheSize(struct __anon_0x4D873* pROM, int nSize) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r30
-    // s32 nSize; // r4
+    // int nSize; // r4
 }
 
 // Erased
-static s32 romGetCacheSize(struct __anon_0x4D873* pROM, s32* pnSize) {
+static int romGetCacheSize(struct __anon_0x4D873* pROM, int* pnSize) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
-    // s32* pnSize; // r1+0x4
+    // int* pnSize; // r1+0x4
 }
 
 // Range: 0x8006D620 -> 0x8006D794
-s32 romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
+int romSetImage(struct __anon_0x4D873* pROM, char* szNameFile) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r28
     // char* szNameFile; // r29
 
     // Local variables
     struct tXL_FILE* pFile; // r1+0x14
-    s32 iName; // r5
-    s32 nSize; // r1+0x10
+    int iName; // r5
+    int nSize; // r1+0x10
 }
 
 // Range: 0x8006D5D8 -> 0x8006D620
-s32 romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
+int romGetImage(struct __anon_0x4D873* pROM, char* acNameFile) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r1+0x0
     // char* acNameFile; // r1+0x4
 
     // Local variables
-    s32 iName; // r6
+    int iName; // r6
 }
 
 // Range: 0x8006D3AC -> 0x8006D5D8
-s32 romEvent(struct __anon_0x4D873* pROM, s32 nEvent, void* pArgument) {
+int romEvent(struct __anon_0x4D873* pROM, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x4D873* pROM; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/rsp.c
+++ b/debug/Fire/rsp.c
@@ -9,34 +9,34 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x56F42; // size = 0x10
 
 // size = 0x10, address = 0x800EE220
 struct _XL_OBJECTTYPE gClassRSP;
 
 // size = 0x20, address = 0x800EE230
-s32 cmask_tab[8];
+int cmask_tab[8];
 
 // size = 0x20, address = 0x800EE250
-s32 emask_tab[8];
+int emask_tab[8];
 
 // size = 0x4, address = 0x801352C4
-static s32 nFirstTime$2148;
+static int nFirstTime$2148;
 
 // size = 0x4, address = 0x80135788
-static s32 counter$2409;
+static int counter$2409;
 
 // size = 0x4, address = 0x801352C8
-static s32 nFirstTime$2648;
+static int nFirstTime$2648;
 
 // size = 0x4, address = 0x801352CC
-static s32 nFirstTime$2757;
+static int nFirstTime$2757;
 
 // size = 0x4, address = 0x801352D0
-static s32 nFirstTime$2796;
+static int nFirstTime$2796;
 
 // size = 0x2, address = 0x8013578C
 static u16 scissorX0;
@@ -54,10 +54,10 @@ static u16 scissorY1;
 static u8 flagBilerp;
 
 // size = 0x4, address = 0x80135794
-static u32 rdpSetTimg_w0;
+static unsigned int rdpSetTimg_w0;
 
 // size = 0x4, address = 0x80135798
-static u32 rdpSetTile_w0;
+static unsigned int rdpSetTile_w0;
 
 // size = 0x2, address = 0x8013579C
 static u16 tmemSliceWmax;
@@ -72,7 +72,7 @@ static u16 flagSplit;
 static u16 imagePtrX0;
 
 // size = 0x4, address = 0x801357A4
-static u32 imageTop;
+static unsigned int imageTop;
 
 // size = 0x2, address = 0x801357A8
 static s16 tmemSrcLines;
@@ -87,33 +87,33 @@ static s16 TMEMMASK$3464[4];
 static s16 TMEMSHIFT$3465[4];
 
 typedef struct __anon_0x575BD {
-    /* 0x00 */ s32 nType;
-    /* 0x04 */ s32 nFlag;
-    /* 0x08 */ s32 nOffsetBoot;
-    /* 0x0C */ s32 nLengthBoot;
-    /* 0x10 */ s32 nOffsetCode;
-    /* 0x14 */ s32 nLengthCode;
-    /* 0x18 */ s32 nOffsetData;
-    /* 0x1C */ s32 nLengthData;
-    /* 0x20 */ s32 nOffsetStack;
-    /* 0x24 */ s32 nLengthStack;
-    /* 0x28 */ s32 nOffsetBuffer;
-    /* 0x2C */ s32 nLengthBuffer;
-    /* 0x30 */ s32 nOffsetMBI;
-    /* 0x34 */ s32 nLengthMBI;
-    /* 0x38 */ s32 nOffsetYield;
-    /* 0x3C */ s32 nLengthYield;
+    /* 0x00 */ int nType;
+    /* 0x04 */ int nFlag;
+    /* 0x08 */ int nOffsetBoot;
+    /* 0x0C */ int nLengthBoot;
+    /* 0x10 */ int nOffsetCode;
+    /* 0x14 */ int nLengthCode;
+    /* 0x18 */ int nOffsetData;
+    /* 0x1C */ int nLengthData;
+    /* 0x20 */ int nOffsetStack;
+    /* 0x24 */ int nLengthStack;
+    /* 0x28 */ int nOffsetBuffer;
+    /* 0x2C */ int nLengthBuffer;
+    /* 0x30 */ int nOffsetMBI;
+    /* 0x34 */ int nLengthMBI;
+    /* 0x38 */ int nOffsetYield;
+    /* 0x3C */ int nLengthYield;
 } __anon_0x575BD; // size = 0x40
 
 typedef struct __anon_0x57890 {
-    /* 0x00 */ s32 iDL;
-    /* 0x04 */ s32 bValid;
+    /* 0x00 */ int iDL;
+    /* 0x04 */ int bValid;
     /* 0x08 */ struct __anon_0x575BD task;
-    /* 0x48 */ s32 nCountVertex;
+    /* 0x48 */ int nCountVertex;
     /* 0x4C */ enum __anon_0x60B3F eTypeUCode;
-    /* 0x50 */ u32 n2TriMult;
-    /* 0x54 */ u32 nVersionUCode;
-    /* 0x58 */ s32 anBaseSegment[16];
+    /* 0x50 */ unsigned int n2TriMult;
+    /* 0x54 */ unsigned int nVersionUCode;
+    /* 0x58 */ int anBaseSegment[16];
     /* 0x98 */ u64* apDL[16];
 } __anon_0x57890; // size = 0xD8
 
@@ -169,8 +169,8 @@ typedef enum __anon_0x581E7 {
 } __anon_0x581E7;
 
 typedef struct tXL_LIST {
-    /* 0x0 */ s32 nItemSize;
-    /* 0x4 */ s32 nItemCount;
+    /* 0x0 */ int nItemSize;
+    /* 0x4 */ int nItemCount;
     /* 0x8 */ void* pNodeHead;
     /* 0xC */ void* pNodeNext;
 } __anon_0x58263; // size = 0x10
@@ -189,34 +189,34 @@ typedef struct __anon_0x583EE {
 } __anon_0x583EE; // size = 0x6
 
 typedef struct __anon_0x5845E {
-    /* 0x0000 */ s32 nMode;
+    /* 0x0000 */ int nMode;
     /* 0x0004 */ struct __anon_0x57890 yield;
-    /* 0x00DC */ u32 nTickLast;
-    /* 0x00E0 */ s32 (*pfUpdateWaiting)();
-    /* 0x00E4 */ u32 n2TriMult;
-    /* 0x00E8 */ s32 aStatus[4];
+    /* 0x00DC */ unsigned int nTickLast;
+    /* 0x00E0 */ int (*pfUpdateWaiting)();
+    /* 0x00E4 */ unsigned int n2TriMult;
+    /* 0x00E8 */ int aStatus[4];
     /* 0x00F8 */ f32 aMatrixOrtho[4][4];
-    /* 0x0138 */ u32 nMode2D;
+    /* 0x0138 */ unsigned int nMode2D;
     /* 0x013C */ struct __anon_0x57AB1 twoDValues;
-    /* 0x015C */ s32 nPass;
-    /* 0x0160 */ u32 nZSortSubDL;
-    /* 0x0164 */ u32 nStatusSubDL;
-    /* 0x0168 */ u32 nNumZSortLights;
-    /* 0x016C */ s32 aLightAddresses[8];
-    /* 0x018C */ s32 nAmbientLightAddress;
+    /* 0x015C */ int nPass;
+    /* 0x0160 */ unsigned int nZSortSubDL;
+    /* 0x0164 */ unsigned int nStatusSubDL;
+    /* 0x0168 */ unsigned int nNumZSortLights;
+    /* 0x016C */ int aLightAddresses[8];
+    /* 0x018C */ int nAmbientLightAddress;
     /* 0x0190 */ struct __anon_0x57BBE aZSortVertex[128];
     /* 0x0B90 */ struct __anon_0x57CD6 aZSortNormal[128];
     /* 0x0D10 */ struct __anon_0x57D55 aZSortMaterial[128];
     /* 0x0F10 */ struct __anon_0x57DF8 aZSortMatrix[128];
     /* 0x2F10 */ struct __anon_0x57E56 aZSortLight[8];
-    /* 0x2F40 */ s32 aZSortInvW[128];
+    /* 0x2F40 */ int aZSortInvW[128];
     /* 0x3140 */ s16 aZSortWiVal[128];
-    /* 0x3240 */ u32 nNumZSortMatrices;
-    /* 0x3244 */ u32 nNumZSortVertices;
-    /* 0x3248 */ u32 nTotalZSortVertices;
-    /* 0x324C */ u32 nNumZSortNormals;
-    /* 0x3250 */ u32 nNumZSortMaterials;
-    /* 0x3254 */ s32 anAudioBaseSegment[16];
+    /* 0x3240 */ unsigned int nNumZSortMatrices;
+    /* 0x3244 */ unsigned int nNumZSortVertices;
+    /* 0x3248 */ unsigned int nTotalZSortVertices;
+    /* 0x324C */ unsigned int nNumZSortNormals;
+    /* 0x3250 */ unsigned int nNumZSortMaterials;
+    /* 0x3254 */ int anAudioBaseSegment[16];
     /* 0x3294 */ s16* anAudioBuffer;
     /* 0x3298 */ s16 anADPCMCoef[5][2][8];
     /* 0x3338 */ u16 nAudioDMOutR[2];
@@ -226,24 +226,24 @@ typedef struct __anon_0x5845E {
     /* 0x3348 */ u16 nAudioFlags;
     /* 0x334A */ u16 nAudioDMEMIn[2];
     /* 0x334E */ u16 nAudioDMEMOut[2];
-    /* 0x3354 */ u32 nAudioLoopAddress;
-    /* 0x3358 */ u32 nAudioDryAmt;
-    /* 0x335C */ u32 nAudioWetAmt;
-    /* 0x3360 */ u32 nAudioVolL;
-    /* 0x3364 */ u32 nAudioVolR;
-    /* 0x3368 */ u32 nAudioVolTGTL;
-    /* 0x336C */ u32 nAudioVolRateLM;
-    /* 0x3370 */ u32 nAudioVolRateLL;
-    /* 0x3374 */ u32 nAudioVolTGTR;
-    /* 0x3378 */ u32 nAudioVolRateRM;
-    /* 0x337C */ u32 nAudioVolRateRL;
+    /* 0x3354 */ unsigned int nAudioLoopAddress;
+    /* 0x3358 */ unsigned int nAudioDryAmt;
+    /* 0x335C */ unsigned int nAudioWetAmt;
+    /* 0x3360 */ unsigned int nAudioVolL;
+    /* 0x3364 */ unsigned int nAudioVolR;
+    /* 0x3368 */ unsigned int nAudioVolTGTL;
+    /* 0x336C */ unsigned int nAudioVolRateLM;
+    /* 0x3370 */ unsigned int nAudioVolRateLL;
+    /* 0x3374 */ unsigned int nAudioVolTGTR;
+    /* 0x3378 */ unsigned int nAudioVolRateRM;
+    /* 0x337C */ unsigned int nAudioVolRateRL;
     /* 0x3380 */ struct __anon_0x58107 vParams;
     /* 0x3390 */ s16 stepF;
     /* 0x3392 */ s16 stepL;
     /* 0x3394 */ s16 stepR;
-    /* 0x3398 */ s32 anGenReg[32];
+    /* 0x3398 */ int anGenReg[32];
     /* 0x3418 */ struct __anon_0x58107 aVectorReg[32];
-    /* 0x3618 */ s32 anCP0Reg[32];
+    /* 0x3618 */ int anCP0Reg[32];
     /* 0x3698 */ struct __anon_0x58107 anCP2Reg[32];
     /* 0x3898 */ s16 anAcc[24];
     /* 0x38C8 */ s16 nVCC;
@@ -254,40 +254,40 @@ typedef struct __anon_0x5845E {
     /* 0x38D6 */ u16 nAudioADPCMOffset;
     /* 0x38D8 */ u16 nAudioScratchOffset;
     /* 0x38DA */ u16 nAudioParBase;
-    /* 0x38DC */ s32 nPC;
-    /* 0x38E0 */ s32 iDL;
-    /* 0x38E4 */ s32 nBIST;
+    /* 0x38DC */ int nPC;
+    /* 0x38E0 */ int iDL;
+    /* 0x38E4 */ int nBIST;
     /* 0x38E8 */ void* pHost;
     /* 0x38EC */ void* pDMEM;
     /* 0x38F0 */ void* pIMEM;
-    /* 0x38F4 */ s32 nStatus;
-    /* 0x38F8 */ s32 nFullDMA;
-    /* 0x38FC */ s32 nBusyDMA;
-    /* 0x3900 */ s32 nSizeGet;
-    /* 0x3904 */ s32 nSizePut;
-    /* 0x3908 */ s32 nSemaphore;
-    /* 0x390C */ s32 nAddressSP;
-    /* 0x3910 */ s32 nGeometryMode;
-    /* 0x3914 */ s32 nAddressRDRAM;
+    /* 0x38F4 */ int nStatus;
+    /* 0x38F8 */ int nFullDMA;
+    /* 0x38FC */ int nBusyDMA;
+    /* 0x3900 */ int nSizeGet;
+    /* 0x3904 */ int nSizePut;
+    /* 0x3908 */ int nSemaphore;
+    /* 0x390C */ int nAddressSP;
+    /* 0x3910 */ int nGeometryMode;
+    /* 0x3914 */ int nAddressRDRAM;
     /* 0x3918 */ struct tXL_LIST* pListUCode;
-    /* 0x391C */ s32 nCountVertex;
+    /* 0x391C */ int nCountVertex;
     /* 0x3920 */ enum __anon_0x60B3F eTypeUCode;
-    /* 0x3924 */ u32 nVersionUCode;
-    /* 0x3928 */ s32 anBaseSegment[16];
+    /* 0x3924 */ unsigned int nVersionUCode;
+    /* 0x3928 */ int anBaseSegment[16];
     /* 0x3968 */ u64* apDL[16];
-    /* 0x39A8 */ s32* Coeff;
+    /* 0x39A8 */ int* Coeff;
     /* 0x39AC */ s16* QTable;
     /* 0x39B0 */ s16* QYTable;
     /* 0x39B4 */ s16* QCbTable;
     /* 0x39B8 */ s16* QCrTable;
-    /* 0x39BC */ s32* Zigzag;
+    /* 0x39BC */ int* Zigzag;
     /* 0x39C0 */ struct __anon_0x58360* rgbaBuf;
     /* 0x39C4 */ struct __anon_0x583EE* yuvBuf;
-    /* 0x39C8 */ s32* dctBuf;
+    /* 0x39C8 */ int* dctBuf;
 } __anon_0x5845E; // size = 0x39CC
 
 // size = 0x4, address = 0x801356BC
-s32 gNoSwapBuffer;
+int gNoSwapBuffer;
 
 typedef enum __anon_0x5943B {
     RUM_NONE = 0,
@@ -302,11 +302,11 @@ typedef struct __anon_0x594BE {
 } __anon_0x594BE; // size = 0x10
 
 typedef struct __anon_0x59558 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x59558; // size = 0x14
 
 typedef struct __anon_0x59699 {
@@ -316,7 +316,7 @@ typedef struct __anon_0x59699 {
 } __anon_0x59699; // size = 0xC
 
 typedef struct __anon_0x59709 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x59699 rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -333,7 +333,7 @@ typedef struct __anon_0x59709 {
 } __anon_0x59709; // size = 0x3C
 
 typedef struct __anon_0x59939 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x59699 rS;
     /* 0x10 */ struct __anon_0x59699 rT;
     /* 0x1C */ struct __anon_0x59699 rSRaw;
@@ -351,7 +351,7 @@ typedef struct __anon_0x59A22 {
 typedef union __anon_0x59B81 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x59B81;
 
@@ -404,20 +404,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x59F26;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -426,11 +426,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x59F8F; // size = 0x6C
 
 typedef struct __anon_0x5A2EC {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -441,7 +441,7 @@ typedef struct __anon_0x5A2EC {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x5A2EC; // size = 0x2C
 
 typedef enum __anon_0x5A5CE {
@@ -451,14 +451,14 @@ typedef enum __anon_0x5A5CE {
 } __anon_0x5A5CE;
 
 typedef struct __anon_0x5A64F {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x5A5CE eProjection;
 } __anon_0x5A64F; // size = 0x24
 
@@ -470,81 +470,81 @@ typedef struct _GXColor {
 } __anon_0x5A7E4; // size = 0x4
 
 typedef struct __anon_0x5A89F {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x594BE viewport;
     /* 0x000C8 */ struct __anon_0x59558 aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x59709 aLight[8];
     /* 0x00320 */ struct __anon_0x59939 lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x59A22 aVertex[80];
     /* 0x00C18 */ struct __anon_0x59C1E TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x5A2EC aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x5A5CE eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -555,50 +555,50 @@ typedef struct __anon_0x5A89F {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x5A89F; // size = 0x3D150
 
 typedef struct __anon_0x5B8F2 {
-    /* 0x00 */ s32 nOffsetCode;
-    /* 0x04 */ s32 nLengthCode;
-    /* 0x08 */ s32 nOffsetData;
-    /* 0x0C */ s32 nLengthData;
+    /* 0x00 */ int nOffsetCode;
+    /* 0x04 */ int nLengthCode;
+    /* 0x08 */ int nOffsetData;
+    /* 0x0C */ int nLengthData;
     /* 0x10 */ char acUCodeName[64];
     /* 0x50 */ u64 nUCodeCheckSum;
-    /* 0x58 */ s32 nCountVertex;
+    /* 0x58 */ int nCountVertex;
     /* 0x5C */ enum __anon_0x60B3F eType;
 } __anon_0x5B8F2; // size = 0x60
 
 typedef struct __anon_0x5C1E6 {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x5C1E6; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x5C24C; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x5C1E6* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -617,8 +617,8 @@ typedef union __anon_0x5C59B {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -632,8 +632,8 @@ typedef union __anon_0x5C59B {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x5C59B;
 
@@ -641,57 +641,57 @@ typedef union __anon_0x5C9AF {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x5C9AF;
 
 typedef struct __anon_0x5CEBD {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x5CEBD; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x5D18B; // size = 0x84
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x5D3CC; // size = 0xC
 
 typedef struct __anon_0x5D481 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x5D481; // size = 0xC
 
 typedef struct OSContext {
@@ -723,61 +723,61 @@ typedef struct OSAlarm {
 } __anon_0x5D803; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x5D91E; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x5C59B aGPR[32];
     /* 0x00140 */ union __anon_0x5C9AF aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x5CEBD* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x5D481 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x5DACB; // size = 0x12090
 
@@ -788,10 +788,10 @@ typedef enum __anon_0x5E613 {
 } __anon_0x5E613;
 
 typedef struct __anon_0x5E675 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x5E675; // size = 0x10
 
 typedef enum __anon_0x5E726 {
@@ -835,7 +835,7 @@ typedef enum __anon_0x5E852 {
 typedef struct __anon_0x5E98D {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x5E613 eMode;
     /* 0x10 */ struct __anon_0x5E675 romCopy;
     /* 0x20 */ enum __anon_0x5E726 eTypeROM;
@@ -843,21 +843,21 @@ typedef struct __anon_0x5E98D {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x5E852 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x5E98D; // size = 0x88
 
 // size = 0x4, address = 0x80135600
 struct __anon_0x5E98D* gpSystem;
 
 typedef struct __anon_0x5EBE0 {
-    /* 0x0 */ s32 nCount;
+    /* 0x0 */ int nCount;
     /* 0x4 */ u8 anData[768];
 } __anon_0x5EBE0; // size = 0x304
 
 typedef struct __anon_0x5EC3E {
     /* 0x0 */ s16 sx;
     /* 0x2 */ s16 sy;
-    /* 0x4 */ s32 invw;
+    /* 0x4 */ int invw;
     /* 0x8 */ s16 xi;
     /* 0xA */ s16 yi;
     /* 0xC */ u8 cc;
@@ -874,7 +874,7 @@ typedef struct __anon_0x5ED4F {
     /* 0x0A */ u16 imageH;
     /* 0x0C */ s16 frameY;
     /* 0x0E */ u16 frameH;
-    /* 0x10 */ u32 imagePtr;
+    /* 0x10 */ unsigned int imagePtr;
     /* 0x14 */ u16 imageLoad;
     /* 0x16 */ u8 imageFmt;
     /* 0x17 */ u8 imageSiz;
@@ -897,7 +897,7 @@ typedef struct __anon_0x5F05A {
     /* 0x0A */ u16 imageH;
     /* 0x0C */ s16 frameY;
     /* 0x0E */ u16 frameH;
-    /* 0x10 */ u32 imagePtr;
+    /* 0x10 */ unsigned int imagePtr;
     /* 0x14 */ u16 imageLoad;
     /* 0x16 */ u8 imageFmt;
     /* 0x17 */ u8 imageSiz;
@@ -905,7 +905,7 @@ typedef struct __anon_0x5F05A {
     /* 0x1A */ u16 imageFlip;
     /* 0x1C */ u16 scaleW;
     /* 0x1E */ u16 scaleH;
-    /* 0x20 */ s32 imageYorig;
+    /* 0x20 */ int imageYorig;
     /* 0x24 */ u8 padding[4];
 } __anon_0x5F05A; // size = 0x28
 
@@ -944,12 +944,12 @@ typedef struct __anon_0x5F6E9 {
 } __anon_0x5F6E9; // size = 0xC
 
 typedef struct __anon_0x5F759 {
-    /* 0x00 */ s32 bFlip;
-    /* 0x04 */ s32 iTile;
-    /* 0x08 */ s32 nX0;
-    /* 0x0C */ s32 nY0;
-    /* 0x10 */ s32 nX1;
-    /* 0x14 */ s32 nY1;
+    /* 0x00 */ int bFlip;
+    /* 0x04 */ int iTile;
+    /* 0x08 */ int nX0;
+    /* 0x0C */ int nY0;
+    /* 0x10 */ int nX1;
+    /* 0x14 */ int nY1;
     /* 0x18 */ f32 rS;
     /* 0x1C */ f32 rT;
     /* 0x20 */ f32 rDeltaS;
@@ -957,36 +957,36 @@ typedef struct __anon_0x5F759 {
 } __anon_0x5F759; // size = 0x28
 
 typedef struct __anon_0x5F8B9 {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 tmem;
     /* 0x0A */ u16 tsize;
     /* 0x0C */ u16 tline;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x5F8B9; // size = 0x18
 
 typedef struct __anon_0x5F9D9 {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 tmem;
     /* 0x0A */ u16 twidth;
     /* 0x0C */ u16 theight;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x5F9D9; // size = 0x18
 
 typedef struct __anon_0x5FAFC {
-    /* 0x00 */ u32 type;
-    /* 0x04 */ u32 image;
+    /* 0x00 */ unsigned int type;
+    /* 0x04 */ unsigned int image;
     /* 0x08 */ u16 phead;
     /* 0x0A */ u16 pnum;
     /* 0x0C */ u16 zero;
     /* 0x0E */ u16 sid;
-    /* 0x10 */ u32 flag;
-    /* 0x14 */ u32 mask;
+    /* 0x10 */ unsigned int flag;
+    /* 0x14 */ unsigned int mask;
 } __anon_0x5FAFC; // size = 0x18
 
 typedef union __anon_0x5FC1B {
@@ -1035,12 +1035,12 @@ typedef struct DVDFileInfo {
 } __anon_0x606E5; // size = 0x3C
 
 typedef struct tXL_FILE {
-    /* 0x00 */ s32 iBuffer;
+    /* 0x00 */ int iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
-    /* 0x0C */ s32 nAttributes;
-    /* 0x10 */ s32 nSize;
-    /* 0x14 */ s32 nOffset;
+    /* 0x0C */ int nAttributes;
+    /* 0x10 */ int nSize;
+    /* 0x14 */ int nOffset;
     /* 0x18 */ enum __anon_0x6029B eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x6079D; // size = 0x58
@@ -1064,16 +1064,16 @@ typedef enum __anon_0x60B3F {
 } __anon_0x60B3F;
 
 // Range: 0x800741CC -> 0x80074454
-static s32 rspLoadMatrix(struct __anon_0x5845E* pRSP, s32 nAddress, f32 (*matrix)[4]) {
+static int rspLoadMatrix(struct __anon_0x5845E* pRSP, int nAddress, f32 (*matrix)[4]) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nAddress; // r4
+    // int nAddress; // r4
     // f32 (* matrix)[4]; // r31
 
     // Local variables
-    s32* pMtx; // r1+0x18
-    s32 nDataA; // r6
-    s32 nDataB; // r7
+    int* pMtx; // r1+0x18
+    int nDataA; // r6
+    int nDataB; // r7
     f32 rScale; // f31
     f32 rUpper; // r1+0x8
     f32 rLower; // r1+0x8
@@ -1082,25 +1082,25 @@ static s32 rspLoadMatrix(struct __anon_0x5845E* pRSP, s32 nAddress, f32 (*matrix
 }
 
 // Erased
-static s32 rspSetDL(struct __anon_0x5845E* pRSP, s32 nOffsetRDRAM, s32 bPush) {
+static int rspSetDL(struct __anon_0x5845E* pRSP, int nOffsetRDRAM, int bPush) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // s32 nOffsetRDRAM; // r1+0xC
-    // s32 bPush; // r31
+    // int nOffsetRDRAM; // r1+0xC
+    // int bPush; // r31
 
     // Local variables
-    s32 nAddress; // r5
-    s32* pDL; // r1+0x14
+    int nAddress; // r5
+    signed int* pDL; // r1+0x14
 }
 
 // Erased
-static s32 rspPopDL(struct __anon_0x5845E* pRSP) {
+static int rspPopDL(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
 }
 
 // Erased
-static s32 rspSetupUCode(struct __anon_0x5845E* pRSP) {
+static int rspSetupUCode(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
 
@@ -1109,232 +1109,232 @@ static s32 rspSetupUCode(struct __anon_0x5845E* pRSP) {
 }
 
 // Erased
-static s32 rspGetNumUCodes(struct __anon_0x5845E* pRSP, u32* pNumCodes) {
+static int rspGetNumUCodes(struct __anon_0x5845E* pRSP, unsigned int* pNumCodes) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32* pNumCodes; // r1+0x4
+    // unsigned int* pNumCodes; // r1+0x4
 }
 
 // Erased
-static s32 rspGetUCodeName(struct __anon_0x5845E* pRSP) {
+static int rspGetUCodeName(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
 
     // Local variables
-    u32 nItemCount; // r1+0x0
+    unsigned int nItemCount; // r1+0x0
     void* pListNode; // r3
 }
 
 // Range: 0x8007306C -> 0x800741CC
-static s32 rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspFindUCode(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r24
     // struct __anon_0x575BD* pTask; // r1+0xC
 
     // Local variables
-    s32 nCountVertex; // r16
+    int nCountVertex; // r16
     struct __anon_0x5B8F2* pUCode; // r1+0x1080
     enum __anon_0x60B3F eType; // r17
     void* pListNode; // r5
-    s32 nOffsetCode; // r1+0x108C
-    s32 nOffsetData; // r14
+    int nOffsetCode; // r1+0x108C
+    int nOffsetData; // r14
     u64 nFUData; // r30
     u64* pFUData; // r1+0x107C
     u64* pFUCode; // r1+0x1078
     u64 nCheckSum; // r27
-    u32 nLengthData; // r1+0x1088
-    u32 i; // r6
-    u32 nLengthCode; // r1+0x1084
+    unsigned int nLengthData; // r1+0x1088
+    unsigned int i; // r6
+    unsigned int nLengthCode; // r1+0x1084
     char aBigBuffer[4096]; // r1+0x5C
     char acUCodeName[64]; // r1+0x1C
 }
 
 // Range: 0x80072EF4 -> 0x8007306C
-static s32 rspSaveYield(struct __anon_0x5845E* pRSP) {
+static int rspSaveYield(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r7
 
     // Local variables
-    s32 iData; // r1+0x8
+    int iData; // r1+0x8
     struct __anon_0x575BD* pTask; // r4
 }
 
 // Range: 0x80072D6C -> 0x80072EF4
-static s32 rspLoadYield(struct __anon_0x5845E* pRSP) {
+static int rspLoadYield(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
 
     // Local variables
-    s32 iData; // r1+0x8
+    int iData; // r1+0x8
     struct __anon_0x575BD* pTask; // r3
 }
 
 // Erased
-static s32 rspParseDisplayLists(struct __anon_0x5845E* pRSP) {
+static int rspParseDisplayLists(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
 
     // Local variables
-    s32 bDone; // r1+0xC
-    s32 nStatus; // r3
-    s32* pDL; // r1+0x8
+    int bDone; // r1+0xC
+    int nStatus; // r3
+    signed int* pDL; // r1+0x8
     u64 nGBI; // r30
 }
 
 // Erased
-static s32 rspTaskComplete(struct __anon_0x5845E* pRSP, s32 bUsedSP, s32 bUsedDP) {
+static int rspTaskComplete(struct __anon_0x5845E* pRSP, int bUsedSP, int bUsedDP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // s32 bUsedSP; // r1+0xC
-    // s32 bUsedDP; // r31
+    // int bUsedSP; // r1+0xC
+    // int bUsedDP; // r31
 }
 
 // Range: 0x80072C10 -> 0x80072D6C
-static s32 rspParseGBI_Setup(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspParseGBI_Setup(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
     // struct __anon_0x575BD* pTask; // r31
 
     // Local variables
-    s32 iSegment; // r1+0x8
+    int iSegment; // r1+0x8
 }
 
 // Range: 0x80072A5C -> 0x80072C10
-static s32 rspParseGBI(struct __anon_0x5845E* pRSP, s32* pbDone, s32 nCount) {
+static int rspParseGBI(struct __anon_0x5845E* pRSP, int* pbDone, int nCount) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r27
-    // s32* pbDone; // r28
-    // s32 nCount; // r29
+    // int* pbDone; // r28
+    // int nCount; // r29
 
     // Local variables
-    s32 bDone; // r1+0x14
-    s32 nStatus; // r3
+    int bDone; // r1+0x14
+    int nStatus; // r3
     u64* pDL; // r26
     struct _CPU* pCPU; // r30
 }
 
 // Erased
-static s32 rspSaveUCode() {}
+static int rspSaveUCode() {}
 
 // Range: 0x80072A08 -> 0x80072A5C
-s32 rspPut8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+int rspPut8(struct __anon_0x5845E* pRSP, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x800729B4 -> 0x80072A08
-s32 rspPut16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+int rspPut16(struct __anon_0x5845E* pRSP, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x80072384 -> 0x800729B4
-s32 rspPut32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+int rspPut32(struct __anon_0x5845E* pRSP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
     struct __anon_0x575BD* pTask; // r4
-    s32 nData; // r31
-    s32 nSize; // r1+0x24
+    int nData; // r31
+    int nSize; // r1+0x24
     void* pTarget; // r1+0x20
     void* pSource; // r4
-    s32 nLength; // r5
+    int nLength; // r5
 }
 
 // Range: 0x80072318 -> 0x80072384
-s32 rspPut64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+int rspPut64(struct __anon_0x5845E* pRSP, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x800722C4 -> 0x80072318
-s32 rspGet8(struct __anon_0x5845E* pRSP, u32 nAddress, char* pData) {
+int rspGet8(struct __anon_0x5845E* pRSP, unsigned int nAddress, char* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // char* pData; // r1+0x8
 }
 
 // Range: 0x80072270 -> 0x800722C4
-s32 rspGet16(struct __anon_0x5845E* pRSP, u32 nAddress, s16* pData) {
+int rspGet16(struct __anon_0x5845E* pRSP, unsigned int nAddress, s16* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x80072124 -> 0x80072270
-s32 rspGet32(struct __anon_0x5845E* pRSP, u32 nAddress, s32* pData) {
+int rspGet32(struct __anon_0x5845E* pRSP, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x800720B8 -> 0x80072124
-s32 rspGet64(struct __anon_0x5845E* pRSP, u32 nAddress, s64* pData) {
+int rspGet64(struct __anon_0x5845E* pRSP, unsigned int nAddress, s64* pData) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // u32 nAddress; // r1+0x4
+    // unsigned int nAddress; // r1+0x4
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x80071FE0 -> 0x800720B8
-s32 rspInvalidateCache(struct __anon_0x5845E* pRSP, s32 nOffset0, s32 nOffset1) {
+int rspInvalidateCache(struct __anon_0x5845E* pRSP, int nOffset0, int nOffset1) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r28
-    // s32 nOffset0; // r29
-    // s32 nOffset1; // r30
+    // int nOffset0; // r29
+    // int nOffset1; // r30
 
     // Local variables
     struct __anon_0x5B8F2* pUCode; // r1+0x14
     void* pListNode; // r31
-    s32 nOffsetUCode0; // r3
-    s32 nOffsetUCode1; // r1+0x8
+    int nOffsetUCode0; // r3
+    int nOffsetUCode1; // r1+0x8
 }
 
 // Range: 0x80071FC0 -> 0x80071FE0
-s32 rspEnableABI(struct __anon_0x5845E* pRSP, s32 bFlag) {
+int rspEnableABI(struct __anon_0x5845E* pRSP, int bFlag) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
-    // s32 bFlag; // r1+0x4
+    // int bFlag; // r1+0x4
 }
 
 // Range: 0x80071F6C -> 0x80071FC0
-s32 rspFrameComplete(struct __anon_0x5845E* pRSP) {
+int rspFrameComplete(struct __anon_0x5845E* pRSP) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r31
 }
 
 // Range: 0x80071D8C -> 0x80071F6C
-s32 rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
+int rspUpdate(struct __anon_0x5845E* pRSP, enum __anon_0x5943B eMode) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r29
     // enum __anon_0x5943B eMode; // r30
 
     // Local variables
     struct __anon_0x575BD* pTask; // r4
-    s32 bDone; // r1+0x10
-    s32 nCount; // r31
+    int bDone; // r1+0x10
+    int nCount; // r31
     struct __anon_0x5A89F* pFrame; // r28
 
     // References
-    // -> s32 gNoSwapBuffer;
+    // -> int gNoSwapBuffer;
 }
 
 // Range: 0x80071BB8 -> 0x80071D8C
-s32 rspEvent(struct __anon_0x5845E* pRSP, s32 nEvent, void* pArgument) {
+int rspEvent(struct __anon_0x5845E* pRSP, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/rspASM.c
+++ b/debug/Fire/rspASM.c
@@ -8,349 +8,349 @@
 #include "dolphin/types.h"
 
 // Erased
-static s32 rspVMULF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMULF(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r31
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r20
+    int i; // r20
     u16 du; // r1+0x8
     s64 taccum; // r19
     s64 clampMask; // r17
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMUDL(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r19
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r31
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r22
+    int i; // r22
     u16 du; // r1+0x8
     s64 taccum; // r3
     s64 clampMask; // r21
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMUDM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMUDM(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r17
     // s16* pVecResult; // r6
-    // u32 nElement; // r18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r23
+    int i; // r23
     u16 du; // r1+0x8
     s64 taccum; // r22
     s64 clampMask; // r20
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Range: 0x8008D0B0 -> 0x8008D248
-static s32 rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+static int rspVMUDN(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, s64* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
+    // unsigned int nElement; // r31
     // s64* pAcc; // r8
 
     // Local variables
-    s32 i; // r20
+    int i; // r20
     u16 du; // r1+0x8
     s64 taccum; // r19
     s64 clampMask; // r17
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMUDH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMUDH(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r31
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r22
+    int i; // r22
     u16 du; // r1+0x8
     s64 taccum; // r21
     s64 clampMask; // r19
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMACF(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r17
     // s16* pVecResult; // r6
-    // u32 nElement; // r18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r23
+    int i; // r23
     u16 du; // r1+0x8
     s64 taccum; // r22
     s64 clampMask; // r20
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMADL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMADL(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r27
     // s16* pVecResult; // r6
-    // u32 nElement; // r28
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r28
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r31
+    int i; // r31
     u16 du; // r1+0x8
     s64 taccum; // r3
     s64 clampMask; // r30
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMADM(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMADM(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r17
     // s16* pVecResult; // r6
-    // u32 nElement; // r18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r23
+    int i; // r23
     u16 du; // r1+0x8
     s64 taccum; // r22
     s64 clampMask; // r20
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Range: 0x8008CF0C -> 0x8008D0B0
-static s32 rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s64* pAcc) {
+static int rspVMADN(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, s64* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r30
     // s16* pVecResult; // r6
-    // u32 nElement; // r31
+    // unsigned int nElement; // r31
     // s64* pAcc; // r8
 
     // Local variables
-    s32 i; // r20
+    int i; // r20
     u16 du; // r1+0x8
     s64 taccum; // r19
     s64 clampMask; // r17
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVMADH(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r18
     // s16* pVecResult; // r6
-    // u32 nElement; // r19
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r19
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r24
+    int i; // r24
     u16 du; // r1+0x8
     s64 taccum; // r23
     s64 clampMask; // r21
 
     // References
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVADD(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVADD(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r10
-    s32 carry; // r28
-    s32 di; // r28
+    int i; // r10
+    int carry; // r28
+    int di; // r28
 
     // References
     // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVSUB(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVSUB(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r10
-    s32 borrow; // r28
-    s32 di; // r29
+    int i; // r10
+    int borrow; // r28
+    int di; // r29
 
     // References
     // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVADDC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVADDC(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r10
-    u32 di; // r27
+    int i; // r10
+    unsigned int di; // r27
 
     // References
     // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVSUBC(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVSUBC(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r10
-    s32 di; // r29
+    int i; // r10
+    int di; // r29
 
     // References
     // -> static u16 rsp_VCO;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVGE(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVGE(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
-    s32 i; // r12
+    int i; // r12
     s16 si; // r1+0x8
     s16 ti; // r1+0x8
 
     // References
     // -> static u16 rsp_VCO;
     // -> static u16 rsp_VCC;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
     // -> static u8 vco_carry[8];
     // -> static u8 vco_equal[8];
 }
 
 // Erased
-static s32 rspVCL(s16* pVec1, s16* pVec2, s16* pVecResult, u32 nElement, s32* pAcc) {
+static int rspVCL(s16* pVec1, s16* pVec2, s16* pVecResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pVec1; // r4
     // s16* pVec2; // r1+0x10
     // s16* pVecResult; // r6
-    // u32 nElement; // r1+0x18
-    // s32* pAcc; // r8
+    // unsigned int nElement; // r1+0x18
+    // signed int* pAcc; // r8
 
     // Local variables
     u16 sf; // r30
     u16 tf; // r29
-    s32 di; // r1+0x8
-    s32 i; // r28
-    s32 ge; // r11
-    s32 le; // r27
-    s32 vce; // r26
-    s32 eq; // r25
-    s32 carry; // r24
+    int di; // r1+0x8
+    int i; // r28
+    int ge; // r11
+    int le; // r27
+    int vce; // r26
+    int eq; // r25
+    int carry; // r24
 
     // References
     // -> static u8 rsp_VCE;
     // -> static u16 rsp_VCO;
     // -> static u16 rsp_VCC;
-    // -> s32 cmask_tab[8];
-    // -> s32 emask_tab[8];
+    // -> int cmask_tab[8];
+    // -> int emask_tab[8];
 }
 
 // Erased
-static s32 rspVSAW(s16* pResult, u32 nElement, s32* pAcc) {
+static int rspVSAW(s16* pResult, unsigned int nElement, signed int* pAcc) {
     // Parameters
     // s16* pResult; // r4
-    // u32 nElement; // r1+0x10
-    // s32* pAcc; // r6
+    // unsigned int nElement; // r1+0x10
+    // signed int* pAcc; // r6
 
     // Local variables
-    s32 i; // r29
-    s32 element; // r28
+    int i; // r29
+    int element; // r28
     u16 ri; // r1+0x8
 }
 
 // Erased
-static s32 rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+static int rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -359,7 +359,7 @@ static s32 rspAsmADD(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
 }
 
 // Erased
-static s32 rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+static int rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -368,7 +368,7 @@ static s32 rspAsmADDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate
 }
 
 // Erased
-static s32 rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+static int rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -377,7 +377,7 @@ static s32 rspAsmAND(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
 }
 
 // Erased
-static s32 rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+static int rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -386,7 +386,7 @@ static s32 rspAsmANDI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate
 }
 
 // Erased
-static s32 rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -395,7 +395,7 @@ static s32 rspAsmLB(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
 }
 
 // Erased
-static s32 rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -404,7 +404,7 @@ static s32 rspAsmLBU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) 
 }
 
 // Erased
-static s32 rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -413,7 +413,7 @@ static s32 rspAsmLH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
 }
 
 // Erased
-static s32 rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -422,7 +422,7 @@ static s32 rspAsmLHU(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) 
 }
 
 // Erased
-static s32 rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
+static int rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -430,7 +430,7 @@ static s32 rspAsmLUI(struct __anon_0x5845E* pRSP, s16 rt, s16 immediate) {
 }
 
 // Erased
-static s32 rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -439,7 +439,7 @@ static s32 rspAsmLW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
 }
 
 // Erased
-static s32 rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+static int rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -447,7 +447,7 @@ static s32 rspAsmMFC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
 }
 
 // Erased
-static s32 rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
+static int rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -455,7 +455,7 @@ static s32 rspAsmMTC0(struct __anon_0x5845E* pRSP, s16 rt, s16 rd) {
 }
 
 // Erased
-static s32 rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
+static int rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -464,10 +464,10 @@ static s32 rspAsmMTC2(struct __anon_0x5845E* pRSP, s16 rt, s16 vd, s16 e) {
 }
 
 // Erased
-static s32 rspAsmNOP() {}
+static int rspAsmNOP() {}
 
 // Erased
-static s32 rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+static int rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -476,7 +476,7 @@ static s32 rspAsmOR(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
 }
 
 // Erased
-static s32 rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
+static int rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -485,7 +485,7 @@ static s32 rspAsmORI(struct __anon_0x5845E* pRSP, s16 rt, s16 rs, s16 immediate)
 }
 
 // Erased
-static s32 rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
+static int rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -494,7 +494,7 @@ static s32 rspAsmSH(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 base) {
 }
 
 // Erased
-static s32 rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+static int rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -503,7 +503,7 @@ static s32 rspAsmSLL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
 }
 
 // Erased
-static s32 rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
+static int rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -512,7 +512,7 @@ static s32 rspAsmSRL(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 sa) {
 }
 
 // Erased
-static s32 rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
+static int rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -521,7 +521,7 @@ static s32 rspAsmSRLV(struct __anon_0x5845E* pRSP, s16 rd, s16 rt, s16 rs) {
 }
 
 // Erased
-static s32 rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
+static int rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rd; // r1+0x4
@@ -530,7 +530,7 @@ static s32 rspAsmSUB(struct __anon_0x5845E* pRSP, s16 rd, s16 rs, s16 rt) {
 }
 
 // Erased
-static s32 rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) {
+static int rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 rt; // r1+0x4
@@ -539,7 +539,7 @@ static s32 rspAsmSW(struct __anon_0x5845E* pRSP, s16 rt, s16 offset, s16 nBase) 
 }
 
 // Erased
-static s32 rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -552,7 +552,7 @@ static s32 rspAsmSSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -566,7 +566,7 @@ static s32 rspAsmSLV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -580,7 +580,7 @@ static s32 rspAsmSDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -594,7 +594,7 @@ static s32 rspAsmSQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -604,7 +604,7 @@ static s32 rspAsmLSV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -618,7 +618,7 @@ static s32 rspAsmLDV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBase) {
+static int rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -626,11 +626,11 @@ static s32 rspAsmLPV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nOffset, s16 nBas
     // s16 nBase; // r1+0xA
 
     // Local variables
-    s32 nAddress; // r5
+    int nAddress; // r5
 }
 
 // Erased
-static s32 rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -644,7 +644,7 @@ static s32 rspAsmLQV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
+static int rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOffset, s16 nBase) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x0
     // s16 nVT; // r1+0x4
@@ -659,7 +659,7 @@ static s32 rspAsmLRV(struct __anon_0x5845E* pRSP, s16 nVT, s16 nElement, s16 nOf
 }
 
 // Erased
-static s32 rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -670,11 +670,11 @@ static s32 rspAsmVAND(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s1
     // Local variables
     s16 i; // r28
     s16 j; // r1+0x8
-    s32 nResult; // r4
+    int nResult; // r4
 }
 
 // Erased
-static s32 rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -685,11 +685,11 @@ static s32 rspAsmVXOR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s1
     // Local variables
     s16 i; // r28
     s16 j; // r1+0x8
-    s32 nResult; // r4
+    int nResult; // r4
 }
 
 // Erased
-static s32 rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -700,11 +700,11 @@ static s32 rspAsmVADD(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s1
     // Local variables
     s16 i; // r30
     s16 j; // r29
-    s32 nResult; // r24
+    int nResult; // r24
 }
 
 // Erased
-static s32 rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -715,11 +715,11 @@ static s32 rspAsmVADDC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // Local variables
     s16 i; // r30
     s16 j; // r29
-    s32 nResult; // r27
+    int nResult; // r27
 }
 
 // Erased
-static s32 rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -730,11 +730,11 @@ static s32 rspAsmVSUB(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s1
     // Local variables
     s16 i; // r30
     s16 j; // r29
-    s32 nResult; // r24
+    int nResult; // r24
 }
 
 // Erased
-static s32 rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -745,11 +745,11 @@ static s32 rspAsmVSUBC(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // Local variables
     s16 i; // r30
     s16 j; // r29
-    s32 nResult; // r25
+    int nResult; // r25
 }
 
 // Erased
-static s32 rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0xC
@@ -760,11 +760,11 @@ static s32 rspAsmVGE(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16
     // Local variables
     s16 i; // r28
     s16 j; // r27
-    s32 nResult; // r24
+    int nResult; // r24
 }
 
 // Erased
-static s32 rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r22
     // s16 nVD; // r1+0xC
@@ -783,7 +783,7 @@ static s32 rspAsmVCL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16
 }
 
 // Erased
-static s32 rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x40
     // s16 nVD; // r1+0x44
@@ -792,14 +792,14 @@ static s32 rspAsmVMADM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r26
-    s32 j; // r25
+    int i; // r26
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x40
     // s16 nVD; // r1+0x44
@@ -808,14 +808,14 @@ static s32 rspAsmVMADN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r26
-    s32 j; // r25
+    int i; // r26
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x40
     // s16 nVD; // r1+0x44
@@ -824,14 +824,14 @@ static s32 rspAsmVMADH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r26
-    s32 j; // r25
+    int i; // r26
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x40
     // s16 nVD; // r1+0x44
@@ -840,14 +840,14 @@ static s32 rspAsmVMADL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r26
-    s32 j; // r25
+    int i; // r26
+    int j; // r25
     s64 product; // r1+0x8
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x38
     // s16 nVD; // r1+0x3C
@@ -856,14 +856,14 @@ static s32 rspAsmVMUDH(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r25
+    int i; // r28
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x38
     // s16 nVD; // r1+0x3C
@@ -872,14 +872,14 @@ static s32 rspAsmVMUDL(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r25
+    int i; // r28
+    int j; // r25
     s64 product; // r1+0x8
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x38
     // s16 nVD; // r1+0x3C
@@ -888,14 +888,14 @@ static s32 rspAsmVMUDM(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r25
+    int i; // r28
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x38
     // s16 nVD; // r1+0x3C
@@ -904,14 +904,14 @@ static s32 rspAsmVMUDN(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r25
+    int i; // r28
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x38
     // s16 nVD; // r1+0x3C
@@ -920,14 +920,14 @@ static s32 rspAsmVMULF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r28
-    s32 j; // r25
+    int i; // r28
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
+static int rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x40
     // s16 nVD; // r1+0x44
@@ -936,14 +936,14 @@ static s32 rspAsmVMACF(struct __anon_0x5845E* pRSP, s16 nVD, s16 nVS, s16 nVT, s
     // s16 nE; // r1+0x12
 
     // Local variables
-    s32 i; // r26
-    s32 j; // r25
+    int i; // r26
+    int j; // r25
     s64 product; // r30
     s16 buffer[8]; // r1+0x1C
 }
 
 // Erased
-static s32 rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
+static int rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r3
     // s16 nVD; // r1+0x4
@@ -954,73 +954,73 @@ static s32 rspAsmVSAR(struct __anon_0x5845E* pRSP, s16 nVD, s16 nE) {
 }
 
 // Erased
-static s32 rspDMARead(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+static int rspDMARead(struct __anon_0x5845E* pRSP, int nDMEMAddress, int nRDRAMAddress, int nLength) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nDMEMAddress; // r1+0xC
-    // s32 nRDRAMAddress; // r1+0x10
-    // s32 nLength; // r30
+    // int nDMEMAddress; // r1+0xC
+    // int nRDRAMAddress; // r1+0x10
+    // int nLength; // r30
 
     // Local variables
-    s32 i; // r5
-    s32 nAddress; // r5
+    int i; // r5
+    int nAddress; // r5
     s16* pDMEM; // r31
     s16* pRDRAM; // r6
     void* pData; // r1+0x1C
 }
 
 // Erased
-static s32 rspDMAWrite(struct __anon_0x5845E* pRSP, s32 nDMEMAddress, s32 nRDRAMAddress, s32 nLength) {
+static int rspDMAWrite(struct __anon_0x5845E* pRSP, int nDMEMAddress, int nRDRAMAddress, int nLength) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r1+0x8
-    // s32 nDMEMAddress; // r1+0xC
-    // s32 nRDRAMAddress; // r1+0x10
-    // s32 nLength; // r31
+    // int nDMEMAddress; // r1+0xC
+    // int nRDRAMAddress; // r1+0x10
+    // int nLength; // r31
 
     // Local variables
-    s32 i; // r5
-    s32 nAddress; // r5
+    int i; // r5
+    int nAddress; // r5
     s16* pDMEM; // r30
     s16* pRDRAM; // r6
     void* pData; // r1+0x1C
 }
 
 // Erased
-static s32 rspDisassemble(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
+static int rspDisassemble(struct __anon_0x5845E* pRSP, struct __anon_0x575BD* pTask) {
     // Parameters
     // struct __anon_0x5845E* pRSP; // r22
     // struct __anon_0x575BD* pTask; // r19
 
     // Local variables
     struct tXL_FILE* pIMEMFile; // r1+0x105C
-    s32 i; // r27
-    s32 h; // r20
-    s32 nCodeAddress; // r7
-    s32 nDataAddress; // r9
-    s32 nFound; // r24
-    u32 nOutData; // r31
+    int i; // r27
+    int h; // r20
+    int nCodeAddress; // r7
+    int nDataAddress; // r9
+    int nFound; // r24
+    unsigned int nOutData; // r31
     void* pCode; // r1+0x1058
     void* pData; // r1+0x1054
-    u32 nRS; // r7
-    u32 nRT; // r20
-    u32 nRD; // r21
-    u32 nSA; // r19
-    u32 nOffset; // r6
-    u32 nTarget; // r5
-    u32 nE; // r7
-    u32 nVT; // r7
-    u32 nVS; // r6
-    u32 nVD; // r5
-    u32 nDE; // r6
-    u32 nBase; // r7
-    u32 nElement; // r6
-    u32 nSize; // r1+0x1048
-    s32 nImmediate; // r7
-    s32 nCount; // r29
+    unsigned int nRS; // r7
+    unsigned int nRT; // r20
+    unsigned int nRD; // r21
+    unsigned int nSA; // r19
+    unsigned int nOffset; // r6
+    unsigned int nTarget; // r5
+    unsigned int nE; // r7
+    unsigned int nVT; // r7
+    unsigned int nVS; // r6
+    unsigned int nVD; // r5
+    unsigned int nDE; // r6
+    unsigned int nBase; // r7
+    unsigned int nElement; // r6
+    unsigned int nSize; // r1+0x1048
+    int nImmediate; // r7
+    int nCount; // r29
     char acOp[8]; // r1+0x1040
     char acTemp[8]; // r1+0x1038
     char acOpString[8]; // r1+0x1030
     char acTempString[128]; // r1+0xFB0
     char acOpList[500][8]; // r1+0x10
-    s32 nFirst; // r23
+    int nFirst; // r23
 }

--- a/debug/Fire/serial.c
+++ b/debug/Fire/serial.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x7869D; // size = 0x10
 
 // size = 0x10, address = 0x800EEA28
@@ -19,51 +19,51 @@ struct _XL_OBJECTTYPE gClassSerial;
 
 typedef struct __anon_0x78791 {
     /* 0x0 */ void* pHost;
-    /* 0x4 */ s32 nAddress;
+    /* 0x4 */ int nAddress;
 } __anon_0x78791; // size = 0x8
 
 // Range: 0x8008F0EC -> 0x8008F0F4
-s32 serialPut8() {}
+int serialPut8() {}
 
 // Range: 0x8008F0E4 -> 0x8008F0EC
-s32 serialPut16() {}
+int serialPut16() {}
 
 // Range: 0x8008EFA4 -> 0x8008F0E4
-s32 serialPut32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
+int serialPut32(struct __anon_0x78791* pSerial, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x78791* pSerial; // r31
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
-    s32 nSize; // r1+0x18
+    int nSize; // r1+0x18
     void* aData; // r1+0x14
 }
 
 // Range: 0x8008EF9C -> 0x8008EFA4
-s32 serialPut64() {}
+int serialPut64() {}
 
 // Range: 0x8008EF94 -> 0x8008EF9C
-s32 serialGet8() {}
+int serialGet8() {}
 
 // Range: 0x8008EF8C -> 0x8008EF94
-s32 serialGet16() {}
+int serialGet16() {}
 
 // Range: 0x8008EF28 -> 0x8008EF8C
-s32 serialGet32(struct __anon_0x78791* pSerial, u32 nAddress, s32* pData) {
+int serialGet32(struct __anon_0x78791* pSerial, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x78791* pSerial; // r1+0x0
-    // u32 nAddress; // r1+0x4
-    // s32* pData; // r1+0x8
+    // unsigned int nAddress; // r1+0x4
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8008EF20 -> 0x8008EF28
-s32 serialGet64() {}
+int serialGet64() {}
 
 // Range: 0x8008EE20 -> 0x8008EF20
-s32 serialEvent(struct __anon_0x78791* pSerial, s32 nEvent, void* pArgument) {
+int serialEvent(struct __anon_0x78791* pSerial, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x78791* pSerial; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/simGCN.c
+++ b/debug/Fire/simGCN.c
@@ -8,7 +8,7 @@
 #include "dolphin/types.h"
 
 typedef struct __anon_0x57A1 {
-    /* 0x0 */ s32 nMode;
+    /* 0x0 */ int nMode;
 } __anon_0x57A1; // size = 0x4
 
 // size = 0x4, address = 0x801355D0
@@ -45,133 +45,133 @@ u8 gno[1473];
 u8 gmesgOK[833];
 
 // size = 0x4, address = 0x80134CE8
-u32 gmsg_ld01Size;
+unsigned int gmsg_ld01Size;
 
 // size = 0x4, address = 0x80134CEC
-u32 gmsg_ld02Size;
+unsigned int gmsg_ld02Size;
 
 // size = 0x4, address = 0x80134CF0
-u32 gmsg_ld03Size;
+unsigned int gmsg_ld03Size;
 
 // size = 0x4, address = 0x80134CF4
-u32 gmsg_ld04Size;
+unsigned int gmsg_ld04Size;
 
 // size = 0x4, address = 0x80134CF8
-u32 gmsg_ld05_1Size;
+unsigned int gmsg_ld05_1Size;
 
 // size = 0x4, address = 0x80134CFC
-u32 gmsg_ld05_2Size;
+unsigned int gmsg_ld05_2Size;
 
 // size = 0x4, address = 0x80134D00
-u32 gmsg_ld06_1Size;
+unsigned int gmsg_ld06_1Size;
 
 // size = 0x4, address = 0x80134D04
-u32 gmsg_ld06_2Size;
+unsigned int gmsg_ld06_2Size;
 
 // size = 0x4, address = 0x80134D08
-u32 gmsg_ld06_3Size;
+unsigned int gmsg_ld06_3Size;
 
 // size = 0x4, address = 0x80134D0C
-u32 gmsg_ld06_4Size;
+unsigned int gmsg_ld06_4Size;
 
 // size = 0x4, address = 0x80134D10
-u32 gmsg_ld07Size;
+unsigned int gmsg_ld07Size;
 
 // size = 0x4, address = 0x80134D14
-u32 gmsg_gf01Size;
+unsigned int gmsg_gf01Size;
 
 // size = 0x4, address = 0x80134D18
-u32 gmsg_gf02Size;
+unsigned int gmsg_gf02Size;
 
 // size = 0x4, address = 0x80134D1C
-u32 gmsg_gf03Size;
+unsigned int gmsg_gf03Size;
 
 // size = 0x4, address = 0x80134D20
-u32 gmsg_gf04Size;
+unsigned int gmsg_gf04Size;
 
 // size = 0x4, address = 0x80134D24
-u32 gmsg_gf05Size;
+unsigned int gmsg_gf05Size;
 
 // size = 0x4, address = 0x80134D28
-u32 gmsg_gf06Size;
+unsigned int gmsg_gf06Size;
 
 // size = 0x4, address = 0x80134D2C
-u32 gmsg_in01Size;
+unsigned int gmsg_in01Size;
 
 // size = 0x4, address = 0x80134D30
-u32 gmsg_in02Size;
+unsigned int gmsg_in02Size;
 
 // size = 0x4, address = 0x80134D34
-u32 gmsg_in03Size;
+unsigned int gmsg_in03Size;
 
 // size = 0x4, address = 0x80134D38
-u32 gmsg_in04Size;
+unsigned int gmsg_in04Size;
 
 // size = 0x4, address = 0x80134D3C
-u32 gmsg_in05Size;
+unsigned int gmsg_in05Size;
 
 // size = 0x4, address = 0x80134D40
-u32 gmsg_sv01Size;
+unsigned int gmsg_sv01Size;
 
 // size = 0x4, address = 0x80134D44
-u32 gmsg_sv01_2Size;
+unsigned int gmsg_sv01_2Size;
 
 // size = 0x4, address = 0x80134D48
-u32 gmsg_sv02Size;
+unsigned int gmsg_sv02Size;
 
 // size = 0x4, address = 0x80134D4C
-u32 gmsg_sv03Size;
+unsigned int gmsg_sv03Size;
 
 // size = 0x4, address = 0x80134D50
-u32 gmsg_sv04Size;
+unsigned int gmsg_sv04Size;
 
 // size = 0x4, address = 0x80134D54
-u32 gmsg_sv05_1Size;
+unsigned int gmsg_sv05_1Size;
 
 // size = 0x4, address = 0x80134D58
-u32 gmsg_sv06_1Size;
+unsigned int gmsg_sv06_1Size;
 
 // size = 0x4, address = 0x80134D5C
-u32 gmsg_sv06_2Size;
+unsigned int gmsg_sv06_2Size;
 
 // size = 0x4, address = 0x80134D60
-u32 gmsg_sv06_3Size;
+unsigned int gmsg_sv06_3Size;
 
 // size = 0x4, address = 0x80134D64
-u32 gmsg_sv06_4Size;
+unsigned int gmsg_sv06_4Size;
 
 // size = 0x4, address = 0x80134D68
-u32 gmsg_sv06_5Size;
+unsigned int gmsg_sv06_5Size;
 
 // size = 0x4, address = 0x80134D6C
-u32 gmsg_sv07Size;
+unsigned int gmsg_sv07Size;
 
 // size = 0x4, address = 0x80134D70
-u32 gmsg_sv08Size;
+unsigned int gmsg_sv08Size;
 
 // size = 0x4, address = 0x80134D74
-u32 gmsg_sv09Size;
+unsigned int gmsg_sv09Size;
 
 // size = 0x4, address = 0x80134D78
-u32 gmsg_sv10Size;
+unsigned int gmsg_sv10Size;
 
 // size = 0x4, address = 0x80134D7C
-u32 gmsg_sv11Size;
+unsigned int gmsg_sv11Size;
 
 // size = 0x4, address = 0x80134D80
-u32 gmsg_sv12Size;
+unsigned int gmsg_sv12Size;
 
 // size = 0x4, address = 0x80134D84
-u32 gmsg_sv_shareSize;
+unsigned int gmsg_sv_shareSize;
 
 // size = 0x4, address = 0x80134D88
-u32 gz_bnrSize;
+unsigned int gz_bnrSize;
 
 // size = 0x4, address = 0x80134D8C
-u32 gz_iconSize;
+unsigned int gz_iconSize;
 
 // size = 0x4, address = 0x80134D90
-s32 gHighlightChoice;
+int gHighlightChoice;
 
 typedef enum __anon_0x61D7 {
     S_M_NONE = -1,
@@ -232,7 +232,7 @@ enum __anon_0x61D7 simulatorMessageCurrent;
 static f32 gOrthoMtx[4][4];
 
 // size = 0x4, address = 0x801355D4
-s32 gButtonDownToggle;
+int gButtonDownToggle;
 
 // size = 0x18, address = 0x800E9960
 s16 Vert_s16[12];
@@ -256,37 +256,37 @@ u32 Colors_u32[3];
 u8 TexCoords_u8[8];
 
 // size = 0x4, address = 0x801355D8
-s32 gDVDResetToggle;
+int gDVDResetToggle;
 
 // size = 0x4, address = 0x801355DC
-static s32 toggle$192;
+static int toggle$192;
 
 // size = 0x140, address = 0x800F4580
-static u32 gContMap[4][20];
+static unsigned int gContMap[4][20];
 
 // size = 0x4, address = 0x801355E0
-static u32 nPrevButton$701;
+static unsigned int nPrevButton$701;
 
 // size = 0x4, address = 0x801355E4
-static u32 nCurrButton$702;
+static unsigned int nCurrButton$702;
 
 // size = 0x4, address = 0x801355E8
-static s32 gbReset;
+static int gbReset;
 
 // size = 0x4, address = 0x801355EC
-static u32 gnTickReset;
+static unsigned int gnTickReset;
 
 // size = 0x4, address = 0x80134D98
-s32 gResetBeginFlag;
+int gResetBeginFlag;
 
 // size = 0x4, address = 0x801355F0
-s32 gPreviousIPLSetting;
+int gPreviousIPLSetting;
 
 // size = 0x4, address = 0x801355F4
-s32 gPreviousForceMenuSetting;
+int gPreviousForceMenuSetting;
 
 // size = 0x4, address = 0x801355F8
-s32 gPreviousAllowResetSetting;
+int gPreviousAllowResetSetting;
 
 // size = 0x20, address = 0x800F46C0
 static char* gaszArgument[8];
@@ -295,13 +295,13 @@ static char* gaszArgument[8];
 char gpErrorMessageBuffer[20480];
 
 // size = 0x4, address = 0x801355FC
-s32 gbDisplayedError;
+int gbDisplayedError;
 
 typedef struct __anon_0x6B86 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x6B86; // size = 0x10
 
 typedef enum __anon_0x6C37 {
@@ -345,7 +345,7 @@ typedef enum __anon_0x6D66 {
 typedef struct __anon_0x6EA4 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0xA6E7 eMode;
     /* 0x10 */ struct __anon_0x6B86 romCopy;
     /* 0x20 */ enum __anon_0x6C37 eTypeROM;
@@ -353,7 +353,7 @@ typedef struct __anon_0x6EA4 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x6D66 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x6EA4; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -368,25 +368,25 @@ typedef enum __anon_0x7115 {
 
 typedef struct __anon_0x7181 {
     /* 0x00 */ void* pSrcData;
-    /* 0x04 */ s32 nFrequency;
-    /* 0x08 */ s32 nDacrate;
-    /* 0x0C */ s32 nSndLen;
+    /* 0x04 */ int nFrequency;
+    /* 0x08 */ int nDacrate;
+    /* 0x0C */ int nSndLen;
     /* 0x10 */ void* apBuffer[16];
-    /* 0x50 */ s32 anSizeBuffer[16];
-    /* 0x90 */ s32 nCountBeep;
-    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0x50 */ int anSizeBuffer[16];
+    /* 0x90 */ int nCountBeep;
+    /* 0x94 */ int anSizeBeep[3];
     /* 0xA0 */ void* apDataBeep[3];
-    /* 0xAC */ s32 iBufferPlay;
-    /* 0xB0 */ s32 iBufferMake;
+    /* 0xAC */ int iBufferPlay;
+    /* 0xB0 */ int iBufferMake;
     /* 0xB4 */ enum __anon_0x7115 eMode;
     /* 0xB8 */ void* pBufferZero;
     /* 0xBC */ void* pBufferHold;
     /* 0xC0 */ void* pBufferRampUp;
     /* 0xC4 */ void* pBufferRampDown;
-    /* 0xC8 */ s32 nSizePlay;
-    /* 0xCC */ s32 nSizeZero;
-    /* 0xD0 */ s32 nSizeHold;
-    /* 0xD4 */ s32 nSizeRamp;
+    /* 0xC8 */ int nSizePlay;
+    /* 0xCC */ int nSizeZero;
+    /* 0xD0 */ int nSizeHold;
+    /* 0xD4 */ int nSizeRamp;
 } __anon_0x7181; // size = 0xD8
 
 // size = 0x4, address = 0x80135604
@@ -400,11 +400,11 @@ typedef struct __anon_0x7511 {
 } __anon_0x7511; // size = 0x10
 
 typedef struct __anon_0x75AB {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x75AB; // size = 0x14
 
 typedef struct __anon_0x76EC {
@@ -414,7 +414,7 @@ typedef struct __anon_0x76EC {
 } __anon_0x76EC; // size = 0xC
 
 typedef struct __anon_0x775C {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x76EC rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -431,7 +431,7 @@ typedef struct __anon_0x775C {
 } __anon_0x775C; // size = 0x3C
 
 typedef struct __anon_0x798C {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x76EC rS;
     /* 0x10 */ struct __anon_0x76EC rT;
     /* 0x1C */ struct __anon_0x76EC rSRaw;
@@ -449,7 +449,7 @@ typedef struct __anon_0x7A75 {
 typedef union __anon_0x7BD4 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x7BD4;
 
@@ -498,20 +498,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x7F13;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -520,11 +520,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x7F7C; // size = 0x6C
 
 typedef struct __anon_0x82D9 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -535,7 +535,7 @@ typedef struct __anon_0x82D9 {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x82D9; // size = 0x2C
 
 typedef enum __anon_0x85BB {
@@ -545,93 +545,93 @@ typedef enum __anon_0x85BB {
 } __anon_0x85BB;
 
 typedef struct __anon_0x863F {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x85BB eProjection;
 } __anon_0x863F; // size = 0x24
 
 typedef struct __anon_0x87F6 {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x7511 viewport;
     /* 0x000C8 */ struct __anon_0x75AB aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x775C aLight[8];
     /* 0x00320 */ struct __anon_0x798C lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x7A75 aVertex[80];
     /* 0x00C18 */ struct __anon_0x7C71 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x82D9 aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x85BB eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -642,10 +642,10 @@ typedef struct __anon_0x87F6 {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x87F6; // size = 0x3D150
 
@@ -665,25 +665,25 @@ void* DemoFrameBuffer1;
 void* DemoFrameBuffer2;
 
 typedef struct __anon_0x9737 {
-    /* 0x00 */ s32 configuration;
-    /* 0x04 */ s32 size;
-    /* 0x08 */ s32 offset;
+    /* 0x00 */ int configuration;
+    /* 0x04 */ int size;
+    /* 0x08 */ int offset;
     /* 0x0C */ char* buffer;
-    /* 0x10 */ s32* writtenBlocks;
-    /* 0x14 */ s32 writtenConfig;
+    /* 0x10 */ int* writtenBlocks;
+    /* 0x14 */ int writtenConfig;
 } __anon_0x9737; // size = 0x18
 
 typedef struct OSCalendarTime {
-    /* 0x00 */ s32 sec;
-    /* 0x04 */ s32 min;
-    /* 0x08 */ s32 hour;
-    /* 0x0C */ s32 mday;
-    /* 0x10 */ s32 mon;
-    /* 0x14 */ s32 year;
-    /* 0x18 */ s32 wday;
-    /* 0x1C */ s32 yday;
-    /* 0x20 */ s32 msec;
-    /* 0x24 */ s32 usec;
+    /* 0x00 */ int sec;
+    /* 0x04 */ int min;
+    /* 0x08 */ int hour;
+    /* 0x0C */ int mday;
+    /* 0x10 */ int mon;
+    /* 0x14 */ int year;
+    /* 0x18 */ int wday;
+    /* 0x1C */ int yday;
+    /* 0x20 */ int msec;
+    /* 0x24 */ int usec;
 } __anon_0x98DA; // size = 0x28
 
 typedef struct CARDFileInfo {
@@ -696,16 +696,16 @@ typedef struct CARDFileInfo {
 } __anon_0x9A48; // size = 0x14
 
 typedef struct __anon_0x9B40 {
-    /* 0x000 */ s32 currentGame;
-    /* 0x004 */ s32 fileSize;
+    /* 0x000 */ int currentGame;
+    /* 0x004 */ int fileSize;
     /* 0x008 */ char name[33];
-    /* 0x02C */ s32 numberOfGames;
+    /* 0x02C */ int numberOfGames;
     /* 0x030 */ struct __anon_0x9737 game;
-    /* 0x048 */ s32 changedDate;
-    /* 0x04C */ s32 changedChecksum;
-    /* 0x050 */ s32 gameSize[16];
-    /* 0x090 */ s32 gameOffset[16];
-    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x048 */ int changedDate;
+    /* 0x04C */ int changedChecksum;
+    /* 0x050 */ int gameSize[16];
+    /* 0x090 */ int gameOffset[16];
+    /* 0x0D0 */ int gameConfigIndex[16];
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
@@ -743,32 +743,32 @@ typedef enum __anon_0x9D56 {
 typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x9B40 file;
     /* 0x35C */ enum __anon_0x9D56 error;
-    /* 0x360 */ s32 slot;
-    /* 0x364 */ s32 (*pPollFunction)();
-    /* 0x368 */ s32 pollPrevBytes;
-    /* 0x36C */ s32 pollSize;
+    /* 0x360 */ int slot;
+    /* 0x364 */ int (*pPollFunction)();
+    /* 0x368 */ int pollPrevBytes;
+    /* 0x36C */ int pollSize;
     /* 0x370 */ char pollMessage[256];
-    /* 0x470 */ s32 saveToggle;
+    /* 0x470 */ int saveToggle;
     /* 0x474 */ char* writeBuffer;
     /* 0x478 */ char* readBuffer;
-    /* 0x47C */ s32 writeToggle;
-    /* 0x480 */ s32 soundToggle;
-    /* 0x484 */ s32 writeStatus;
-    /* 0x488 */ s32 writeIndex;
-    /* 0x48C */ s32 accessType;
-    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x47C */ int writeToggle;
+    /* 0x480 */ int soundToggle;
+    /* 0x484 */ int writeStatus;
+    /* 0x488 */ int writeIndex;
+    /* 0x48C */ int accessType;
+    /* 0x490 */ int gameIsLoaded;
     /* 0x494 */ char saveFileName[256];
     /* 0x594 */ char saveComment[256];
     /* 0x694 */ char* saveIcon;
     /* 0x698 */ char* saveBanner;
     /* 0x69C */ char saveGameName[256];
-    /* 0x79C */ s32 saveFileSize;
-    /* 0x7A0 */ s32 saveGameSize;
-    /* 0x7A4 */ s32 bufferCreated;
-    /* 0x7A8 */ s32 cardSize;
-    /* 0x7AC */ s32 wait;
-    /* 0x7B0 */ s32 isBroken;
-    /* 0x7B4 */ s32 saveConfiguration;
+    /* 0x79C */ int saveFileSize;
+    /* 0x7A0 */ int saveGameSize;
+    /* 0x7A4 */ int bufferCreated;
+    /* 0x7A8 */ int cardSize;
+    /* 0x7AC */ int wait;
+    /* 0x7B0 */ int isBroken;
+    /* 0x7B4 */ int saveConfiguration;
 } __anon_0x9FF8; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
@@ -776,9 +776,9 @@ struct _MCARD mCard;
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0xA4E0; // size = 0x10
 
 // size = 0x10, address = 0x800EA7C8
@@ -862,11 +862,11 @@ typedef enum __anon_0xC003 {
 
 typedef struct __anon_0xC654 {
     /* 0x000 */ char rom[36];
-    /* 0x024 */ s32 controllerConfiguration[4][20];
-    /* 0x164 */ s32 rumbleConfiguration;
-    /* 0x168 */ s32 storageDevice;
-    /* 0x16C */ s32 normalControllerConfig;
-    /* 0x170 */ s32 currentControllerConfig;
+    /* 0x024 */ int controllerConfiguration[4][20];
+    /* 0x164 */ int rumbleConfiguration;
+    /* 0x168 */ int storageDevice;
+    /* 0x16C */ int normalControllerConfig;
+    /* 0x170 */ int currentControllerConfig;
 } __anon_0xC654; // size = 0x174
 
 typedef enum __anon_0xC9F9 {
@@ -915,7 +915,7 @@ typedef struct _GXRenderModeObj {
 struct _GXRenderModeObj* rmode;
 
 // size = 0x4, address = 0x80135644
-s32 gMovieErrorToggle;
+int gMovieErrorToggle;
 
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
@@ -1005,9 +1005,9 @@ typedef struct _GXTexObj {
 } __anon_0xE08E; // size = 0x20
 
 // Range: 0x8000F0FC -> 0x8000F7CC
-s32 simulatorGXInit() {
+int simulatorGXInit() {
     // Local variables
-    s32 i; // r31
+    int i; // r31
     struct _GXColor GX_DEFAULT_BG; // r1+0x58
     struct _GXColor BLACK; // r1+0x54
     struct _GXColor WHITE; // r1+0x50
@@ -1041,7 +1041,7 @@ static void simulatorDEMODoneRender() {
 }
 
 // Erased
-static s32 simulatorDrawBlack() {
+static int simulatorDrawBlack() {
     // Local variables
     struct _GXColor color; // r1+0x6C
 
@@ -1054,32 +1054,32 @@ static s32 simulatorDrawBlack() {
 }
 
 // Range: 0x8000EE18 -> 0x8000F020
-s32 simulatorDVDShowError(s32 nStatus) {
+int simulatorDVDShowError(int nStatus) {
     // Parameters
-    // s32 nStatus; // r26
+    // int nStatus; // r26
 
     // Local variables
-    s32 continueToggle; // r28
+    int continueToggle; // r28
     enum __anon_0x61D7 nMessage; // r27
 
     // References
     // -> struct __anon_0x6EA4* gpSystem;
-    // -> s32 gDVDResetToggle;
-    // -> static s32 toggle$192;
+    // -> int gDVDResetToggle;
+    // -> static int toggle$192;
 }
 
 // Range: 0x8000EDA8 -> 0x8000EE18
-s32 simulatorDVDOpen(char* szNameFile, struct DVDFileInfo* pFileInfo) {
+int simulatorDVDOpen(char* szNameFile, struct DVDFileInfo* pFileInfo) {
     // Parameters
     // char* szNameFile; // r30
     // struct DVDFileInfo* pFileInfo; // r31
 
     // Local variables
-    s32 nStatus; // r3
+    int nStatus; // r3
 }
 
 // Range: 0x8000ECC4 -> 0x8000EDA8
-s32 simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset,
+int simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead, s32 nOffset,
                      void (*callback)(s32, struct DVDFileInfo*)) {
     // Parameters
     // struct DVDFileInfo* pFileInfo; // r26
@@ -1089,21 +1089,21 @@ s32 simulatorDVDRead(struct DVDFileInfo* pFileInfo, void* anData, s32 nSizeRead,
     // void (* callback)(s32, struct DVDFileInfo*); // r7
 
     // Local variables
-    s32 nStatus; // r31
-    s32 bRetry; // r30
+    int nStatus; // r31
+    int bRetry; // r30
 }
 
 // Range: 0x8000ECA0 -> 0x8000ECC4
-s32 simulatorPlayMovie() {}
+int simulatorPlayMovie() {}
 
 // Range: 0x8000E484 -> 0x8000ECA0
-s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar, s32 percent) {
+int simulatorDrawImage(struct __anon_0xDB69* tpl, int nX0, int nY0, int drawBar, int percent) {
     // Parameters
     // struct __anon_0xDB69* tpl; // r22
-    // s32 nX0; // r30
-    // s32 nY0; // r23
-    // s32 drawBar; // r24
-    // s32 percent; // r25
+    // int nX0; // r30
+    // int nY0; // r23
+    // int drawBar; // r24
+    // int percent; // r25
 
     // Local variables
     struct _GXTexObj texObj; // r1+0xDC
@@ -1128,19 +1128,19 @@ s32 simulatorDrawImage(struct __anon_0xDB69* tpl, s32 nX0, s32 nY0, s32 drawBar,
 }
 
 // Range: 0x8000DBB4 -> 0x8000E484
-s32 simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message,
-                            struct __anon_0xDB69* tplYes, s32 nX0Yes, s32 nY0Yes, struct __anon_0xDB69* tplNo,
-                            s32 nX0No, s32 nY0No) {
+int simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, int nX0Message, int nY0Message,
+                            struct __anon_0xDB69* tplYes, int nX0Yes, int nY0Yes, struct __anon_0xDB69* tplNo,
+                            int nX0No, int nY0No) {
     // Parameters
     // struct __anon_0xDB69* tplMessage; // r21
-    // s32 nX0Message; // r22
-    // s32 nY0Message; // r30
+    // int nX0Message; // r22
+    // int nY0Message; // r30
     // struct __anon_0xDB69* tplYes; // r23
-    // s32 nX0Yes; // r24
-    // s32 nY0Yes; // r25
+    // int nX0Yes; // r24
+    // int nY0Yes; // r25
     // struct __anon_0xDB69* tplNo; // r26
-    // s32 nX0No; // r27
-    // s32 nY0No; // r28
+    // int nX0No; // r27
+    // int nY0No; // r28
 
     // Local variables
     struct _GXTexObj texObj; // r1+0xAC
@@ -1155,7 +1155,7 @@ s32 simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s3
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
     // -> u8 DemoStatEnable;
-    // -> s32 gHighlightChoice;
+    // -> int gHighlightChoice;
     // -> u8 TexCoords_u8[8];
     // -> u32 Colors_u32[3];
     // -> s16 VertNo_s16[12];
@@ -1165,15 +1165,15 @@ s32 simulatorDrawYesNoImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s3
 }
 
 // Range: 0x8000D58C -> 0x8000DBB4
-s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 nY0Message, struct __anon_0xDB69* tplOK,
-                         s32 nX0OK, s32 nY0OK) {
+int simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, int nX0Message, int nY0Message, struct __anon_0xDB69* tplOK,
+                         int nX0OK, int nY0OK) {
     // Parameters
     // struct __anon_0xDB69* tplMessage; // r29
-    // s32 nX0Message; // r28
-    // s32 nY0Message; // r27
+    // int nX0Message; // r28
+    // int nY0Message; // r27
     // struct __anon_0xDB69* tplOK; // r23
-    // s32 nX0OK; // r24
-    // s32 nY0OK; // r25
+    // int nX0OK; // r24
+    // int nY0OK; // r25
 
     // Local variables
     struct _GXTexObj texObj; // r1+0x98
@@ -1196,14 +1196,14 @@ s32 simulatorDrawOKImage(struct __anon_0xDB69* tplMessage, s32 nX0Message, s32 n
 }
 
 // Range: 0x8000D35C -> 0x8000D58C
-s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 drawBar, s32 percent) {
+int simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, int drawBar, int percent) {
     // Parameters
     // enum __anon_0x61D7 simulatorErrorMessage; // r28
-    // s32 drawBar; // r29
-    // s32 percent; // r31
+    // int drawBar; // r29
+    // int percent; // r31
 
     // References
-    // -> s32 gbDisplayedError;
+    // -> int gbDisplayedError;
     // -> u8 gfatalErr[13025];
     // -> u8 gnoDisk[7937];
     // -> u8 gretryErr[9281];
@@ -1213,7 +1213,7 @@ s32 simulatorDrawErrorMessage(enum __anon_0x61D7 simulatorErrorMessage, s32 draw
 }
 
 // Range: 0x8000D1F0 -> 0x8000D35C
-s32 simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
+int simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
     // Parameters
     // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
 
@@ -1222,66 +1222,66 @@ s32 simulatorPrepareMessage(enum __anon_0x61D7 simulatorErrorMessage) {
 
     // References
     // -> char gpErrorMessageBuffer[20480];
-    // -> u32 gmsg_gf02Size;
+    // -> unsigned int gmsg_gf02Size;
     // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv09Size;
-    // -> u32 gmsg_in02Size;
+    // -> unsigned int gmsg_sv09Size;
+    // -> unsigned int gmsg_in02Size;
 }
 
 // Erased
-static s32 simulatorDrawErrorMessageFromDVD(s32 drawBar, s32 percent) {
+static int simulatorDrawErrorMessageFromDVD(int drawBar, int percent) {
     // Parameters
-    // s32 drawBar; // r29
-    // s32 percent; // r30
+    // int drawBar; // r29
+    // int percent; // r30
 
     // References
     // -> char gpErrorMessageBuffer[20480];
 }
 
 // Range: 0x8000CF24 -> 0x8000D1F0
-s32 simulatorDrawYesNoMessageLoop(struct __anon_0xDB69* simulatorQuestion, s32* yes) {
+int simulatorDrawYesNoMessageLoop(struct __anon_0xDB69* simulatorQuestion, int* yes) {
     // Parameters
     // struct __anon_0xDB69* simulatorQuestion; // r26
-    // s32* yes; // r27
+    // int* yes; // r27
 
     // References
     // -> struct __anon_0x6EA4* gpSystem;
     // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
     // -> u8 gno[1473];
     // -> u8 gyes[1473];
-    // -> s32 gHighlightChoice;
+    // -> int gHighlightChoice;
 }
 
 // Range: 0x8000CB7C -> 0x8000CF24
-s32 simulatorDrawYesNoMessage(enum __anon_0x61D7 simulatorMessage, s32* yes) {
+int simulatorDrawYesNoMessage(enum __anon_0x61D7 simulatorMessage, int* yes) {
     // Parameters
     // enum __anon_0x61D7 simulatorMessage; // r1+0x8
-    // s32* yes; // r30
+    // int* yes; // r30
 
     // Local variables
     struct DVDFileInfo fileInfo; // r1+0x10
 
     // References
     // -> char gpErrorMessageBuffer[20480];
-    // -> u32 gmsg_sv08Size;
+    // -> unsigned int gmsg_sv08Size;
     // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv06_5Size;
-    // -> u32 gmsg_sv06_4Size;
-    // -> u32 gmsg_in01Size;
-    // -> u32 gmsg_gf01Size;
-    // -> u32 gmsg_ld07Size;
-    // -> u32 gmsg_ld06_4Size;
-    // -> u32 gmsg_ld05_2Size;
+    // -> unsigned int gmsg_sv06_5Size;
+    // -> unsigned int gmsg_sv06_4Size;
+    // -> unsigned int gmsg_in01Size;
+    // -> unsigned int gmsg_gf01Size;
+    // -> unsigned int gmsg_ld07Size;
+    // -> unsigned int gmsg_ld06_4Size;
+    // -> unsigned int gmsg_ld05_2Size;
 }
 
 // Erased
-static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
+static int simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
     // Parameters
     // struct __anon_0xDB69* simulatorMessage; // r27
 
     // References
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
     // -> struct __anon_0x6EA4* gpSystem;
     // -> struct __anon_0xAD2F DemoPad[4];
     // -> u8 gmesgOK[833];
@@ -1289,7 +1289,7 @@ static s32 simulatorDrawOKMessageLoop(struct __anon_0xDB69* simulatorMessage) {
 }
 
 // Range: 0x80009A30 -> 0x8000CB7C
-s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
+int simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
     // Parameters
     // enum __anon_0x61D7 simulatorErrorMessage; // r1+0x8
 
@@ -1297,49 +1297,49 @@ s32 simulatorDrawErrorMessageWait(enum __anon_0x61D7 simulatorErrorMessage) {
     struct DVDFileInfo fileInfo; // r1+0x80
 
     // References
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
     // -> struct __anon_0x6EA4* gpSystem;
     // -> struct __anon_0xAD2F DemoPad[4];
     // -> u8 gmesgOK[833];
     // -> char gpErrorMessageBuffer[20480];
     // -> u8 gyes[1473];
-    // -> u32 gmsg_sv_shareSize;
+    // -> unsigned int gmsg_sv_shareSize;
     // -> enum __anon_0x61D7 simulatorMessageCurrent;
-    // -> u32 gmsg_sv12Size;
-    // -> u32 gmsg_sv11Size;
-    // -> u32 gmsg_sv10Size;
-    // -> u32 gmsg_sv07Size;
-    // -> u32 gmsg_sv06_3Size;
-    // -> u32 gmsg_sv06_2Size;
-    // -> u32 gmsg_sv06_1Size;
-    // -> u32 gmsg_sv05_1Size;
-    // -> u32 gmsg_sv04Size;
-    // -> u32 gmsg_sv03Size;
-    // -> u32 gmsg_sv02Size;
-    // -> u32 gmsg_sv01_2Size;
-    // -> u32 gmsg_sv01Size;
-    // -> u32 gmsg_in05Size;
-    // -> u32 gmsg_in04Size;
-    // -> u32 gmsg_in03Size;
-    // -> u32 gmsg_gf06Size;
-    // -> u32 gmsg_gf05Size;
-    // -> u32 gmsg_gf04Size;
-    // -> u32 gmsg_gf03Size;
-    // -> u32 gmsg_ld06_3Size;
-    // -> u32 gmsg_ld06_2Size;
-    // -> u32 gmsg_ld06_1Size;
-    // -> u32 gmsg_ld05_1Size;
-    // -> u32 gmsg_ld04Size;
-    // -> u32 gmsg_ld03Size;
-    // -> u32 gmsg_ld02Size;
-    // -> u32 gmsg_ld01Size;
+    // -> unsigned int gmsg_sv12Size;
+    // -> unsigned int gmsg_sv11Size;
+    // -> unsigned int gmsg_sv10Size;
+    // -> unsigned int gmsg_sv07Size;
+    // -> unsigned int gmsg_sv06_3Size;
+    // -> unsigned int gmsg_sv06_2Size;
+    // -> unsigned int gmsg_sv06_1Size;
+    // -> unsigned int gmsg_sv05_1Size;
+    // -> unsigned int gmsg_sv04Size;
+    // -> unsigned int gmsg_sv03Size;
+    // -> unsigned int gmsg_sv02Size;
+    // -> unsigned int gmsg_sv01_2Size;
+    // -> unsigned int gmsg_sv01Size;
+    // -> unsigned int gmsg_in05Size;
+    // -> unsigned int gmsg_in04Size;
+    // -> unsigned int gmsg_in03Size;
+    // -> unsigned int gmsg_gf06Size;
+    // -> unsigned int gmsg_gf05Size;
+    // -> unsigned int gmsg_gf04Size;
+    // -> unsigned int gmsg_gf03Size;
+    // -> unsigned int gmsg_ld06_3Size;
+    // -> unsigned int gmsg_ld06_2Size;
+    // -> unsigned int gmsg_ld06_1Size;
+    // -> unsigned int gmsg_ld05_1Size;
+    // -> unsigned int gmsg_ld04Size;
+    // -> unsigned int gmsg_ld03Size;
+    // -> unsigned int gmsg_ld02Size;
+    // -> unsigned int gmsg_ld01Size;
 }
 
 // Range: 0x80009980 -> 0x80009A30
-void simulatorReset(s32 IPL, s32 forceMenu) {
+void simulatorReset(int IPL, int forceMenu) {
     // Parameters
-    // s32 IPL; // r30
-    // s32 forceMenu; // r31
+    // int IPL; // r30
+    // int forceMenu; // r31
 
     // References
     // -> struct _MCARD mCard;
@@ -1356,19 +1356,19 @@ void simulatorResetAndPlayMovie() {
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
     // -> u8 DemoStatEnable;
-    // -> s32 gMovieErrorToggle;
+    // -> int gMovieErrorToggle;
     // -> struct _GXRenderModeObj* rmode;
     // -> struct _MCARD mCard;
 }
 
 // Erased
-static s32 simulatorSetPart() {}
+static int simulatorSetPart() {}
 
 // Erased
-static s32 simulatorAddXtraTime() {}
+static int simulatorAddXtraTime() {}
 
 // Erased
-static s32 simulatorShowParts() {}
+static int simulatorShowParts() {}
 
 // Erased
 static enum __anon_0xC9F9 simulatorGetView() {
@@ -1378,7 +1378,7 @@ static enum __anon_0xC9F9 simulatorGetView() {
 }
 
 // Erased
-static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
+static int simulatorSetView(enum __anon_0xC9F9 eView) {
     // Parameters
     // enum __anon_0xC9F9 eView; // r1+0x8
 
@@ -1388,95 +1388,95 @@ static s32 simulatorSetView(enum __anon_0xC9F9 eView) {
 }
 
 // Range: 0x8000974C -> 0x80009824
-s32 simulatorSetControllerMap(u32* mapData, s32 channel) {
+int simulatorSetControllerMap(unsigned int* mapData, int channel) {
     // Parameters
-    // u32* mapData; // r1+0x0
-    // s32 channel; // r1+0x4
+    // unsigned int* mapData; // r1+0x0
+    // int channel; // r1+0x4
 
     // Local variables
-    s32 i; // r7
+    int i; // r7
 
     // References
-    // -> static u32 gContMap[4][20];
+    // -> static unsigned int gContMap[4][20];
 }
 
 // Range: 0x80009684 -> 0x8000974C
-s32 simulatorCopyControllerMap(u32* mapDataOutput, u32* mapDataInput) {
+int simulatorCopyControllerMap(unsigned int* mapDataOutput, unsigned int* mapDataInput) {
     // Parameters
-    // u32* mapDataOutput; // r1+0x0
-    // u32* mapDataInput; // r1+0x4
+    // unsigned int* mapDataOutput; // r1+0x0
+    // unsigned int* mapDataInput; // r1+0x4
 
     // Local variables
-    s32 i; // r7
+    int i; // r7
 }
 
 // Erased
-static s32 simulatorChangeControllerConfig(s32 channel, s32 nCurrButton) {
+static int simulatorChangeControllerConfig(int channel, int nCurrButton) {
     // Parameters
-    // s32 channel; // r31
-    // s32 nCurrButton; // r1+0xC
+    // int channel; // r31
+    // int nCurrButton; // r1+0xC
 
     // References
-    // -> static u32 gContMap[4][20];
+    // -> static unsigned int gContMap[4][20];
     // -> static struct __anon_0xC654 gSystemRomConfigurationList[1];
     // -> struct __anon_0x6EA4* gpSystem;
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80009110 -> 0x80009684
-s32 simulatorReadController(s32 channel, u32* anData) {
+int simulatorReadController(int channel, unsigned int* anData) {
     // Parameters
-    // s32 channel; // r29
-    // u32* anData; // r30
+    // int channel; // r29
+    // unsigned int* anData; // r30
 
     // Local variables
     f32 subStickTest; // f1
-    s32 stickX; // r1+0x8
-    s32 stickY; // r1+0x8
-    s32 subStickX; // r6
-    s32 subStickY; // r7
-    s32 nDirButton; // r3
+    int stickX; // r1+0x8
+    int stickY; // r1+0x8
+    int subStickX; // r6
+    int subStickY; // r7
+    int nDirButton; // r3
 
     // References
-    // -> static u32 gContMap[4][20];
-    // -> static u32 nCurrButton$702;
+    // -> static unsigned int gContMap[4][20];
+    // -> static unsigned int nCurrButton$702;
     // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
-    // -> static u32 nPrevButton$701;
+    // -> int gButtonDownToggle;
+    // -> static unsigned int nPrevButton$701;
 }
 
 // Erased
-static void DEMOInitWindow(s32 nSizeX, s32 nSizeY, s32 nColorR, s32 nColorG, s32 nColorB) {
+static void DEMOInitWindow(int nSizeX, int nSizeY, int nColorR, int nColorG, int nColorB) {
     // Parameters
-    // s32 nSizeX; // r3
-    // s32 nSizeY; // r1+0xC
-    // s32 nColorR; // r29
-    // s32 nColorG; // r30
-    // s32 nColorB; // r31
+    // int nSizeX; // r3
+    // int nSizeY; // r1+0xC
+    // int nColorR; // r29
+    // int nColorG; // r30
+    // int nColorB; // r31
 
     // Local variables
     struct _GXColor color; // r1+0x20
 }
 
 // Range: 0x80009108 -> 0x80009110
-s32 simulatorShowLoad() {}
+int simulatorShowLoad() {}
 
 // Erased
-static s32 simulatorResetController() {}
+static int simulatorResetController() {}
 
 // Range: 0x800090B4 -> 0x80009108
-s32 simulatorDetectController(s32 channel) {
+int simulatorDetectController(int channel) {
     // Parameters
-    // s32 channel; // r31
+    // int channel; // r31
 
     // Local variables
     struct PADStatus status[4]; // r1+0xC
 }
 
 // Range: 0x80009038 -> 0x800090B4
-s32 simulatorReadPak(s32 channel, u16 address, u8* data) {
+int simulatorReadPak(int channel, u16 address, u8* data) {
     // Parameters
-    // s32 channel; // r29
+    // int channel; // r29
     // u16 address; // r30
     // u8* data; // r31
 
@@ -1488,9 +1488,9 @@ s32 simulatorReadPak(s32 channel, u16 address, u8* data) {
 }
 
 // Range: 0x80008FBC -> 0x80009038
-s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
+int simulatorWritePak(int channel, u16 address, u8* data) {
     // Parameters
-    // s32 channel; // r29
+    // int channel; // r29
     // u16 address; // r30
     // u8* data; // r31
 
@@ -1502,13 +1502,13 @@ s32 simulatorWritePak(s32 channel, u16 address, u8* data) {
 }
 
 // Range: 0x80008F4C -> 0x80008FBC
-s32 simulatorReadEEPROM(u8 address, u8* data) {
+int simulatorReadEEPROM(u8 address, u8* data) {
     // Parameters
     // u8 address; // r30
     // u8* data; // r31
 
     // Local variables
-    s32 size; // r1+0x10
+    int size; // r1+0x10
 
     // References
     // -> struct _MCARD mCard;
@@ -1516,13 +1516,13 @@ s32 simulatorReadEEPROM(u8 address, u8* data) {
 }
 
 // Range: 0x80008EDC -> 0x80008F4C
-s32 simulatorWriteEEPROM(u8 address, u8* data) {
+int simulatorWriteEEPROM(u8 address, u8* data) {
     // Parameters
     // u8 address; // r30
     // u8* data; // r31
 
     // Local variables
-    s32 size; // r1+0x10
+    int size; // r1+0x10
 
     // References
     // -> struct _MCARD mCard;
@@ -1530,59 +1530,59 @@ s32 simulatorWriteEEPROM(u8 address, u8* data) {
 }
 
 // Range: 0x80008EA8 -> 0x80008EDC
-s32 simulatorReadSRAM(u32 address, u8* data, s32 size) {
+int simulatorReadSRAM(unsigned int address, u8* data, int size) {
     // Parameters
-    // u32 address; // r4
+    // unsigned int address; // r4
     // u8* data; // r6
-    // s32 size; // r5
+    // int size; // r5
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80008E74 -> 0x80008EA8
-s32 simulatorWriteSRAM(u32 address, u8* data, s32 size) {
+int simulatorWriteSRAM(unsigned int address, u8* data, int size) {
     // Parameters
-    // u32 address; // r4
+    // unsigned int address; // r4
     // u8* data; // r6
-    // s32 size; // r5
+    // int size; // r5
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80008E40 -> 0x80008E74
-s32 simulatorReadFLASH(u32 address, u8* data, s32 size) {
+int simulatorReadFLASH(unsigned int address, u8* data, int size) {
     // Parameters
-    // u32 address; // r4
+    // unsigned int address; // r4
     // u8* data; // r6
-    // s32 size; // r5
+    // int size; // r5
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80008E0C -> 0x80008E40
-s32 simulatorWriteFLASH(u32 address, u8* data, s32 size) {
+int simulatorWriteFLASH(unsigned int address, u8* data, int size) {
     // Parameters
-    // u32 address; // r4
+    // unsigned int address; // r4
     // u8* data; // r6
-    // s32 size; // r5
+    // int size; // r5
 
     // References
     // -> struct _MCARD mCard;
 }
 
 // Range: 0x80008DE4 -> 0x80008E0C
-s32 simulatorRumbleStart(s32 channel) {
+int simulatorRumbleStart(int channel) {
     // Parameters
-    // s32 channel; // r3
+    // int channel; // r3
 }
 
 // Range: 0x80008DBC -> 0x80008DE4
-s32 simulatorRumbleStop(s32 channel) {
+int simulatorRumbleStop(int channel) {
     // Parameters
-    // s32 channel; // r3
+    // int channel; // r3
 }
 
 // Erased
@@ -1592,55 +1592,55 @@ static void* sScreenshotAlloc() {}
 static void sScreenshotFree() {}
 
 // Range: 0x80008BDC -> 0x80008DBC
-s32 simulatorTestReset(s32 IPL, s32 forceMenu, s32 allowReset, s32 usePreviousSettings) {
+int simulatorTestReset(int IPL, int forceMenu, int allowReset, int usePreviousSettings) {
     // Parameters
-    // s32 IPL; // r24
-    // s32 forceMenu; // r25
-    // s32 allowReset; // r26
-    // s32 usePreviousSettings; // r27
+    // int IPL; // r24
+    // int forceMenu; // r25
+    // int allowReset; // r26
+    // int usePreviousSettings; // r27
 
     // Local variables
-    u32 bFlag; // r1+0x8
-    u32 nTick; // r1+0x8
-    s32 prevIPLSetting; // r28
-    s32 prevForceMenuSetting; // r27
-    s32 prevAllowResetSetting; // r1+0x8
+    unsigned int bFlag; // r1+0x8
+    unsigned int nTick; // r1+0x8
+    int prevIPLSetting; // r28
+    int prevForceMenuSetting; // r27
+    int prevAllowResetSetting; // r1+0x8
 
     // References
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
+    // -> static unsigned int gnTickReset;
+    // -> static int gbReset;
     // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gResetBeginFlag;
-    // -> s32 gPreviousAllowResetSetting;
-    // -> s32 gPreviousForceMenuSetting;
-    // -> s32 gPreviousIPLSetting;
+    // -> int gResetBeginFlag;
+    // -> int gPreviousAllowResetSetting;
+    // -> int gPreviousForceMenuSetting;
+    // -> int gPreviousIPLSetting;
 }
 
 // Erased
-static s32 simulatorDrawText(s32 nX, s32 nY, char* szText, s32 nColorR, s32 nColorG, s32 nColorB) {
+static int simulatorDrawText(int nX, int nY, char* szText, int nColorR, int nColorG, int nColorB) {
     // Parameters
-    // s32 nX; // r26
-    // s32 nY; // r27
+    // int nX; // r26
+    // int nY; // r27
     // char* szText; // r28
-    // s32 nColorR; // r29
-    // s32 nColorG; // r30
-    // s32 nColorB; // r31
+    // int nColorR; // r29
+    // int nColorG; // r30
+    // int nColorB; // r31
 
     // Local variables
     struct _GXColor color; // r1+0x24
 }
 
 // Range: 0x80008B44 -> 0x80008BDC
-s32 simulatorDrawMCardText() {
+int simulatorDrawMCardText() {
     // References
     // -> char gpErrorMessageBuffer[20480];
 }
 
 // Range: 0x80008A14 -> 0x80008B44
-s32 simulatorMCardPollDrawBar() {
+int simulatorMCardPollDrawBar() {
     // Local variables
     f32 rate; // r1+0x8
-    s32 nBytes; // r1+0x8
+    int nBytes; // r1+0x8
 
     // References
     // -> char gpErrorMessageBuffer[20480];
@@ -1648,10 +1648,10 @@ s32 simulatorMCardPollDrawBar() {
 }
 
 // Range: 0x800088E4 -> 0x80008A14
-s32 simulatorMCardPollDrawFormatBar() {
+int simulatorMCardPollDrawFormatBar() {
     // Local variables
     f32 rate; // r1+0x8
-    s32 nBytes; // r1+0x8
+    int nBytes; // r1+0x8
 
     // References
     // -> char gpErrorMessageBuffer[20480];
@@ -1659,30 +1659,30 @@ s32 simulatorMCardPollDrawFormatBar() {
 }
 
 // Range: 0x800086DC -> 0x800088E4
-static s32 simulatorDrawCursor(s32 nX, s32 nY) {
+static int simulatorDrawCursor(int nX, int nY) {
     // Parameters
-    // s32 nX; // r30
-    // s32 nY; // r31
+    // int nX; // r30
+    // int nY; // r31
 
     // Local variables
     struct _GXColor color; // r1+0x18
-    s32 nTick; // r4
+    int nTick; // r4
 }
 
 // Erased
-static s32 simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, s32* yes) {
+static int simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, int* yes) {
     // Parameters
     // char* line1; // r21
     // char* line2; // r22
     // char* line3; // r23
-    // s32* yes; // r24
+    // int* yes; // r24
 
     // Local variables
-    s32 nCount; // r25
+    int nCount; // r25
 
     // References
     // -> struct __anon_0xAD2F DemoPad[4];
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
     // -> void* DemoCurrentBuffer;
     // -> void* DemoFrameBuffer2;
     // -> void* DemoFrameBuffer1;
@@ -1690,17 +1690,17 @@ static s32 simulatorDrawYesNoScreen(char* line1, char* line2, char* line3, s32* 
 }
 
 // Erased
-static s32 simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
+static int simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
     // Parameters
     // char* line1; // r22
     // char* line2; // r23
     // char* line3; // r24
 
     // Local variables
-    s32 nCount; // r25
+    int nCount; // r25
 
     // References
-    // -> s32 gButtonDownToggle;
+    // -> int gButtonDownToggle;
     // -> struct __anon_0xAD2F DemoPad[4];
     // -> void* DemoCurrentBuffer;
     // -> void* DemoFrameBuffer2;
@@ -1709,10 +1709,10 @@ static s32 simulatorDrawOKScreen(char* line1, char* line2, char* line3) {
 }
 
 // Erased
-static s32 simulatorPickROM() {}
+static int simulatorPickROM() {}
 
 // Erased
-static s32 simulatorMenu() {}
+static int simulatorMenu() {}
 
 // Erased
 static void MyGXInit() {
@@ -1722,7 +1722,7 @@ static void MyGXInit() {
 }
 
 // Erased
-static s32 editSoundMenu() {
+static int editSoundMenu() {
     // Local variables
     s32* menuValues[3]; // r1+0x94
     s32 menuMinMax[3][2]; // r1+0x7C
@@ -1750,9 +1750,9 @@ static s32 editSoundMenu() {
 }
 
 // Range: 0x80008578 -> 0x800086DC
-static s32 simulatorParseArguments() {
+static int simulatorParseArguments() {
     // Local variables
-    s32 iArgument; // r23
+    int iArgument; // r23
     char* szText; // r1+0x14
     char* szValue; // r1+0x10
 
@@ -1761,7 +1761,7 @@ static s32 simulatorParseArguments() {
 }
 
 // Range: 0x80008538 -> 0x80008578
-s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
+int simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
     // Parameters
     // enum __anon_0xA982 eType; // r1+0x0
     // char** pszArgument; // r1+0x4
@@ -1771,16 +1771,16 @@ s32 simulatorGetArgument(enum __anon_0xA982 eType, char** pszArgument) {
 }
 
 // Range: 0x80007F80 -> 0x80008538
-s32 xlMain() {
+int xlMain() {
     // Local variables
     struct _GXColor color; // r1+0x3C
     enum __anon_0xA6E7 eMode; // r1+0x38
-    s32 nSize0; // r1+0x34
-    s32 nSize1; // r1+0x30
-    s32 iName; // r5
+    int nSize0; // r1+0x34
+    int nSize1; // r1+0x30
+    int iName; // r5
     char* szNameROM; // r1+0x2C
     char acNameROM[32]; // r1+0xC
-    s32 rumbleYes; // r1+0x8
+    int rumbleYes; // r1+0x8
 
     // References
     // -> static struct __anon_0x57A1* gpCode;
@@ -1793,8 +1793,8 @@ s32 xlMain() {
     // -> struct _XL_OBJECTTYPE gClassCode;
     // -> static char* gaszArgument[8];
     // -> struct _MCARD mCard;
-    // -> static u32 gnTickReset;
-    // -> static s32 gbReset;
+    // -> static unsigned int gnTickReset;
+    // -> static int gbReset;
     // -> u8 gmesgOK[833];
     // -> u8 gno[1473];
     // -> u8 gyes[1473];
@@ -1809,8 +1809,8 @@ s32 xlMain() {
     // -> void* DemoCurrentBuffer;
     // -> void* DemoFrameBuffer2;
     // -> u8 DemoStatEnable;
-    // -> s32 gResetBeginFlag;
-    // -> s32 gButtonDownToggle;
-    // -> s32 gbDisplayedError;
-    // -> s32 gDVDResetToggle;
+    // -> int gResetBeginFlag;
+    // -> int gButtonDownToggle;
+    // -> int gbDisplayedError;
+    // -> int gDVDResetToggle;
 }

--- a/debug/Fire/soundGCN.c
+++ b/debug/Fire/soundGCN.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x20667; // size = 0x10
 
 // size = 0x10, address = 0x800EA7D8
@@ -29,25 +29,25 @@ typedef enum __anon_0x2084C {
 
 typedef struct __anon_0x208BA {
     /* 0x00 */ void* pSrcData;
-    /* 0x04 */ s32 nFrequency;
-    /* 0x08 */ s32 nDacrate;
-    /* 0x0C */ s32 nSndLen;
+    /* 0x04 */ int nFrequency;
+    /* 0x08 */ int nDacrate;
+    /* 0x0C */ int nSndLen;
     /* 0x10 */ void* apBuffer[16];
-    /* 0x50 */ s32 anSizeBuffer[16];
-    /* 0x90 */ s32 nCountBeep;
-    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0x50 */ int anSizeBuffer[16];
+    /* 0x90 */ int nCountBeep;
+    /* 0x94 */ int anSizeBeep[3];
     /* 0xA0 */ void* apDataBeep[3];
-    /* 0xAC */ s32 iBufferPlay;
-    /* 0xB0 */ s32 iBufferMake;
+    /* 0xAC */ int iBufferPlay;
+    /* 0xB0 */ int iBufferMake;
     /* 0xB4 */ enum __anon_0x2084C eMode;
     /* 0xB8 */ void* pBufferZero;
     /* 0xBC */ void* pBufferHold;
     /* 0xC0 */ void* pBufferRampUp;
     /* 0xC4 */ void* pBufferRampDown;
-    /* 0xC8 */ s32 nSizePlay;
-    /* 0xCC */ s32 nSizeZero;
-    /* 0xD0 */ s32 nSizeHold;
-    /* 0xD4 */ s32 nSizeRamp;
+    /* 0xC8 */ int nSizePlay;
+    /* 0xCC */ int nSizeZero;
+    /* 0xD0 */ int nSizeHold;
+    /* 0xD4 */ int nSizeRamp;
 } __anon_0x208BA; // size = 0xD8
 
 typedef enum __anon_0x20C8D {
@@ -96,12 +96,12 @@ typedef struct DVDFileInfo {
 } __anon_0x21262; // size = 0x3C
 
 typedef struct tXL_FILE {
-    /* 0x00 */ s32 iBuffer;
+    /* 0x00 */ int iBuffer;
     /* 0x04 */ void* pData;
     /* 0x08 */ void* pBuffer;
-    /* 0x0C */ s32 nAttributes;
-    /* 0x10 */ s32 nSize;
-    /* 0x14 */ s32 nOffset;
+    /* 0x0C */ int nAttributes;
+    /* 0x10 */ int nSize;
+    /* 0x14 */ int nOffset;
     /* 0x18 */ enum __anon_0x20E13 eType;
     /* 0x1C */ struct DVDFileInfo info;
 } __anon_0x2131A; // size = 0x58
@@ -113,10 +113,10 @@ typedef enum __anon_0x2152F {
 } __anon_0x2152F;
 
 typedef struct __anon_0x21596 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x21596; // size = 0x10
 
 typedef enum __anon_0x21647 {
@@ -160,7 +160,7 @@ typedef enum __anon_0x21778 {
 typedef struct __anon_0x218B8 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x2152F eMode;
     /* 0x10 */ struct __anon_0x21596 romCopy;
     /* 0x20 */ enum __anon_0x21647 eTypeROM;
@@ -168,7 +168,7 @@ typedef struct __anon_0x218B8 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x21778 storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x218B8; // size = 0x88
 
 // size = 0x4, address = 0x80135600
@@ -181,24 +181,24 @@ typedef enum __anon_0x221A3 {
 } __anon_0x221A3;
 
 // Range: 0x8001D250 -> 0x8001D34C
-s32 soundWipeBuffers(struct __anon_0x208BA* pSound) {
+int soundWipeBuffers(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r31
 
     // Local variables
-    s32 iBuffer; // r30
+    int iBuffer; // r30
 }
 
 // Range: 0x8001CD8C -> 0x8001D250
-static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon_0x221A3 eRamp) {
+static int soundMakeRamp(struct __anon_0x208BA* pSound, int iBuffer, enum __anon_0x221A3 eRamp) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r1+0x8
-    // s32 iBuffer; // r1+0xC
+    // int iBuffer; // r1+0xC
     // enum __anon_0x221A3 eRamp; // r1+0x10
 
     // Local variables
-    s32 bFlag; // r8
-    s32 iData; // r1+0x8
+    int bFlag; // r8
+    int iData; // r1+0x8
     s16* anData; // r9
     s16 nData0; // r10
     s16 nData1; // r11
@@ -211,26 +211,26 @@ static s32 soundMakeRamp(struct __anon_0x208BA* pSound, s32 iBuffer, enum __anon
 }
 
 // Erased
-static s32 soundMakeZero(struct __anon_0x208BA* pSound) {
+static int soundMakeZero(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r3
 
     // Local variables
-    s32 iData; // r7
+    int iData; // r7
 }
 
 // Erased
-static s32 soundMakeHold() {}
+static int soundMakeHold() {}
 
 // Range: 0x8001CCCC -> 0x8001CD8C
-static s32 soundPlayBuffer(struct __anon_0x208BA* pSound) {
+static int soundPlayBuffer(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r1+0x8
 
     // Local variables
     void* pData; // r6
-    s32 iBuffer; // r4
-    s32 nSize; // r4
+    int iBuffer; // r4
+    int nSize; // r4
 }
 
 // Range: 0x8001CCA4 -> 0x8001CCCC
@@ -240,7 +240,7 @@ static void soundCallbackDMA() {
 }
 
 // Range: 0x8001CAB8 -> 0x8001CCA4
-static s32 soundMakeBuffer(struct __anon_0x208BA* pSound) {
+static int soundMakeBuffer(struct __anon_0x208BA* pSound) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r29
 
@@ -249,13 +249,13 @@ static s32 soundMakeBuffer(struct __anon_0x208BA* pSound) {
     s16* curBufP; // r3
     u32 sampleStep; // r1+0x8
     u32 sample; // r6
-    s32 j; // r7
-    s32 nSize; // r4
-    s32 samp; // r11
-    s32 iBuffer; // r31
+    int j; // r7
+    int nSize; // r4
+    int samp; // r11
+    int iBuffer; // r31
     s32 vol; // r8
-    s32 bFlag; // r28
-    s32 bPlay; // r30
+    int bFlag; // r28
+    int bPlay; // r30
     s32 volAdjust; // r11
 
     // References
@@ -263,43 +263,43 @@ static s32 soundMakeBuffer(struct __anon_0x208BA* pSound) {
 }
 
 // Range: 0x8001CA80 -> 0x8001CAB8
-s32 soundSetLength(struct __anon_0x208BA* pSound, s32 nSize) {
+int soundSetLength(struct __anon_0x208BA* pSound, int nSize) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r3
-    // s32 nSize; // r1+0xC
+    // int nSize; // r1+0xC
 }
 
 // Range: 0x8001CA60 -> 0x8001CA80
-s32 soundSetDACRate(struct __anon_0x208BA* pSound, s32 nDacRate) {
+int soundSetDACRate(struct __anon_0x208BA* pSound, int nDacRate) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r1+0x0
-    // s32 nDacRate; // r1+0x4
+    // int nDacRate; // r1+0x4
 }
 
 // Erased
-static s32 soundSetBitRate() {}
+static int soundSetBitRate() {}
 
 // Range: 0x8001CA54 -> 0x8001CA60
-s32 soundSetAddress(struct __anon_0x208BA* pSound, void* pData) {
+int soundSetAddress(struct __anon_0x208BA* pSound, void* pData) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r1+0x0
     // void* pData; // r1+0x4
 }
 
 // Range: 0x8001CA20 -> 0x8001CA54
-s32 soundGetDMABuffer(u32* pnSize) {
+int soundGetDMABuffer(unsigned int* pnSize) {
     // Parameters
-    // u32* pnSize; // r31
+    // unsigned int* pnSize; // r31
 }
 
 // Range: 0x8001C880 -> 0x8001CA20
-s32 soundSetBufferSize(struct __anon_0x208BA* pSound, s32 nSize) {
+int soundSetBufferSize(struct __anon_0x208BA* pSound, int nSize) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r31
-    // s32 nSize; // r29
+    // int nSize; // r29
 
     // Local variables
-    s32 iBuffer; // r29
+    int iBuffer; // r29
 }
 
 // Erased
@@ -321,7 +321,7 @@ static void soundCallbackBeep() {
 }
 
 // Range: 0x8001C70C -> 0x8001C824
-s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
+int soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char* szNameFile) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r28
     // enum __anon_0x20C8D iBeep; // r1+0xC
@@ -332,27 +332,27 @@ s32 soundLoadBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep, char
 }
 
 // Range: 0x8001C690 -> 0x8001C70C
-s32 soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+int soundPlayBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r29
     // enum __anon_0x20C8D iBeep; // r1+0xC
 }
 
 // Erased
-static s32 soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
+static int soundFreeBeep(struct __anon_0x208BA* pSound, enum __anon_0x20C8D iBeep) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r5
     // enum __anon_0x20C8D iBeep; // r1+0xC
 }
 
 // Range: 0x8001C498 -> 0x8001C690
-s32 soundEvent(struct __anon_0x208BA* pSound, s32 nEvent) {
+int soundEvent(struct __anon_0x208BA* pSound, int nEvent) {
     // Parameters
     // struct __anon_0x208BA* pSound; // r3
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
 
     // Local variables
-    s32 iBuffer; // r1+0x8
+    int iBuffer; // r1+0x8
 
     // References
     // -> s32 gVolumeCurve[257];

--- a/debug/Fire/sram.c
+++ b/debug/Fire/sram.c
@@ -9,9 +9,9 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x749C7; // size = 0x10
 
 // size = 0x10, address = 0x800EE768
@@ -22,89 +22,89 @@ typedef struct __anon_0x74AB9 {
 } __anon_0x74AB9; // size = 0x4
 
 // Range: 0x8008E430 -> 0x8008E4A8
-s32 sramCopySRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
+int sramCopySRAM(struct __anon_0x74AB9* pSRAM, int nOffsetRAM, int nOffsetSRAM, int nSize) {
     // Parameters
     // struct __anon_0x74AB9* pSRAM; // r1+0x8
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetSRAM; // r31
-    // s32 nSize; // r1+0x14
+    // int nOffsetRAM; // r4
+    // int nOffsetSRAM; // r31
+    // int nSize; // r1+0x14
 
     // Local variables
     void* pTarget; // r1+0x18
 }
 
 // Range: 0x8008E3B8 -> 0x8008E430
-s32 sramTransferSRAM(struct __anon_0x74AB9* pSRAM, s32 nOffsetRAM, s32 nOffsetSRAM, s32 nSize) {
+int sramTransferSRAM(struct __anon_0x74AB9* pSRAM, int nOffsetRAM, int nOffsetSRAM, int nSize) {
     // Parameters
     // struct __anon_0x74AB9* pSRAM; // r1+0x8
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetSRAM; // r31
-    // s32 nSize; // r1+0x14
+    // int nOffsetRAM; // r4
+    // int nOffsetSRAM; // r31
+    // int nSize; // r1+0x14
 
     // Local variables
     void* pTarget; // r1+0x18
 }
 
 // Range: 0x8008E388 -> 0x8008E3B8
-static s32 sramPut8(u32 nAddress, char* pData) {
+static int sramPut8(unsigned int nAddress, char* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // char* pData; // r5
 }
 
 // Range: 0x8008E358 -> 0x8008E388
-static s32 sramPut16(u32 nAddress, s16* pData) {
+static int sramPut16(unsigned int nAddress, s16* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // s16* pData; // r5
 }
 
 // Range: 0x8008E328 -> 0x8008E358
-static s32 sramPut32(u32 nAddress, s32* pData) {
+static int sramPut32(unsigned int nAddress, int* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r5
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r5
 }
 
 // Range: 0x8008E2F8 -> 0x8008E328
-static s32 sramPut64(u32 nAddress, s64* pData) {
+static int sramPut64(unsigned int nAddress, s64* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // s64* pData; // r5
 }
 
 // Range: 0x8008E2C8 -> 0x8008E2F8
-static s32 sramGet8(u32 nAddress, char* pData) {
+static int sramGet8(unsigned int nAddress, char* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // char* pData; // r5
 }
 
 // Range: 0x8008E298 -> 0x8008E2C8
-static s32 sramGet16(u32 nAddress, s16* pData) {
+static int sramGet16(unsigned int nAddress, s16* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // s16* pData; // r5
 }
 
 // Range: 0x8008E268 -> 0x8008E298
-static s32 sramGet32(u32 nAddress, s32* pData) {
+static int sramGet32(unsigned int nAddress, int* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r5
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r5
 }
 
 // Range: 0x8008E238 -> 0x8008E268
-static s32 sramGet64(u32 nAddress, s64* pData) {
+static int sramGet64(unsigned int nAddress, s64* pData) {
     // Parameters
-    // u32 nAddress; // r1+0xC
+    // unsigned int nAddress; // r1+0xC
     // s64* pData; // r5
 }
 
 // Range: 0x8008E138 -> 0x8008E238
-s32 sramEvent(struct __anon_0x74AB9* pSram, s32 nEvent, void* pArgument) {
+int sramEvent(struct __anon_0x74AB9* pSram, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x74AB9* pSram; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }

--- a/debug/Fire/system.c
+++ b/debug/Fire/system.c
@@ -8,34 +8,34 @@
 #include "dolphin/types.h"
 
 // size = 0x4, address = 0x80134E60
-u32 nTickMultiplier;
+unsigned int nTickMultiplier;
 
 // size = 0x4, address = 0x80134E64
 f32 fTickScale;
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x343BA; // size = 0x10
 
 // size = 0x10, address = 0x800EB310
 struct _XL_OBJECTTYPE gClassSystem;
 
 // size = 0x140, address = 0x800EB320
-static u32 contMap[4][20];
+static unsigned int contMap[4][20];
 
 // size = 0x4, address = 0x801356D8
-u32 gnFlagZelda;
+unsigned int gnFlagZelda;
 
 typedef struct __anon_0x3459E {
     /* 0x000 */ char rom[36];
-    /* 0x024 */ s32 controllerConfiguration[4][20];
-    /* 0x164 */ s32 rumbleConfiguration;
-    /* 0x168 */ s32 storageDevice;
-    /* 0x16C */ s32 normalControllerConfig;
-    /* 0x170 */ s32 currentControllerConfig;
+    /* 0x024 */ int controllerConfiguration[4][20];
+    /* 0x164 */ int rumbleConfiguration;
+    /* 0x168 */ int storageDevice;
+    /* 0x16C */ int normalControllerConfig;
+    /* 0x170 */ int currentControllerConfig;
 } __anon_0x3459E; // size = 0x174
 
 // size = 0x174, address = 0x801308E0
@@ -49,11 +49,11 @@ typedef struct __anon_0x34768 {
 } __anon_0x34768; // size = 0x10
 
 typedef struct __anon_0x34802 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x34802; // size = 0x14
 
 typedef struct __anon_0x34943 {
@@ -63,7 +63,7 @@ typedef struct __anon_0x34943 {
 } __anon_0x34943; // size = 0xC
 
 typedef struct __anon_0x349B3 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x34943 rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -80,7 +80,7 @@ typedef struct __anon_0x349B3 {
 } __anon_0x349B3; // size = 0x3C
 
 typedef struct __anon_0x34BE3 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x34943 rS;
     /* 0x10 */ struct __anon_0x34943 rT;
     /* 0x1C */ struct __anon_0x34943 rSRaw;
@@ -98,7 +98,7 @@ typedef struct __anon_0x34CCC {
 typedef union __anon_0x34E2B {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x34E2B;
 
@@ -151,20 +151,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x351D0;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -173,11 +173,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x35239; // size = 0x6C
 
 typedef struct __anon_0x35596 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -188,7 +188,7 @@ typedef struct __anon_0x35596 {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x35596; // size = 0x2C
 
 typedef enum __anon_0x35878 {
@@ -198,14 +198,14 @@ typedef enum __anon_0x35878 {
 } __anon_0x35878;
 
 typedef struct __anon_0x358FC {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x35878 eProjection;
 } __anon_0x358FC; // size = 0x24
 
@@ -217,81 +217,81 @@ typedef struct _GXColor {
 } __anon_0x35A91; // size = 0x4
 
 typedef struct __anon_0x35B4C {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x34768 viewport;
     /* 0x000C8 */ struct __anon_0x34802 aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x349B3 aLight[8];
     /* 0x00320 */ struct __anon_0x34BE3 lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x34CCC aVertex[80];
     /* 0x00C18 */ struct __anon_0x34EC8 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x35596 aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x35878 eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -302,10 +302,10 @@ typedef struct __anon_0x35B4C {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x35B4C; // size = 0x3D150
 
@@ -321,25 +321,25 @@ typedef enum __anon_0x36A3E {
 
 typedef struct __anon_0x36AAA {
     /* 0x00 */ void* pSrcData;
-    /* 0x04 */ s32 nFrequency;
-    /* 0x08 */ s32 nDacrate;
-    /* 0x0C */ s32 nSndLen;
+    /* 0x04 */ int nFrequency;
+    /* 0x08 */ int nDacrate;
+    /* 0x0C */ int nSndLen;
     /* 0x10 */ void* apBuffer[16];
-    /* 0x50 */ s32 anSizeBuffer[16];
-    /* 0x90 */ s32 nCountBeep;
-    /* 0x94 */ s32 anSizeBeep[3];
+    /* 0x50 */ int anSizeBuffer[16];
+    /* 0x90 */ int nCountBeep;
+    /* 0x94 */ int anSizeBeep[3];
     /* 0xA0 */ void* apDataBeep[3];
-    /* 0xAC */ s32 iBufferPlay;
-    /* 0xB0 */ s32 iBufferMake;
+    /* 0xAC */ int iBufferPlay;
+    /* 0xB0 */ int iBufferMake;
     /* 0xB4 */ enum __anon_0x36A3E eMode;
     /* 0xB8 */ void* pBufferZero;
     /* 0xBC */ void* pBufferHold;
     /* 0xC0 */ void* pBufferRampUp;
     /* 0xC4 */ void* pBufferRampDown;
-    /* 0xC8 */ s32 nSizePlay;
-    /* 0xCC */ s32 nSizeZero;
-    /* 0xD0 */ s32 nSizeHold;
-    /* 0xD4 */ s32 nSizeRamp;
+    /* 0xC8 */ int nSizePlay;
+    /* 0xCC */ int nSizeZero;
+    /* 0xD0 */ int nSizeHold;
+    /* 0xD4 */ int nSizeRamp;
 } __anon_0x36AAA; // size = 0xD8
 
 // size = 0x4, address = 0x80135604
@@ -388,10 +388,10 @@ struct _XL_OBJECTTYPE gClassPeripheral;
 struct _XL_OBJECTTYPE gClassRdb;
 
 typedef struct __anon_0x37040 {
-    /* 0x0 */ s32 nSize;
-    /* 0x4 */ s32 nOffsetRAM;
-    /* 0x8 */ s32 nOffsetROM;
-    /* 0xC */ s32 (*pCallback)();
+    /* 0x0 */ int nSize;
+    /* 0x4 */ int nOffsetRAM;
+    /* 0x8 */ int nOffsetROM;
+    /* 0xC */ int (*pCallback)();
 } __anon_0x37040; // size = 0x10
 
 typedef enum __anon_0x370F1 {
@@ -414,7 +414,7 @@ typedef enum __anon_0x370F1 {
 typedef struct __anon_0x37240 {
     /* 0x00 */ void* pFrame;
     /* 0x04 */ void* pSound;
-    /* 0x08 */ s32 bException;
+    /* 0x08 */ int bException;
     /* 0x0C */ enum __anon_0x3A085 eMode;
     /* 0x10 */ struct __anon_0x37040 romCopy;
     /* 0x20 */ enum __anon_0x370F1 eTypeROM;
@@ -422,35 +422,35 @@ typedef struct __anon_0x37240 {
     /* 0x68 */ u64 nAddressBreak;
     /* 0x70 */ enum __anon_0x394CD storageDevice;
     /* 0x74 */ u8 anException[16];
-    /* 0x84 */ s32 bJapaneseVersion;
+    /* 0x84 */ int bJapaneseVersion;
 } __anon_0x37240; // size = 0x88
 
 typedef struct __anon_0x37408 {
-    /* 0x0 */ s32 nOffsetHost;
-    /* 0x4 */ s32 nAddressN64;
+    /* 0x0 */ int nOffsetHost;
+    /* 0x4 */ int nAddressN64;
 } __anon_0x37408; // size = 0x8
 
 typedef struct cpu_callerID {
-    /* 0x0 */ s32 N64address;
-    /* 0x4 */ s32 GCNaddress;
+    /* 0x0 */ int N64address;
+    /* 0x4 */ int GCNaddress;
 } __anon_0x3746E; // size = 0x8
 
 typedef struct cpu_function {
     /* 0x00 */ void* pnBase;
     /* 0x04 */ void* pfCode;
-    /* 0x08 */ s32 nCountJump;
+    /* 0x08 */ int nCountJump;
     /* 0x0C */ struct __anon_0x37408* aJump;
-    /* 0x10 */ s32 nAddress0;
-    /* 0x14 */ s32 nAddress1;
+    /* 0x10 */ int nAddress0;
+    /* 0x14 */ int nAddress1;
     /* 0x18 */ struct cpu_callerID* block;
-    /* 0x1C */ s32 callerID_total;
-    /* 0x20 */ s32 callerID_flag;
-    /* 0x24 */ u32 nChecksum;
-    /* 0x28 */ s32 timeToLive;
-    /* 0x2C */ s32 memory_size;
-    /* 0x30 */ s32 heapID;
-    /* 0x34 */ s32 heapWhere;
-    /* 0x38 */ s32 treeheapWhere;
+    /* 0x1C */ int callerID_total;
+    /* 0x20 */ int callerID_flag;
+    /* 0x24 */ unsigned int nChecksum;
+    /* 0x28 */ int timeToLive;
+    /* 0x2C */ int memory_size;
+    /* 0x30 */ int heapID;
+    /* 0x34 */ int heapWhere;
+    /* 0x38 */ int treeheapWhere;
     /* 0x3C */ struct cpu_function* prev;
     /* 0x40 */ struct cpu_function* left;
     /* 0x44 */ struct cpu_function* right;
@@ -469,8 +469,8 @@ typedef union __anon_0x377BD {
     /* 0x2 */ s16 _1s16;
     /* 0x4 */ s16 _2s16;
     /* 0x6 */ s16 s16;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
     /* 0x0 */ u8 _0u8;
     /* 0x1 */ u8 _1u8;
@@ -484,8 +484,8 @@ typedef union __anon_0x377BD {
     /* 0x2 */ u16 _1u16;
     /* 0x4 */ u16 _2u16;
     /* 0x6 */ u16 u16;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x377BD;
 
@@ -493,57 +493,57 @@ typedef union __anon_0x37BD1 {
     /* 0x0 */ f32 _0f32;
     /* 0x4 */ f32 f32;
     /* 0x0 */ f64 f64;
-    /* 0x0 */ s32 _0s32;
-    /* 0x4 */ s32 s32;
+    /* 0x0 */ int _0s32;
+    /* 0x4 */ int s32;
     /* 0x0 */ s64 s64;
-    /* 0x0 */ u32 _0u32;
-    /* 0x4 */ u32 u32;
+    /* 0x0 */ unsigned int _0u32;
+    /* 0x4 */ unsigned int u32;
     /* 0x0 */ u64 u64;
 } __anon_0x37BD1;
 
 typedef struct __anon_0x380DF {
-    /* 0x00 */ s32 nType;
+    /* 0x00 */ int nType;
     /* 0x04 */ void* pObject;
-    /* 0x08 */ s32 nOffsetAddress;
-    /* 0x0C */ s32 (*pfGet8)(void*, u32, char*);
-    /* 0x10 */ s32 (*pfGet16)(void*, u32, s16*);
-    /* 0x14 */ s32 (*pfGet32)(void*, u32, s32*);
-    /* 0x18 */ s32 (*pfGet64)(void*, u32, s64*);
-    /* 0x1C */ s32 (*pfPut8)(void*, u32, char*);
-    /* 0x20 */ s32 (*pfPut16)(void*, u32, s16*);
-    /* 0x24 */ s32 (*pfPut32)(void*, u32, s32*);
-    /* 0x28 */ s32 (*pfPut64)(void*, u32, s64*);
-    /* 0x2C */ u32 nAddressPhysical0;
-    /* 0x30 */ u32 nAddressPhysical1;
+    /* 0x08 */ int nOffsetAddress;
+    /* 0x0C */ int (*pfGet8)(void*, unsigned int, char*);
+    /* 0x10 */ int (*pfGet16)(void*, unsigned int, s16*);
+    /* 0x14 */ int (*pfGet32)(void*, unsigned int, int*);
+    /* 0x18 */ int (*pfGet64)(void*, unsigned int, s64*);
+    /* 0x1C */ int (*pfPut8)(void*, unsigned int, char*);
+    /* 0x20 */ int (*pfPut16)(void*, unsigned int, s16*);
+    /* 0x24 */ int (*pfPut32)(void*, unsigned int, int*);
+    /* 0x28 */ int (*pfPut64)(void*, unsigned int, s64*);
+    /* 0x2C */ unsigned int nAddressPhysical0;
+    /* 0x30 */ unsigned int nAddressPhysical1;
 } __anon_0x380DF; // size = 0x34
 
 typedef struct cpu_treeRoot {
     /* 0x00 */ u16 total;
-    /* 0x04 */ s32 total_memory;
-    /* 0x08 */ s32 root_address;
-    /* 0x0C */ s32 start_range;
-    /* 0x10 */ s32 end_range;
-    /* 0x14 */ s32 cache_miss;
-    /* 0x18 */ s32 cache[20];
+    /* 0x04 */ int total_memory;
+    /* 0x08 */ int root_address;
+    /* 0x0C */ int start_range;
+    /* 0x10 */ int end_range;
+    /* 0x14 */ int cache_miss;
+    /* 0x18 */ int cache[20];
     /* 0x68 */ struct cpu_function* left;
     /* 0x6C */ struct cpu_function* right;
-    /* 0x70 */ s32 kill_limit;
-    /* 0x74 */ s32 kill_number;
-    /* 0x78 */ s32 side;
+    /* 0x70 */ int kill_limit;
+    /* 0x74 */ int kill_number;
+    /* 0x78 */ int side;
     /* 0x7C */ struct cpu_function* restore;
-    /* 0x80 */ s32 restore_side;
+    /* 0x80 */ int restore_side;
 } __anon_0x383AD; // size = 0x84
 
 typedef struct _CPU_ADDRESS {
-    /* 0x0 */ s32 nN64;
-    /* 0x4 */ s32 nHost;
+    /* 0x0 */ int nN64;
+    /* 0x4 */ int nHost;
     /* 0x8 */ struct cpu_function* pFunction;
 } __anon_0x385EE; // size = 0xC
 
 typedef struct __anon_0x386A3 {
-    /* 0x0 */ u32 nAddress;
-    /* 0x4 */ u32 nOpcodeOld;
-    /* 0x8 */ u32 nOpcodeNew;
+    /* 0x0 */ unsigned int nAddress;
+    /* 0x4 */ unsigned int nOpcodeOld;
+    /* 0x8 */ unsigned int nOpcodeNew;
 } __anon_0x386A3; // size = 0xC
 
 typedef struct OSContext {
@@ -575,61 +575,61 @@ typedef struct OSAlarm {
 } __anon_0x38A25; // size = 0x28
 
 typedef struct cpu_optimize {
-    /* 0x00 */ u32 validCheck;
-    /* 0x04 */ u32 destGPR_check;
-    /* 0x08 */ s32 destGPR;
-    /* 0x0C */ s32 destGPR_mapping;
-    /* 0x10 */ u32 destFPR_check;
-    /* 0x14 */ s32 destFPR;
-    /* 0x18 */ u32 addr_check;
-    /* 0x1C */ s32 addr_last;
-    /* 0x20 */ u32 checkType;
-    /* 0x24 */ u32 checkNext;
+    /* 0x00 */ unsigned int validCheck;
+    /* 0x04 */ unsigned int destGPR_check;
+    /* 0x08 */ int destGPR;
+    /* 0x0C */ int destGPR_mapping;
+    /* 0x10 */ unsigned int destFPR_check;
+    /* 0x14 */ int destFPR;
+    /* 0x18 */ unsigned int addr_check;
+    /* 0x1C */ int addr_last;
+    /* 0x20 */ unsigned int checkType;
+    /* 0x24 */ unsigned int checkNext;
 } __anon_0x38B40; // size = 0x28
 
 typedef struct _CPU {
-    /* 0x00000 */ s32 nMode;
-    /* 0x00004 */ s32 nTick;
+    /* 0x00000 */ int nMode;
+    /* 0x00004 */ int nTick;
     /* 0x00008 */ void* pHost;
     /* 0x00010 */ s64 nLo;
     /* 0x00018 */ s64 nHi;
-    /* 0x00020 */ s32 nCountAddress;
-    /* 0x00024 */ s32 iDeviceDefault;
-    /* 0x00028 */ u32 nPC;
-    /* 0x0002C */ u32 nWaitPC;
-    /* 0x00030 */ u32 nCallLast;
+    /* 0x00020 */ int nCountAddress;
+    /* 0x00024 */ int iDeviceDefault;
+    /* 0x00028 */ unsigned int nPC;
+    /* 0x0002C */ unsigned int nWaitPC;
+    /* 0x00030 */ unsigned int nCallLast;
     /* 0x00034 */ struct cpu_function* pFunctionLast;
-    /* 0x00038 */ s32 nReturnAddrLast;
-    /* 0x0003C */ s32 survivalTimer;
+    /* 0x00038 */ int nReturnAddrLast;
+    /* 0x0003C */ int survivalTimer;
     /* 0x00040 */ union __anon_0x377BD aGPR[32];
     /* 0x00140 */ union __anon_0x37BD1 aFPR[32];
     /* 0x00240 */ u64 aTLB[48][5];
-    /* 0x009C0 */ s32 anFCR[32];
+    /* 0x009C0 */ int anFCR[32];
     /* 0x00A40 */ s64 anCP0[32];
-    /* 0x00B40 */ s32 (*pfStep)(struct _CPU*);
-    /* 0x00B44 */ s32 (*pfJump)(struct _CPU*);
-    /* 0x00B48 */ s32 (*pfCall)(struct _CPU*);
-    /* 0x00B4C */ s32 (*pfIdle)(struct _CPU*);
-    /* 0x00B50 */ s32 (*pfRam)(struct _CPU*);
-    /* 0x00B54 */ s32 (*pfRamF)(struct _CPU*);
-    /* 0x00B58 */ u32 nTickLast;
-    /* 0x00B5C */ u32 nRetrace;
-    /* 0x00B60 */ u32 nRetraceUsed;
+    /* 0x00B40 */ int (*pfStep)(struct _CPU*);
+    /* 0x00B44 */ int (*pfJump)(struct _CPU*);
+    /* 0x00B48 */ int (*pfCall)(struct _CPU*);
+    /* 0x00B4C */ int (*pfIdle)(struct _CPU*);
+    /* 0x00B50 */ int (*pfRam)(struct _CPU*);
+    /* 0x00B54 */ int (*pfRamF)(struct _CPU*);
+    /* 0x00B58 */ unsigned int nTickLast;
+    /* 0x00B5C */ unsigned int nRetrace;
+    /* 0x00B60 */ unsigned int nRetraceUsed;
     /* 0x00B64 */ struct __anon_0x380DF* apDevice[256];
     /* 0x00F64 */ u8 aiDevice[65536];
     /* 0x10F64 */ void* gHeap1;
     /* 0x10F68 */ void* gHeap2;
-    /* 0x10F6C */ u32 aHeap1Flag[192];
-    /* 0x1126C */ u32 aHeap2Flag[13];
+    /* 0x10F6C */ unsigned int aHeap1Flag[192];
+    /* 0x1126C */ unsigned int aHeap2Flag[13];
     /* 0x112A0 */ struct cpu_treeRoot* gTree;
     /* 0x112A4 */ struct _CPU_ADDRESS aAddressCache[256];
-    /* 0x11EA4 */ s32 nCountCodeHack;
+    /* 0x11EA4 */ int nCountCodeHack;
     /* 0x11EA8 */ struct __anon_0x386A3 aCodeHack[32];
     /* 0x12028 */ s64 nTimeRetrace;
     /* 0x12030 */ struct OSAlarm alarmRetrace;
-    /* 0x12058 */ u32 nFlagRAM;
-    /* 0x1205C */ u32 nFlagCODE;
-    /* 0x12060 */ u32 nCompileFlag;
+    /* 0x12058 */ unsigned int nFlagRAM;
+    /* 0x1205C */ unsigned int nFlagCODE;
+    /* 0x12060 */ unsigned int nCompileFlag;
     /* 0x12064 */ struct cpu_optimize nOptimize;
 } __anon_0x38CED; // size = 0x12090
 
@@ -645,7 +645,7 @@ typedef enum __anon_0x39384 {
 
 typedef struct __anon_0x393FF {
     /* 0x00 */ char* szType;
-    /* 0x04 */ u32 nMask;
+    /* 0x04 */ unsigned int nMask;
     /* 0x08 */ enum __anon_0x3994B eCode;
     /* 0x0C */ enum __anon_0x3979C eType;
     /* 0x10 */ enum __anon_0x39384 eTypeMips;
@@ -746,25 +746,25 @@ typedef enum __anon_0x3A085 {
 struct __anon_0x37240* gpSystem;
 
 typedef struct __anon_0x3A807 {
-    /* 0x00 */ s32 configuration;
-    /* 0x04 */ s32 size;
-    /* 0x08 */ s32 offset;
+    /* 0x00 */ int configuration;
+    /* 0x04 */ int size;
+    /* 0x08 */ int offset;
     /* 0x0C */ char* buffer;
-    /* 0x10 */ s32* writtenBlocks;
-    /* 0x14 */ s32 writtenConfig;
+    /* 0x10 */ int* writtenBlocks;
+    /* 0x14 */ int writtenConfig;
 } __anon_0x3A807; // size = 0x18
 
 typedef struct OSCalendarTime {
-    /* 0x00 */ s32 sec;
-    /* 0x04 */ s32 min;
-    /* 0x08 */ s32 hour;
-    /* 0x0C */ s32 mday;
-    /* 0x10 */ s32 mon;
-    /* 0x14 */ s32 year;
-    /* 0x18 */ s32 wday;
-    /* 0x1C */ s32 yday;
-    /* 0x20 */ s32 msec;
-    /* 0x24 */ s32 usec;
+    /* 0x00 */ int sec;
+    /* 0x04 */ int min;
+    /* 0x08 */ int hour;
+    /* 0x0C */ int mday;
+    /* 0x10 */ int mon;
+    /* 0x14 */ int year;
+    /* 0x18 */ int wday;
+    /* 0x1C */ int yday;
+    /* 0x20 */ int msec;
+    /* 0x24 */ int usec;
 } __anon_0x3A9AA; // size = 0x28
 
 typedef struct CARDFileInfo {
@@ -777,16 +777,16 @@ typedef struct CARDFileInfo {
 } __anon_0x3AB18; // size = 0x14
 
 typedef struct __anon_0x3AC10 {
-    /* 0x000 */ s32 currentGame;
-    /* 0x004 */ s32 fileSize;
+    /* 0x000 */ int currentGame;
+    /* 0x004 */ int fileSize;
     /* 0x008 */ char name[33];
-    /* 0x02C */ s32 numberOfGames;
+    /* 0x02C */ int numberOfGames;
     /* 0x030 */ struct __anon_0x3A807 game;
-    /* 0x048 */ s32 changedDate;
-    /* 0x04C */ s32 changedChecksum;
-    /* 0x050 */ s32 gameSize[16];
-    /* 0x090 */ s32 gameOffset[16];
-    /* 0x0D0 */ s32 gameConfigIndex[16];
+    /* 0x048 */ int changedDate;
+    /* 0x04C */ int changedChecksum;
+    /* 0x050 */ int gameSize[16];
+    /* 0x090 */ int gameOffset[16];
+    /* 0x0D0 */ int gameConfigIndex[16];
     /* 0x110 */ char gameName[16][33];
     /* 0x320 */ struct OSCalendarTime time;
     /* 0x348 */ struct CARDFileInfo fileInfo;
@@ -824,42 +824,42 @@ typedef enum __anon_0x3AE26 {
 typedef struct _MCARD {
     /* 0x000 */ struct __anon_0x3AC10 file;
     /* 0x35C */ enum __anon_0x3AE26 error;
-    /* 0x360 */ s32 slot;
-    /* 0x364 */ s32 (*pPollFunction)();
-    /* 0x368 */ s32 pollPrevBytes;
-    /* 0x36C */ s32 pollSize;
+    /* 0x360 */ int slot;
+    /* 0x364 */ int (*pPollFunction)();
+    /* 0x368 */ int pollPrevBytes;
+    /* 0x36C */ int pollSize;
     /* 0x370 */ char pollMessage[256];
-    /* 0x470 */ s32 saveToggle;
+    /* 0x470 */ int saveToggle;
     /* 0x474 */ char* writeBuffer;
     /* 0x478 */ char* readBuffer;
-    /* 0x47C */ s32 writeToggle;
-    /* 0x480 */ s32 soundToggle;
-    /* 0x484 */ s32 writeStatus;
-    /* 0x488 */ s32 writeIndex;
-    /* 0x48C */ s32 accessType;
-    /* 0x490 */ s32 gameIsLoaded;
+    /* 0x47C */ int writeToggle;
+    /* 0x480 */ int soundToggle;
+    /* 0x484 */ int writeStatus;
+    /* 0x488 */ int writeIndex;
+    /* 0x48C */ int accessType;
+    /* 0x490 */ int gameIsLoaded;
     /* 0x494 */ char saveFileName[256];
     /* 0x594 */ char saveComment[256];
     /* 0x694 */ char* saveIcon;
     /* 0x698 */ char* saveBanner;
     /* 0x69C */ char saveGameName[256];
-    /* 0x79C */ s32 saveFileSize;
-    /* 0x7A0 */ s32 saveGameSize;
-    /* 0x7A4 */ s32 bufferCreated;
-    /* 0x7A8 */ s32 cardSize;
-    /* 0x7AC */ s32 wait;
-    /* 0x7B0 */ s32 isBroken;
-    /* 0x7B4 */ s32 saveConfiguration;
+    /* 0x79C */ int saveFileSize;
+    /* 0x7A0 */ int saveGameSize;
+    /* 0x7A4 */ int bufferCreated;
+    /* 0x7A8 */ int cardSize;
+    /* 0x7AC */ int wait;
+    /* 0x7B0 */ int isBroken;
+    /* 0x7B4 */ int saveConfiguration;
 } __anon_0x3B0C8; // size = 0x7B8
 
 // size = 0x7B8, address = 0x801079B0
 struct _MCARD mCard;
 
 // size = 0x4, address = 0x80134D8C
-u32 gz_iconSize;
+unsigned int gz_iconSize;
 
 // size = 0x4, address = 0x80134D88
-u32 gz_bnrSize;
+unsigned int gz_bnrSize;
 
 typedef struct DVDDiskID {
     /* 0x0 */ char gameName[4];
@@ -901,57 +901,57 @@ typedef enum __anon_0x3BAA7 {
 } __anon_0x3BAA7;
 
 typedef struct __anon_0x3BB09 {
-    /* 0x0 */ s32 iCache;
-    /* 0x4 */ u32 nSize;
-    /* 0x8 */ u32 nTickUsed;
+    /* 0x0 */ int iCache;
+    /* 0x4 */ unsigned int nSize;
+    /* 0x8 */ unsigned int nTickUsed;
     /* 0xC */ char keep;
 } __anon_0x3BB09; // size = 0x10
 
 typedef struct __anon_0x3BC1D {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 (*pCallback)();
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int (*pCallback)();
     /* 0x08 */ u8* pTarget;
-    /* 0x0C */ u32 nSize;
-    /* 0x10 */ u32 nOffset;
+    /* 0x0C */ unsigned int nSize;
+    /* 0x10 */ unsigned int nOffset;
 } __anon_0x3BC1D; // size = 0x14
 
 typedef struct __anon_0x3BCFD {
-    /* 0x00 */ s32 bWait;
-    /* 0x04 */ s32 bDone;
-    /* 0x08 */ s32 nResult;
+    /* 0x00 */ int bWait;
+    /* 0x04 */ int bDone;
+    /* 0x08 */ int nResult;
     /* 0x0C */ u8* anData;
-    /* 0x10 */ s32 (*pCallback)();
-    /* 0x14 */ s32 iCache;
-    /* 0x18 */ s32 iBlock;
-    /* 0x1C */ s32 nOffset;
-    /* 0x20 */ u32 nOffset0;
-    /* 0x24 */ u32 nOffset1;
-    /* 0x28 */ u32 nSize;
-    /* 0x2C */ u32 nSizeRead;
+    /* 0x10 */ int (*pCallback)();
+    /* 0x14 */ int iCache;
+    /* 0x18 */ int iBlock;
+    /* 0x1C */ int nOffset;
+    /* 0x20 */ unsigned int nOffset0;
+    /* 0x24 */ unsigned int nOffset1;
+    /* 0x28 */ unsigned int nSize;
+    /* 0x2C */ unsigned int nSizeRead;
 } __anon_0x3BCFD; // size = 0x30
 
 typedef struct __anon_0x3BEE8 {
     /* 0x00000 */ void* pHost;
     /* 0x00004 */ void* pBuffer;
-    /* 0x00008 */ s32 bFlip;
-    /* 0x0000C */ s32 bLoad;
+    /* 0x00008 */ int bFlip;
+    /* 0x0000C */ int bLoad;
     /* 0x00010 */ char acNameFile[513];
-    /* 0x00214 */ u32 nSize;
+    /* 0x00214 */ unsigned int nSize;
     /* 0x00218 */ enum __anon_0x3BAA7 eModeLoad;
     /* 0x0021C */ struct __anon_0x3BB09 aBlock[4096];
-    /* 0x1021C */ u32 nTick;
+    /* 0x1021C */ unsigned int nTick;
     /* 0x10220 */ u8* pCacheRAM;
     /* 0x10224 */ u8 anBlockCachedRAM[1024];
     /* 0x10624 */ u8 anBlockCachedARAM[2046];
     /* 0x10E24 */ struct __anon_0x3BC1D copy;
     /* 0x10E38 */ struct __anon_0x3BCFD load;
-    /* 0x10E68 */ s32 nCountBlockRAM;
-    /* 0x10E6C */ s32 nSizeCacheRAM;
+    /* 0x10E68 */ int nCountBlockRAM;
+    /* 0x10E6C */ int nSizeCacheRAM;
     /* 0x10E70 */ u8 acHeader[64];
-    /* 0x10EB0 */ u32* anOffsetBlock;
-    /* 0x10EB4 */ s32 nCountOffsetBlocks;
+    /* 0x10EB0 */ unsigned int* anOffsetBlock;
+    /* 0x10EB4 */ int nCountOffsetBlocks;
     /* 0x10EB8 */ struct DVDFileInfo fileInfo;
-    /* 0x10EF4 */ s32 offsetToRom;
+    /* 0x10EF4 */ int offsetToRom;
 } __anon_0x3BEE8; // size = 0x10EF8
 
 typedef enum __anon_0x3C277 {
@@ -976,177 +976,177 @@ typedef struct __anon_0x3C350 {
 } __anon_0x3C350; // size = 0x30
 
 // Range: 0x80030B38 -> 0x80030E70
-static s32 systemSetupGameRAM(struct __anon_0x37240* pSystem) {
+static int systemSetupGameRAM(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r27
 
     // Local variables
     char* szExtra; // r1+0x414
-    s32 bExpansion; // r30
-    s32 nSizeRAM; // r28
-    s32 nSizeCacheROM; // r29
-    s32 nSizeExtra; // r3
+    int bExpansion; // r30
+    int nSizeRAM; // r28
+    int nSizeCacheROM; // r29
+    int nSizeExtra; // r3
     struct __anon_0x3BEE8* pROM; // r29
-    u32 nCode; // r28
-    u32 iCode; // r1+0x8
-    u32 anCode[256]; // r1+0x14
+    unsigned int nCode; // r28
+    unsigned int iCode; // r1+0x8
+    unsigned int anCode[256]; // r1+0x14
 
     // References
-    // -> u32 gnFlagZelda;
+    // -> unsigned int gnFlagZelda;
 }
 
 // Erased
-static s32 systemMapControllerIndex(s32 gameIndex, s32 configIndex) {
+static int systemMapControllerIndex(int gameIndex, int configIndex) {
     // Parameters
-    // s32 gameIndex; // r1+0xC
-    // s32 configIndex; // r30
+    // int gameIndex; // r1+0xC
+    // int configIndex; // r30
 
     // Local variables
-    s32 i; // r31
+    int i; // r31
 
     // References
-    // -> static u32 contMap[4][20];
+    // -> static unsigned int contMap[4][20];
     // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
 }
 
 // Range: 0x80030364 -> 0x80030B38
-s32 systemGetInitialConfiguration(struct __anon_0x3BEE8* pROM, s32 index) {
+int systemGetInitialConfiguration(struct __anon_0x3BEE8* pROM, int index) {
     // Parameters
     // struct __anon_0x3BEE8* pROM; // r24
-    // s32 index; // r1+0x10
+    // int index; // r1+0x10
 
     // Local variables
     char* szText; // r1+0x14
 
     // References
     // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
-    // -> static u32 contMap[4][20];
+    // -> static unsigned int contMap[4][20];
 }
 
 // Range: 0x8002DD70 -> 0x80030364
-static s32 systemSetupGameALL(struct __anon_0x37240* pSystem) {
+static int systemSetupGameALL(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r18
 
     // Local variables
-    s32 nSizeSound; // r23
-    s32 iController; // r21
-    s32 nSize; // r1+0x60
-    u32* anMode; // r1+0x5C
-    s32 i; // r25
+    int nSizeSound; // r23
+    int iController; // r21
+    int nSize; // r1+0x60
+    unsigned int* anMode; // r1+0x5C
+    int i; // r25
     u64 nTimeRetrace; // r1+0x10
     char acCode[5]; // r1+0x54
     struct DVDFileInfo fileInfo; // r1+0x18
     struct _CPU* pCPU; // r31
     struct __anon_0x3BEE8* pROM; // r19
     struct __anon_0x3C350* pPIF; // r29
-    s32 defaultConfiguration; // r1+0x14
+    int defaultConfiguration; // r1+0x14
 
     // References
-    // -> static u32 contMap[4][20];
+    // -> static unsigned int contMap[4][20];
     // -> struct __anon_0x3459E gSystemRomConfigurationList[1];
     // -> struct _MCARD mCard;
     // -> struct __anon_0x37240* gpSystem;
-    // -> u32 gz_bnrSize;
-    // -> u32 gz_iconSize;
-    // -> u32 nTickMultiplier;
-    // -> u32 gnFlagZelda;
+    // -> unsigned int gz_bnrSize;
+    // -> unsigned int gz_iconSize;
+    // -> unsigned int nTickMultiplier;
+    // -> unsigned int gnFlagZelda;
     // -> f32 fTickScale;
 }
 
 // Erased
-static s32 systemClearExceptions(struct __anon_0x37240* pSystem) {
+static int systemClearExceptions(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r1+0x0
 
     // Local variables
-    s32 iException; // r1+0x0
+    int iException; // r1+0x0
 }
 
 // Range: 0x8002DB94 -> 0x8002DD70
-static s32 systemGetException(enum __anon_0x3979C eType, struct __anon_0x393FF* pException) {
+static int systemGetException(enum __anon_0x3979C eType, struct __anon_0x393FF* pException) {
     // Parameters
     // enum __anon_0x3979C eType; // r1+0x4
     // struct __anon_0x393FF* pException; // r1+0x8
 }
 
 // Range: 0x8002DB84 -> 0x8002DB94
-static s32 systemGet8(char* pData) {
+static int systemGet8(char* pData) {
     // Parameters
     // char* pData; // r1+0x8
 }
 
 // Range: 0x8002DB74 -> 0x8002DB84
-static s32 systemGet16(s16* pData) {
+static int systemGet16(s16* pData) {
     // Parameters
     // s16* pData; // r1+0x8
 }
 
 // Range: 0x8002DB64 -> 0x8002DB74
-static s32 systemGet32(s32* pData) {
+static int systemGet32(int* pData) {
     // Parameters
-    // s32* pData; // r1+0x8
+    // int* pData; // r1+0x8
 }
 
 // Range: 0x8002DB50 -> 0x8002DB64
-static s32 systemGet64(s64* pData) {
+static int systemGet64(s64* pData) {
     // Parameters
     // s64* pData; // r1+0x8
 }
 
 // Range: 0x8002DB48 -> 0x8002DB50
-static s32 systemPut8() {}
+static int systemPut8() {}
 
 // Range: 0x8002DB40 -> 0x8002DB48
-static s32 systemPut16() {}
+static int systemPut16() {}
 
 // Range: 0x8002DB38 -> 0x8002DB40
-static s32 systemPut32() {}
+static int systemPut32() {}
 
 // Range: 0x8002DB30 -> 0x8002DB38
-static s32 systemPut64() {}
+static int systemPut64() {}
 
 // Range: 0x8002D9F8 -> 0x8002DB30
-static s32 __systemCopyROM_Complete() {
+static int __systemCopyROM_Complete() {
     // Local variables
-    s32 iAddress; // r30
-    s32 nCount; // r1+0x88
-    u32 nAddress0; // r30
-    u32 nAddress1; // r31
-    u32 anAddress[32]; // r1+0x8
+    int iAddress; // r30
+    int nCount; // r1+0x88
+    unsigned int nAddress0; // r30
+    unsigned int nAddress1; // r31
+    unsigned int anAddress[32]; // r1+0x8
 
     // References
     // -> struct __anon_0x37240* gpSystem;
 }
 
 // Range: 0x8002D904 -> 0x8002D9F8
-s32 systemCopyROM(struct __anon_0x37240* pSystem, s32 nOffsetRAM, s32 nOffsetROM, s32 nSize, s32 (*pCallback)()) {
+int systemCopyROM(struct __anon_0x37240* pSystem, int nOffsetRAM, int nOffsetROM, int nSize, int (*pCallback)()) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r29
-    // s32 nOffsetRAM; // r4
-    // s32 nOffsetROM; // r30
-    // s32 nSize; // r1+0x14
-    // s32 (* pCallback)(); // r31
+    // int nOffsetRAM; // r4
+    // int nOffsetROM; // r30
+    // int nSize; // r1+0x14
+    // int (* pCallback)(); // r31
 
     // Local variables
     void* pTarget; // r1+0x1C
 }
 
 // Erased
-static s32 systemSetBreak(struct __anon_0x37240* pSystem, s64 nAddress) {
+static int systemSetBreak(struct __anon_0x37240* pSystem, s64 nAddress) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r1+0x0
     // s64 nAddress; // r1+0x8
 }
 
 // Erased
-static s32 systemClearBreak(struct __anon_0x37240* pSystem) {
+static int systemClearBreak(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r1+0x0
 }
 
 // Range: 0x8002D894 -> 0x8002D904
-s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
+int systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r30
     // enum __anon_0x3A085 eMode; // r31
@@ -1156,7 +1156,7 @@ s32 systemSetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085 eMode) {
 }
 
 // Range: 0x8002D82C -> 0x8002D894
-s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
+int systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r30
     // enum __anon_0x3A085* peMode; // r31
@@ -1166,7 +1166,7 @@ s32 systemGetMode(struct __anon_0x37240* pSystem, enum __anon_0x3A085* peMode) {
 }
 
 // Range: 0x8002D740 -> 0x8002D82C
-s32 systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD storageDevice) {
+int systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD storageDevice) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r30
     // enum __anon_0x394CD storageDevice; // r31
@@ -1177,59 +1177,59 @@ s32 systemSetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD s
 }
 
 // Range: 0x8002D730 -> 0x8002D740
-s32 systemGetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD* pStorageDevice) {
+int systemGetStorageDevice(struct __anon_0x37240* pSystem, enum __anon_0x394CD* pStorageDevice) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r1+0x0
     // enum __anon_0x394CD* pStorageDevice; // r1+0x4
 }
 
 // Range: 0x8002D578 -> 0x8002D730
-s32 systemReset(struct __anon_0x37240* pSystem) {
+int systemReset(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r29
 
     // Local variables
     s64 nPC; // r1+0x10
-    s32 nOffsetRAM; // r4
+    int nOffsetRAM; // r4
     enum __anon_0x394CD eObject; // r30
 }
 
 // Range: 0x8002D47C -> 0x8002D578
-s32 systemExecute(struct __anon_0x37240* pSystem, s32 nCount) {
+int systemExecute(struct __anon_0x37240* pSystem, int nCount) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r31
-    // s32 nCount; // r4
+    // int nCount; // r4
 
     // References
     // -> struct _XL_OBJECTTYPE gClassSystem;
 }
 
 // Range: 0x8002D324 -> 0x8002D47C
-s32 systemCheckInterrupts(struct __anon_0x37240* pSystem) {
+int systemCheckInterrupts(struct __anon_0x37240* pSystem) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r25
 
     // Local variables
-    s32 iException; // r30
-    s32 nMaskFinal; // r29
-    s32 bUsed; // r28
-    s32 bDone; // r27
+    int iException; // r30
+    int nMaskFinal; // r29
+    int bUsed; // r28
+    int bDone; // r27
     struct __anon_0x393FF exception; // r1+0xC
     enum __anon_0x3994B eCodeFinal; // r26
 }
 
 // Range: 0x8002D2EC -> 0x8002D324
-s32 systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
+int systemExceptionPending(struct __anon_0x37240* pSystem, enum __anon_0x3979C eType) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r1+0x0
     // enum __anon_0x3979C eType; // r1+0x4
 }
 
 // Range: 0x8002CA14 -> 0x8002D2EC
-s32 systemEvent(struct __anon_0x37240* pSystem, s32 nEvent, void* pArgument) {
+int systemEvent(struct __anon_0x37240* pSystem, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x37240* pSystem; // r31
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r26
 
     // Local variables

--- a/debug/Fire/video.c
+++ b/debug/Fire/video.c
@@ -9,31 +9,31 @@
 
 typedef struct _XL_OBJECTTYPE {
     /* 0x0 */ char* szName;
-    /* 0x4 */ s32 nSizeObject;
+    /* 0x4 */ int nSizeObject;
     /* 0x8 */ struct _XL_OBJECTTYPE* pClassBase;
-    /* 0xC */ s32 (*pfEvent)(void*, s32, void*);
+    /* 0xC */ int (*pfEvent)(void*, int, void*);
 } __anon_0x75A44; // size = 0x10
 
 // size = 0x10, address = 0x800EE870
 struct _XL_OBJECTTYPE gClassVideo;
 
 typedef struct __anon_0x75B37 {
-    /* 0x00 */ s32 nScan;
-    /* 0x04 */ s32 bBlack;
-    /* 0x08 */ s32 nBurst;
-    /* 0x0C */ s32 nSizeX;
+    /* 0x00 */ int nScan;
+    /* 0x04 */ int bBlack;
+    /* 0x08 */ int nBurst;
+    /* 0x0C */ int nSizeX;
     /* 0x10 */ void* pHost;
-    /* 0x14 */ s32 nStatus;
-    /* 0x18 */ s32 nTiming;
-    /* 0x1C */ s32 nAddress;
-    /* 0x20 */ s32 nScanInterrupt;
-    /* 0x24 */ s32 nScaleX;
-    /* 0x28 */ s32 nScaleY;
-    /* 0x2C */ s32 nStartH;
-    /* 0x30 */ s32 nStartV;
-    /* 0x34 */ s32 nSyncH;
-    /* 0x38 */ s32 nSyncV;
-    /* 0x3C */ s32 nSyncLeap;
+    /* 0x14 */ int nStatus;
+    /* 0x18 */ int nTiming;
+    /* 0x1C */ int nAddress;
+    /* 0x20 */ int nScanInterrupt;
+    /* 0x24 */ int nScaleX;
+    /* 0x28 */ int nScaleY;
+    /* 0x2C */ int nStartH;
+    /* 0x30 */ int nStartV;
+    /* 0x34 */ int nSyncH;
+    /* 0x38 */ int nSyncV;
+    /* 0x3C */ int nSyncLeap;
 } __anon_0x75B37; // size = 0x40
 
 typedef struct __anon_0x76165 {
@@ -44,11 +44,11 @@ typedef struct __anon_0x76165 {
 } __anon_0x76165; // size = 0x10
 
 typedef struct __anon_0x761FF {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nWidth;
-    /* 0x08 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nWidth;
+    /* 0x08 */ int nFormat;
     /* 0x0C */ void* pData;
-    /* 0x10 */ s32 nAddress;
+    /* 0x10 */ int nAddress;
 } __anon_0x761FF; // size = 0x14
 
 typedef struct __anon_0x76340 {
@@ -58,7 +58,7 @@ typedef struct __anon_0x76340 {
 } __anon_0x76340; // size = 0xC
 
 typedef struct __anon_0x763B0 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x76340 rVecOrigTowards;
     /* 0x10 */ f32 rColorR;
     /* 0x14 */ f32 rColorG;
@@ -75,7 +75,7 @@ typedef struct __anon_0x763B0 {
 } __anon_0x763B0; // size = 0x3C
 
 typedef struct __anon_0x765E0 {
-    /* 0x00 */ s32 bTransformed;
+    /* 0x00 */ int bTransformed;
     /* 0x04 */ struct __anon_0x76340 rS;
     /* 0x10 */ struct __anon_0x76340 rT;
     /* 0x1C */ struct __anon_0x76340 rSRaw;
@@ -93,7 +93,7 @@ typedef struct __anon_0x766C9 {
 typedef union __anon_0x76828 {
     /* 0x0 */ u8 u8[4096];
     /* 0x0 */ u16 u16[2048];
-    /* 0x0 */ u32 u32[1024];
+    /* 0x0 */ unsigned int u32[1024];
     /* 0x0 */ u64 u64[512];
 } __anon_0x76828;
 
@@ -146,20 +146,20 @@ typedef enum _GXTexWrapMode {
 } __anon_0x76BCD;
 
 typedef struct _FRAME_TEXTURE {
-    /* 0x00 */ s32 nMode;
-    /* 0x04 */ s32 iPackPixel;
-    /* 0x08 */ s32 iPackColor;
-    /* 0x0C */ s32 nFrameLast;
+    /* 0x00 */ int nMode;
+    /* 0x04 */ int iPackPixel;
+    /* 0x08 */ int iPackColor;
+    /* 0x0C */ int nFrameLast;
     /* 0x10 */ s16 nSizeX;
     /* 0x12 */ s16 nSizeY;
-    /* 0x14 */ u32 nAddress;
-    /* 0x18 */ u32 nCodePixel;
-    /* 0x1C */ u32 nCodeColor;
+    /* 0x14 */ unsigned int nAddress;
+    /* 0x18 */ unsigned int nCodePixel;
+    /* 0x1C */ unsigned int nCodeColor;
     /* 0x20 */ struct _FRAME_TEXTURE* pTextureNext;
-    /* 0x24 */ u32 nData0;
-    /* 0x28 */ u32 nData1;
-    /* 0x2C */ u32 nData2;
-    /* 0x30 */ u32 nData3;
+    /* 0x24 */ unsigned int nData0;
+    /* 0x28 */ unsigned int nData1;
+    /* 0x2C */ unsigned int nData2;
+    /* 0x30 */ unsigned int nData3;
     /* 0x34 */ enum _GXTexFmt eFormat;
     /* 0x38 */ struct _GXTlutObj objectTLUT;
     /* 0x44 */ struct _GXTexObj objectTexture;
@@ -168,11 +168,11 @@ typedef struct _FRAME_TEXTURE {
 } __anon_0x76C36; // size = 0x6C
 
 typedef struct __anon_0x76F93 {
-    /* 0x00 */ s32 nSize;
-    /* 0x04 */ s32 nTMEM;
-    /* 0x08 */ s32 iTLUT;
-    /* 0x0C */ s32 nSizeX;
-    /* 0x10 */ s32 nFormat;
+    /* 0x00 */ int nSize;
+    /* 0x04 */ int nTMEM;
+    /* 0x08 */ int iTLUT;
+    /* 0x0C */ int nSizeX;
+    /* 0x10 */ int nFormat;
     /* 0x14 */ s16 nMaskS;
     /* 0x16 */ s16 nMaskT;
     /* 0x18 */ s16 nModeS;
@@ -183,7 +183,7 @@ typedef struct __anon_0x76F93 {
     /* 0x22 */ s16 nY0;
     /* 0x24 */ s16 nX1;
     /* 0x26 */ s16 nY1;
-    /* 0x28 */ u32 nCodePixel;
+    /* 0x28 */ unsigned int nCodePixel;
 } __anon_0x76F93; // size = 0x2C
 
 typedef enum __anon_0x77275 {
@@ -193,14 +193,14 @@ typedef enum __anon_0x77275 {
 } __anon_0x77275;
 
 typedef struct __anon_0x772F8 {
-    /* 0x00 */ s32 nCount;
+    /* 0x00 */ int nCount;
     /* 0x04 */ f32 rScale;
     /* 0x08 */ f32 rAspect;
     /* 0x0C */ f32 rFieldOfViewY;
     /* 0x10 */ f32 rClipNear;
     /* 0x14 */ f32 rClipFar;
-    /* 0x18 */ u32 nAddressFloat;
-    /* 0x1C */ u32 nAddressFixed;
+    /* 0x18 */ unsigned int nAddressFloat;
+    /* 0x1C */ unsigned int nAddressFixed;
     /* 0x20 */ enum __anon_0x77275 eProjection;
 } __anon_0x772F8; // size = 0x24
 
@@ -212,81 +212,81 @@ typedef struct _GXColor {
 } __anon_0x7748D; // size = 0x4
 
 typedef struct __anon_0x77548 {
-    /* 0x00000 */ u32 anCIMGAddresses[8];
+    /* 0x00000 */ unsigned int anCIMGAddresses[8];
     /* 0x00020 */ u16 nNumCIMGAddresses;
-    /* 0x00024 */ s32 bBlurOn;
-    /* 0x00028 */ s32 bHackPause;
-    /* 0x0002C */ s32 nHackCount;
-    /* 0x00030 */ s32 nFrameCounter;
-    /* 0x00034 */ s32 bPauseThisFrame;
-    /* 0x00038 */ s32 bCameFromBomberNotes;
-    /* 0x0003C */ s32 bInBomberNotes;
-    /* 0x00040 */ s32 bShrinking;
-    /* 0x00044 */ s32 bSnapShot;
-    /* 0x00048 */ s32 bUsingLens;
+    /* 0x00024 */ int bBlurOn;
+    /* 0x00028 */ int bHackPause;
+    /* 0x0002C */ int nHackCount;
+    /* 0x00030 */ int nFrameCounter;
+    /* 0x00034 */ int bPauseThisFrame;
+    /* 0x00038 */ int bCameFromBomberNotes;
+    /* 0x0003C */ int bInBomberNotes;
+    /* 0x00040 */ int bShrinking;
+    /* 0x00044 */ int bSnapShot;
+    /* 0x00048 */ int bUsingLens;
     /* 0x0004C */ u8 cBlurAlpha;
-    /* 0x00050 */ s32 bBlurredThisFrame;
-    /* 0x00054 */ s32 nFrameCIMGCalls;
-    /* 0x00058 */ s32 bModifyZBuffer;
-    /* 0x0005C */ s32 bOverrideDepth;
-    /* 0x00060 */ s32 nZBufferSets;
-    /* 0x00064 */ s32 nLastFrameZSets;
-    /* 0x00068 */ s32 bPauseBGDrawn;
-    /* 0x0006C */ s32 bFrameOn;
-    /* 0x00070 */ s32 bBackBufferDrawn;
-    /* 0x00074 */ s32 bGrabbedFrame;
+    /* 0x00050 */ int bBlurredThisFrame;
+    /* 0x00054 */ int nFrameCIMGCalls;
+    /* 0x00058 */ int bModifyZBuffer;
+    /* 0x0005C */ int bOverrideDepth;
+    /* 0x00060 */ int nZBufferSets;
+    /* 0x00064 */ int nLastFrameZSets;
+    /* 0x00068 */ int bPauseBGDrawn;
+    /* 0x0006C */ int bFrameOn;
+    /* 0x00070 */ int bBackBufferDrawn;
+    /* 0x00074 */ int bGrabbedFrame;
     /* 0x00078 */ u64* pnGBI;
-    /* 0x0007C */ u32 nFlag;
+    /* 0x0007C */ unsigned int nFlag;
     /* 0x00080 */ f32 rScaleX;
     /* 0x00084 */ f32 rScaleY;
-    /* 0x00088 */ u32 nCountFrames;
-    /* 0x0008C */ u32 nMode;
-    /* 0x00090 */ u32 aMode[10];
+    /* 0x00088 */ unsigned int nCountFrames;
+    /* 0x0008C */ unsigned int nMode;
+    /* 0x00090 */ unsigned int aMode[10];
     /* 0x000B8 */ struct __anon_0x76165 viewport;
     /* 0x000C8 */ struct __anon_0x761FF aBuffer[4];
-    /* 0x00118 */ u32 nOffsetDepth0;
-    /* 0x0011C */ u32 nOffsetDepth1;
-    /* 0x00120 */ s32 nWidthLine;
+    /* 0x00118 */ unsigned int nOffsetDepth0;
+    /* 0x0011C */ unsigned int nOffsetDepth1;
+    /* 0x00120 */ int nWidthLine;
     /* 0x00124 */ f32 rDepth;
     /* 0x00128 */ f32 rDelta;
-    /* 0x0012C */ s32 (*aDraw[4])(void*, void*);
-    /* 0x0013C */ s32 nCountLight;
+    /* 0x0012C */ int (*aDraw[4])(void*, void*);
+    /* 0x0013C */ int nCountLight;
     /* 0x00140 */ struct __anon_0x763B0 aLight[8];
     /* 0x00320 */ struct __anon_0x765E0 lookAt;
-    /* 0x00354 */ s32 nCountVertex;
+    /* 0x00354 */ int nCountVertex;
     /* 0x00358 */ struct __anon_0x766C9 aVertex[80];
     /* 0x00C18 */ struct __anon_0x768C5 TMEM;
     /* 0x01C18 */ void* aPixelData;
     /* 0x01C1C */ void* aColorData;
-    /* 0x01C20 */ s32 nBlocksPixel;
-    /* 0x01C24 */ s32 nBlocksMaxPixel;
-    /* 0x01C28 */ s32 nBlocksColor;
-    /* 0x01C2C */ s32 nBlocksMaxColor;
-    /* 0x01C30 */ s32 nBlocksTexture;
-    /* 0x01C34 */ s32 nBlocksMaxTexture;
-    /* 0x01C38 */ u32 anPackPixel[48];
-    /* 0x01CF8 */ u32 anPackColor[320];
-    /* 0x021F8 */ u32 nAddressLoad;
-    /* 0x021FC */ u32 nCodePixel;
-    /* 0x02200 */ u32 nTlutCode[16];
+    /* 0x01C20 */ int nBlocksPixel;
+    /* 0x01C24 */ int nBlocksMaxPixel;
+    /* 0x01C28 */ int nBlocksColor;
+    /* 0x01C2C */ int nBlocksMaxColor;
+    /* 0x01C30 */ int nBlocksTexture;
+    /* 0x01C34 */ int nBlocksMaxTexture;
+    /* 0x01C38 */ unsigned int anPackPixel[48];
+    /* 0x01CF8 */ unsigned int anPackColor[320];
+    /* 0x021F8 */ unsigned int nAddressLoad;
+    /* 0x021FC */ unsigned int nCodePixel;
+    /* 0x02200 */ unsigned int nTlutCode[16];
     /* 0x02240 */ struct _FRAME_TEXTURE aTexture[2048];
-    /* 0x38240 */ u32 anTextureUsed[64];
+    /* 0x38240 */ unsigned int anTextureUsed[64];
     /* 0x38340 */ struct _FRAME_TEXTURE* apTextureCached[4096];
-    /* 0x3C340 */ s32 iTileLoad;
-    /* 0x3C344 */ u32 n2dLoadTexType;
-    /* 0x3C348 */ s32 nLastX0;
-    /* 0x3C34C */ s32 nLastY0;
-    /* 0x3C350 */ s32 nLastX1;
-    /* 0x3C354 */ s32 nLastY1;
+    /* 0x3C340 */ int iTileLoad;
+    /* 0x3C344 */ unsigned int n2dLoadTexType;
+    /* 0x3C348 */ int nLastX0;
+    /* 0x3C34C */ int nLastY0;
+    /* 0x3C350 */ int nLastX1;
+    /* 0x3C354 */ int nLastY1;
     /* 0x3C358 */ struct __anon_0x76F93 aTile[8];
-    /* 0x3C4B8 */ s32 anSizeX[2];
-    /* 0x3C4C0 */ s32 anSizeY[2];
-    /* 0x3C4C8 */ s32 iHintMatrix;
-    /* 0x3C4CC */ s32 iMatrixModel;
-    /* 0x3C4D0 */ s32 iHintProjection;
+    /* 0x3C4B8 */ int anSizeX[2];
+    /* 0x3C4C0 */ int anSizeY[2];
+    /* 0x3C4C8 */ int iHintMatrix;
+    /* 0x3C4CC */ int iMatrixModel;
+    /* 0x3C4D0 */ int iHintProjection;
     /* 0x3C4D4 */ f32 matrixView[4][4];
-    /* 0x3C514 */ s32 iHintLast;
-    /* 0x3C518 */ s32 iHintHack;
+    /* 0x3C514 */ int iHintLast;
+    /* 0x3C518 */ int iHintHack;
     /* 0x3C51C */ enum __anon_0x77275 eTypeProjection;
     /* 0x3C520 */ f32 aMatrixModel[10][4][4];
     /* 0x3C7A0 */ f32 matrixProjection[4][4];
@@ -297,25 +297,25 @@ typedef struct __anon_0x77548 {
     /* 0x3D122 */ u8 lastTile;
     /* 0x3D123 */ u8 iTileDrawn;
     /* 0x3D124 */ struct _GXColor aColor[5];
-    /* 0x3D138 */ u32 nModeVtx;
+    /* 0x3D138 */ unsigned int nModeVtx;
     /* 0x3D13C */ u16* nTempBuffer;
     /* 0x3D140 */ u16* nCopyBuffer;
-    /* 0x3D144 */ u32* nLensBuffer;
+    /* 0x3D144 */ unsigned int* nLensBuffer;
     /* 0x3D148 */ u16* nCameraBuffer;
 } __anon_0x77548; // size = 0x3D150
 
 // Range: 0x8008EE18 -> 0x8008EE20
-s32 videoPut8() {}
+int videoPut8() {}
 
 // Range: 0x8008EE10 -> 0x8008EE18
-s32 videoPut16() {}
+int videoPut16() {}
 
 // Range: 0x8008EB9C -> 0x8008EE10
-s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
+int videoPut32(struct __anon_0x75B37* pVideo, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x75B37* pVideo; // r31
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r1+0x10
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r1+0x10
 
     // Local variables
     void* pRAM; // r1+0x14
@@ -324,51 +324,51 @@ s32 videoPut32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
 }
 
 // Range: 0x8008EB94 -> 0x8008EB9C
-s32 videoPut64() {}
+int videoPut64() {}
 
 // Range: 0x8008EB8C -> 0x8008EB94
-s32 videoGet8() {}
+int videoGet8() {}
 
 // Range: 0x8008EB84 -> 0x8008EB8C
-s32 videoGet16() {}
+int videoGet16() {}
 
 // Range: 0x8008EA68 -> 0x8008EB84
-s32 videoGet32(struct __anon_0x75B37* pVideo, u32 nAddress, s32* pData) {
+int videoGet32(struct __anon_0x75B37* pVideo, unsigned int nAddress, int* pData) {
     // Parameters
     // struct __anon_0x75B37* pVideo; // r30
-    // u32 nAddress; // r1+0xC
-    // s32* pData; // r31
+    // unsigned int nAddress; // r1+0xC
+    // int* pData; // r31
 }
 
 // Range: 0x8008EA60 -> 0x8008EA68
-s32 videoGet64() {}
+int videoGet64() {}
 
 // Erased
-static s32 videoTickScan() {}
+static int videoTickScan() {}
 
 // Range: 0x8008E9F4 -> 0x8008EA60
-s32 videoForceRetrace(struct __anon_0x75B37* pVideo) {
+int videoForceRetrace(struct __anon_0x75B37* pVideo) {
     // Parameters
     // struct __anon_0x75B37* pVideo; // r31
 }
 
 // Erased
-static s32 videoGetMode(struct __anon_0x75B37* pVideo, s32* pbBlack, s32* pnSizeX, s32* pnSizeY) {
+static int videoGetMode(struct __anon_0x75B37* pVideo, int* pbBlack, int* pnSizeX, int* pnSizeY) {
     // Parameters
     // struct __anon_0x75B37* pVideo; // r1+0x8
-    // s32* pbBlack; // r1+0xC
-    // s32* pnSizeX; // r1+0x10
-    // s32* pnSizeY; // r1+0x14
+    // int* pbBlack; // r1+0xC
+    // int* pnSizeX; // r1+0x10
+    // int* pnSizeY; // r1+0x14
 
     // Local variables
-    s32 nSizeX; // r1+0x8
-    s32 nSizeY; // r3
+    int nSizeX; // r1+0x8
+    int nSizeY; // r3
 }
 
 // Range: 0x8008E8A0 -> 0x8008E9F4
-s32 videoEvent(struct __anon_0x75B37* pVideo, s32 nEvent, void* pArgument) {
+int videoEvent(struct __anon_0x75B37* pVideo, int nEvent, void* pArgument) {
     // Parameters
     // struct __anon_0x75B37* pVideo; // r30
-    // s32 nEvent; // r1+0xC
+    // int nEvent; // r1+0xC
     // void* pArgument; // r31
 }


### PR DESCRIPTION
Turns out guessing `int` vs `s32` is not obvious, so maybe this will help with the last few matches. Generated by https://github.com/cadmic/decomp-toolkit/tree/oot-gc-debug-info