### PR TITLE
Cleanup 1

### DIFF
--- a/include/emulator/rsp.h
+++ b/include/emulator/rsp.h
@@ -53,6 +53,8 @@
 #define G_TX_WRAP (1 << 0)
 #define G_TX_CLAMP (1 << 1)
 
+struct Frame;
+
 typedef enum RspAudioUCodeType {
     RUT_NOCODE = -1,
     RUT_ABI1 = 0,

--- a/src/debugger/DebuggerDriver.c
+++ b/src/debugger/DebuggerDriver.c
@@ -278,7 +278,7 @@ int DBWrite(const void* data, u32 size) {
     ++SendCount;
 
     value = ((SendCount & 1) ? 0x1000 : 0);
-    while (!DBGWrite(value | 0x1C000, data, ALIGN_NEXT(size, 4)))
+    while (!DBGWrite(value | 0x1C000, (u32*)data, ALIGN_NEXT(size, 4)))
         ;
 
     do {

--- a/src/emulator/_cpuGCN.c
+++ b/src/emulator/_cpuGCN.c
@@ -227,6 +227,10 @@ static inline void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
         }                              \
     } while (0)
 
+// Note: the original compiler (GC/1.1) doesn't understand this but it's useful for modding as it helps reducing the
+// compiling time.
+#pragma optimization_level 1
+
 /**
  * @brief The main MIPS->PPC Dynamic recompiler.
  *
@@ -276,7 +280,7 @@ static bool cpuGetPPC(Cpu* pCPU, s32* pnAddress, CpuFunction* pFunction, s32* an
     prev = 0;
     update = false;
 
-    if (ramGetBuffer(SYSTEM_RAM(pCPU->pHost), &pnOpcode, *pnAddress, NULL)) {
+    if (ramGetBuffer(SYSTEM_RAM(pCPU->pHost), (void**)&pnOpcode, *pnAddress, NULL)) {
         nAddress = *pnAddress;
         nOpcode = pnOpcode[0];
         nOpcodeNext = pnOpcode[1];
@@ -6063,6 +6067,8 @@ static bool cpuGetPPC(Cpu* pCPU, s32* pnAddress, CpuFunction* pFunction, s32* an
     }
 }
 
+#pragma optimization_level reset
+
 /**
  * @brief Creates a new recompiled function block.
  *
@@ -8375,7 +8381,7 @@ static s32 cpuExecuteOpcode(Cpu* pCPU, s32 nCount0, s32 nAddressN64, s32 nAddres
     aiDevice = pCPU->aiDevice;
     apDevice = pCPU->apDevice;
 
-    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), &opcode, nAddressN64, NULL);
+    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), (void**)&opcode, nAddressN64, NULL);
     nOpcode = *opcode;
     pCPU->nPC = nAddressN64 + 4;
     if (nOpcode == 0xACBF011C) { // sw $ra,0x11C($a1)
@@ -10025,7 +10031,7 @@ static s32 cpuExecuteLoadStore(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAddr
     interpret = 0;
     check2 = 0x90C30000 + OFFSETOF(pCPU, nWaitPC);
 
-    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), &opcode, nAddressN64, NULL);
+    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), (void**)&opcode, nAddressN64, NULL);
 
     address = pCPU->aGPR[MIPS_RS(*opcode)].s32 + MIPS_IMM_S16(*opcode);
     device = pCPU->aiDevice[(u32)(address) >> 16];
@@ -10306,7 +10312,7 @@ static s32 cpuExecuteLoadStoreF(Cpu* pCPU, s32 nCount, s32 nAddressN64, s32 nAdd
     interpret = 0;
     check2 = 0x90C30000 + OFFSETOF(pCPU, nWaitPC);
 
-    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), &opcode, nAddressN64, NULL);
+    ramGetBuffer(SYSTEM_RAM(pCPU->pHost), (void**)&opcode, nAddressN64, NULL);
 
     address = pCPU->aGPR[MIPS_RS(*opcode)].s32 + MIPS_IMM_S16(*opcode);
     device = pCPU->aiDevice[(u32)(address) >> 16];

--- a/src/emulator/_cpuGCN.c
+++ b/src/emulator/_cpuGCN.c
@@ -227,7 +227,7 @@ static inline void cpuCompileNOP(s32* anCode, s32* iCode, s32 number) {
         }                              \
     } while (0)
 
-// Note: the original compiler (GC/1.1) doesn't understand this but it's useful for modding as it helps reducing the
+// Note: the original compiler (GC/1.1) doesn't understand this but it's useful for modding as it helps reduce the
 // compiling time.
 #pragma optimization_level 1
 

--- a/src/emulator/_frameGCN.c
+++ b/src/emulator/_frameGCN.c
@@ -5173,11 +5173,13 @@ static bool frameEvent(Frame* pFrame, s32 nEvent, void* pArgument) {
             pFrame->nCameraBuffer = NULL;
             if (((gpSystem->eTypeROM == SRT_PANEL) || (gpSystem->eTypeROM == SRT_ZELDA2) ||
                  (gpSystem->eTypeROM == SRT_DRMARIO)) &&
-                !xlHeapTake((void**)&pFrame->nTempBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                !xlHeapTake((void**)&pFrame->nTempBuffer,
+                            0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
                 return false;
             }
             if ((gpSystem->eTypeROM == SRT_ZELDA2) &&
-                !xlHeapTake((void**)&pFrame->nCopyBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                !xlHeapTake((void**)&pFrame->nCopyBuffer,
+                            0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
                 return false;
             }
 #if IS_OOT

--- a/src/emulator/_frameGCN.c
+++ b/src/emulator/_frameGCN.c
@@ -5173,20 +5173,20 @@ static bool frameEvent(Frame* pFrame, s32 nEvent, void* pArgument) {
             pFrame->nCameraBuffer = NULL;
             if (((gpSystem->eTypeROM == SRT_PANEL) || (gpSystem->eTypeROM == SRT_ZELDA2) ||
                  (gpSystem->eTypeROM == SRT_DRMARIO)) &&
-                !xlHeapTake(&pFrame->nTempBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                !xlHeapTake((void**)&pFrame->nTempBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
                 return false;
             }
             if ((gpSystem->eTypeROM == SRT_ZELDA2) &&
-                !xlHeapTake(&pFrame->nCopyBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                !xlHeapTake((void**)&pFrame->nCopyBuffer, 0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
                 return false;
             }
 #if IS_OOT
-            if ((gpSystem->eTypeROM == SRT_ZELDA2) && !xlHeapTake(&pFrame->nLensBuffer, 0x30000000 | 0x4B000)) {
+            if ((gpSystem->eTypeROM == SRT_ZELDA2) && !xlHeapTake((void**)&pFrame->nLensBuffer, 0x30000000 | 0x4B000)) {
                 return false;
             }
 #endif
             if (gpSystem->eTypeROM == SRT_ZELDA2 &&
-                !xlHeapTake(&pFrame->nCameraBuffer, 0x30000000 | CAMERA_BUFFER_SIZE)) {
+                !xlHeapTake((void**)&pFrame->nCameraBuffer, 0x30000000 | CAMERA_BUFFER_SIZE)) {
                 return false;
             }
             break;

--- a/src/emulator/cpu.c
+++ b/src/emulator/cpu.c
@@ -1451,7 +1451,7 @@ bool cpuFindFunction(Cpu* pCPU, s32 theAddress, CpuFunction** tree_node) {
     if (pCPU->gTree == NULL) {
         check = 0;
         pCPU->survivalTimer = 1;
-        if (!xlHeapTake(&pCPU->gTree, sizeof(CpuTreeRoot))) {
+        if (!xlHeapTake((void**)&pCPU->gTree, sizeof(CpuTreeRoot))) {
             return false;
         }
         treeInit(pCPU, 0x80150002);

--- a/src/emulator/mcardGCN.c
+++ b/src/emulator/mcardGCN.c
@@ -381,12 +381,12 @@ static bool mcardVerifyChecksumFileHeader(MemCard* pMCard) {
     if (!mcardReadyFile(pMCard)) {
         return false;
     }
-    if (!xlHeapTake(&buffer, HEADER_SIZE | 0x30000000)) {
+    if (!xlHeapTake((void**)&buffer, HEADER_SIZE | 0x30000000)) {
         return false;
     }
 
     if (!mcardReadAnywhereNoTime(pMCard, 0, HEADER_SIZE, buffer)) {
-        if (!xlHeapFree(&buffer)) {
+        if (!xlHeapFree((void**)&buffer)) {
             return false;
         }
         mcardFinishCard(pMCard);
@@ -396,14 +396,14 @@ static bool mcardVerifyChecksumFileHeader(MemCard* pMCard) {
     DCInvalidateRange(buffer, HEADER_SIZE);
 
     if (!mcardCheckChecksumFileHeader(pMCard, buffer)) {
-        if (!xlHeapFree(&buffer)) {
+        if (!xlHeapFree((void**)&buffer)) {
             return false;
         }
         mcardFinishCard(pMCard);
         return false;
     }
 
-    if (!xlHeapFree(&buffer)) {
+    if (!xlHeapFree((void**)&buffer)) {
         return false;
     }
     mcardFinishCard(pMCard);
@@ -1554,7 +1554,7 @@ bool mcardFileCreate(MemCard* pMCard, char* name, char* comment, char* icon, cha
         if (!mcardReadyFile(pMCard)) {
             return false;
         }
-        if (!xlHeapTake(&buffer, totalSize | 0x30000000)) {
+        if (!xlHeapTake((void**)&buffer, totalSize | 0x30000000)) {
             return false;
         }
         memset(buffer, 0, totalSize);
@@ -1681,7 +1681,7 @@ bool mcardFileCreate(MemCard* pMCard, char* name, char* comment, char* icon, cha
             return false;
         }
 
-        if (!xlHeapFree(&buffer)) {
+        if (!xlHeapFree((void**)&buffer)) {
             return false;
         }
 

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -1215,7 +1215,7 @@ static bool rspAPoleFilter1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     pDMEM16 = pRSP->anAudioBuffer;
     nSrcAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pStateAddress, nSrcAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pStateAddress, nSrcAddress, NULL)) {
         return false;
     }
 
@@ -1414,7 +1414,7 @@ static bool rspAResample1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     nSrcStep = nCommandHi & 0xFFFF;
     flags = (nCommandHi >> 16) & 0xFF;
     nSrcAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pData, nSrcAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pData, nSrcAddress, NULL)) {
         return false;
     }
 
@@ -1479,7 +1479,7 @@ static inline bool rspASaveBuffer1(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     u32* pData;
     s32 nAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
 
-    if (ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pData, nAddress, &nSize)) {
+    if (ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pData, nAddress, &nSize)) {
         xlHeapCopy(pData, &pRSP->anAudioBuffer[pRSP->nAudioDMEMOut[0]], nSize * sizeof(s16));
     }
 
@@ -1586,7 +1586,7 @@ static bool rspParseABI(Rsp* pRSP, RspTask* pTask) {
 
     if (!(pRSP->eTypeAudioUCode == RUT_ABI1 || pRSP->eTypeAudioUCode == RUT_ABI2 ||
           pRSP->eTypeAudioUCode == RUT_UNKNOWN)) {
-        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pFUCode, pTask->nOffsetCode, NULL)) {
+        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pFUCode, pTask->nOffsetCode, NULL)) {
             return false;
         }
 
@@ -1671,7 +1671,7 @@ static bool rspParseABI1(Rsp* pRSP, RspTask* pTask) {
     u32 nSize;
 
     nSize = pTask->nLengthMBI & 0x7FFFFF;
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pABI32, pTask->nOffsetMBI, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pABI32, pTask->nOffsetMBI, NULL)) {
         return false;
     }
     pABILast32 = pABI32 + (nSize >> 2);
@@ -2272,7 +2272,7 @@ static bool rspAResample2(Rsp* pRSP, u32 nCommandLo, u32 nCommandHi) {
     nSrcStep = nCommandHi & 0xFFFF;
     flags = (nCommandHi >> 16) & 0xFF;
     nSrcAddress = AUDIO_SEGMENT_ADDRESS(pRSP, nCommandLo);
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pData, nSrcAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pData, nSrcAddress, NULL)) {
         return false;
     }
 
@@ -2545,7 +2545,7 @@ static bool rspParseABI2(Rsp* pRSP, RspTask* pTask) {
     s32 pad[4];
 
     nSize = pTask->nLengthMBI & 0x7FFFFF;
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pABI32, pTask->nOffsetMBI, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pABI32, pTask->nOffsetMBI, NULL)) {
         return false;
     }
     pABILast32 = pABI32 + (nSize >> 2);
@@ -3152,7 +3152,7 @@ static bool rspParseABI3(Rsp* pRSP, RspTask* pTask) {
     u32 nSize;
 
     nSize = pTask->nLengthMBI & 0x7FFFFF;
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pABI32, pTask->nOffsetMBI, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pABI32, pTask->nOffsetMBI, NULL)) {
         return false;
     }
     pABILast32 = pABI32 + (nSize >> 2);
@@ -4714,11 +4714,11 @@ static bool rspParseJPEG_EncodeZ(Rsp* pRSP, RspTask* pTask) {
     s32 size;
     s32 pad2[3];
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &infoStruct, pTask->nOffsetMBI, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&infoStruct, pTask->nOffsetMBI, NULL)) {
         return false;
     }
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &system_imb, infoStruct[0], NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&system_imb, infoStruct[0], NULL)) {
         return false;
     }
 
@@ -4747,11 +4747,11 @@ static bool rspParseJPEG_DecodeZ(Rsp* pRSP, RspTask* pTask) {
     s32 size;
     s32 pad2[3];
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &infoStruct, pTask->nOffsetMBI, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&infoStruct, pTask->nOffsetMBI, NULL)) {
         return false;
     }
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &system_imb, infoStruct[0], NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&system_imb, infoStruct[0], NULL)) {
         return false;
     }
 
@@ -4810,7 +4810,7 @@ static bool rspFillObjSprite(Rsp* pRSP, s32 nAddress, uObjSprite* pSprite) {
     u8* pnData8;
     u8* pObjSprite;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pObjSprite, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pObjSprite, nAddress, NULL)) {
         return false;
     }
 
@@ -4841,7 +4841,7 @@ bool rspFillObjBgScale(Rsp* pRSP, s32 nAddress, uObjBg* pBg) {
     u16* pnData16;
     u32* pnData32;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pObjBg, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pObjBg, nAddress, NULL)) {
         return false;
     }
 
@@ -4876,7 +4876,7 @@ bool rspFillObjBg(Rsp* pRSP, s32 nAddress, uObjBg* pBg) {
     u16* pnData16;
     u32* pnData32;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pObjBg, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pObjBg, nAddress, NULL)) {
         return false;
     }
 
@@ -5431,7 +5431,7 @@ bool rspFillObjTxtr(Rsp* pRSP, s32 nAddress, uObjTxtr* pTxtr, u32* pLoadType) {
     u8* pTxtrBlock;
     u32 nLoadType;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pTxtrBlock, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pTxtrBlock, nAddress, NULL)) {
         return false;
     }
 
@@ -6151,7 +6151,7 @@ static inline bool rspObjSubMatrix(Rsp* pRSP, Frame* pFrame, s32 nAddress) {
     s16 nX;
     s16 nY;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pObjSubMtx, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pObjSubMtx, nAddress, NULL)) {
         return false;
     }
 
@@ -6186,7 +6186,7 @@ static bool rspObjMatrix(Rsp* pRSP, Frame* pFrame, s32 nAddress) {
     s16 nX;
     s16 nY;
 
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pObjMtx, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pObjMtx, nAddress, NULL)) {
         return false;
     }
 
@@ -6486,7 +6486,7 @@ static bool rspParseGBI_F3DEX1(Rsp* pRSP, u64** ppnGBI, bool* pbDone) {
                         s32 iLight = (((nCommandHi >> 16) & 0xFF) - 0x86) >> 1;
                         s32 nAddress = SEGMENT_ADDRESS(pRSP, nCommandLo);
 
-                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pData, nAddress, NULL)) {
+                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pData, nAddress, NULL)) {
                             return false;
                         }
                         if (!frameSetLight(pFrame, iLight, pData)) {
@@ -7209,14 +7209,14 @@ static bool rspParseGBI_F3DEX2(Rsp* pRSP, u64** ppnGBI, bool* pbDone) {
                                     }
 
                                     if (bFound) {
-                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pLight, nAddress, NULL)) {
+                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pLight, nAddress, NULL)) {
                                             return false;
                                         }
                                         if (!frameSetLight(pFrame, iIndex, pLight)) {
                                             return false;
                                         }
                                     } else if (pRSP->nNumZSortLights < 7 && pRSP->nAmbientLightAddress != 0) {
-                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pLight, nAddress, NULL)) {
+                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pLight, nAddress, NULL)) {
                                             return false;
                                         }
                                         if (!frameSetLight(pFrame, pRSP->nNumZSortLights, pLight)) {
@@ -7227,7 +7227,7 @@ static bool rspParseGBI_F3DEX2(Rsp* pRSP, u64** ppnGBI, bool* pbDone) {
                                     }
 
                                     if (pRSP->nAmbientLightAddress != 0) {
-                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pLight, pRSP->nAmbientLightAddress,
+                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pLight, pRSP->nAmbientLightAddress,
                                                           NULL)) {
                                             return false;
                                         }
@@ -7531,7 +7531,7 @@ static bool rspParseGBI_F3DEX2(Rsp* pRSP, u64** ppnGBI, bool* pbDone) {
                 s32 iVertex0 = ((nCommandHi & 0xFF) >> 1) - nCount;
                 s32 nAddress = SEGMENT_ADDRESS(pRSP, nCommandLo);
 
-                if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pBuffer, nAddress, NULL)) {
+                if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pBuffer, nAddress, NULL)) {
                     return false;
                 }
                 if (!frameLoadVertex(pFrame, pBuffer, iVertex0, nCount)) {
@@ -7882,7 +7882,7 @@ static bool rspLoadMatrix(Rsp* pRSP, s32 nAddress, Mtx44 matrix) {
     u16 nLower;
 
     rScale = 1.0f / 65536.0f;
-    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), &pMtx, nAddress, NULL)) {
+    if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pMtx, nAddress, NULL)) {
         return false;
     }
 

--- a/src/emulator/rsp.c
+++ b/src/emulator/rsp.c
@@ -7227,8 +7227,8 @@ static bool rspParseGBI_F3DEX2(Rsp* pRSP, u64** ppnGBI, bool* pbDone) {
                                     }
 
                                     if (pRSP->nAmbientLightAddress != 0) {
-                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pLight, pRSP->nAmbientLightAddress,
-                                                          NULL)) {
+                                        if (!ramGetBuffer(SYSTEM_RAM(pRSP->pHost), (void**)&pLight,
+                                                          pRSP->nAmbientLightAddress, NULL)) {
                                             return false;
                                         }
                                         if (!frameSetLight(pFrame, pRSP->nNumZSortLights, pLight)) {


### PR DESCRIPTION
my gcc experiments revealed changes required to build properly with it, this is what this PR brings (basically this is all missing casts, mostly `(void**)`), also I added a pragma around `cpuGetPPC` explaining why this is useful (tldr good for modding but this compiler version doesn't understand it so it has no effect on matching builds)