### PR TITLE
Clean up instances of if (cond && !func())

### DIFF
--- a/src/emulator/_frameGCN.c
+++ b/src/emulator/_frameGCN.c
@@ -5171,25 +5171,30 @@ static bool frameEvent(Frame* pFrame, s32 nEvent, void* pArgument) {
             pFrame->nLensBuffer = NULL;
 #endif
             pFrame->nCameraBuffer = NULL;
-            if (((gpSystem->eTypeROM == SRT_PANEL) || (gpSystem->eTypeROM == SRT_ZELDA2) ||
-                 (gpSystem->eTypeROM == SRT_DRMARIO)) &&
-                !xlHeapTake((void**)&pFrame->nTempBuffer,
-                            0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
-                return false;
+            if (gpSystem->eTypeROM == SRT_PANEL || gpSystem->eTypeROM == SRT_ZELDA2 ||
+                gpSystem->eTypeROM == SRT_DRMARIO) {
+                if (!xlHeapTake((void**)&pFrame->nTempBuffer,
+                                0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                    return false;
+                }
             }
-            if ((gpSystem->eTypeROM == SRT_ZELDA2) &&
-                !xlHeapTake((void**)&pFrame->nCopyBuffer,
-                            0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
-                return false;
+            if (gpSystem->eTypeROM == SRT_ZELDA2) {
+                if (!xlHeapTake((void**)&pFrame->nCopyBuffer,
+                                0x30000000 | (N64_FRAME_WIDTH * N64_FRAME_HEIGHT * sizeof(u16)))) {
+                    return false;
+                }
             }
 #if IS_OOT
-            if ((gpSystem->eTypeROM == SRT_ZELDA2) && !xlHeapTake((void**)&pFrame->nLensBuffer, 0x30000000 | 0x4B000)) {
-                return false;
+            if (gpSystem->eTypeROM == SRT_ZELDA2) {
+                if (!xlHeapTake((void**)&pFrame->nLensBuffer, 0x30000000 | 0x4B000)) {
+                    return false;
+                }
             }
 #endif
-            if (gpSystem->eTypeROM == SRT_ZELDA2 &&
-                !xlHeapTake((void**)&pFrame->nCameraBuffer, 0x30000000 | CAMERA_BUFFER_SIZE)) {
-                return false;
+            if (gpSystem->eTypeROM == SRT_ZELDA2) {
+                if (!xlHeapTake((void**)&pFrame->nCameraBuffer, 0x30000000 | CAMERA_BUFFER_SIZE)) {
+                    return false;
+                }
             }
             break;
 #endif

--- a/src/emulator/cpu.c
+++ b/src/emulator/cpu.c
@@ -994,7 +994,7 @@ bool cpuReset(Cpu* pCPU) {
         return false;
     }
     if (pCPU->gHeap2 == NULL) {
-        if (!xlHeapTake(&pCPU->gHeap2, 0x300000 | 0x30000000)) {
+        if (!xlHeapTake(&pCPU->gHeap2, 0x104000 | 0x30000000)) {
             return false;
         }
     }
@@ -1003,7 +1003,7 @@ bool cpuReset(Cpu* pCPU) {
         return false;
     }
     if (gHeapTree == NULL) {
-        if (!xlHeapTake(gHeapTree, 0x300000 | 0x30000000)) {
+        if (!xlHeapTake(&gHeapTree, 0x46500 | 0x30000000)) {
             return false;
         }
     }

--- a/src/emulator/cpu.c
+++ b/src/emulator/cpu.c
@@ -984,22 +984,28 @@ bool cpuReset(Cpu* pCPU) {
     if (!cpuHeapReset(pCPU->aHeap1Flag, ARRAY_COUNT(pCPU->aHeap1Flag))) {
         return false;
     }
-    if (pCPU->gHeap1 == NULL && !xlHeapTake(&pCPU->gHeap1, 0x300000 | 0x30000000)) {
-        return false;
+    if (pCPU->gHeap1 == NULL) {
+        if (!xlHeapTake(&pCPU->gHeap1, 0x300000 | 0x30000000)) {
+            return false;
+        }
     }
 
     if (!cpuHeapReset(pCPU->aHeap2Flag, ARRAY_COUNT(pCPU->aHeap2Flag))) {
         return false;
     }
-    if (pCPU->gHeap2 == NULL && !xlHeapTake(&pCPU->gHeap2, 0x104000 | 0x30000000)) {
-        return false;
+    if (pCPU->gHeap2 == NULL) {
+        if (!xlHeapTake(&pCPU->gHeap2, 0x300000 | 0x30000000)) {
+            return false;
+        }
     }
 
     if (!cpuHeapReset(aHeapTreeFlag, ARRAY_COUNT(aHeapTreeFlag))) {
         return false;
     }
-    if (gHeapTree == NULL && !xlHeapTake(&gHeapTree, 0x46500 | 0x30000000)) {
-        return false;
+    if (gHeapTree == NULL) {
+        if (!xlHeapTake(gHeapTree, 0x300000 | 0x30000000)) {
+            return false;
+        }
     }
 
     if (pCPU->gTree != NULL) {

--- a/src/emulator/library.c
+++ b/src/emulator/library.c
@@ -3782,11 +3782,17 @@ bool libraryTestFunction(Library* pLibrary, CpuFunction* pFunction) {
 }
 
 static bool librarySearch(Library* pLibrary, CpuFunction* pFunction) {
-    if (pFunction->left != NULL && !librarySearch(pLibrary, pFunction->left)) {
-        return false;
-    } else if (pFunction->right != NULL && !librarySearch(pLibrary, pFunction->right)) {
-        return false;
-    } else if (!libraryTestFunction(pLibrary, pFunction)) {
+    if (pFunction->left != NULL) {
+        if (!librarySearch(pLibrary, pFunction->left)) {
+            return false;
+        }
+    }
+    if (pFunction->right != NULL) {
+        if (!librarySearch(pLibrary, pFunction->right)) {
+            return false;
+        }
+    }
+    if (!libraryTestFunction(pLibrary, pFunction)) {
         return false;
     }
     return true;
@@ -3807,10 +3813,15 @@ static inline bool libraryUpdate(Library* pLibrary)
     }
 
     if (pCPU->gTree != NULL) {
-        if (pCPU->gTree->left != NULL && !librarySearch(pLibrary, pCPU->gTree->left)) {
-            return false;
-        } else if (pCPU->gTree->right != NULL && !librarySearch(pLibrary, pCPU->gTree->right)) {
-            return false;
+        if (pCPU->gTree->left != NULL) {
+            if (!librarySearch(pLibrary, pCPU->gTree->left)) {
+                return false;
+            }
+        }
+        if (pCPU->gTree->right != NULL) {
+            if (!librarySearch(pLibrary, pCPU->gTree->right)) {
+                return false;
+            }
         }
     }
 

--- a/src/emulator/pif.c
+++ b/src/emulator/pif.c
@@ -402,9 +402,10 @@ bool pifProcessOutputData(Pif* pPIF) {
         }
 
         prx = PIF_GET_RAM_ADDR(pPIF, iData++);
-        if (PIF_GET_RAM_DATA(pPIF, iData) == 1 &&
-            !pifExecuteCommand(pPIF, PIF_GET_RAM_ADDR(pPIF, iData), ptx, prx, channel)) {
-            return false;
+        if (PIF_GET_RAM_DATA(pPIF, iData) == 1) {
+            if (!pifExecuteCommand(pPIF, PIF_GET_RAM_ADDR(pPIF, iData), ptx, prx, channel)) {
+                return false;
+            }
         }
 
         channel++;

--- a/src/emulator/ram.c
+++ b/src/emulator/ram.c
@@ -221,8 +221,10 @@ bool ramGetBuffer(Ram* pRAM, void** ppRAM, u32 nOffset, u32* pnSize) {
 }
 
 bool ramWipe(Ram* pRAM) {
-    if (pRAM->nSize != 0 && !xlHeapFill32(pRAM->pBuffer, pRAM->nSize, 0)) {
-        return false;
+    if (pRAM->nSize != 0) {
+        if (!xlHeapFill32(pRAM->pBuffer, pRAM->nSize, 0)) {
+            return false;
+        }
     }
 
     return true;

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -2781,165 +2781,164 @@ bool simulatorPreloadDiskMessages(void) {
     if (DVDOpen(path_readingDisk, &fileInfo)) {
         size = (fileInfo.length + 0x1F) & ~0x1F;
 
-        if (greadingDisk != NULL)
+        if (greadingDisk != NULL) {
             if (!xlHeapFree((void**)&greadingDisk)) {
                 return false;
             }
-    }
+        }
 
-    if (!xlHeapTake((void**)&greadingDisk, size | 0x30000000)) {
-        return false;
-    }
-
-    DVDReadPrio(&fileInfo, greadingDisk, size, 0, 2);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)greadingDisk);
-}
-else {
-    return false;
-}
-
-if (DVDOpen(path_wrongDisk, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
-
-    if (gwrongDisk != NULL) {
-        if (!xlHeapFree((void**)&gwrongDisk)) {
+        if (!xlHeapTake((void**)&greadingDisk, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gwrongDisk, size | 0x30000000)) {
+        DVDReadPrio(&fileInfo, greadingDisk, size, 0, 2);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)greadingDisk);
+    } else {
         return false;
     }
 
-    DVDReadPrio(&fileInfo, gwrongDisk, size, 0, 2);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gwrongDisk);
-} else {
-    return false;
-}
+    if (DVDOpen(path_wrongDisk, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_noDisk, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gwrongDisk != NULL) {
+            if (!xlHeapFree((void**)&gwrongDisk)) {
+                return false;
+            }
+        }
 
-    if (gnoDisk != NULL) {
-        if (!xlHeapFree((void**)&gnoDisk)) {
+        if (!xlHeapTake((void**)&gwrongDisk, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gnoDisk, size | 0x30000000)) {
+        DVDReadPrio(&fileInfo, gwrongDisk, size, 0, 2);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gwrongDisk);
+    } else {
         return false;
     }
 
-    DVDReadPrio(&fileInfo, gnoDisk, size, 0, 2);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gnoDisk);
-} else {
-    return false;
-}
+    if (DVDOpen(path_noDisk, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_retryErr, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gnoDisk != NULL) {
+            if (!xlHeapFree((void**)&gnoDisk)) {
+                return false;
+            }
+        }
 
-    if (gretryErr != NULL) {
-        if (!xlHeapFree((void**)&gretryErr)) {
+        if (!xlHeapTake((void**)&gnoDisk, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gretryErr, size | 0x30000000)) {
+        DVDReadPrio(&fileInfo, gnoDisk, size, 0, 2);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gnoDisk);
+    } else {
         return false;
     }
 
-    simulatorDVDRead(&fileInfo, gretryErr, size, 0, NULL);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gretryErr);
-} else {
-    return false;
-}
+    if (DVDOpen(path_retryErr, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_fatalErr, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gretryErr != NULL) {
+            if (!xlHeapFree((void**)&gretryErr)) {
+                return false;
+            }
+        }
 
-    if (gfatalErr != NULL) {
-        if (!xlHeapFree((void**)&gfatalErr)) {
+        if (!xlHeapTake((void**)&gretryErr, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gfatalErr, size | 0x30000000)) {
+        simulatorDVDRead(&fileInfo, gretryErr, size, 0, NULL);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gretryErr);
+    } else {
         return false;
     }
 
-    simulatorDVDRead(&fileInfo, gfatalErr, size, 0, NULL);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gfatalErr);
-} else {
-    return false;
-}
+    if (DVDOpen(path_fatalErr, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_yes, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gfatalErr != NULL) {
+            if (!xlHeapFree((void**)&gfatalErr)) {
+                return false;
+            }
+        }
 
-    if (gyes != NULL) {
-        if (!xlHeapFree((void**)&gyes)) {
+        if (!xlHeapTake((void**)&gfatalErr, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gyes, size | 0x30000000)) {
+        simulatorDVDRead(&fileInfo, gfatalErr, size, 0, NULL);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gfatalErr);
+    } else {
         return false;
     }
 
-    simulatorDVDRead(&fileInfo, gyes, size, 0, NULL);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gyes);
-} else {
-    return false;
-}
+    if (DVDOpen(path_yes, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_no, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gyes != NULL) {
+            if (!xlHeapFree((void**)&gyes)) {
+                return false;
+            }
+        }
 
-    if (gno != NULL) {
-        if (!xlHeapFree((void**)&gno)) {
+        if (!xlHeapTake((void**)&gyes, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gno, size | 0x30000000)) {
+        simulatorDVDRead(&fileInfo, gyes, size, 0, NULL);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gyes);
+    } else {
         return false;
     }
 
-    simulatorDVDRead(&fileInfo, gno, size, 0, NULL);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gno);
-} else {
-    return false;
-}
+    if (DVDOpen(path_no, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-if (DVDOpen(path_mesgOK, &fileInfo)) {
-    size = (fileInfo.length + 0x1F) & ~0x1F;
+        if (gno != NULL) {
+            if (!xlHeapFree((void**)&gno)) {
+                return false;
+            }
+        }
 
-    if (gmesgOK != NULL) {
-        if (!xlHeapFree((void**)&gmesgOK)) {
+        if (!xlHeapTake((void**)&gno, size | 0x30000000)) {
             return false;
         }
-    }
 
-    if (!xlHeapTake((void**)&gmesgOK, size | 0x30000000)) {
+        simulatorDVDRead(&fileInfo, gno, size, 0, NULL);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gno);
+    } else {
         return false;
     }
 
-    simulatorDVDRead(&fileInfo, gmesgOK, size, 0, NULL);
-    DVDClose(&fileInfo);
-    simulatorUnpackTexPalette((TEXPalette*)gmesgOK);
-} else {
-    return false;
-}
+    if (DVDOpen(path_mesgOK, &fileInfo)) {
+        size = (fileInfo.length + 0x1F) & ~0x1F;
 
-return true;
+        if (gmesgOK != NULL) {
+            if (!xlHeapFree((void**)&gmesgOK)) {
+                return false;
+            }
+        }
+
+        if (!xlHeapTake((void**)&gmesgOK, size | 0x30000000)) {
+            return false;
+        }
+
+        simulatorDVDRead(&fileInfo, gmesgOK, size, 0, NULL);
+        DVDClose(&fileInfo);
+        simulatorUnpackTexPalette((TEXPalette*)gmesgOK);
+    } else {
+        return false;
+    }
+
+    return true;
 }
 #endif
 

--- a/src/emulator/simGCN.c
+++ b/src/emulator/simGCN.c
@@ -526,8 +526,10 @@ bool simulatorDVDShowError(s32 nStatus, void* anData, s32 nSizeRead, u32 nOffset
             if (!simulatorTestReset(false, false, true, false)) {
                 return false;
             }
-        } else if ((nStatus != -1) && (!simulatorTestReset(true, false, true, false))) {
-            return false;
+        } else if (nStatus != -1) {
+            if (!simulatorTestReset(true, false, true, false)) {
+                return false;
+            }
         }
 #endif
 
@@ -2759,8 +2761,10 @@ bool simulatorPreloadDiskMessages(void) {
     if (DVDOpen(path_coverOpen, &fileInfo)) {
         size = (fileInfo.length + 0x1F) & ~0x1F;
 
-        if (gcoverOpen != NULL && !xlHeapFree((void**)&gcoverOpen)) {
-            return false;
+        if (gcoverOpen != NULL) {
+            if (!xlHeapFree((void**)&gcoverOpen)) {
+                return false;
+            }
         }
 
         if (!xlHeapTake((void**)&gcoverOpen, size | 0x30000000)) {
@@ -2777,148 +2781,165 @@ bool simulatorPreloadDiskMessages(void) {
     if (DVDOpen(path_readingDisk, &fileInfo)) {
         size = (fileInfo.length + 0x1F) & ~0x1F;
 
-        if (greadingDisk != NULL && !xlHeapFree((void**)&greadingDisk)) {
-            return false;
-        }
+        if (greadingDisk != NULL)
+            if (!xlHeapFree((void**)&greadingDisk)) {
+                return false;
+            }
+    }
 
-        if (!xlHeapTake((void**)&greadingDisk, size | 0x30000000)) {
-            return false;
-        }
-
-        DVDReadPrio(&fileInfo, greadingDisk, size, 0, 2);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)greadingDisk);
-    } else {
+    if (!xlHeapTake((void**)&greadingDisk, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_wrongDisk, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    DVDReadPrio(&fileInfo, greadingDisk, size, 0, 2);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)greadingDisk);
+}
+else {
+    return false;
+}
 
-        if (gwrongDisk != NULL && !xlHeapFree((void**)&gwrongDisk)) {
+if (DVDOpen(path_wrongDisk, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gwrongDisk != NULL) {
+        if (!xlHeapFree((void**)&gwrongDisk)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gwrongDisk, size | 0x30000000)) {
-            return false;
-        }
-
-        DVDReadPrio(&fileInfo, gwrongDisk, size, 0, 2);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gwrongDisk);
-    } else {
+    if (!xlHeapTake((void**)&gwrongDisk, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_noDisk, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    DVDReadPrio(&fileInfo, gwrongDisk, size, 0, 2);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gwrongDisk);
+} else {
+    return false;
+}
 
-        if (gnoDisk != NULL && !xlHeapFree((void**)&gnoDisk)) {
+if (DVDOpen(path_noDisk, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gnoDisk != NULL) {
+        if (!xlHeapFree((void**)&gnoDisk)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gnoDisk, size | 0x30000000)) {
-            return false;
-        }
-
-        DVDReadPrio(&fileInfo, gnoDisk, size, 0, 2);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gnoDisk);
-    } else {
+    if (!xlHeapTake((void**)&gnoDisk, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_retryErr, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    DVDReadPrio(&fileInfo, gnoDisk, size, 0, 2);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gnoDisk);
+} else {
+    return false;
+}
 
-        if (gretryErr != NULL && !xlHeapFree((void**)&gretryErr)) {
+if (DVDOpen(path_retryErr, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gretryErr != NULL) {
+        if (!xlHeapFree((void**)&gretryErr)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gretryErr, size | 0x30000000)) {
-            return false;
-        }
-
-        simulatorDVDRead(&fileInfo, gretryErr, size, 0, NULL);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gretryErr);
-    } else {
+    if (!xlHeapTake((void**)&gretryErr, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_fatalErr, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    simulatorDVDRead(&fileInfo, gretryErr, size, 0, NULL);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gretryErr);
+} else {
+    return false;
+}
 
-        if (gfatalErr != NULL && !xlHeapFree((void**)&gfatalErr)) {
+if (DVDOpen(path_fatalErr, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gfatalErr != NULL) {
+        if (!xlHeapFree((void**)&gfatalErr)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gfatalErr, size | 0x30000000)) {
-            return false;
-        }
-
-        simulatorDVDRead(&fileInfo, gfatalErr, size, 0, NULL);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gfatalErr);
-    } else {
+    if (!xlHeapTake((void**)&gfatalErr, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_yes, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    simulatorDVDRead(&fileInfo, gfatalErr, size, 0, NULL);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gfatalErr);
+} else {
+    return false;
+}
 
-        if (gyes != NULL && !xlHeapFree((void**)&gyes)) {
+if (DVDOpen(path_yes, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gyes != NULL) {
+        if (!xlHeapFree((void**)&gyes)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gyes, size | 0x30000000)) {
-            return false;
-        }
-
-        simulatorDVDRead(&fileInfo, gyes, size, 0, NULL);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gyes);
-    } else {
+    if (!xlHeapTake((void**)&gyes, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_no, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    simulatorDVDRead(&fileInfo, gyes, size, 0, NULL);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gyes);
+} else {
+    return false;
+}
 
-        if (gno != NULL && !xlHeapFree((void**)&gno)) {
+if (DVDOpen(path_no, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gno != NULL) {
+        if (!xlHeapFree((void**)&gno)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gno, size | 0x30000000)) {
-            return false;
-        }
-
-        simulatorDVDRead(&fileInfo, gno, size, 0, NULL);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gno);
-    } else {
+    if (!xlHeapTake((void**)&gno, size | 0x30000000)) {
         return false;
     }
 
-    if (DVDOpen(path_mesgOK, &fileInfo)) {
-        size = (fileInfo.length + 0x1F) & ~0x1F;
+    simulatorDVDRead(&fileInfo, gno, size, 0, NULL);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gno);
+} else {
+    return false;
+}
 
-        if (gmesgOK != NULL && !xlHeapFree((void**)&gmesgOK)) {
+if (DVDOpen(path_mesgOK, &fileInfo)) {
+    size = (fileInfo.length + 0x1F) & ~0x1F;
+
+    if (gmesgOK != NULL) {
+        if (!xlHeapFree((void**)&gmesgOK)) {
             return false;
         }
+    }
 
-        if (!xlHeapTake((void**)&gmesgOK, size | 0x30000000)) {
-            return false;
-        }
-
-        simulatorDVDRead(&fileInfo, gmesgOK, size, 0, NULL);
-        DVDClose(&fileInfo);
-        simulatorUnpackTexPalette((TEXPalette*)gmesgOK);
-    } else {
+    if (!xlHeapTake((void**)&gmesgOK, size | 0x30000000)) {
         return false;
     }
 
-    return true;
+    simulatorDVDRead(&fileInfo, gmesgOK, size, 0, NULL);
+    DVDClose(&fileInfo);
+    simulatorUnpackTexPalette((TEXPalette*)gmesgOK);
+} else {
+    return false;
+}
+
+return true;
 }
 #endif
 

--- a/src/emulator/soundGCN.c
+++ b/src/emulator/soundGCN.c
@@ -21,25 +21,35 @@ s32 gVolumeCurve[257] ATTRIBUTE_ALIGN(32);
 bool soundWipeBuffers(Sound* pSound) {
     s32 iBuffer;
 
-    if (pSound->pBufferZero != NULL && !xlHeapFree(&pSound->pBufferZero)) {
-        return false;
+    if (pSound->pBufferZero != NULL) {
+        if (!xlHeapFree(&pSound->pBufferZero)) {
+            return false;
+        }
     }
 
-    if (pSound->pBufferHold != NULL && !xlHeapFree(&pSound->pBufferHold)) {
-        return false;
+    if (pSound->pBufferHold != NULL) {
+        if (!xlHeapFree(&pSound->pBufferHold)) {
+            return false;
+        }
     }
 
-    if (pSound->pBufferRampUp != NULL && !xlHeapFree(&pSound->pBufferRampUp)) {
-        return false;
+    if (pSound->pBufferRampUp != NULL) {
+        if (!xlHeapFree(&pSound->pBufferRampUp)) {
+            return false;
+        }
     }
 
-    if (pSound->pBufferRampDown != NULL && !xlHeapFree(&pSound->pBufferRampDown)) {
-        return false;
+    if (pSound->pBufferRampDown != NULL) {
+        if (!xlHeapFree(&pSound->pBufferRampDown)) {
+            return false;
+        }
     }
 
     for (iBuffer = 0; iBuffer < 16; iBuffer++) {
-        if (pSound->apBuffer[iBuffer] != NULL && !xlHeapFree(&pSound->apBuffer[iBuffer])) {
-            return false;
+        if (pSound->apBuffer[iBuffer] != NULL) {
+            if (!xlHeapFree(&pSound->apBuffer[iBuffer])) {
+                return false;
+            }
         }
     }
 
@@ -253,8 +263,10 @@ bool soundMakeBuffer(Sound* pSound) {
 
     OSRestoreInterrupts(bFlag);
 
-    if (pSound->eMode != SPM_PLAY && !soundMakeRamp(pSound, iBuffer, SR_INCREASE)) {
-        return false;
+    if (pSound->eMode != SPM_PLAY) {
+        if (!soundMakeRamp(pSound, iBuffer, SR_INCREASE)) {
+            return false;
+        }
     }
 
     if (!soundMakeRamp(pSound, iBuffer, SR_DECREASE)) {

--- a/src/emulator/system.c
+++ b/src/emulator/system.c
@@ -719,9 +719,10 @@ static bool systemSetupGameALL(System* pSystem) {
         strcat(buf1, "z_icon.tpl");
 #endif
 
-        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -731,9 +732,10 @@ static bool systemSetupGameALL(System* pSystem) {
         strcat(buf2, "z_bnr.tpl");
 #endif
 
-        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -847,9 +849,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -859,9 +862,10 @@ static bool systemSetupGameALL(System* pSystem) {
                 strcat(buf2, "z_bnr.tpl");
 #endif
 
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -872,9 +876,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -882,9 +887,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -900,9 +906,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
             strcat(buf1, "z_icon.tpl");
 #endif
-            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                return false;
+            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                    return false;
+                }
             }
 
             DVDClose(&fileInfo);
@@ -911,9 +918,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
             strcat(buf2, "z_bnr.tpl");
 #endif
-            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                return false;
+            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                    return false;
+                }
             }
 
             DVDClose(&fileInfo);
@@ -952,9 +960,10 @@ static bool systemSetupGameALL(System* pSystem) {
         strcat(buf1, "z_icon.tpl");
 #endif
 
-        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -964,9 +973,10 @@ static bool systemSetupGameALL(System* pSystem) {
         strcat(buf2, "z_bnr.tpl");
 #endif
 
-        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -1067,9 +1077,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
         strcat(buf1, "z_icon.tpl");
 #endif
-        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -1078,9 +1089,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
         strcat(buf2, "z_bnr.tpl");
 #endif
-        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -1093,9 +1105,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
         strcat(buf1, "z_icon.tpl");
 #endif
-        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 
         DVDClose(&fileInfo);
@@ -1103,14 +1116,16 @@ static bool systemSetupGameALL(System* pSystem) {
 
 #if IS_OOT_EU || IS_MM
         strcat(buf2, "z_bnr.tpl");
-        if (DVDOpen(buf2, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(buf2, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 #else
-        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-            return false;
+        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                return false;
+            }
         }
 #endif
         DVDClose(&fileInfo);
@@ -1139,9 +1154,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
             strcat(buf1, "z_icon.tpl");
 #endif
-            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                return false;
+            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                    return false;
+                }
             }
 
             DVDClose(&fileInfo);
@@ -1149,14 +1165,16 @@ static bool systemSetupGameALL(System* pSystem) {
 
 #if IS_OOT_EU || IS_MM
             strcat(buf2, "z_bnr.tpl");
-            if (DVDOpen(buf2, &fileInfo) == 1 &&
-                !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                return false;
+            if (DVDOpen(buf2, &fileInfo) == 1) {
+                if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                    return false;
+                }
             }
 #else
-            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                return false;
+            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                    return false;
+                }
             }
 #endif
 
@@ -1212,9 +1230,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1223,9 +1242,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1274,9 +1294,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1285,9 +1306,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1316,9 +1338,10 @@ static bool systemSetupGameALL(System* pSystem) {
 
 #if IS_MM
                 strcat(buf1, "z_icon.tpl");
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
                 DVDClose(&fileInfo);
                 simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
@@ -1341,9 +1364,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1352,9 +1376,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1368,9 +1393,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1379,9 +1405,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1395,9 +1422,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf1, "z_icon.tpl");
 #endif
-                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1406,9 +1434,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                 strcat(buf2, "z_bnr.tpl");
 #endif
-                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                    !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                    return false;
+                if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                    if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                        return false;
+                    }
                 }
 
                 DVDClose(&fileInfo);
@@ -1421,9 +1450,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                     strcat(buf1, "z_icon.tpl");
 #endif
-                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                        !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                        return false;
+                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                        if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                            return false;
+                        }
                     }
 
                     DVDClose(&fileInfo);
@@ -1431,9 +1461,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                     strcat(buf2, "z_bnr.tpl");
 #endif
-                    if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                        !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                        return false;
+                    if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                        if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                            return false;
+                        }
                     }
 
                     DVDClose(&fileInfo);
@@ -1445,9 +1476,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                     strcat(buf1, "z_icon.tpl");
 #endif
-                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                        !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                        return false;
+                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                        if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                            return false;
+                        }
                     }
 
                     DVDClose(&fileInfo);
@@ -1455,14 +1487,16 @@ static bool systemSetupGameALL(System* pSystem) {
 
 #if IS_OOT_EU || IS_MM
                     strcat(buf2, "z_bnr.tpl");
-                    if (DVDOpen(buf2, &fileInfo) == 1 &&
-                        !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                        return false;
+                    if (DVDOpen(buf2, &fileInfo) == 1) {
+                        if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                            return false;
+                        }
                     }
 #else
-                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                        !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                        return false;
+                    if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                        if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                            return false;
+                        }
                     }
 #endif
 
@@ -1499,9 +1533,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                         strcat(buf1, "z_icon.tpl");
 #endif
-                        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                            return false;
+                        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                                return false;
+                            }
                         }
 
                         DVDClose(&fileInfo);
@@ -1509,9 +1544,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                         strcat(buf2, "z_bnr.tpl");
 #endif
-                        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                            return false;
+                        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                                return false;
+                            }
                         }
 
                         DVDClose(&fileInfo);
@@ -1574,9 +1610,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                         strcat(buf1, "z_icon.tpl");
 #endif
-                        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                            !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                            return false;
+                        if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                            if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
+                                return false;
+                            }
                         }
 
                         DVDClose(&fileInfo);
@@ -1585,9 +1622,10 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                         strcat(buf2, "z_bnr.tpl");
 #endif
-                        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                            !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                            return false;
+                        if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                            if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
+                                return false;
+                            }
                         }
 
                         DVDClose(&fileInfo);
@@ -1608,9 +1646,11 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                             strcat(buf1, "z_icon.tpl");
 #endif
-                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
@@ -1619,9 +1659,11 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                             strcat(buf2, "z_bnr.tpl");
 #endif
-                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
@@ -1650,9 +1692,11 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                             strcat(buf1, "z_icon.tpl");
 #endif
-                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
@@ -1661,9 +1705,11 @@ static bool systemSetupGameALL(System* pSystem) {
 #if IS_OOT_EU || IS_MM
                             strcat(buf2, "z_bnr.tpl");
 #endif
-                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
@@ -1689,17 +1735,21 @@ static bool systemSetupGameALL(System* pSystem) {
                             pSystem->eTypeROM = SRT_SLICRADIC;
 
                             strcat(buf1, "z_icon.tpl");
-                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_ICON_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveIcon, (gz_iconSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
                             simulatorUnpackTexPalette((TEXPalette*)mCard.saveIcon);
                             strcat(buf2, "z_bnr.tpl");
-                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1 &&
-                                !simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0, NULL)) {
-                                return false;
+                            if (DVDOpen(Z_BNR_PATH, &fileInfo) == 1) {
+                                if (!simulatorDVDRead(&fileInfo, mCard.saveBanner, (gz_bnrSize + 0x1F) & ~0x1F, 0,
+                                                      NULL)) {
+                                    return false;
+                                }
                             }
 
                             DVDClose(&fileInfo);
@@ -2041,8 +2091,10 @@ bool systemReset(System* pSystem) {
         }
 #else
         for (eObject = 0; eObject < SOT_COUNT; eObject++) {
-            if (pSystem->apObject[eObject] != NULL && !xlObjectEvent(pSystem->apObject[eObject], 0x1003, NULL)) {
-                return false;
+            if (pSystem->apObject[eObject] != NULL) {
+                if (!xlObjectEvent(pSystem->apObject[eObject], 0x1003, NULL)) {
+                    return false;
+                }
             }
         }
 
@@ -2139,8 +2191,8 @@ bool systemCheckInterrupts(System* pSystem) {
         if (!cpuException(SYSTEM_CPU(pSystem), CEC_INTERRUPT, nMaskFinal)) {
             return false;
         }
-    } else {
-        if ((eCodeFinal != CEC_NONE) && !cpuException(SYSTEM_CPU(pSystem), eCodeFinal, 0)) {
+    } else if (eCodeFinal != CEC_NONE) {
+        if (!cpuException(SYSTEM_CPU(pSystem), eCodeFinal, 0)) {
             return false;
         }
     }
@@ -2353,17 +2405,22 @@ bool systemEvent(System* pSystem, s32 nEvent, void* pArgument) {
             break;
         case 3:
             for (storageDevice = 0; storageDevice < SOT_COUNT; storageDevice++) {
-                if ((storageDevice != SOT_FLASH) && (storageDevice != SOT_SRAM)) {
+                if (storageDevice != SOT_FLASH && storageDevice != SOT_SRAM) {
                     if (!xlObjectFree(&pSystem->apObject[storageDevice])) {
                         return false;
                     }
                 } else if (storageDevice == SOT_FLASH) {
-                    if ((pSystem->storageDevice == SOT_FLASH) && !xlObjectFree(&pSystem->apObject[SOT_FLASH])) {
-                        return false;
+                    if (pSystem->storageDevice == SOT_FLASH) {
+                        if (!xlObjectFree(&pSystem->apObject[SOT_FLASH])) {
+                            return false;
+                        }
                     }
-                } else if ((storageDevice == SOT_SRAM) && (pSystem->storageDevice == SOT_SRAM) &&
-                           !xlObjectFree(&pSystem->apObject[SOT_SRAM])) {
-                    return false;
+                } else if (storageDevice == SOT_SRAM) {
+                    if (pSystem->storageDevice == SOT_SRAM) {
+                        if (!xlObjectFree(&pSystem->apObject[SOT_SRAM])) {
+                            return false;
+                        }
+                    }
                 }
             }
             break;


### PR DESCRIPTION
for instances of 
```
if (cond && !func(...)) {
    return false;
}
```
where `cond` is a "check something" thing and `func` is a "do something" thing, rewrite this as
```
if (cond) {
    if (!func(...)) {
        return false;
    }
}
```
I find this easier to read since the `if (!func(...)) return false;` is standard boilerplate and isn't really part of the condition.