### PR TITLE
Remove non-matching CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        matching: [true, false]
     defaults:
       run:
         shell: bash
@@ -34,34 +32,12 @@ jobs:
 
     # Build the project
     - name: Build
-      if: matrix.matching
       run: |
         python configure.py --map --binutils /binutils --compilers /compilers
         ninja all_source build/{mq-j,mq-u,mq-e,ce-j,ce-u,ce-e,mm-j,mm-u,mm-e}/progress.json build/report.json
 
-    # Build the project (non-matching)
-    - name: Build (non-matching)
-      if: ${{ !matrix.matching }}
-      run: |
-        python configure.py --map --binutils /binutils --compilers /compilers --non-matching --no-asm-processor
-        ninja all_source build/{mq-j,mq-u,mq-e,ce-j,ce-u,ce-e,mm-j,mm-u,mm-e}/progress.json build/report.json
-
-    # Upload progress if we're on the main branch
-    - name: Upload progress
-      if: ${{ !matrix.matching && github.ref == 'refs/heads/main' }}
-      continue-on-error: true
-      env:
-        PROGRESS_SLUG: oot-gc
-        PROGRESS_API_KEY: ${{ secrets.PROGRESS_API_KEY }}
-      run: |
-        for version in {mq-j,mq-u,mq-e,ce-j,ce-u,ce-e,mm-j,mm-u,mm-e}; do
-          python tools/upload_progress.py -b https://progress.decomp.club/ \
-            -p $PROGRESS_SLUG -v $version build/$version/progress.json
-        done
-
     # Upload map files
     - name: Upload map
-      if: matrix.matching
       uses: actions/upload-artifact@v4
       with:
         name: combined_maps
@@ -69,7 +45,6 @@ jobs:
 
     # Upload progress report
     - name: Upload report
-      if: ${{ !matrix.matching }}
       uses: actions/upload-artifact@v4
       with:
         name: combined_report


### PR DESCRIPTION
This isn't necessary now that we don't use asm_processor. Also the decomp.club progress upload wasn't working so I've just removed it (since we use decomp.dev now)